### PR TITLE
Implemented ability for config file to specify allowable bind directories

### DIFF
--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -118,24 +118,24 @@ user bind control = yes
 # ALLOW SELECT BINDS: [BOOL]
 # DEFAULT: no
 # Limit user bind options to the specificed source and destination
-# directories specificed in singularity.conf
+# directories in singularity.conf
 allow select binds = no
 
 
-# USER BIND SOURCES: [STRING]
+# USER BIND SOURCE: [STRING]
 # DEFAULT: Undefined
 # Specify locations that users are always allowed to bind from, regardless of
 # USER BIND CONTORL. USER BIND SOURCES is a list of locations on the host
 # file system.
-user bind sources = 
+#user bind source = 
 
 
-# USER BIND DESTINATIONS: [STRING]
+# USER BIND DESTINATION: [STRING]
 # DEFAULT: Undefined
 # Specify locations that users are always allowed to bind to, regardless of
 # USER BIND CONTORL. USER BIND SOURCES is a list of locations on the container
 # file system.
-user bind destinations = 
+#user bind destination = 
 
 
 # MOUNT SLAVE: [BOOL]

--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -115,6 +115,29 @@ bind path = /etc/hosts
 user bind control = yes
 
 
+# ALLOW SELECT BINDS: [BOOL]
+# DEFAULT: no
+# Limit user bind options to the specificed source and destination
+# directories specificed in singularity.conf
+allow select binds = no
+
+
+# USER BIND SOURCES: [STRING]
+# DEFAULT: Undefined
+# Specify locations that users are always allowed to bind from, regardless of
+# USER BIND CONTORL. USER BIND SOURCES is a list of locations on the host
+# file system.
+user bind sources = 
+
+
+# USER BIND DESTINATIONS: [STRING]
+# DEFAULT: Undefined
+# Specify locations that users are always allowed to bind to, regardless of
+# USER BIND CONTORL. USER BIND SOURCES is a list of locations on the container
+# file system.
+user bind destinations = 
+
+
 # MOUNT SLAVE: [BOOL]
 # DEFAULT: yes
 # Should we automatically propagate file-system changes from the host?

--- a/src/lib/mount/userbinds/userbinds.c
+++ b/src/lib/mount/userbinds/userbinds.c
@@ -92,7 +92,7 @@ void singularity_mount_userbinds(void) {
 	      }
 	      if ( tmp_path == NULL ) {
 		singularity_message(WARNING, "Ignoring user bind request: %s is not in allowed sources.\n", source);
-		return;
+		continue;
 	      } else {
 		singularity_message(DEBUG, "Proceeding since %s is subdir of %s\n", source, tmp_path);
 	      }
@@ -104,7 +104,7 @@ void singularity_mount_userbinds(void) {
 	      }
 	      if ( tmp_path == NULL ) {
 		singularity_message(WARNING, "Ignoring user bind request: %s is not in allowed destinations.\n", dest);
-		return;
+		continue;
 	      }
 	    }
 	      

