### PR TITLE
BF: clarify "modified BSD" license in about.html

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -73,8 +73,11 @@ reproducibility.
 
 <h4 class="loud">License</h4>
 <p>
-Singularity is released under a modified BSD license. The only modification
+Singularity is released under a BSD license with 2 modifications. One of the modifications
 being that you may not use the names of any project members or contributors
 (namely UC or the US Department of Energy) to endorse or promote products or
-services derived from or using this software.
+services derived from or using this software. And the other is that if you
+share modified code publicly (or with Berkeley National Laboratory), you will
+grant similar license terms on your "Enhancements"
+(see <a href="https://github.com/gmkurtzer/singularity/blob/master/LICENSE">LICENSE</a> file for more details).
 </p>


### PR DESCRIPTION
"modified BSD" name is commonly used to refer to BSD-3 license
see eg https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22Revised_BSD_License.22.2C_.22New_BSD_License.22.2C_or_.22Modified_BSD_License.22.29
which is not the entirety of the license terms here, since BSD-3 doesn't have any additional statements about terms of how derived work (Enhancements) must be licensed.

So I took my shot at clarifying the wording.  IMHO #117 should be reopened and closed only whenever some adjustment to wording of that paragraph online was done

Closes #117
