### PR TITLE
Adding show command (useful for containers with same name) to see ins…

### DIFF
--- a/libexec/cli/Makefile.am
+++ b/libexec/cli/Makefile.am
@@ -9,9 +9,9 @@ dist_cliexec_SCRIPTS = build.exec build.help build.summary \
 	install.exec install.help install.summary \
 	run.exec run.help run.summary \
 	shell.exec shell.help shell.summary \
+	show.exec show.help show.summary \
 	specgen.exec specgen.help specgen.summary \
 	strace.exec strace.help strace.summary \
 	test.exec test.help test.summary
 
 MAINTAINERCLEANFILES = Makefile.in
-

--- a/libexec/cli/show.exec
+++ b/libexec/cli/show.exec
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright (c) 2015-2016, Gregory M. Kurtzer. All rights reserved.
+#
+# “Singularity” Copyright (c) 2016, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+# If you have questions about your rights to use or distribute this software,
+# please contact Berkeley Lab's Innovation & Partnerships Office at
+# IPO@lbl.gov.
+#
+# NOTICE.  This Software was developed under funding from the U.S. Department of
+# Energy and the U.S. Government consequently retains certain rights. As such,
+# the U.S. Government has been granted for itself and others acting on its
+# behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+# to reproduce, distribute copies to the public, prepare derivative works, and
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
+
+
+## Basic sanity
+if [ -z "$libexecdir" ]; then
+    echo "Could not identify the Singularity libexecdir."
+    exit 1
+fi
+
+## Load functions
+if [ -f "$libexecdir/singularity/functions" ]; then
+    . "$libexecdir/singularity/functions"
+else
+    echo "Error loading functions: $libexecdir/singularity/functions"
+    exit 1
+fi
+
+load_mod cache
+load_mod sexec
+
+if [ -z "$1" ]; then
+    echo "USAGE: singularity (options) show [container name]"
+    exit 1
+fi
+
+SAPPNAME="$1"
+
+if ! cache_sappname2uuid "$SAPPNAME" "SAPPUUID"; then
+    message ERROR "Singularity container is not installed: $SAPPNAME\n"
+    exit 255
+fi
+
+if ! cache_sappdir "$SAPPUUID" "SAPPDIR"; then
+    message ERROR "Could not identify cache directory for $SAPPUUID\n"
+    exit 255
+fi
+
+SINGULARITY_COMMAND="show"
+CONTAINERPATH="$SAPPDIR"
+export SAPPNAME SINGULARITY_COMMAND CONTAINERPATH
+shift
+
+message 2 "Showing '$SAPPNAME'\n"
+
+RETVAL=1
+
+NAME="undefined"
+SUMMARY="undefined"
+SIZE="0"
+cache_sappuuid2name "$SAPPUUID" "NAME"
+cache_sappsummary "$SAPPUUID" "SUMMARY"
+cache_sapptimestamp "$SAPPUUID" "TIMESTAMP"
+cache_sappsize "$SAPPUUID" "SIZE"
+cache_sappmaintainer "$SAPPUUID" "MAINTAINER"
+cache_sappbuilddist "$SAPPUUID" "BUILD_DISTR"
+cache_sappbuildkernel "$SAPPUUID" "BUILD_KERN"
+cache_sappnbfiles "$SAPPUUID" "NB_FILES"
+
+BUILD_DISTR=`echo $BUILD_DISTR | cut -f2 -d"="`
+
+printf "_______: Summary of %s :_______\n" "$NAME"
+
+printf "Name:              %-20s\n" "$NAME"
+printf "UUID:              %-37s\n" "$SAPPUUID"
+printf "Size:              %-12s\n" "$SIZE"
+printf "Summary:           %s\n" "$SUMMARY"
+printf "Install time/date: %s\n" "$TIMESTAMP"
+printf "Maintainer:        %s\n" "$MAINTAINER"
+printf "Build distrib.:    %s\n" "$BUILD_DISTR"
+printf "Build kernel.:     %s\n" "$BUILD_KERN"
+printf "Number of files:   %d\n" "$NB_FILES"
+
+RETVAL=0
+
+exit $RETVAL

--- a/libexec/cli/show.exec
+++ b/libexec/cli/show.exec
@@ -65,7 +65,13 @@ RETVAL=1
 
 NAME="undefined"
 SUMMARY="undefined"
+TIMESTAMP="undefined"
 SIZE="0"
+MAINTAINER="undefined"
+BUILD_DISTR="undefined"
+BUILD_KERN="undefined"
+NB_FILES=0
+
 cache_sappuuid2name "$SAPPUUID" "NAME"
 cache_sappsummary "$SAPPUUID" "SUMMARY"
 cache_sapptimestamp "$SAPPUUID" "TIMESTAMP"

