### PR TITLE
Fixing "get_manifest" to show list of available tags if provided tag fails

### DIFF
--- a/libexec/python/docker.py
+++ b/libexec/python/docker.py
@@ -138,7 +138,7 @@ def get_manifest(repo_name,namespace,repo_tag="latest"):
         # If the call fails, give the user a list of acceptable tags
         tags = get_tags(namespace=namespace,
                         repo_name=repo_name)
-        print("\n".join([x['name'] for x in tags]))
+        print("\n".join(tags))
         print("Error getting manifest using url %s" %(base))
         sys.exit(1)
 

--- a/libexec/python/docker.py
+++ b/libexec/python/docker.py
@@ -139,7 +139,7 @@ def get_manifest(repo_name,namespace,repo_tag="latest"):
         tags = get_tags(namespace=namespace,
                         repo_name=repo_name)
         print("\n".join(tags))
-        print("Error getting manifest using url %s" %(base))
+        print("Error getting manifest for %s/%s:%s. Acceptable tags are listed above." %(namespace,repo_name,repo_tag))
         sys.exit(1)
 
     return response

--- a/libexec/python/docker.py
+++ b/libexec/python/docker.py
@@ -136,7 +136,9 @@ def get_manifest(repo_name,namespace,repo_tag="latest"):
         response = json.loads(response)
     except:
         # If the call fails, give the user a list of acceptable tags
-
+        tags = get_tags(namespace=namespace,
+                        repo_name=repo_name)
+        print("\n".join([x['name'] for x in tags]))
         print("Error getting manifest using url %s" %(base))
         sys.exit(1)
 


### PR DESCRIPTION
This is a quick PR to add a line in to the except loop of get_manifest that will show the user a list of acceptable tags given that the provided tag failed. I meant to include yesterday, wrote the function, and just forgot to add the line :)
