### PR TITLE
Minor changes to bootstrap.html

### DIFF
--- a/content/bootstrap.html
+++ b/content/bootstrap.html
@@ -65,7 +65,7 @@ but if using "redhat", this will be installed from outside the bootstrapped
 system.
 </li>
 <li>
-<b>InstallFiles</b>: Install a file into the container. Note that relative paths
+<b>InstallFile</b>: Install a file into the container. Note that relative paths
 work just fine, but care must be taken from the calling directory.
 </li>
 <li>

--- a/content/bootstrap.html
+++ b/content/bootstrap.html
@@ -72,9 +72,11 @@ work just fine, but care must be taken from the calling directory.
 <b>RunCmd</b>: Run a command within the new container operating system
 during the bootstrap.  May be repeated to run multiple commands.
 </li>
+<li>
 <b>RunScript</b>: Add a command line to the "runscript" invoked by
 'singularity run' or by executing the container directly.
-May be repeated to add multiple command lines.
+May be repeated to add multiple command lines.  
+</li>
 <li>
 <b>Cleanup</b>: Cleanup any temporary files like YUM/Apt caches.
 </li>


### PR DESCRIPTION
Just some minor errors I've encountered on the bootstrap documentation page. Both relate to the list of singularity keywords under the example bootstrap file. One is that InstallFile is incorrectly listed as InstallFiles. Second is a missing bullet point for RunScript. 
