### PR TITLE
Changed InstallFiles to InstallFile on website

### DIFF
--- a/content/bootstrap.html
+++ b/content/bootstrap.html
@@ -65,7 +65,7 @@ but if using "redhat", this will be installed from outside the bootstrapped
 system.
 </li>
 <li>
-<b>InstallFiles</b>: Install a file into the container. Note that relative paths
+<b>InstallFile</b>: Install a file into the container. Note that relative paths
 work just fine, but care must be taken from the calling directory.
 </li>
 <li>


### PR DESCRIPTION
On the bootstrap documentation page, it has a list of keywords, and one of those is listed as InstallFiles. From personal experience with Singularity2.0, and what it says in the code, it seems that the correct function is InstallFile not InstallFiles