--- a/libexec/cli/show.help
+++ b/libexec/cli/show.help
@@ -1,0 +1,8 @@
+USAGE: singularity (options) show [container name/UUID]
+
+Display informations about a Singularity container.
+
+For additional help, please visit our public documentation pages which are
+found at:
+
+    http://gmkurtzer.github.io/singularity

--- a/libexec/cli/show.summary
+++ b/libexec/cli/show.summary
@@ -1,0 +1,1 @@
+Display informations about a Singularity container

--- a/libexec/mods/cache.smod
+++ b/libexec/mods/cache.smod
@@ -1,23 +1,23 @@
 #!/bin/bash
-# 
+#
 # Copyright (c) 2015-2016, Gregory M. Kurtzer. All rights reserved.
-# 
+#
 # “Singularity” Copyright (c) 2016, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
-# 
+#
 # If you have questions about your rights to use or distribute this software,
 # please contact Berkeley Lab's Innovation & Partnerships Office at
 # IPO@lbl.gov.
-# 
+#
 # NOTICE.  This Software was developed under funding from the U.S. Department of
 # Energy and the U.S. Government consequently retains certain rights. As such,
 # the U.S. Government has been granted for itself and others acting on its
 # behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 # to reproduce, distribute copies to the public, prepare derivative works, and
-# perform publicly and display publicly, and to permit other to do so. 
-# 
-# 
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
 
 
 
@@ -240,6 +240,74 @@ cache_sappsummary() {
     return 1
 }
 
+
+# INPUT 1: SAPP UUID
+# INPUT 2: Variable name to populate the SAPP installed; human readable timestamp
+# RETURN: True if that UUID is installed and the name is properly defined
+cache_sapptimestamp() {
+    SAPPUUID="$1"
+    VARNAME="$2"
+
+    if [ -z "$SAPPUUID" ]; then
+        message ERROR "SAPPUUID undefined\n"
+        exit 1
+    fi
+
+    if [ -f "$CACHEDIR/$UUID_DIR/$SAPPUUID/installed" -a -s "$CACHEDIR/$UUID_DIR/$SAPPUUID/installed" ]; then
+        read $VARNAME < "$CACHEDIR/$UUID_DIR/$SAPPUUID/installed"
+        return 0
+    fi
+
+    eval "$VARNAME='--'"
+    return 1
+}
+
+
+# INPUT 1: SAPP UUID
+# INPUT 2: Variable name to populate the SAPP maintainer
+# RETURN: True if that UUID is installed and the name is properly defined
+cache_sappmaintainer() {
+    SAPPUUID="$1"
+    VARNAME="$2"
+
+    if [ -z "$SAPPUUID" ]; then
+        message ERROR "SAPPUUID undefined\n"
+        exit 1
+    fi
+
+    if [ -f "$CACHEDIR/$UUID_DIR/$SAPPUUID/maintainer" -a -s "$CACHEDIR/$UUID_DIR/$SAPPUUID/maintainer" ]; then
+        read $VARNAME < "$CACHEDIR/$UUID_DIR/$SAPPUUID/maintainer"
+        return 0
+    fi
+
+    eval "$VARNAME='--'"
+    return 1
+}
+
+
+
+
+# INPUT 1: SAPP UUID
+# INPUT 2: Variable name to populate the SAPP NB_FILES
+# RETURN: True if that UUID is installed and the name is properly defined
+cache_sappnbfiles() {
+    SAPPUUID="$1"
+    VARNAME="$2"
+
+    if [ -z "$SAPPUUID" ]; then
+        message ERROR "SAPPUUID undefined\n"
+        exit 1
+    fi
+
+    if [ -f "$CACHEDIR/$UUID_DIR/$SAPPUUID/files" -a -s "$CACHEDIR/$UUID_DIR/$SAPPUUID/files" ]; then
+        NB_FILES=`wc -l "$CACHEDIR/$UUID_DIR/$SAPPUUID/files" | cut -f 1 -d" "`
+        read $VARNAME <<< "$NB_FILES"
+        return 0
+    fi
+
+    eval "$VARNAME='--'"
+    return 1
+}
 
 
 # INPUT 1: SAPP UUID
@@ -539,6 +607,3 @@ _sappinstall() {
 
     return 0
 }
-
-
-


### PR DESCRIPTION
Hi,

This pull request allows a user to use the "show" command which is simply looking in the container directory to display the content of summary, installed, build_..., (...) files.

For instance, it can be useful if you have many containers with the same name and you want to display specific informations about a container from UUID.

Best regards,

Rémy
