### PR TITLE
ENH: use flawfinder in test.sh, install flawfinder in travis env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ compiler:
 before_install:
   # so that adjusted PATH propagates into sudo
   - sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
+  - sudo apt-get install flawfinder
 
 script:
   - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
   # so that adjusted PATH propagates into sudo
   - sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
   - sudo apt-get install flawfinder
+  # necessary ATM. See https://github.com/gmkurtzer/singularity/pull/140
+  - sudo apt-get install yum
 
 script:
   - ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -118,6 +118,14 @@ stest 0 sudo rm -rf "$TEMPDIR"
 stest 0 make maintainer-clean
 
 /bin/echo
+if `which flawfinder > /dev/null``; then
+    /bin/echo "Testing source code with flawfinder"
+    stest 0 sh -c "flawfinder . | tee /dev/stderr | grep -q -e 'No hits found'"
+else
+    /bin/echo "WARNING: flawfinder is not found, test skipped"
+fi
+
+/bin/echo
 /bin/echo "Done. All tests completed successfully"
 /bin/echo
 


### PR DESCRIPTION
locally: fails to run test.sh before flawfinder run 

```
Building test container...
 + sudo singularity create -s 568 container.img                 (retval=0) OK
 + sudo singularity bootstrap container.img /home/yoh/deb/persp (retval=1) ERROR
Setting RELEASE=7
ERROR: Neither yum nor dnf in PATH!
Full output in: /tmp/tmp.RY842ZBOox

```
