### PR TITLE
Specify docker registry and need/not need for token

### DIFF
--- a/libexec/bootstrap/modules-v2/build-docker.sh
+++ b/libexec/bootstrap/modules-v2/build-docker.sh
@@ -73,6 +73,36 @@ else
     SINGULARITY_DOCKER_INCLUDE_CMD=""
 fi
 
+
+### Obtain the remote registry url, if provided
+SINGULARITY_DOCKER_REGISTRY=`singularity_key_get "Registry" "$SINGULARITY_BUILDDEF"`
+if [ -n "${SINGULARITY_DOCKER_REGISTRY:-}" ]; then
+    message 1 "Registry: $SINGULARITY_DOCKER_REGISTRY\n"
+    SINGULARITY_DOCKER_REGISTRY="--registry $SINGULARITY_DOCKER_REGISTRY"   
+else
+    SINGULARITY_DOCKER_REGISTRY=""   
+fi
+
+
+### Does the registry require authentication?
+SINGULARITY_DOCKER_AUTH=`singularity_key_get "Token" "$SINGULARITY_BUILDDEF"`
+if [ -n "${SINGULARITY_DOCKER_AUTH:-}" ]; then
+    message 1 "Token: $SINGULARITY_DOCKER_AUTH\n"
+
+    # A command of "no" means don't add token auth header
+    if [ "$SINGULARITY_DOCKER_AUTH" == "no" ]; then
+        SINGULARITY_DOCKER_AUTH="--no-token"
+
+    # Anything else, we do authentication
+    else
+        SINGULARITY_DOCKER_AUTH=""
+    fi
+
+else
+    SINGULARITY_DOCKER_AUTH=""   
+fi
+
+
 # Ensure the user has provided a docker image name with "From"
 if [ -z "$SINGULARITY_DOCKER_IMAGE" ]; then
     echo "Please specify the Docker image name with From: in the definition file."
@@ -86,9 +116,7 @@ fi
 
 ### Run it!
 
-# TODO: if made into official module, export to pythonpath here
-#TODO: at install, python dependencies need to be installed, and check for python
-python $SINGULARITY_libexecdir/singularity/python/cli.py --docker $SINGULARITY_DOCKER_IMAGE --rootfs $SINGULARITY_ROOTFS $SINGULARITY_DOCKER_INCLUDE_CMD
+python $SINGULARITY_libexecdir/singularity/python/cli.py --docker $SINGULARITY_DOCKER_IMAGE --rootfs $SINGULARITY_ROOTFS $SINGULARITY_DOCKER_INCLUDE_CMD $SINGULARITY_DOCKER_REGISTRY $SINGULARITY_DOCKER_AUTH
 
 # If we got here, exit...
 exit 0

--- a/libexec/cli/bootstrap.help
+++ b/libexec/cli/bootstrap.help
@@ -17,9 +17,22 @@ You can also bootstrap a Docker image, in which case you must also specify
 the namespace (library), image repository (ubuntu) and tag (14.04.1) that
 you want to use:
 
-    OSBuild: docker
+    BootStrap: docker
     From: library/ubuntu:14.04.1
 
+The default Docker registry is registry-1.docker.io. To change that, add the
+Registry argument:
+
+    BootStrap: docker
+    From: tensorflow/tensorflow:latest
+    Registry: gcr.io
+
+If you want to remove token authentication, then add the Token argument:
+
+    BootStrap: docker
+    From: tensorflow/tensorflow:latest
+    Registry: gcr.io
+    Token: no
 
 CREATE OPTIONS:
     -f/--force      Force a rebootstrap of an OS (note: this does not delete

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -23,6 +23,7 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -41,6 +42,24 @@ if sys.version_info[0] < 3:
 ## HTTP OPERATIONS #########################################################
 ############################################################################
 
+def add_http(url,use_https=True):
+    '''add_http will add a http / https prefix to a url, in case the user didn't
+    specify
+    :param url: the url to add the prefix to
+    :param use_https: should we default to https? default is True
+    '''
+    prefix = "https://"
+    if use_https == False:
+        prefix="http://"
+    
+    # Does the url have http?
+    if re.search('^http*',url) == None:
+        url = "%s%s" %(prefix,url)
+
+    # Always remove extra slash
+    url = url.strip('/')
+
+    return url
 
 def api_get_pagination(url):
    '''api_pagination is a wrapper for "api_get" that will also handle pagination


### PR DESCRIPTION
This is a start of work to specify a registry different from `registry-1.docker.io` For example, Google's tensorflow image is hosted at gcr.io, and having a weird token in the header also leads to the call to get_tags to fail. Thus, we would want to remove the Token, and specify a custom registry URL. We can do that with the following bootstrap file:

```
  Bootstrap: docker
  From: tensorflow/tensorflow:latest
  IncludeCmd: yes  
  Registry: gcr.io
  Token: no
```

The old format still works fine, of course, if we want to use default registry and default (with token for auth):

```
  Bootstrap: docker
  From: ubuntu:latest
  IncludeCmd: yes
```

Likely specific images will need debugging and specific definition files, for example with the tensorflow image I got a permissions issue when running python:

```
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1861, in get_metadata
with io.open(self.path, encoding='utf-8') as f:
  IOError: [Errno 13] Permission denied: '/usr/lib/python2.7/dist-packages/.wh.six-1.5.2.egg-info'
```

@gmkurtzer let me know if you have insight to the error - it looks like this was an install with a wheel and I'm not sure why we wouldn't have the right permissions. Permissions are hard.
