### PR TITLE
Add support for 'target' mode.

### DIFF
--- a/libexec/cli/exec.exec
+++ b/libexec/cli/exec.exec
@@ -97,7 +97,10 @@ if [[ -e "$SINGULARITY_libexecdir/singularity/sexec" && "x${SINGULARITY_FORCE_NO
   exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
 else
   unset SINGULARITY_FORCE_NOSUID
-  export SINGULARITY_USERNS=1
+  if [ "x${SINGULARITY_FORCE_NOUSERNS-}" == "x" ]; then
+    unset SINGULARITY_FORCE_NOUSERNS
+    export SINGULARITY_USERNS=1
+  fi
   exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
 fi
 

--- a/libexec/cli/run.exec
+++ b/libexec/cli/run.exec
@@ -97,7 +97,10 @@ if [[ -e "$SINGULARITY_libexecdir/singularity/sexec" && "x${SINGULARITY_FORCE_NO
   exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
 else
   unset SINGULARITY_FORCE_NOSUID
-  export SINGULARITY_USERNS=1
+  if [ "x${SINGULARITY_FORCE_NOUSERNS-}" == "x" ]; then
+    unset SINGULARITY_FORCE_NOUSERNS
+    export SINGULARITY_USERNS=1
+  fi
   exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
 fi
 

--- a/libexec/cli/shell.exec
+++ b/libexec/cli/shell.exec
@@ -104,7 +104,10 @@ if [[ -e "$SINGULARITY_libexecdir/singularity/sexec" && "x${SINGULARITY_FORCE_NO
   exec "$SINGULARITY_libexecdir/singularity/sexec" "$@" <&0
 else
   unset SINGULARITY_FORCE_NOSUID
-  export SINGULARITY_USERNS=1
+  if [ "x${SINGULARITY_FORCE_NOUSERNS-}" == "x" ]; then
+    unset SINGULARITY_FORCE_NOUSERNS
+    export SINGULARITY_USERNS=1
+  fi
   exec "$SINGULARITY_libexecdir/singularity/sexec_nosuid" "$@" <&0
 fi
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ CLEANFILES = core.* *~
 AM_CFLAGS = -Wall -fpie
 AM_LDFLAGS = -pie
 sexec_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
-sexec_nosuid_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
+sexec_nosuid_CPPFLAGS = -DSINGULARITY_NOSUID=1 -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
 bootstrap_CPPFLAGS = -DLIBEXECDIR=\"$(libexecdir)\"
 ftrace_CPPFLAGS = -DARCH_$(SINGULARITY_ARCH)
 
@@ -25,8 +25,8 @@ ftrace_SOURCES = ftrace.c file.c util.c message.c
 ftype_SOURCES = ftype.c util.c file.c message.c
 sexec_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c namespaces.c
 sexec_nosuid_SOURCES = sexec.c util.c loop-control.c mounts.c container_files.c file.c image.c config_parser.c container_actions.c privilege.c message.c namespaces.c
-image_create_SOURCES = image-create.c file.c util.c image.c message.c
-image_expand_SOURCES = image-expand.c file.c util.c image.c message.c
+image_create_SOURCES = image-create.c file.c util.c image.c message.c privilege.c
+image_expand_SOURCES = image-expand.c file.c util.c image.c message.c privilege.c
 image_mount_SOURCES = image-mount.c util.c loop-control.c mounts.c file.c image.c message.c config_parser.c privilege.c
 image_bind_SOURCES = image-bind.c util.c loop-control.c mounts.c file.c image.c message.c config_parser.c privilege.c
 

--- a/src/file.c
+++ b/src/file.c
@@ -38,12 +38,12 @@
 #include "config.h"
 #include "util.h"
 #include "message.h"
-
+#include "privilege.h"
 
 char *file_id(char *path) {
     struct stat filestat;
     char *ret;
-    uid_t uid = getuid();
+    uid_t uid = priv_getuid();
 
     message(DEBUG, "Called file_id(%s)\n", path);
 

--- a/src/privilege.h
+++ b/src/privilege.h
@@ -28,9 +28,15 @@ typedef struct {
     int disable_setgroups;
     uid_t orig_uid;
     uid_t orig_gid;
+    int target_mode;  // Set to 1 if we are running in "target mode" (admin specifies UID/GID)
 } s_privinfo;
 
 int priv_userns_enabled();
+int priv_target_mode();
+uid_t priv_getuid();
+gid_t priv_getgid();
+const gid_t *priv_getgids();
+int priv_getgidcount();
 
 // These all return void because on failure they ABORT()
 void update_uid_map(pid_t child, uid_t outside, int);

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -181,21 +181,21 @@ int main(int argc, char ** argv) {
 
         priv_init_userns_outside();
 #else
-    message(VERBOSE, "No user namespace support available: re-execing setuid version\n");
-    char sexec_path[] = LIBEXECDIR "/singularity/sexec";
-    char *sexec = "sexec";
-    argv[0] = sexec;
+        message(VERBOSE, "No user namespace support available: re-execing setuid version\n");
+        char sexec_path[] = LIBEXECDIR "/singularity/sexec";
+        char *sexec = "sexec";
+        argv[0] = sexec;
 
-    char **new_argv = calloc(argc+1, sizeof(char*));
-    int idx;
-    //  Note new_argv is one-larger than argv; the last element must be NULL.
-    for (idx=0; idx<argc; idx++) {
-        new_argv[idx] = argv[idx];
-    }
+        char **new_argv = calloc(argc+1, sizeof(char*));
+        int idx;
+        //  Note new_argv is one-larger than argv; the last element must be NULL.
+        for (idx=0; idx<argc; idx++) {
+            new_argv[idx] = argv[idx];
+        }
 
-    execv(sexec_path, new_argv);
-    message(ERROR, "Failed to execute sexec binary (%s): %s\n", sexec_path, strerror(errno));
-    ABORT(255);
+        execv(sexec_path, new_argv);
+        message(ERROR, "Failed to execute sexec binary (%s): %s\n", sexec_path, strerror(errno));
+        ABORT(255);
 #endif
     }
 
@@ -615,7 +615,7 @@ int main(int argc, char ** argv) {
             namespace_join(daemon_pid);
         }
 
-        if ( orig_uid != 0 ) { // If we are root, no need to mess with passwd or group
+        if ( orig_uid != 0 || priv_target_mode() ) { // If we are root, no need to mess with passwd or group
             message(DEBUG, "Checking configuration file for 'config passwd'\n");
             config_rewind();
             if ( config_get_key_bool("config passwd", 1) > 0 ) {

--- a/src/util.c
+++ b/src/util.c
@@ -119,3 +119,26 @@ char *random_string(int length) {
     return(ret);
 }
 */
+
+int str2int(const char *input_str, long int *output_num) {
+    long int result;
+    char *endptr;
+    errno = 0;
+    // Empty string is an error:
+    if ( *input_str == '\0' ) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    result = strtol(input_str, &endptr, 10);
+    // In the case of overflow / underflow or (possibly)
+    // no digits consumed.
+    if (errno) {return -1;}
+
+    if ( *endptr == '\0' ) { // All data was consumed.
+        if (output_num) {*output_num = result;}
+        return 0;
+    }
+    errno = EINVAL;
+    return -1;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -29,6 +29,16 @@ void chomp(char *str);
 int strlength(const char *string, int max_len);
 //char *random_string(int length);
 
+// Given a const char * string containing a base-10 integer,
+// try to convert to an C integer.
+// This is a bit less error prone (and stricter!) than strtoll:
+// - Returns -1 on error and sets errno appropriately.
+// - On failure, output_num is not touched.
+// - On success, sets output_num to the parsed value (if output_num
+//   is not null).
+// - If the whole string isn't consumed, then -1 is returned and
+//   errno is set to EINVAL
+int str2int(const char *input_str, long int *output_num);
 
 #define ABORT(a) {exit(a);}
 


### PR DESCRIPTION
When executing the non-setuid binary as root, target mode allows
the desired UID / GID be set to a non-root user.  For example:

```
sudo SINGULARITY_FORCE_NOSUID=1 SINGULARITY_FORCE_NOUSERNS=1 SINGULARITY_TARGET_GID=10058 SINGULARITY_TARGET_UID=1221 /opt/singularity/bin/singularity -d shell /cvmfs/cernvm-prod.cern.ch/cvm3
```

would force singularity to run as UID 1221 / GID 10058.

Broadly, this is not targeted for end-users but to allow singularity
to integrate with other setuid binaries (and avoid having to put a
new setuid binary on the system...).

NOTE:
- The desired UID can now be different from the real UID.  Hence, all calls
  to getgid / getuid are now routed through the privilege subsystem.  Probably
  a good idea regardless to avoid programming errors!
- Fixed a few pre-existing SIGSEGV's around the fact that getgrgid and getpwuid can fail and
  return a NULL pointer.
