### PR TITLE
add python to the libexec dir in singularity.spec

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -60,6 +60,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/image-create
 %{_libexecdir}/singularity/image-expand
 %{_libexecdir}/singularity/image-mount
+%{_libexecdir}/singularity/python
 %{_bindir}/singularity
 %{_bindir}/run-singularity
 %{_mandir}/man1/*


### PR DESCRIPTION
Without this line in singularity.spec, I am unable to do an rpmbuild on el7.
