### PR TITLE
ENH: explicit PS4 for robust operation of set -x

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# set PS4 explicitly to be POSIX shell compatible for set -x
+export PS4=+
+
 if autoreconf -V >/dev/null 2>&1 ; then
     set -x
     autoreconf -i -f


### PR DESCRIPTION
Well... the thing is the combination of using `#!/bin/sh` (i.e. posix compliant shell) and some non-compliant folks using e.g. bash with some custom bash specific PS4... running ./autogen.sh then could lead to some obscure error messages such as 

``` shell
$> dash ./autogen.sh
./autogen.sh: 5: ./autogen.sh: Bad substitution
```

so just a little hint in case you would like to keep that set -x around ;)
