### PR TITLE
Fix default expansion size in images.html

### DIFF
--- a/content/images.html
+++ b/content/images.html
@@ -99,7 +99,7 @@ $ ls -l container.img
 
 <p>
 Similar to the create sub-command, you can override the default size (which is
-1024MiB) by using the --size option.
+512MiB) by using the --size option.
 </p>
 
 <h2>Copying, sharing, branching, and distributing your image</h2>


### PR DESCRIPTION
From what the example text seems to say, as well as what singularity tells me when I expand an image, it seems the default is actually 512 MiB, not 1024 MiB.

Also despite the facts that I know MiB is more accurate than MB and that the newer version of singularity outputs the message with MiB not MB, it seems strange to use "MiB" when the example above uses MB; but I'll leave that choice up to you.