--- a/src/lib/mount/userbinds/userbinds.c
+++ b/src/lib/mount/userbinds/userbinds.c
@@ -46,7 +46,7 @@ void singularity_mount_userbinds(void) {
     if ( ( bind_path_string = envar_path("SINGULARITY_BINDPATH") ) != NULL ) {
 
         singularity_message(DEBUG, "Checking for 'user bind control' in config\n");
-        if ( singularity_config_get_bool("user bind control", 1) <= 0 ) {
+        if ( ( singularity_config_get_bool("user bind control", 1) <= 0 ) && ( singularity_config_get_bool("allow select binds", 1) <=0 ) ) {
             singularity_message(WARNING, "Ignoring user bind request: user bind control is disabled by system administrator\n");
             return;
         }

--- a/src/lib/mount/userbinds/userbinds.c
+++ b/src/lib/mount/userbinds/userbinds.c
@@ -51,6 +51,7 @@ void singularity_mount_userbinds(void) {
             return;
         }
 
+	singularity_config_rewind();
 	if (singularity_config_get_bool("allow select binds", 0) <= 0) {
 	  singularity_message(WARNING, "allow select binds set to off\n");
 	}
@@ -81,6 +82,7 @@ void singularity_mount_userbinds(void) {
 
 	    
 	    singularity_message(DEBUG, "Checking if %s is within user bind sources if enabled\n", source);
+	    singularity_config_rewind();
 	    if ( singularity_config_get_bool("allow select binds", 0) > 0 ) {
 	      char *tmp_path;
 	      singularity_message(DEBUG, "allow select binds on\n");
@@ -94,6 +96,8 @@ void singularity_mount_userbinds(void) {
 	      } else {
 		singularity_message(DEBUG, "Proceeding since %s is subdir of %s\n", source, tmp_path);
 	      }
+
+	      singularity_config_rewind();
 	      
 	      while ( ( ( tmp_path = singularity_config_get_value("user bind destination") ) != NULL ) && ( is_subdir(tmp_path, dest) <= 0 ) ) {
 		continue;

--- a/src/lib/mount/userbinds/userbinds.c
+++ b/src/lib/mount/userbinds/userbinds.c
@@ -46,7 +46,7 @@ void singularity_mount_userbinds(void) {
     if ( ( bind_path_string = envar_path("SINGULARITY_BINDPATH") ) != NULL ) {
 
         singularity_message(DEBUG, "Checking for 'user bind control' in config\n");
-        if ( ( singularity_config_get_bool("user bind control", 1) <= 0 ) && ( singularity_config_get_bool("allow select binds", 1) <=0 ) ) {
+        if ( ( singularity_config_get_bool("user bind control", 1) <= 0 ) && ( singularity_config_get_bool("allow select binds", 1) <= 0 ) ) {
             singularity_message(WARNING, "Ignoring user bind request: user bind control is disabled by system administrator\n");
             return;
         }
@@ -74,6 +74,26 @@ void singularity_mount_userbinds(void) {
             }
 
             singularity_message(DEBUG, "Found bind: %s -> container:%s\n", source, dest);
+
+	    
+	    singularity_message(DEBUG, "Checking if %s is within user bind sources if enabled\n", source);
+	    if ( singularity_config_get_bool("allow select binds", 1) > 0 ) {
+	      char *tmp_path;
+	      while ( ( ( tmp_path = singularity_config_get_value("user bind source") ) != NULL ) && ( is_subdir(tmp_path, source) <= 0 ) ) {
+		continue;
+	      }
+	      if ( tmp_path == NULL ) {
+		singularity_message(WARNING, "Ignoring user bind request: %s is not in allowed sources.\n", source);
+		return;
+	      }
+	      while ( ( ( tmp_path = singularity_config_get_value("user bind destination") ) != NULL ) && ( is_subdir(tmp_path, dest) <= 0 ) ) {
+		continue;
+	      }
+	      if ( tmp_path == NULL ) {
+		singularity_message(WARNING, "Ignoring user bind request: %s is not in allowed destinations.\n", dest);
+		return;
+	    }
+	      
 
             singularity_message(DEBUG, "Checking if bind point is already mounted: %s\n", dest);
             if ( check_mounted(dest) >= 0 ) {

--- a/src/lib/mount/userbinds/userbinds.c
+++ b/src/lib/mount/userbinds/userbinds.c
@@ -86,7 +86,7 @@ void singularity_mount_userbinds(void) {
 	    if ( singularity_config_get_bool("allow select binds", 0) > 0 ) {
 	      char *tmp_path;
 	      singularity_message(DEBUG, "allow select binds on\n");
-	      while ( ( ( tmp_path = singularity_config_get_value("user bind source") ) != NULL ) && ( is_subdir(tmp_path, source) <= 0 ) ) {
+	      while ( ( (tmp_path = singularity_config_get_value("user bind source") ) != NULL) && (is_subdir(tmp_path, source) <= 0) ) {
 		singularity_message(DEBUG, "tmp_path: %s source: %s\n", tmp_path, source);
 		continue;
 	      }
@@ -98,13 +98,15 @@ void singularity_mount_userbinds(void) {
 	      }
 
 	      singularity_config_rewind();
-	      
-	      while ( ( ( tmp_path = singularity_config_get_value("user bind destination") ) != NULL ) && ( is_subdir(tmp_path, dest) <= 0 ) ) {
+	      while ( ( (tmp_path = singularity_config_get_value("user bind destination") ) != NULL) && (is_subdir(tmp_path, dest) <= 0) ) {
+		singularity_message(DEBUG, "tmp_path: %s dest: %s\n", tmp_path, dest);
 		continue;
 	      }
 	      if ( tmp_path == NULL ) {
 		singularity_message(WARNING, "Ignoring user bind request: %s is not in allowed destinations.\n", dest);
 		continue;
+	      } else {
+		singularity_message(DEBUG, "Proceeding since %s is subdir of %s\n", dest, tmp_path);
 	      }
 	    }
 	      

--- a/src/lib/mount/userbinds/userbinds.c
+++ b/src/lib/mount/userbinds/userbinds.c
@@ -46,7 +46,7 @@ void singularity_mount_userbinds(void) {
     if ( ( bind_path_string = envar_path("SINGULARITY_BINDPATH") ) != NULL ) {
 
         singularity_message(DEBUG, "Checking for 'user bind control' in config\n");
-        if ( ( singularity_config_get_bool("user bind control", 1) <= 0 ) && ( singularity_config_get_bool("allow select binds", 1) <= 0 ) ) {
+        if ( ( singularity_config_get_bool("user bind control", 1) <= 0 ) && ( singularity_config_get_bool("allow select binds", 0) <= 0 ) ) {
             singularity_message(WARNING, "Ignoring user bind request: user bind control is disabled by system administrator\n");
             return;
         }
@@ -77,7 +77,7 @@ void singularity_mount_userbinds(void) {
 
 	    
 	    singularity_message(DEBUG, "Checking if %s is within user bind sources if enabled\n", source);
-	    if ( singularity_config_get_bool("allow select binds", 1) > 0 ) {
+	    if ( singularity_config_get_bool("allow select binds", 0) > 0 ) {
 	      char *tmp_path;
 	      while ( ( ( tmp_path = singularity_config_get_value("user bind source") ) != NULL ) && ( is_subdir(tmp_path, source) <= 0 ) ) {
 		continue;

--- a/src/lib/mount/userbinds/userbinds.c
+++ b/src/lib/mount/userbinds/userbinds.c
@@ -51,6 +51,10 @@ void singularity_mount_userbinds(void) {
             return;
         }
 
+	if (singularity_config_get_bool("allow select binds", 0) <= 0) {
+	  singularity_message(WARNING, "allow select binds set to off\n");
+	}
+
 #ifndef SINGULARITY_NO_NEW_PRIVS
         singularity_message(WARNING, "Ignoring user bind request: host does not support PR_SET_NO_NEW_PRIVS\n");
         return;
@@ -79,19 +83,25 @@ void singularity_mount_userbinds(void) {
 	    singularity_message(DEBUG, "Checking if %s is within user bind sources if enabled\n", source);
 	    if ( singularity_config_get_bool("allow select binds", 0) > 0 ) {
 	      char *tmp_path;
+	      singularity_message(DEBUG, "allow select binds on\n");
 	      while ( ( ( tmp_path = singularity_config_get_value("user bind source") ) != NULL ) && ( is_subdir(tmp_path, source) <= 0 ) ) {
+		singularity_message(DEBUG, "tmp_path: %s source: %s\n", tmp_path, source);
 		continue;
 	      }
 	      if ( tmp_path == NULL ) {
 		singularity_message(WARNING, "Ignoring user bind request: %s is not in allowed sources.\n", source);
 		return;
+	      } else {
+		singularity_message(DEBUG, "Proceeding since %s is subdir of %s\n", source, tmp_path);
 	      }
+	      
 	      while ( ( ( tmp_path = singularity_config_get_value("user bind destination") ) != NULL ) && ( is_subdir(tmp_path, dest) <= 0 ) ) {
 		continue;
 	      }
 	      if ( tmp_path == NULL ) {
 		singularity_message(WARNING, "Ignoring user bind request: %s is not in allowed destinations.\n", dest);
 		return;
+	      }
 	    }
 	      
 

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -149,7 +149,7 @@ int is_subdir(char *path, char *subpath) {
     singularity_message(DEBUG, "test_subpath: %s\n", test_subpath);
     if ( strcmp(test_subpath, test_path) == 0 ) {
       singularity_message(DEBUG, "%s is subdir of %s\n", subpath, path);
-      return(0);
+      return(1);
     } else {
       test_subpath = dirname(strdup(test_subpath));
     }

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -130,13 +130,14 @@ int is_subdir(char *path, char *subpath) {
   char *test_path;
   char *test_subpath;
 
-  if( strcmp(path[strlen(path)-1], "/" ) ) {
+  if( strcmp(&path[strlen(path)-1], "/" ) == 0 ) {
     test_path = strndup(path, strlen(path)-1);
+    singularity_message(DEBUG, "removed trailing / from %s -> %s\n", path, test_path);
   } else {
     test_path = strdup(path);
   }
   
-  if ( strcmp(subpath[strlen(subpath)-1], "/") ) {
+  if ( strcmp(&subpath[strlen(subpath)-1], "/") == 0 ) {
     test_subpath = strndup(subpath, strlen(subpath)-1);
   } else {
     test_subpath = strdup(subpath);

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -126,6 +126,21 @@ int is_dir(char *path) {
     return(-1);
 }
 
+int is_subdir(char *path, char *subpath) {
+  char *testdir = strdup(subpath);
+
+  singularity_message(DEBUG, "Testing if %s is contained within %s\n", subpath, path);
+
+  while ( strcmp(testdir, "/") != 0 ) {
+    if ( strcmp(testdir, path) == 0 ) {
+      return(0);
+    } else {
+      testdir = dirname(strdup(testdir));
+    }
+  }
+  return(-1);
+}
+
 int is_suid(char *path) {
     struct stat filestat;
 
@@ -394,7 +409,3 @@ char *basedir(char *dir) {
 
     return(ret);
 }
-
-
-
-

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -151,7 +151,7 @@ int is_subdir(char *testpath, char *basepath) {
   close(parent_fd);
 
   if ( (test_fd_st.st_dev != testpath_st.st_dev) || (test_fd_st.st_ino != testpath_st.st_ino) ) {
-    close(test_fd)
+    close(test_fd);
     return(-1);
   }
 

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -127,18 +127,30 @@ int is_dir(char *path) {
 }
 
 int is_subdir(char *path, char *subpath) {
-  char *testdir = strdup(subpath);
+  char *test_path;
+  char *test_subpath;
 
+  if( strcmp(path[strlen(path)-1], "/" ) ) {
+    test_path = strndup(path, strlen(path)-1);
+  } else {
+    test_path = strdup(path);
+  }
+  
+  if ( strcmp(subpath[strlen(subpath)-1], "/") ) {
+    test_subpath = strndup(subpath, strlen(subpath)-1);
+  } else {
+    test_subpath = strdup(subpath);
+  }
+  
   singularity_message(DEBUG, "Testing if %s is contained within %s\n", subpath, path);
 
-  while ( strcmp(testdir, "/") != 0 ) {
-    singularity_message(DEBUG, "testdir: %s\n", testdir);
-    if ( strcmp(testdir, path) == 0 ) {
+  while ( strcmp(test_subpath, "/") != 0 ) {
+    singularity_message(DEBUG, "test_subpath: %s\n", test_subpath);
+    if ( strcmp(test_subpath, test_path) == 0 ) {
       singularity_message(DEBUG, "%s is subdir of %s\n", subpath, path);
       return(0);
     } else {
-      testdir = dirname(strdup(testdir));
-      
+      test_subpath = dirname(strdup(test_subpath));
     }
   }
   return(-1);

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -131,18 +131,18 @@ int is_subdir(char *path, char *subpath) {
     char *test_subpath;
 
     if( strcmp(&path[strlen(path)-1], "/" ) == 0 ) {
-        test_path = strndup(path, strlen(path)-1);
+        test_path = realpath(strndup(path, strlen(path)-1), NULL);
     } else {
-        test_path = strdup(path);
+        test_path = realpath(path, NULL);
     }
   
     if ( strcmp(&subpath[strlen(subpath)-1], "/") == 0 ) {
-        test_subpath = strndup(subpath, strlen(subpath)-1);
+        test_subpath = realpath(strndup(subpath, strlen(subpath)-1), NULL);
     } else {
-        test_subpath = strdup(subpath);
+        test_subpath = realpath(subpath, NULL);
     }
   
-    singularity_message(DEBUG, "Testing if %s is contained within %s\n", subpath, path);
+    singularity_message(DEBUG, "Testing if %s is contained within %s\n", test_subpath, test_path);
 
     while ( strcmp(test_subpath, "/") != 0 ) {
         if ( strcmp(test_subpath, test_path) == 0 ) {

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -127,34 +127,33 @@ int is_dir(char *path) {
 }
 
 int is_subdir(char *path, char *subpath) {
-  char *test_path;
-  char *test_subpath;
+    char *test_path;
+    char *test_subpath;
 
-  if( strcmp(&path[strlen(path)-1], "/" ) == 0 ) {
-    test_path = strndup(path, strlen(path)-1);
-    singularity_message(DEBUG, "removed trailing / from %s -> %s\n", path, test_path);
-  } else {
-    test_path = strdup(path);
-  }
-  
-  if ( strcmp(&subpath[strlen(subpath)-1], "/") == 0 ) {
-    test_subpath = strndup(subpath, strlen(subpath)-1);
-  } else {
-    test_subpath = strdup(subpath);
-  }
-  
-  singularity_message(DEBUG, "Testing if %s is contained within %s\n", subpath, path);
-
-  while ( strcmp(test_subpath, "/") != 0 ) {
-    singularity_message(DEBUG, "test_subpath: %s\n", test_subpath);
-    if ( strcmp(test_subpath, test_path) == 0 ) {
-      singularity_message(DEBUG, "%s is subdir of %s\n", subpath, path);
-      return(1);
+    if( strcmp(&path[strlen(path)-1], "/" ) == 0 ) {
+        test_path = strndup(path, strlen(path)-1);
     } else {
-      test_subpath = dirname(strdup(test_subpath));
+        test_path = strdup(path);
     }
-  }
-  return(-1);
+  
+    if ( strcmp(&subpath[strlen(subpath)-1], "/") == 0 ) {
+        test_subpath = strndup(subpath, strlen(subpath)-1);
+    } else {
+        test_subpath = strdup(subpath);
+    }
+  
+    singularity_message(DEBUG, "Testing if %s is contained within %s\n", subpath, path);
+
+    while ( strcmp(test_subpath, "/") != 0 ) {
+        if ( strcmp(test_subpath, test_path) == 0 ) {
+            singularity_message(DEBUG, "%s is subdir of %s\n", subpath, path);
+            return(1);
+        } else {
+            test_subpath = dirname(strdup(test_subpath));
+        }
+    }
+    singularity_message(DEBUG, "%s is not a subdir of %s\n", subpath, path);
+    return(-1);
 }
 
 int is_suid(char *path) {

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -132,10 +132,13 @@ int is_subdir(char *path, char *subpath) {
   singularity_message(DEBUG, "Testing if %s is contained within %s\n", subpath, path);
 
   while ( strcmp(testdir, "/") != 0 ) {
+    singularity_message(DEBUG, "testdir: %s\n", testdir);
     if ( strcmp(testdir, path) == 0 ) {
+      singularity_message(DEBUG, "%s is subdir of %s\n", subpath, path);
       return(0);
     } else {
       testdir = dirname(strdup(testdir));
+      
     }
   }
   return(-1);

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -126,6 +126,37 @@ int is_dir(char *path) {
     return(-1);
 }
 
+int is_subdir(char *testpath, char *basepath) {
+  struct stat testpath_st;
+  struct stat basepath_st;
+  struct stat test_fd_st;
+  int parent_fd;
+  int test_fd;
+  char *real_fname = basename(testpath);
+  
+  if ( ( stat(testpath, &testpath_st) == -1 ) || ( stat(basepath, &basepath_st) == -1 ) ) {
+    return(-1);
+  }
+  
+  if ( (basepath_st.st_dev == testpath_st.st_dev) && (basepath_st.st_ino == testpath_st.st_ino) ) {
+    parent_fd = open(basepath, O_CLOEXEC);
+  } else {
+    parent_fd = is_subdir(dirname(testpath), basepath);
+  }
+
+  test_fd = openat(parent_fd, real_fname, O_CLOEXEC);
+  fstat(test_fd, &test_fd_st);
+  close(parent_fd);
+
+  if ( (test_fd_st.st_dev != testpath_st.st_dev) || (test_fd_st.st_ino != testpath_st.st_ino) ) {
+    close(test_fd)
+    return(-1);
+  }
+
+  return(test_fd);   
+}
+  
+
 int is_subdir(char *path, char *subpath) {
     char *test_path;
     char *test_subpath;

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -132,7 +132,9 @@ int is_subdir(char *testpath, char *basepath) {
   struct stat test_fd_st;
   int parent_fd;
   int test_fd;
-  char *real_fname = basename(testpath);
+  char *testpath_real;
+  realpath(testpath, testpath_real);
+  char *real_fname = basename(testpath_real);
   
   if ( ( stat(testpath, &testpath_st) == -1 ) || ( stat(basepath, &basepath_st) == -1 ) ) {
     return(-1);
@@ -156,36 +158,6 @@ int is_subdir(char *testpath, char *basepath) {
   return(test_fd);   
 }
   
-
-int is_subdir(char *path, char *subpath) {
-    char *test_path;
-    char *test_subpath;
-
-    if( strcmp(&path[strlen(path)-1], "/" ) == 0 ) {
-        test_path = realpath(strndup(path, strlen(path)-1), NULL);
-    } else {
-        test_path = realpath(path, NULL);
-    }
-  
-    if ( strcmp(&subpath[strlen(subpath)-1], "/") == 0 ) {
-        test_subpath = realpath(strndup(subpath, strlen(subpath)-1), NULL);
-    } else {
-        test_subpath = realpath(subpath, NULL);
-    }
-  
-    singularity_message(DEBUG, "Testing if %s is contained within %s\n", test_subpath, test_path);
-
-    while ( strcmp(test_subpath, "/") != 0 ) {
-        if ( strcmp(test_subpath, test_path) == 0 ) {
-            singularity_message(DEBUG, "%s is subdir of %s\n", subpath, path);
-            return(1);
-        } else {
-            test_subpath = dirname(strdup(test_subpath));
-        }
-    }
-    singularity_message(DEBUG, "%s is not a subdir of %s\n", subpath, path);
-    return(-1);
-}
 
 int is_suid(char *path) {
     struct stat filestat;

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -24,6 +24,7 @@ int is_file(char *path);
 int is_fifo(char *path);
 int is_link(char *path);
 int is_dir(char *path);
+int is_subdir(char *path, char *subpath);
 int is_exec(char *path);
 int is_write(char *path);
 int is_suid(char *path);


### PR DESCRIPTION
In #256 there was an issue reported that users could never bind when PR_SET_NO_NEW_PRIVS is not enabled on the kernel. @bbockelm proposed a solution where an admin could list directories in the config file that are always allowed to be bind mounted. This pull request implements this suggestion and provides new functionality:

New config options:

```
# ALLOW SELECT BINDS: [BOOL]                                                                                                             
# DEFAULT: no                                                                                                                            
# Limit user bind options to the specified source and destination                                                                       
# directories in singularity.conf                                                                                                        
allow select binds = no


# USER BIND SOURCE: [STRING]                                                                                                             
# DEFAULT: Undefined                                                                                                                     
# Specify locations that users are always allowed to bind from, regardless of                                                            
# USER BIND CONTROL. USER BIND SOURCES is a list of locations on the host                                                                
# file system.                                                                                                                           
#user bind source =                                                                                                                      


# USER BIND DESTINATION: [STRING]                                                                                                        
# DEFAULT: Undefined                                                                                                                     
# Specify locations that users are always allowed to bind to, regardless of                                                              
# USER BIND CONTROL. USER BIND SOURCES is a list of locations on the container                                                           
# file system.                                                                                                                           
#user bind destination =
```

user bind source/destination configs function like bind path with one entry per line. Any subdirectory of the directories specified in user bind source/destination will also be accepted. If user bind control and allow select binds are both set to yes, users will still only be able to bind on the specified directories. Attempting to bind a location not specified in the config will trigger a WARNING to the user and continue as normal without mounting, however an attempt will still be made to bind mount other locations if multiple are present.

Current default for allow select binds is no, however it could be changed to yes to allow for more security. If you set allow select binds default to yes and revert user bind control default to no, any administrator must manually switch on user bind control, possibly preventing admins from accidentally leaving open a security hole.
