### PR TITLE
initial port for alpinelinux

### DIFF
--- a/alpinelinux/README.txt
+++ b/alpinelinux/README.txt
@@ -1,0 +1,126 @@
+Porting singularity to the lightweight musl libc.
+
+Building requirements:
+$ sudo apk update && sudo apk upgrade
+$ sudo apk add alpine-sdk autoconf automake libtool linux-headers
+$ mkdir singularity-build
+$ cd singularity-build
+
+fetch the APKBUILD 
+
+$ apbuild -r
+
+if you get something like:
+~/singularity-build$ abuild -r
+No private key found. Use 'abuild-keygen' to generate the keys.
+Then you can either:
+  * set the PACKAGER_PRIVKEY in /home/tru/.abuild/abuild.conf
+    ('abuild-keygen -a' does this for you)
+  * set the PACKAGER_PRIVKEY in /etc/abuild.conf
+  * specify the key with the -k option to abuild-sign
+
+>>> ERROR: singularity: all failed
+you need to properly setup your alpine build environment :P
+
+~/singularity-build$ abuild-keygen -a
+>>> Generating public/private rsa key pair for abuild
+Enter file in which to save the key [/home/tru/.abuild/tru-5805cc3f.rsa]: 
+Generating RSA private key, 2048 bit long modulus
+..................................................................................................+++
+.................+++
+e is 65537 (0x10001)
+writing RSA key
+>>> 
+>>> You'll need to install /home/tru/.abuild/tru-5805cc3f.rsa.pub into 
+>>> /etc/apk/keys to be able to install packages and repositories signed with
+>>> /home/tru/.abuild/tru-5805cc3f.rsa
+>>> 
+>>> Please remember to make a safe backup of your private key:
+>>> /home/tru/.abuild/tru-5805cc3f.rsa
+>>> 
+
+
+~/singularity-build$ abuild -r
+>>> singularity: Checking sanity of /home/tru/singularity-build/APKBUILD...
+>>> WARNING: singularity: depends_dev found but no development subpackage found
+>>> singularity: Analyzing dependencies...
+abuild-apk: User tru is not a member of group abuild
+
+>>> ERROR: singularity: all failed
+>>> singularity: Uninstalling dependencies...
+abuild-apk: User tru is not a member of group abuild
+
+Just add yourself to the abuild group, logout and login.
+
+~/singularity-build$ abuild -r
+>>> singularity: Checking sanity of /home/tru/singularity-build/APKBUILD...
+>>> WARNING: singularity: depends_dev found but no development subpackage found
+>>> singularity: Analyzing dependencies...
+WARNING: Ignoring /home/tru/packages//tru/x86_64/APKINDEX.tar.gz: No such file or directory
+(1/1) Installing .makedepends-singularity (0)
+OK: 249 MiB in 84 packages
+>>> singularity: Cleaning temporary build dirs...
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   134    0   134    0     0    284      0 --:--:-- --:--:-- --:--:--   292
+100 47328    0 47328    0     0  45085      0 --:--:--  0:00:01 --:--:--  125k
+>>> singularity: Checking sha512sums...
+singularity-2.1.2.tar.gz: OK
+>>> singularity: Unpacking /var/cache/distfiles/singularity-2.1.2.tar.gz...
++autoreconf -i -f
+libtoolize: putting auxiliary files in '.'.
+libtoolize: copying file './ltmain.sh'
+libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, '.'.
+...
+>>> singularity-doc*: Preparing subpackage singularity-doc...
+fatal: Not a git repository (or any of the parent directories): .git
+fatal: Not a git repository (or any of the parent directories): .git
+>>> singularity*: Running postcheck for singularity-doc
+>>> singularity*: Running split function examples...
+>>> singularity-examples*: Preparing subpackage singularity-examples...
+fatal: Not a git repository (or any of the parent directories): .git
+fatal: Not a git repository (or any of the parent directories): .git
+>>> singularity*: Running postcheck for singularity-examples
+>>> WARNING: singularity*: Found /usr/share/doc but package name doesn't end with -doc
+>>> singularity*: Running postcheck for singularity
+>>> singularity*: Preparing package singularity...
+>>> singularity*: Stripping binaries
+fatal: Not a git repository (or any of the parent directories): .git
+fatal: Not a git repository (or any of the parent directories): .git
+>>> singularity-doc*: Scanning shared objects
+>>> singularity-examples*: Scanning shared objects
+>>> singularity*: Scanning shared objects
+>>> singularity-doc*: Tracing dependencies...
+>>> singularity-doc*: Package size: 40.0 KB
+>>> singularity-doc*: Compressing data...
+>>> singularity-doc*: Create checksum...
+>>> singularity-doc*: Create singularity-doc-2.1.2-r0.apk
+>>> singularity-examples*: Tracing dependencies...
+>>> singularity-examples*: Package size: 48.0 KB
+>>> singularity-examples*: Compressing data...
+>>> singularity-examples*: Create checksum...
+>>> singularity-examples*: Create singularity-examples-2.1.2-r0.apk
+>>> singularity*: Tracing dependencies...
+	so:libc.musl-x86_64.so.1
+>>> singularity*: Package size: 364.0 KB
+>>> singularity*: Compressing data...
+>>> singularity*: Create checksum...
+>>> singularity*: Create singularity-2.1.2-r0.apk
+>>> singularity: Cleaning up srcdir
+>>> singularity: Cleaning up pkgdir
+>>> singularity: Uninstalling dependencies...
+>>> singularity: Updating the cached abuild repository index...
+fatal: Not a git repository (or any of the parent directories): .git
+>>> singularity: Signing the index...
+
+You should have a your freshly cooked packages in ~/packages.
+
+$ find ~/packages/
+/home/tru/packages/
+/home/tru/packages/tru
+/home/tru/packages/tru/x86_64
+/home/tru/packages/tru/x86_64/singularity-2.1.2-r0.apk
+/home/tru/packages/tru/x86_64/singularity-doc-2.1.2-r0.apk
+/home/tru/packages/tru/x86_64/singularity-examples-2.1.2-r0.apk
+/home/tru/packages/tru/x86_64/APKINDEX.tar.gz
+

