### PR TITLE
Set the NO_NEW_PRIVS flag when it is available.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,21 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#define _GNU_SOURCE
                   )
 
 
+AC_MSG_CHECKING([for feature: NO_NEW_PRIVS])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+                                     #include <sys/prctl.h>
+                                   ]],
+                                   [[prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+                                     prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0);]])],
+                      [
+                          AC_MSG_RESULT([yes])
+                          NAMESPACE_DEFINES="$NAMESPACE_DEFINES -DSINGULARITY_NO_NEW_PRIVS"
+                      ], [
+                          AC_MSG_RESULT([no])
+                      ]
+                  )
+
+
 AC_MSG_CHECKING([for namespace: CLONE_NEWNS])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#define _GNU_SOURCE
                                      #include <sched.h>

--- a/src/mounts.c
+++ b/src/mounts.c
@@ -108,7 +108,7 @@ int mount_bind(char * source, char * dest, int writable) {
     }
 
     message(DEBUG, "Calling mount(%s, %s, ...)\n", source, dest);
-    if ( mount(source, dest, NULL, MS_BIND|MS_REC, NULL) < 0 ) {
+    if ( mount(source, dest, NULL, MS_BIND|MS_NOSUID|MS_REC, NULL) < 0 ) {
         message(ERROR, "Could not bind %s: %s\n", dest, strerror(errno));
         ABORT(255);
     }

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -28,6 +28,9 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/param.h>
+#ifdef SINGULARITY_NO_NEW_PRIVS
+#include <sys/prctl.h>
+#endif
 #include <errno.h> 
 #include <signal.h>
 #include <sched.h>
@@ -724,7 +727,16 @@ int main(int argc, char ** argv) {
                     ABORT(1);
                 }
 
-
+#if defined(SINGULARITY_NO_NEW_PRIVS)
+                // Prevent this container from gaining any future privileges.
+                message(DEBUG, "Setting NO_NEW_PRIVS to prevent future privilege escalations.\n");
+                if ( prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 ) {
+                    message(ERROR, "Could not set NO_NEW_PRIVS safeguard: %s\n", strerror(errno));
+                    ABORT(1);
+                }
+#else  // SINGULARITY_NO_NEW_PRIVS
+                message(VERBOSE2, "Not enabling NO_NEW_PRIVS flag due to lack of compile-time support.\n");
+#endif
                 // Do what we came here to do!
                 if ( command == NULL ) {
                     message(WARNING, "No command specified, launching 'shell'\n");


### PR DESCRIPTION
The `NO_NEW_PRIVS` flag instructs the kernel to disallow any future privilege escalations (i.e., via setuid or setgid executables).  This seems to be a reasonable safeguard to add.

To test, simply copy `/usr/bin/ping` to `/tmp` (chown to root and set to mode 4755).  Without this patch, `ping` works.  With this patch, `ping` does not work.

I also added `MS_NOSUID` to all the bind mounts.  It seems that it doesn't take effect?  Curious.
