### PR TITLE
Enable slave mounts by default

### DIFF
--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -116,11 +116,11 @@ user bind control = yes
 
 
 # MOUNT SLAVE: [BOOL]
-# DEFAULT: no
+# DEFAULT: yes
 # Should we automatically propagate file-system changes from the host?
 # This should be set to 'yes' when autofs mounts in the system should
 # show up in the container.
-mount slave = no
+mount slave = yes
 
 
 # CONTAINER DIR: [STRING]


### PR DESCRIPTION
I haven't seen any issues when utilizing mounts, I'm not aware of any security concerns, and it does allow `autofs` to work by default.

Let's toggle the default configuration value.
