### PR TITLE
Mark conf file as no-replace

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -38,7 +38,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 %doc AUTHORS COPYING ChangeLog INSTALL NEWS README.md
 %attr(0755, root, root) %dir %{_sysconfdir}/singularity
-%attr(0644, root, root) %config %{_sysconfdir}/singularity/*
+%attr(0644, root, root) %config(noreplace) %{_sysconfdir}/singularity/*
 %dir %{_libexecdir}/singularity
 %attr(4755, root, root) %{_libexecdir}/singularity/sexec
 %{_libexecdir}/singularity/mods


### PR DESCRIPTION
Files marked as `%config` have their changes overridden on upgrade by the package version.  It's traditional on RHEL platforms to mark package config files as `%config(noreplace)`, preventing nasty surprises during upgrades.
