### PR TITLE
ENH: set -e and set -u in sample bash scripts under libexec

### DIFF
--- a/libexec/bootstrap.sh
+++ b/libexec/bootstrap.sh
@@ -19,12 +19,15 @@
 # 
 # 
 
+set -e
 
 ## Basic sanity
 if [ -z "$SINGULARITY_libexecdir" ]; then
     echo "Could not identify the Singularity libexecdir."
     exit 1
 fi
+
+set -u
 
 ## Load functions
 if [ -f "$SINGULARITY_libexecdir/singularity/functions" ]; then

--- a/libexec/copy.sh
+++ b/libexec/copy.sh
@@ -19,12 +19,15 @@
 # 
 # 
 
+set -e
 
 ## Basic sanity
 if [ -z "$SINGULARITY_libexecdir" ]; then
     echo "Could not identify the Singularity libexecdir."
     exit 1
 fi
+
+set -u
 
 ## Load functions
 if [ -f "$SINGULARITY_libexecdir/singularity/functions" ]; then

--- a/libexec/docker-import.sh
+++ b/libexec/docker-import.sh
@@ -44,6 +44,8 @@
 #          properly, in particular "shell" v. "exec"
 #        Consider the locale, e.g. for use of =~
 
+set -e
+
 docker_cleanup() {
     if [[ -n $id ]]; then
         message 1 "Cleaning up Docker container...\n"
@@ -55,10 +57,13 @@ docker_cleanup() {
 # If we've started a container, we want to remove it on exit.
 trap docker_cleanup 0
 
-if [[ -z $FILE ]]; then
+if [[ -z "$FILE" ]]; then
     message ERROR "No Docker image specified (with --file)\n"
     exit 1
 fi
+
+set -u
+
 dock=$FILE
 sing=$1
 

--- a/libexec/functions
+++ b/libexec/functions
@@ -19,7 +19,7 @@
 # 
 # 
 
-
+set -e
 
 if [ -z "$MESSAGELEVEL" ]; then
     /bin/echo "Warning: MESSAGELEVEL is undefined, temporarily setting to '5' (all messages)"
@@ -35,6 +35,7 @@ if [ -z "$HOME" ]; then
     export HOME
 fi
 
+set -u
 
 message() {
     LEVEL="$1"
@@ -231,6 +232,6 @@ parse_opts() {
 
 
 
-if [ "$DEBUG" = "1" ]; then
+if [ "${DEBUG:-}" = "1" ]; then
     set -x
 fi


### PR DESCRIPTION
Just for a "demo" of #134 

Whenever a variable wants to be consumed even if not defined `${VAR:-}` could be used to explicitly assume empty value if not defined under the `set -u` mode.

Benefits of set -u -- code becomes more robust without continuing running if some variable was not checked to be not empty explicitly.   of set -e: script will exit right away if any error happens, instead of continuing plowing through possibly causing a disaster ;-)  

Possible side-effects:  if PS\* env variables use some variables loosely allowing them to be assumed empty if not defined, and script relies on using the corresponding PS (e.g. PS4 in set -x mode), could lead to failures if `set -u`
