### PR TITLE
fixing all pointers to old repo, and updating badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/gmkurtzer/singularity.svg?branch=master)](https://travis-ci.org/gmkurtzer/singularity)
+[![Build Status](https://travis-ci.org/singularityware/singularity.svg?branch=master)](https://travis-ci.org/singularityware/singularity)
 
 
 # Singularity - Enabling users to have full control of their environment.

--- a/docs/Administration.md
+++ b/docs/Administration.md
@@ -15,7 +15,7 @@ You can download the source code either from the latest stable tarball release o
 ```bash
 $ mkdir ~/git
 $ cd ~/git
-$ git clone https://github.com/gmkurtzer/singularity.git
+$ git clone https://github.com/singularityware/singularity.git
 $ cd singularity
 $ ./autogen.sh
 ```
@@ -176,7 +176,8 @@ Given that loop devices are consumable (there are a limited number of them on a 
 
 Edit or create the file `/etc/modprobe.d/loop.conf` and add the following line:
 
-```options loop max_loop=128
+```
+options loop max_loop=128
 
 ```
 

--- a/docs/User.md
+++ b/docs/User.md
@@ -155,7 +155,7 @@ If you already have Singularity installed, or if you are using Singularity from 
 ```bash
 $ mkdir ~/git
 $ cd ~/git
-$ git clone https://github.com/gmkurtzer/singularity.git
+$ git clone https://github.com/singularityware/singularity.git
 $ cd singularity
 $ ./autogen.sh
 $ ./configure --prefix=/usr/local --sysconfdir=/etc
@@ -775,7 +775,7 @@ When bootstrapping a container, it is best to consider the following:
 
 As always, goto http://singularity.lbl.gov for the latest information, documentation, support, and news.
 
-If you think you have found a bug, or want to request a new feature, submit a bug report at: https://github.com/gmkurtzer/singularity/issues/new
+If you think you have found a bug, or want to request a new feature, submit a bug report at: https://github.com/singularityware/singularity/issues/new
 
 ## Want to Join the Team?!
 We want you! Your help! Your contributions! Your presence! Come and hop on our Slack channel by requesting an invite from gmkurtzer@lbl.gov!

--- a/libexec/cli/bootstrap.help
+++ b/libexec/cli/bootstrap.help
@@ -50,5 +50,5 @@ demonstrated above.
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/copy.help
+++ b/libexec/cli/copy.help
@@ -15,5 +15,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/create.help
+++ b/libexec/cli/create.help
@@ -15,5 +15,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/exec.help
+++ b/libexec/cli/exec.help
@@ -45,5 +45,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/expand.help
+++ b/libexec/cli/expand.help
@@ -13,5 +13,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/export.help
+++ b/libexec/cli/export.help
@@ -19,5 +19,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/import.help
+++ b/libexec/cli/import.help
@@ -37,5 +37,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/mount.help
+++ b/libexec/cli/mount.help
@@ -15,5 +15,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/run.help
+++ b/libexec/cli/run.help
@@ -50,5 +50,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/shell.help
+++ b/libexec/cli/shell.help
@@ -57,5 +57,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/start.help
+++ b/libexec/cli/start.help
@@ -19,5 +19,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/stop.help
+++ b/libexec/cli/stop.help
@@ -10,5 +10,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/libexec/cli/test.help
+++ b/libexec/cli/test.help
@@ -19,5 +19,5 @@ EXAMPLES:
 For additional help, please visit our public documentation pages which are
 found at:
 
-    http://gmkurtzer.github.io/singularity
+    http://singularity.lbl.gov/
 

--- a/man/singularity.1
+++ b/man/singularity.1
@@ -37,6 +37,6 @@ Full documentation can be found on the Singularity web site at:
 .B http://singularity.lbl.gov/
 .SH BUGS
 Please submit bug reports to the GitHub issue tracker at
-.B https://github.com/gmkurtzer/singularity/issues/new
+.B https://github.com/singularityware/singularity/issues/new
 .SH AUTHOR
 Gregory M. Kurtzer <gmkurtzer@lbl.gov>


### PR DESCRIPTION
@gmkurtzer here are fixes to each of the help files with the correct help docs url. The references to the old repo are also fixed throughout the various docs.
