### PR TITLE
Initial implementation of user-specified bind mounts.

### DIFF
--- a/src/mounts.h
+++ b/src/mounts.h
@@ -20,4 +20,4 @@
 
 
 int mount_image(char * image_path, char * mount_point, int writable);
-int mount_bind(char * source, char * dest, int writable);
+int mount_bind(char * source, char * dest, int writable, const char *tmp_dir);


### PR DESCRIPTION
This adds user bind-mounts _if_ NO_NEW_PRIVS is available.  Currently,
this is not hooked up to the CLI (one must provide the correct env vars).

As the user likely will specify directories that don't exist in the
underlying container, this adds a very preliminary form of creation
of mount points inside the container.  It has a major drawback: it
clobbers the top-level directory that _does_ exist.  So, if /foo/bar
exists and the user requests that /foo/bar/baz is bind-mounted from
the host, then we will do a mount on /foo/bar, wiping out the contents
of /foo/bar.  This makes a pretty poor mechanism for adding files such
as /etc/resolv.conf (as it would have a side-effect of removing the
rest of /etc).

A more thorough approach would involve an overlayfs mount: however,
I'd like to keep this more limited version as at least an option as
it would be usable in unprivileged mode (overlayfs is not available
to unprivileged users!).

Note that the helper directories for the bind mount are kept in /tmp;
I plan to move them to the session directory in the future once
directory cleaning is fixed there.
