### PR TITLE
Ensure directory exists before trying to write to a file in it

### DIFF
--- a/libexec/mods/linux_build.smod
+++ b/libexec/mods/linux_build.smod
@@ -172,6 +172,7 @@ Finalize() {
             if [ -e "$SINGULARITY_BUILD_ROOT/$i" ]; then
                 rm -rf "$SINGULARITY_BUILD_ROOT/$i"
             fi
+            mkdir -m 755 -p $(dirname "$i")
             > "$SINGULARITY_BUILD_ROOT/$i"
         fi
     done


### PR DESCRIPTION
This resolves a "no such file or directory" for /etc//mtab when bootstrapping rpms.
Maybe the extra / should be dropped, i.e. "$SINGULARITY_BUILD_ROOT$i" etc.
