### PR TITLE
Scratch directory fixups

### DIFF
--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -71,12 +71,14 @@ _singularity() {
             if [[ ${cur} == -B || ${cur} == --bind ]]; then
                 #TODO: Not really a path, but this should be a bind spec...
                 _filedir
+            elif [[ ${cur} == -S || ${cur} == --scratch* ]]; then
+                _filedir
             elif [[ ${cur} == -H || ${cur} == --home ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -* ]] ; then
-                COMPREPLY=( $(compgen -W "--help --bind --home --contain --containall --ipc --pid --user --workdir --writable" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "--help --bind --scratch --home --contain --containall --ipc --pid --user --workdir --writable" -- ${cur}) )
             else
                 _filedir
             fi

--- a/libexec/cli/exec.exec
+++ b/libexec/cli/exec.exec
@@ -81,9 +81,9 @@ while true; do
             SINGULARITY_UNSHARE_IPC=1
             export SINGULARITY_CONTAIN SINGULARITY_UNSHARE_PID SINGULARITY_UNSHARE_IPC
         ;;
-        -S|--scratchdir|--scratch-dir)
+        -S|--scratchdir|--scratch-dir|--scratch)
             shift
-            SINGULARITY_SCRATCHDIR="$1"
+            SINGULARITY_SCRATCHDIR="$1,${SINGULARITY_SCRATCHDIR:-}"
             export SINGULARITY_SCRATCHDIR
             shift
         ;;

--- a/libexec/cli/run.exec
+++ b/libexec/cli/run.exec
@@ -75,9 +75,9 @@ while true; do
             export SINGULARITY_WORKDIR
             shift
         ;;
-        -S|--scratchdir|--scratch-dir)
+        -S|--scratchdir|--scratch-dir|--scratch)
             shift
-            SINGULARITY_SCRATCHDIR="$1"
+            SINGULARITY_SCRATCHDIR="$1,${SINGULARITY_SCRATCHDIR:-}"
             export SINGULARITY_SCRATCHDIR
             shift
         ;;

--- a/libexec/cli/shell.exec
+++ b/libexec/cli/shell.exec
@@ -86,9 +86,9 @@ while true; do
             export SINGULARITY_WORKDIR
             shift
         ;;
-        -S|--scratchdir|--scratch-dir)
+        -S|--scratchdir|--scratch-dir|--scratch)
             shift
-            SINGULARITY_SCRATCHDIR="$1"
+            SINGULARITY_SCRATCHDIR="$1,${SINGULARITY_SCRATCHDIR:-}"
             export SINGULARITY_SCRATCHDIR
             shift
         ;;

--- a/src/lib/mount/scratch/scratch.c
+++ b/src/lib/mount/scratch/scratch.c
@@ -66,9 +66,9 @@ void singularity_mount_scratch(void) {
     }
 
     singularity_message(DEBUG, "Checking if overlay is enabled\n");
