### PR TITLE
Fix RunCmd for multi-word args

### DIFF
--- a/libexec/mods/linux_build.smod
+++ b/libexec/mods/linux_build.smod
@@ -163,7 +163,7 @@ RunScript() {
 }
 
 RunCmd() {
-    if ! chroot "$SINGULARITY_BUILD_ROOT" /bin/sh -c "$@"; then
+    if ! chroot "$SINGULARITY_BUILD_ROOT" /bin/sh -c "'$@'"; then
         message ERROR "Failed to run: $*\n"
         return 1
     fi


### PR DESCRIPTION
I tried something like "RunCmd ln -sf something /singularity" and it failed.  This makes that work, but may not be the best solution due to quoting.  Maybe either stipulate a single arg or pipe quoted components of "$@" into sh if it must use sh.  I wonder if it's better to require an exec-able command for the chroot.
