### PR TITLE
Add support for user-specified PWD from the command line.

### DIFF
--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -71,14 +71,14 @@ _singularity() {
             if [[ ${cur} == -B || ${cur} == --bind ]]; then
                 #TODO: Not really a path, but this should be a bind spec...
                 _filedir
-            elif [[ ${cur} == -S || ${cur} == --scratch* ]]; then
+            elif [[ ${cur} == -S || ${cur} == --scratch* || ${cur} == --pwd ]]; then
                 _filedir
             elif [[ ${cur} == -H || ${cur} == --home ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -* ]] ; then
-                COMPREPLY=( $(compgen -W "--help --bind --scratch --home --contain --containall --ipc --pid --user --workdir --writable" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "--help --bind --scratch --home --pwd --contain --containall --ipc --pid --user --workdir --writable" -- ${cur}) )
             else
                 _filedir
             fi

--- a/libexec/cli/exec.exec
+++ b/libexec/cli/exec.exec
@@ -109,6 +109,12 @@ while true; do
             SINGULARITY_UNSHARE_IPC=1
             export SINGULARITY_UNSHARE_IPC
         ;;
+        --pwd)
+            shift
+            SINGULARITY_TARGET_PWD="$1"
+            export SINGULARITY_TARGET_PWD
+            shift
+        ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"
             exit 1

--- a/libexec/cli/exec.help
+++ b/libexec/cli/exec.help
@@ -14,6 +14,8 @@ EXEC OPTIONS:
                         the container
     -i/--ipc            Run container in a new IPC namespace
     -p/--pid            Run container in a new PID namespace
+    --pwd               Initial working directory for payload process inside 
+                        the container
     -S/--scratch <path> Include a scratch directory within the container that 
                         is linked to a temporary dir (use -W to force location)
     -u/--user           Try to run completely unprivileged (only works on very

--- a/libexec/cli/run.exec
+++ b/libexec/cli/run.exec
@@ -109,6 +109,12 @@ while true; do
             SINGULARITY_UNSHARE_IPC=1
             export SINGULARITY_UNSHARE_IPC
         ;;
+        --pwd)
+            shift
+            SINGULARITY_TARGET_PWD="$1"
+            export SINGULARITY_TARGET_PWD
+            shift
+        ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"
             exit 1

--- a/libexec/cli/run.help
+++ b/libexec/cli/run.help
@@ -19,6 +19,8 @@ RUN OPTIONS:
                         the container
     -i/--ipc            Run container in a new IPC namespace
     -p/--pid            Run container in a new PID namespace
+    --pwd               Initial working directory for payload process inside
+                        the container
     -S/--scratch <path> Include a scratch directory within the container that 
                         is linked to a temporary dir (use -W to force location)
     -u/--user           Try to run completely unprivileged (only works on very

--- a/libexec/cli/shell.exec
+++ b/libexec/cli/shell.exec
@@ -120,6 +120,12 @@ while true; do
             SINGULARITY_UNSHARE_IPC=1
             export SINGULARITY_UNSHARE_IPC
         ;;
+        --pwd)
+            shift
+            SINGULARITY_TARGET_PWD="$1"
+            export SINGULARITY_TARGET_PWD
+            shift
+        ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"
             exit 1

--- a/libexec/cli/shell.help
+++ b/libexec/cli/shell.help
@@ -17,6 +17,8 @@ SHELL OPTIONS:
                         the container
     -i/--ipc            Run container in a new IPC namespace
     -p/--pid            Run container in a new PID namespace (creates child)
+    --pwd               Initial working directory for payload process inside
+                        the container
     -S/--scratch <path> Include a scratch directory within the container that
                         is linked to a temporary dir (use -W to force location)
     -s/--shell <shell>  Path to program to use for interactive shell


### PR DESCRIPTION
When the `$PWD` is not available inside the container, singularity currently defaults to starting the process inside the user's `$HOME`.

It's not a bad strategy, particularly for interactive use.  However, when invoked from other tools (such as a batch system), it would be useful to be able to specify this directly.