-    if ( singularity_rootfs_overlay_enabled() <= 0 ) {
-        singularity_message(VERBOSE, "Not mounting current directory: overlay is not enabled\n");
-        return;
+    int overlayfs_enabled = singularity_rootfs_overlay_enabled() > 0;
+    if ( !overlayfs_enabled ) {
+        singularity_message(VERBOSE, "Overlay is not enabled: cannot make directories not preexisting in container scratch.\n");
     }
 
     singularity_message(DEBUG, "Checking SINGULARITY_WORKDIR from environment\n");
@@ -112,13 +112,15 @@ void singularity_mount_scratch(void) {
         ABORT(255);
     }
 
-    singularity_priv_escalate();
-    singularity_message(DEBUG, "Creating scratch directory inside container\n");
-    r = s_mkpath(joinpath(container_dir, scratchdir_path), 0755);
-    singularity_priv_drop();
-    if ( r < 0 ) {
-        singularity_message(VERBOSE, "Skipping scratch directory mount, could not create dir inside container %s: %s\n", scratchdir_path, strerror(errno));
-        return;
+    if (overlayfs_enabled) {
+        singularity_priv_escalate();
+        singularity_message(DEBUG, "Creating scratch directory inside container\n");
+        r = s_mkpath(joinpath(container_dir, scratchdir_path), 0755);
+        singularity_priv_drop();
+        if ( r < 0 ) {
+            singularity_message(VERBOSE, "Skipping scratch directory mount, could not create dir inside container %s: %s\n", scratchdir_path, strerror(errno));
+            return;
+        }
     }
 
     singularity_priv_escalate();
@@ -126,7 +128,7 @@ void singularity_mount_scratch(void) {
     r = mount(sourcedir_path, joinpath(container_dir, scratchdir_path), NULL, MS_BIND|MS_NOSUID|MS_REC, NULL);
     singularity_priv_drop();
     if ( r < 0 ) {
-        singularity_message(WARNING, "Could not bind scratch direcotry into container %s: %s\n", sourcedir_path, strerror(errno));
+        singularity_message(WARNING, "Could not bind scratch directory into container %s: %s\n", sourcedir_path, strerror(errno));
         ABORT(255);
     }
 

--- a/src/lib/mount/scratch/scratch.c
+++ b/src/lib/mount/scratch/scratch.c
@@ -107,31 +107,42 @@ void singularity_mount_scratch(void) {
 
     sourcedir_path = joinpath(tmpdir_path, "/scratch");
 
-    if ( s_mkpath(sourcedir_path, 0750) < 0 ) {
-        singularity_message(ERROR, "Could not create scratch source directory %s: %s\n", sourcedir_path, strerror(errno));
-        ABORT(255);
-    }
+    char *outside_token = NULL;
+    char *current = strtok_r(strdup(scratchdir_path), ",", &outside_token);
 
-    if (overlayfs_enabled) {
+    while ( current != NULL ) {
+
+        char *full_sourcedir_path = joinpath(sourcedir_path, current);
+
+        if ( s_mkpath(full_sourcedir_path, 0750) < 0 ) {
+             singularity_message(ERROR, "Could not create scratch source directory %s: %s\n", full_sourcedir_path, strerror(errno));
+             ABORT(255);
+         }
+
+        if (overlayfs_enabled) {
+            singularity_priv_escalate();
+            singularity_message(DEBUG, "Creating scratch directory inside container\n");
+            r = s_mkpath(joinpath(container_dir, current), 0755);
+            singularity_priv_drop();
+            if ( r < 0 ) {
+                singularity_message(VERBOSE, "Skipping scratch directory mount, could not create dir inside container %s: %s\n", current, strerror(errno));
+                return;
+            }
+        }
+
         singularity_priv_escalate();
-        singularity_message(DEBUG, "Creating scratch directory inside container\n");
-        r = s_mkpath(joinpath(container_dir, scratchdir_path), 0755);
+        singularity_message(VERBOSE, "Binding '%s' to '%s/%s'\n", full_sourcedir_path, container_dir, current);
+        r = mount(full_sourcedir_path, joinpath(container_dir, current), NULL, MS_BIND|MS_NOSUID|MS_REC, NULL);
         singularity_priv_drop();
         if ( r < 0 ) {
-            singularity_message(VERBOSE, "Skipping scratch directory mount, could not create dir inside container %s: %s\n", scratchdir_path, strerror(errno));
-            return;
+            singularity_message(WARNING, "Could not bind scratch directory into container %s: %s\n", full_sourcedir_path, strerror(errno));
+            ABORT(255);
         }
-    }
 
-    singularity_priv_escalate();
-    singularity_message(VERBOSE, "Binding '%s' to '%s/%s'\n", sourcedir_path, container_dir, scratchdir_path);
-    r = mount(sourcedir_path, joinpath(container_dir, scratchdir_path), NULL, MS_BIND|MS_NOSUID|MS_REC, NULL);
-    singularity_priv_drop();
-    if ( r < 0 ) {
-        singularity_message(WARNING, "Could not bind scratch directory into container %s: %s\n", sourcedir_path, strerror(errno));
-        ABORT(255);
+        current = strtok_r(NULL, ",", &outside_token);
+        // Ignore empty directories.
+        while (current && !strlen(current)) {current = strtok_r(NULL, ",", &outside_token);}
     }
-
     return;
 }
 


### PR DESCRIPTION
A few improvements for the scratch directories:
- Allows scratch directories to be used even if `overlayfs` is disabled.  If the directory doesn't exist inside the container, it is a fatal error.
- Allows multiple scratch directories to be specified.
- Add bash completion updates for `--scratch`.
