### PR TITLE
Have signals forward transparently to the payload process.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,8 +23,8 @@ bin_PROGRAMS = sexec image-create image-expand image-mount image-bind sexec_nosu
 
 ftrace_SOURCES = ftrace.c file.c util.c message.c
 ftype_SOURCES = ftype.c util.c file.c message.c
-sexec_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c namespaces.c
-sexec_nosuid_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c namespaces.c
+sexec_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c namespaces.c signal_handlers.c
+sexec_nosuid_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c namespaces.c signal_handlers.c
 image_create_SOURCES = image-create.c file.c util.c image.c message.c
 image_expand_SOURCES = image-expand.c file.c util.c image.c message.c
 image_mount_SOURCES = image-mount.c util.c loop-control.c mounts.c file.c image.c message.c config_parser.c privilege.c

--- a/src/namespaces.c
+++ b/src/namespaces.c
@@ -37,7 +37,9 @@
 
 
 void namespace_unshare(void) {
-    namespace_unshare_pid();
+    // NOTE: we don't call namespace_unshare_pid() here!  This is
+    // because we must call *first* in the namespace daemon, as it only goes
+    // into effect for the first child.
     namespace_unshare_fs();
     namespace_unshare_mount();
 }

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -892,7 +892,7 @@ int main(int argc, char ** argv) {
             strncpy(argv[0], "Singularity: exec", strlen(argv[0])); // Flawfinder: ignore
 
             message(VERBOSE3, "Dropping privilege...\n");
-            priv_drop();
+            priv_drop_perm();
 
             message(VERBOSE2, "Waiting for Exec process...\n");
 

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -33,7 +33,7 @@
 #include <ctype.h>
 #endif  // SINGULARITY_NO_NEW_PRIVS
 #include <errno.h> 
-#include <signal.h>
+#include <sched.h>
 #include <string.h>
 #include <fcntl.h>  
 #include <grp.h>
@@ -51,7 +51,7 @@
 #include "privilege.h"
 #include "message.h"
 #include "namespaces.h"
-
+#include "signal_handlers.h"
 
 #ifndef LOCALSTATEDIR
 #define LOCALSTATEDIR "/etc"
@@ -67,20 +67,6 @@
 #ifndef MS_REC
 #define MS_REC 16384
 #endif
-
-pid_t exec_fork_pid = 0;
-
-// TODO: This is broke, and needs some love!
-void sighandler(int sig) {
-    signal(sig, sighandler);
-
-    if ( exec_fork_pid > 0 ) {
-        fprintf(stderr, "Singularity is sending SIGKILL to child pid: %d\n", exec_fork_pid);
-
-        kill(exec_fork_pid, SIGKILL);
-    }
-}
-
 
 
 int main(int argc, char ** argv) {
@@ -118,11 +104,6 @@ int main(int argc, char ** argv) {
 //****************************************************************************//
 // Init
 //****************************************************************************//
-
-    signal(SIGINT, sighandler);
-    signal(SIGQUIT, sighandler);
-    signal(SIGTERM, sighandler);
-    signal(SIGKILL, sighandler);
 
     // Record the original UID, before user namespace code might change it.
     orig_uid = getuid();
@@ -531,11 +512,13 @@ int main(int argc, char ** argv) {
 
 
     message(VERBOSE, "Creating namespace process\n");
+    signal_pre_fork();
     // Fork off namespace process
     namespace_fork_pid = fork();
     if ( namespace_fork_pid == 0 ) {
 
         message(DEBUG, "Hello from namespace child process\n");
+        signal_post_child();
         if ( daemon_pid == -1 ) {
             if ( use_userns ) {
                 priv_init_userns_inside();
@@ -762,10 +745,9 @@ int main(int argc, char ** argv) {
         // Fork off exec process
         message(VERBOSE, "Forking exec process\n");
 
-        exec_fork_pid = fork();
+        pid_t exec_fork_pid = fork();
         if ( exec_fork_pid == 0 ) {
             message(DEBUG, "Hello from exec child process\n");
-
             message(VERBOSE, "Entering container file system space\n");
             if ( chroot(containerdir) < 0 ) { // Flawfinder: ignore (yep, yep, yep... we know!)
                 message(ERROR, "failed enter CONTAINERIMAGE: %s\n", containerdir);
@@ -895,6 +877,7 @@ int main(int argc, char ** argv) {
 
         // Wait for exec process to finish
         } else if ( exec_fork_pid > 0 ) {
+            setup_signal_handler(exec_fork_pid);
             int tmpstatus;
 
             if ( strcmp(command, "start") == 0 ) {
@@ -912,6 +895,7 @@ int main(int argc, char ** argv) {
 
             message(VERBOSE2, "Waiting for Exec process...\n");
 
+            blockpid_or_signal();
             waitpid(exec_fork_pid, &tmpstatus, 0);
             retval = WEXITSTATUS(tmpstatus);
         } else {
@@ -924,12 +908,15 @@ int main(int argc, char ** argv) {
 
     // Wait for namespace process to finish
     } else if ( namespace_fork_pid > 0 ) {
+        signal_post_parent();
+        setup_signal_handler(namespace_fork_pid);
         int tmpstatus;
         strncpy(argv[0], "Singularity: namespace", strlen(argv[0])); // Flawfinder: ignore
 
         message(VERBOSE3, "Dropping privilege...\n");
         priv_drop();
 
+        blockpid_or_signal();
         waitpid(namespace_fork_pid, &tmpstatus, 0);
         retval = WEXITSTATUS(tmpstatus);
     } else {

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -513,6 +513,7 @@ int main(int argc, char ** argv) {
 
     message(VERBOSE, "Creating namespace process\n");
     signal_pre_fork();
+    namespace_unshare_pid();
     // Fork off namespace process
     namespace_fork_pid = fork();
     if ( namespace_fork_pid == 0 ) {

--- a/src/signal_handlers.c
+++ b/src/signal_handlers.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2016, Brian Bockelman. All rights reserved.
+ *
+ * “Singularity” Copyright (c) 2016, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of any
+ * required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ *
+ * This software is licensed under a customized 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ *
+ * NOTICE.  This Software was developed under funding from the U.S. Department of
+ * Energy and the U.S. Government consequently retains certain rights. As such,
+ * the U.S. Government has been granted for itself and others acting on its
+ * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+ * to reproduce, distribute copies to the public, prepare derivative works, and
+ * perform publicly and display publicly, and to permit other to do so.
+ *
+ */
+
+#define _GNU_SOURCE
+#include "signal_handlers.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <poll.h>
+
+#include "message.h"
+#include "util.h"
+
+pid_t child_pid = 0;
+int generic_signal_rpipe = -1;
+int generic_signal_wpipe = -1;
+int sigchld_signal_rpipe = -1;
+int sigchld_signal_wpipe = -1;
+int watchdog_rpipe = -1;
+int watchdog_wpipe = -1;
+
+void handle_sigchld(int sig, siginfo_t *siginfo, void * _) {
+    if ( siginfo->si_pid == child_pid ) {
+        char one = '1';
+        while (-1 == write(sigchld_signal_wpipe, &one, 1) && errno == EINTR) {}
+    }
+}
+
+void handle_signal(int sig, siginfo_t * _, void * __) {
+    char info = (char)sig;
+    while (-1 == write(generic_signal_wpipe, &info, 1) && errno == EINTR) {}
+}
+
+void setup_signal_handler(pid_t pid) {
+    sigset_t blocked_mask, old_mask, empty_mask;
+    sigfillset(&blocked_mask);
+    sigemptyset(&empty_mask);
+    sigprocmask(SIG_SETMASK, &blocked_mask, &old_mask);
+    child_pid = pid;
+
+    struct sigaction action;
+    action.sa_sigaction = handle_signal;
+    action.sa_flags = SA_SIGINFO|SA_RESTART;
+    // All our handlers are signal safe.
+    action.sa_mask = empty_mask;
+
+    if ( -1 == sigaction(SIGINT, &action, NULL) ) {
+        message(ERROR, "Failed to install SIGINT signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGQUIT, &action, NULL) ) {
+        message(ERROR, "Failed to install SIGQUIT signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGTERM, &action, NULL) ) {
+        message(ERROR, "Failed to install SIGTERM signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGHUP, &action, NULL) ) {
+        message(ERROR, "Failed to install SIGHUP signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGUSR1, &action, NULL) ) {
+        message(ERROR, "Failed to install SIGUSR1 signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGUSR2, &action, NULL) ) {
+        message(ERROR, "Failed to install SIGUSR2 signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    action.sa_sigaction = handle_sigchld;
+    if ( -1 == sigaction(SIGCHLD, &action, NULL) ) {
+        message(ERROR, "Failed to install SIGCHLD signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+
+    int pipes[2];
+    if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
+        message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    generic_signal_rpipe = pipes[0];
+    generic_signal_wpipe = pipes[1];
+
+    if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
+        message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    sigchld_signal_rpipe = pipes[0];
+    sigchld_signal_wpipe = pipes[1];
+
+    sigprocmask(SIG_SETMASK, &old_mask, NULL);
+}
+
+
+void signal_pre_fork() {
+    int pipes[2];
+    if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
+        message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    watchdog_rpipe = pipes[0];
+    watchdog_wpipe = pipes[1];
+}
+
+
+void signal_post_parent() {
+    message(DEBUG, "Closing watchdog read pipe, FD: %d\n", watchdog_rpipe);
+    if (watchdog_rpipe != -1) {
+        close(watchdog_rpipe);
+    }
+    watchdog_rpipe = -1;
+}
+
+
+void signal_post_child() {
+    message(DEBUG, "Closing watchdog write pipe, FD: %d\n", watchdog_wpipe);
+    if (watchdog_wpipe != -1) {
+        close(watchdog_wpipe);
+    }
+    watchdog_wpipe = -1;
+}
+
+
+void blockpid_or_signal() {
+    struct pollfd fds[3];
+    fds[0].fd = sigchld_signal_rpipe;
+    fds[0].events = POLLIN;
+    fds[0].revents = 0;
+    fds[1].fd = generic_signal_rpipe;
+    fds[1].events = POLLIN;
+    fds[1].revents = 0;
+    fds[2].fd = watchdog_rpipe;
+    fds[2].events = POLLIN;
+    fds[2].revents = 0;
+    int retval;
+    int child_ok = 1;
+    do {
+        while ( -1 == (retval = poll(fds, watchdog_rpipe == -1 ? 2 : 3, -1)) && errno == EINTR ) {}
+        if ( -1 == retval ) {
+            message(ERROR, "Failed to wait for file descriptors: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        if (fds[0].revents) {
+            child_ok = 0;
+        }
+        if (fds[1].revents) {
+            char signum = SIGKILL;
+            while (-1 == (retval = read(generic_signal_rpipe, &signum, 1)) && errno == EINTR) {}
+            if (-1 == retval) {
+                message(ERROR, "Failed to read from signal handler pipe: %s\n", strerror(errno));
+                ABORT(255);
+            }
+            kill(child_pid, signum);
+        }
+        if (watchdog_rpipe != -1 && fds[2].revents) {
+            // Parent died.  Immediately kill child.
+            kill(child_pid, SIGKILL);
+            close(watchdog_rpipe);
+            watchdog_rpipe = -1;
+        }
+    } while ( child_ok );
+}

--- a/src/signal_handlers.h
+++ b/src/signal_handlers.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2015-2016, Gregory M. Kurtzer. All rights reserved.
+ * Copyright (c) 2016, Brian Bockelman. All rights reserved.
  * 
  * “Singularity” Copyright (c) 2016, The Regents of the University of California,
  * through Lawrence Berkeley National Laboratory (subject to receipt of any
@@ -18,18 +18,24 @@
  * 
  */
 
+#ifndef __SINGULARITY_SIGNAL_HANDLERS_H_
+#define __SINGULARITY_SIGNAL_HANDLERS_H_
 
-#include <unistd.h>
-#include <stdlib.h>
+#include <sys/types.h>
 
-int intlen(int input);
-char *int2str(int num);
-char *joinpath(char * path1, char * path2);
-char *strjoin(char *str1, char *str2);
-void chomp(char *str);
-int strlength(char *string, int max_len);
-//char *random_string(int length);
+// Setup all the necessary signal handlers.
+void setup_signal_handler(pid_t pid);
+// Block until the given PID exits (but _don't_ call wait() on it),
+// but also process signal handler activity in the meantime.
+// On return, waitpid should be invoked on pid.
+//
+// If an "interesting" signal is caught while we're in this function,
+// then we'll forward it to `pid` via kill(), then return.
+void blockpid_or_signal();
 
+// Setup the communication pipes for monitoring the status of the parent.
+void signal_pre_fork();
+void signal_post_child();
+void signal_post_parent();
 
-#define ABORT(a) {exit(a);}
-
+#endif // __SINGULARITY_SIGNAL_HANDLERS_H_


### PR DESCRIPTION
Signals are now forwarded correctly from parent to child; if the
namespace daemon is killed, then the exec daemon will exit immediately.
