### PR TITLE
Add user namespace support / unprivileged mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ src/image-create
 src/image-expand
 src/image-mount
 src/sexec
+src/sexec_nosuid
 src/stamp-h1
 

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#define _GNU_SOURCE
                   )
 
 
+AC_ARG_WITH([userns],
+            AS_HELP_STRING([--with-userns], [Enable use of user namespaces]),
+            [NAMESPACE_DEFINES="$NAMESPACE_DEFINES -DSINGULARITY_USERNS"]
+           )
+
 AC_SUBST(NAMESPACE_DEFINES)
 
 AC_CHECK_FUNCS(setns, [

--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -17,6 +17,13 @@ allow pid ns = yes
 # feature is disabled.
 allow user scratch = yes
 
+# ALLOW SETUID: [BOOL]
+# DEFAULT: yes
+# Should we allow users to utilize the setuid binary for launching singularity?
+# The majority of features require this to be set to yes, but newer Fedora and
+# Ubuntu kernels can provide limited functionality in unprivileged mode.
+allow setuid = yes
+
 # MOUNT PROC: [BOOL]
 # DEFAULT: yes
 # Should we automatically mount /proc within the container?

--- a/libexec/cli/exec.exec
+++ b/libexec/cli/exec.exec
@@ -83,5 +83,10 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
+if [ -d "$SINGULARITY_IMAGE" ]; then
+  export SINGULARITY_USERNS=1
+  exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
+else
+  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
+fi
 
-exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0

--- a/libexec/cli/exec.exec
+++ b/libexec/cli/exec.exec
@@ -88,10 +88,11 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
-if [ -d "$SINGULARITY_IMAGE" ]; then
+if [[ -e "$SINGULARITY_libexecdir/singularity/sexec" && "x${SINGULARITY_FORCE_NOSUID-}" == "x" ]]; then
+  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
+else
+  unset SINGULARITY_FORCE_NOSUID
   export SINGULARITY_USERNS=1
   exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
-else
-  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
 fi
 

--- a/libexec/cli/run.exec
+++ b/libexec/cli/run.exec
@@ -83,5 +83,10 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
+if [ -d "$SINGULARITY_IMAGE" ]; then
+  export SINGULARITY_USERNS=1
+  exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
+else
+  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
+fi
 
-exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0

--- a/libexec/cli/run.exec
+++ b/libexec/cli/run.exec
@@ -88,10 +88,11 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
-if [ -d "$SINGULARITY_IMAGE" ]; then
+if [[ -e "$SINGULARITY_libexecdir/singularity/sexec" && "x${SINGULARITY_FORCE_NOSUID-}" == "x" ]]; then
+  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
+else
+  unset SINGULARITY_FORCE_NOSUID
   export SINGULARITY_USERNS=1
   exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
-else
-  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
 fi
 

--- a/libexec/cli/shell.exec
+++ b/libexec/cli/shell.exec
@@ -95,9 +95,11 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
-if [ -d "$SINGULARITY_IMAGE" ]; then
+if [[ -e "$SINGULARITY_libexecdir/singularity/sexec" && "x${SINGULARITY_FORCE_NOSUID-}" == "x" ]]; then
+  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
+else
+  unset SINGULARITY_FORCE_NOSUID
   export SINGULARITY_USERNS=1
   exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
-else
-  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
 fi
+

--- a/libexec/cli/shell.exec
+++ b/libexec/cli/shell.exec
@@ -88,4 +88,9 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
-exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
+if [ -d "$SINGULARITY_IMAGE" ]; then
+  export SINGULARITY_USERNS=1
+  exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
+else
+  exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
+fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ DISTCLEANFILES = Makefile
 CLEANFILES = core.* *~ 
 AM_CFLAGS = -Wall
 sexec_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(NAMESPACE_DEFINES) $(NO_SETNS)
+sexec_nosuid_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(NAMESPACE_DEFINES) $(NO_SETNS)
 bootstrap_CPPFLAGS = -DLIBEXECDIR=\"$(libexecdir)\"
 ftrace_CPPFLAGS = -DARCH_$(SINGULARITY_ARCH)
 
@@ -17,11 +18,12 @@ install-exec-hook:
 	fi
 
 bindir = $(libexecdir)/singularity
-bin_PROGRAMS = sexec image-create image-expand image-mount image-bind
+bin_PROGRAMS = sexec image-create image-expand image-mount image-bind sexec_nosuid
 
 ftrace_SOURCES = ftrace.c file.c util.c message.c
 ftype_SOURCES = ftype.c util.c file.c message.c
 sexec_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c
+sexec_nosuid_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c
 image_create_SOURCES = image-create.c file.c util.c image.c message.c
 image_expand_SOURCES = image-expand.c file.c util.c image.c message.c
 image_mount_SOURCES = image-mount.c util.c loop-control.c mounts.c file.c image.c message.c

--- a/src/mounts.c
+++ b/src/mounts.c
@@ -111,9 +111,11 @@ void mount_bind(char * source, char * dest, int writable) {
         ABORT(255);
     }
 
-    //  NOTE: This used to be separated into two distinct mount calls (one to mount, a second to remount
-    //  as read-only).  I changed this to a single mount() call as user-namespaces aren't allowed to
-    //  remount.
+    //  NOTE: The kernel history is a bit ... murky ... as to whether MS_RDONLY can be set in the
+    //  same syscall as the bind.  It seems to no longer work on modern kernels - hence, we also
+    //  do it below.  *However*, if we are using user namespaces, we get an EPERM error on the
+    //  separate mount command below.  Hence, we keep the flag in the first call until the kernel
+    //  picture cleras up.
     message(DEBUG, "Calling mount(%s, %s, ...)\n", source, dest);
     if ( mount(source, dest, NULL, MS_BIND|MS_NOSUID|MS_REC|(writable <= 0 ? MS_RDONLY : 0), NULL) < 0 ) {
         message(ERROR, "Could not bind %s: %s\n", dest, strerror(errno));

--- a/src/privilege.c
+++ b/src/privilege.c
@@ -19,13 +19,16 @@
  */
 
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <pwd.h>
 #include <errno.h> 
 #include <string.h>
+#include <stdio.h>
 #include <grp.h>
 
 #include "privilege.h"
@@ -33,6 +36,107 @@
 #include "file.h"
 #include "util.h"
 #include "message.h"
+
+
+static int disable_setgroups = 0;
+
+void update_uid_map(pid_t child, uid_t outside, int is_child) {
+    char * map_file;
+    char * map;
+    ssize_t map_len;
+    int fd;
+
+    message(DEBUG, "Updating UID map.\n");
+    if (asprintf(&map_file, "/proc/%i/uid_map", child) < 0) {
+        message(ERROR, "Can't allocate uid map filename\n");
+        ABORT(255);
+    }
+    if (is_child) {
+        map_len = asprintf(&map, "%i 0 1\n", outside);
+    } else {
+        map_len = asprintf(&map, "0 %i 1\n", outside);
+    }
+    if (map_len < 0) {
+        free(map_file);
+        message(ERROR, "Can't allocate uid map\n");
+        ABORT(255);
+    }
+
+    fd = open(map_file, O_RDWR);
+    free(map_file);
+    if (fd == -1) {
+        perror("Open Mapfile");
+        free(map);
+        ABORT(255);
+    }
+    if (write(fd, map, map_len) != map_len) {
+        perror("Writing Map");
+        free(map);
+        ABORT(255);
+    }
+    free(map);
+    close(fd);
+}
+
+
+void update_gid_map(pid_t child, gid_t outside, int is_child) {
+    char * setgroups_file, * map_file;
+    char * map;
+    ssize_t map_len;
+    int fd;
+
+    message(DEBUG, "Updating GID map.\n");
+    if (asprintf(&map_file, "/proc/%i/gid_map", child) < 0) {
+        message(ERROR, "Can't allocate uid map filename\n");
+        ABORT(255);
+    }
+    if (is_child) {
+        map_len = asprintf(&map, "%i 0 1\n", outside);
+    } else {
+        map_len = asprintf(&map, "0 %i 1\n", outside);
+    }
+    if (map_len < 0) {
+        free(map_file);
+        message(ERROR, "Can't allocate gid map\n");
+        ABORT(255);
+    }
+    if (asprintf(&setgroups_file, "/proc/%i/setgroups", child) < 0) {
+        message(ERROR, "Can't allocate setgroups filename\n");
+        ABORT(255);
+    }
+    fd = open(setgroups_file, O_RDWR);
+    free(setgroups_file);
+    if (fd == -1) {
+        perror("Open /proc/$$/setgroups file");
+        free(map_file);
+        free(map);
+        ABORT(255);
+    }
+    if (write(fd, "deny", 4) != 4) {
+        perror("Writing setgroups deny");
+        free(map_file);
+        free(map);
+        close(fd);
+    }
+    close(fd);
+    disable_setgroups = 1;
+
+    fd = open(map_file, O_RDWR);
+    free(map_file);
+    if (fd == -1) {
+        perror("Open GID mapfile");
+        free(map);
+        exit(-1);
+    }
+    if (write(fd, map, map_len) != map_len) {
+        perror("Writing GID map");
+        free(map);
+        close(fd);
+        exit(-1);
+    }
+    free(map);
+    close(fd);
+}
 
 
 int get_user_privs(struct s_privinfo *uinfo) {
@@ -126,10 +230,14 @@ int drop_privs_perm(struct s_privinfo *uinfo) {
     }
 
     if ( geteuid() == 0 ) {
-        message(DEBUG, "Resetting supplementary groups\n");
-        if ( setgroups(uinfo->gids_count, uinfo->gids) < 0 ) {
-            fprintf(stderr, "ABOFT: Could not reset supplementary group list: %s\n", strerror(errno));
-            return(-1);
+        if (!disable_setgroups) {
+            message(DEBUG, "Resetting supplementary groups\n");
+            if ( setgroups(uinfo->gids_count, uinfo->gids) < 0 ) {
+                fprintf(stderr, "ABOFT: Could not reset supplementary group list: %s\n", strerror(errno));
+                return(-1);
+            }
+        } else {
+            message(DEBUG, "Not resetting supplementary groups as we are running in a user namespace.\n");
         }
 
         message(DEBUG, "Dropping real and effective privileges to GID = '%d'\n", uinfo->gid);

--- a/src/privilege.h
+++ b/src/privilege.h
@@ -33,5 +33,6 @@ int drop_privs(struct s_privinfo *uinfo);
 int escalate_privs(void);
 int get_user_privs(struct s_privinfo *uinfo);
 
-
+void update_uid_map(pid_t child, uid_t outside, int);
+void update_gid_map(pid_t child, gid_t outside, int);
 

--- a/src/privilege.h
+++ b/src/privilege.h
@@ -26,7 +26,6 @@ typedef struct {
     size_t gids_count;
     int userns_ready;
     int disable_setgroups;
-    int orig_pid;
     uid_t orig_uid;
     uid_t orig_gid;
 } s_privinfo;


### PR DESCRIPTION
This commit adds support for unprivileged operation _if_ we are using
a chroot instead of a raw disk image (use of loopback devices are still
banned for raw disk images).  Remapping is done so the invoking user
'looks right' in the namespace, but all other file ownership looks strange.

Should work on modern Ubuntu and Fedora variants.  RHEL7 doesn't have
enough backported patches to make this function.  As it's tricky to
determine whether a given host has support for this mode, it must be
explicitly enabled at compile time.
