### PR TITLE
reorganizing python scripts to close #10, and fixing bug to close #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ src/*.o
 singularity-*.tar.gz
 *.m4
 config.*
+*.pyc
 
 Makefile
 Makefile.in

--- a/configure.ac
+++ b/configure.ac
@@ -272,5 +272,6 @@ AC_CONFIG_FILES([
    libexec/cli/Makefile
    libexec/helpers/Makefile
    libexec/python/Makefile
+   libexec/python/docker/Makefile
 ])
 AC_OUTPUT

--- a/libexec/bootstrap/modules-v2/build-docker.sh
+++ b/libexec/bootstrap/modules-v2/build-docker.sh
@@ -89,7 +89,7 @@ fi
 
 # TODO: if made into official module, export to pythonpath here
 #TODO: at install, python dependencies need to be installed, and check for python
-python $SINGULARITY_libexecdir/singularity/python/bootstrap.py --docker $SINGULARITY_DOCKER_IMAGE --rootfs $SINGULARITY_ROOTFS $SINGULARITY_DOCKER_INCLUDE_CMD
+python $SINGULARITY_libexecdir/singularity/python/cli.py --docker $SINGULARITY_DOCKER_IMAGE --rootfs $SINGULARITY_ROOTFS $SINGULARITY_DOCKER_INCLUDE_CMD
 
 # If we got here, exit...
 exit 0

--- a/libexec/helpers/image-import.sh
+++ b/libexec/helpers/image-import.sh
@@ -54,7 +54,7 @@ fi
 case "$IMPORT_URI" in
     docker://*)
         CONTAINER_NAME=`echo "$IMPORT_URI" | sed -e 's@^docker://@@'`
-        if ! SINGULARITY_IMPORT_GET="$SINGULARITY_libexecdir/singularity/python/bootstrap.py --rootfs '$SINGULARITY_ROOTFS' --docker '$CONTAINER_NAME' --cmd"; then
+        if ! SINGULARITY_IMPORT_GET="$SINGULARITY_libexecdir/singularity/python/cli.py --rootfs '$SINGULARITY_ROOTFS' --docker '$CONTAINER_NAME' --cmd"; then
             ABORT $?
         fi
     ;;

--- a/libexec/image-handler.sh
+++ b/libexec/image-handler.sh
@@ -64,7 +64,7 @@ case "$SINGULARITY_IMAGE" in
             fi
         fi
         CONTAINER_NAME=`echo "$SINGULARITY_IMAGE" | sed -e 's@^docker://@@'`
-        if ! eval "$SINGULARITY_libexecdir/singularity/python/bootstrap.py --rootfs '$CONTAINER_DIR' --docker '$CONTAINER_NAME' --cmd"; then
+        if ! eval "$SINGULARITY_libexecdir/singularity/python/cli.py --rootfs '$CONTAINER_DIR' --docker '$CONTAINER_NAME' --cmd"; then
             ABORT $?
         fi
         SINGULARITY_IMAGE="$CONTAINER_DIR"

--- a/libexec/python/Makefile.am
+++ b/libexec/python/Makefile.am
@@ -1,6 +1,8 @@
+SUBDIRS = docker
+
 scriptlibexecdir = $(libexecdir)/singularity/python
 
-dist_scriptlibexec_SCRIPTS = bootstrap.py docker.py utils.py
+dist_scriptlibexec_SCRIPTS = cli.py __init__.py utils.py
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -24,7 +24,7 @@ perform publicly and display publicly, and to permit other to do so.
 
 '''
 
-from docker import get_layer, create_runscript, get_manifest, get_config, get_images
+from docker.api import get_layer, create_runscript, get_manifest, get_config, get_images
 from utils import extract_tar, change_permissions
 import argparse
 import os
@@ -160,7 +160,7 @@ def main():
                                          base_dir=singularity_rootfs)
 
             # change permission of runscript to 0755 (default)
-            change_permissions("%s/runscript" %(singularity_rootfs))
+            change_permissions("%s/singularity" %(singularity_rootfs))
         else:
             print("No Docker CMD found, skipping runscript.")
 

--- a/libexec/python/docker/Makefile.am
+++ b/libexec/python/docker/Makefile.am
@@ -1,0 +1,6 @@
+scriptlibexecdir = $(libexecdir)/singularity/python/docker
+
+dist_scriptlibexec_SCRIPTS = api.py __init__.py
+
+MAINTAINERCLEANFILES = Makefile.in
+

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -23,8 +23,10 @@ perform publicly and display publicly, and to permit other to do so.
 
 '''
 
-from utils import api_get, write_file
 import sys
+sys.path.append('..') # parent directory
+
+from utils import api_get, write_file
 import json
 
 api_base = "https://registry-1.docker.io"


### PR DESCRIPTION
This PR will do two things:
## Python / Docker Organization
- reorganize the python folder to add specificity to the "submodules." They aren't official modules (all imports are relative and the scripts added via Makefiles) but we can now better organize python scripts using folders. If we need to make an "official" module at some point we can discuss, but I think it's overkill.
  - When we have more extensive docker functionality, I'm going to eventually break apart the docker/api.py script into more specific functions, for now it's all under "api.py"
## Runscript permissions bug

I was trying to change a file called "runscript" instead of "singularity." I don't even know how I put my shoes on the right feet in the morning.

I just tested this for the bootstrap and it looked good, we probably should have more testing for other stuffs! I can take a look at the continuous integration at some point and add more tests.
