### PR TITLE
Add support for slave mounts.

### DIFF
--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -28,6 +28,12 @@ mount sys = yes
 # attempt to mount it's base path into the container?
 mount home = yes
 
+# MOUNT SLAVE: [BOOL]
+# DEFAULT: no
+# Should we automatically propogate filesystem changes from the host?
+# This should be set to 'yes' when autofs mounts in the system should
+# show up in the container.
+mount slave = no
 
 # BIND PATH: [STRING]
 # DEFAULT: Undefined

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -499,10 +499,11 @@ int main(int argc, char ** argv) {
                 ABORT(255);
             }
 
+            int slave = config_get_key_bool(config_fp, "mount slave", 0);
             // Privatize the mount namespaces
-            message(DEBUG, "Making mounts private\n");
-            if ( mount(NULL, "/", NULL, MS_PRIVATE|MS_REC, NULL) < 0 ) {
-                message(ERROR, "Could not make mountspaces private: %s\n", strerror(errno));
+            message(DEBUG, "Making mounts %s\n", (slave ? "slave" : "private"));
+            if ( mount(NULL, "/", NULL, (slave ? MS_SLAVE : MS_PRIVATE)|MS_REC, NULL) < 0 ) {
+                message(ERROR, "Could not make mountspaces %s: %s\n", (slave ? "slave" : "private"), strerror(errno));
                 ABORT(255);
             }
 


### PR DESCRIPTION
Previously, the entire set of mounts within the container were
marked 'private': this means any changes in the host OS would not
show up in the container.

However, in places that use autofs (e.g., distributing software),
we want the autofs daemon (which lives in the host OS) to be able
to make mounts that show up in the container.  To do that, we must
mark the mounts as 'slave': changes in the host show up in the
container, but not vice-versa.

Unfortunately, it seems that it's all-or-nothing: we can't do slave
mounts _only_ for a single bind mount.  Accordingly, I set this to
be a global, container-wide option as opposed to only setting it for
a single bind mount at-a-time.  The default is to use private mounts
(the pre-existing behavior).
