### PR TITLE
py2/py3 compatibility for urllib/urllib2

### DIFF
--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -28,10 +28,13 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import urllib
-import urllib2
-
-from urllib2 import HTTPError
+try:
+    from urllib.parse import urlencode
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib import urlencode
+    from urllib2 import urlopen, Request, HTTPError
 
 # Python less than version 3 must import OSError
 if sys.version_info[0] < 3:
@@ -128,16 +131,16 @@ def api_get(url,data=None,default_header=True,headers=None,stream=None,return_re
         do_stream = True
 
     if data != None:
-        args = urllib.urlencode(data)
-        request = urllib2.Request(url=url, 
+        args = urlencode(data)
+        request = Request(url=url, 
                                   data=args, 
                                   headers=headers) 
     else:
-        request = urllib2.Request(url=url, 
+        request = Request(url=url, 
                                   headers=headers) 
 
     try:
-        response = urllib2.urlopen(request)
+        response = urlopen(request)
 
     # If we have an HTTPError, try to follow the response
     except HTTPError as error:

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -151,7 +151,7 @@ def api_get(url,data=None,default_header=True,headers=None,stream=None,return_re
         return response
 
     if do_stream == False:
-        return response.read()
+        return response.read().decode('utf-8')
        
     chunk_size = 1 << 20
     with open(stream, 'wb') as filey:


### PR DESCRIPTION
Documentation at http://singularity.lbl.gov/docs-exec shows running this example
$ singularity exec docker://python:latest /usr/local/bin/python hello.py
Doing so with python3 as default python interpreter brings up an error as urllib2 is python2 only:
ImportError: No module named 'urllib2'
This is a change to make the code py2/py3 compatible