--- a/alpinelinux/singularity-2.1.2/APKBUILD
+++ b/alpinelinux/singularity-2.1.2/APKBUILD
@@ -1,0 +1,60 @@
+# Contributor: "Tru Huynh <tru@pasteur.fr>"
+# Maintainer: "Tru Huynh <tru@pasteur.fr>"
+pkgname=singularity
+pkgver=2.1.2
+pkgrel=0
+pkgdesc="Singularity: Application containers for Linux"
+url="http://singularity.lbl.gov"
+arch="x86_64"
+license="LNL"
+depends=""
+depends_dev="autoconf automake gcc make libtool linux-headers"
+makedepends="$depends_dev"
+install=""
+subpackages="$pkgname-doc $pkgname-examples"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/singularityware/singularity/archive/${pkgver}.tar.gz"
+options="suid"
+builddir=$srcdir/${pkgname}-${pkgver}
+build() {
+        cd "$builddir"      
+        ./autogen.sh
+        ./configure \
+                --build=$CBUILD \
+                --host=$CHOST \
+                --prefix=/usr \
+                --sysconfdir=/etc \
+                --mandir=/usr/share/man \
+                --localstatedir=/var \
+                || return 1
+        make || return 1
+}
+
+package() {
+        cd "$builddir"
+        make DESTDIR="$pkgdir" install || return 1
+}
+
+doc() {
+	arch="noarch"
+        cd "$builddir"
+        mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname" || return 1
+	# Doc files
+	_docs="AUTHORS COPYING ChangeLog INSTALL NEWS README.md"
+	for _doc in $_docs; do
+#		install -Dm644 "$srcdir"/$pkgname-master/$_doc \
+		install -Dm644 "$srcdir"/$pkgname-$pkgver/$_doc \
+			"$subpkgdir"/usr/share/doc/$pkgname/$_doc || return 1
+	done
+}
+
+examples() {
+	arch="noarch"
+        # Put the examples into a seperate package
+        cd "$builddir"
+        mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname"/examples || return 1
+        mv "$builddir"/examples/* "$subpkgdir"/usr/share/doc/"$pkgname"/examples || return 1
+}
+md5sums="d581dc080e6d5e2e055e4cc91572c829  singularity-2.1.2.tar.gz"
+sha256sums="8175adb404ea402b73333eb909dc6b63135444390a8f632900e7113030563458  singularity-2.1.2.tar.gz"
+sha512sums="6d90e613d50692d8b72d92f02df3aae34190f99ce123361f8db8e8ec2104a8d1a75a2956fc8b01bef572508f0b2ae6e87aaf6067efdf2278fceed52220890e8e  singularity-2.1.2.tar.gz"
+

--- a/alpinelinux/singularity-2.2/APKBUILD
+++ b/alpinelinux/singularity-2.2/APKBUILD
@@ -1,0 +1,58 @@
+# Contributor: "Tru Huynh <tru@pasteur.fr>"
+# Maintainer: "Tru Huynh <tru@pasteur.fr>"
+pkgname=singularity
+pkgver=2.2
+pkgrel=0
+pkgdesc="Singularity: Application containers for Linux"
+url="http://singularity.lbl.gov"
+arch="x86_64"
+license="LNL"
+depends=""
+depends_dev="autoconf automake gcc make libtool linux-headers"
+makedepends="$depends_dev"
+install=""
+subpackages="$pkgname-doc $pkgname-examples"
+#source="${pkgname}-${pkgver}.tar.gz"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/singularityware/singularity/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.gz"
+options="suid"
+builddir=$srcdir/${pkgname}-${pkgver}
+build() {
+        cd "$builddir"      
+        ./configure \
+                --build=$CBUILD \
+                --host=$CHOST \
+                --prefix=/usr \
+                --sysconfdir=/etc \
+                --mandir=/usr/share/man \
+                --localstatedir=/var \
+                || return 1
+        make || return 1
+}
+
+package() {
+        cd "$builddir"
+        make DESTDIR="$pkgdir" install || return 1
+}
+
+doc() {
+	arch="noarch"
+        cd "$builddir"
+        mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname" || return 1
+	# Doc files
+	_docs="AUTHORS COPYING ChangeLog INSTALL NEWS README.md"
+	for _doc in $_docs; do
+		install -Dm644 "$srcdir"/$pkgname-$pkgver/$_doc \
+			"$subpkgdir"/usr/share/doc/$pkgname/$_doc || return 1
+	done
+}
+
+examples() {
+	arch="noarch"
+        # Put the examples into a seperate package
+        cd "$builddir"
+        mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname"/examples || return 1
+        mv "$builddir"/examples/* "$subpkgdir"/usr/share/doc/"$pkgname"/examples || return 1
+}
+md5sums="74d05c2f2275bbfde36a2f05a736b7fe  singularity-2.2.tar.gz"
+sha256sums="3dcb23300d6a5a248659880cbcd98a073bc4a49d19c279ba0460256ed480f3e9  singularity-2.2.tar.gz"
+sha512sums="ae22a2a33dd7d013f4fd12e751d83aeaf3b0acfe98d79d4f827e1380703cc17e624b67afde1f8af6e5a762d493a8748d073570133207b82db8f8e3483055379b  singularity-2.2.tar.gz"

--- a/alpinelinux/singularity-master/APKBUILD
+++ b/alpinelinux/singularity-master/APKBUILD
@@ -1,0 +1,58 @@
+# Contributor: "Tru Huynh <tru@pasteur.fr>"
+# Maintainer: "Tru Huynh <tru@pasteur.fr>"
+pkgname=singularity
+pkgver=2
+pkgrel=0
+pkgdesc="Singularity: Application containers for Linux"
+url="http://singularity.lbl.gov"
+arch="x86_64"
+license="LNL"
+depends=""
+depends_dev="autoconf automake gcc make libtool linux-headers"
+makedepends="$depends_dev"
+install=""
+subpackages="$pkgname-doc $pkgname-examples"
+source="${pkgname}-${pkgver}.zip::https://github.com/gmkurtzer/singularity/archive/master.zip"
+options="suid"
+builddir=$srcdir/singularity-master
+build() {
+        cd "$builddir"      
+        ./autogen.sh
+        ./configure \
+                --build=$CBUILD \
+                --host=$CHOST \
+                --prefix=/usr \
+                --sysconfdir=/etc \
+                --mandir=/usr/share/man \
+                --localstatedir=/var \
+                || return 1
+        make || return 1
+}
+
+package() {
+        cd "$builddir"
+        make DESTDIR="$pkgdir" install || return 1
+}
+
+doc() {
+	arch="noarch"
+        cd "$builddir"
+        mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname" || return 1
+	# Doc files
+	_docs="AUTHORS COPYING ChangeLog INSTALL NEWS README.md"
+	for _doc in $_docs; do
+		install -Dm644 "$srcdir"/$pkgname-master/$_doc \
+			"$subpkgdir"/usr/share/doc/$pkgname/$_doc || return 1
+	done
+}
+
+examples() {
+	arch="noarch"
+        # Put the examples into a seperate package
+        cd "$builddir"
+        mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname"/examples || return 1
+        mv "$builddir"/examples/* "$subpkgdir"/usr/share/doc/"$pkgname"/examples || return 1
+}
+md5sums="23030140f8945148b83bdb0eadd0ed40  singularity-2.zip"
+sha256sums="1b027788abc2e5ba3aae1b5786d97373857cb70b526d37c34ade02c4e6b380f3  singularity-2.zip"
+sha512sums="fb148069f59afd205b90ae4189b01e1b7cbe3f0c755b032c00cb4841e491cf46b5ed586bc5a1898018c6b717de10f5a65f4a1106b1e5c237750794c41b0cc6b0  singularity-2.zip"


### PR DESCRIPTION
the 2.1.2 works fine but 2.2 and master are failing during the installation phase of "abuild -r", the manual installation procedure works fine.. 

imho, it is caused by the "install-data-hook: make_suid" changed, imho it should be reverted to "install-exec-hook: make_suid"
