### PR TITLE
Added VERBOSE message to always output path of sexec_suid_path

### DIFF
--- a/src/sexec.c
+++ b/src/sexec.c
@@ -87,7 +87,8 @@ int main(int argc, char **argv) {
             singularity_message(VERBOSE2, "Checking if we were requested to run as NOSUID by user\n");
             if ( envar_defined("SINGULARITY_NOSUID") == FALSE ) {
                 char sexec_suid_path[] = LIBEXECDIR "/singularity/sexec-suid";
-
+		
+		singularity_message(VERBOSE, "Checking for sexec-suid at %s\n", sexec_suid_path);
                 if ( ( is_owner(sexec_suid_path, 0 ) == 0 ) && ( is_suid(sexec_suid_path) == 0 ) ) {
                     singularity_message(VERBOSE, "Invoking SUID sexec: %s\n", sexec_suid_path);
 

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -89,14 +89,20 @@ int main(int argc, char **argv) {
                 char sexec_suid_path[] = LIBEXECDIR "/singularity/sexec-suid";
 		
 		singularity_message(VERBOSE, "Checking for sexec-suid at %s\n", sexec_suid_path);
-                if ( ( is_owner(sexec_suid_path, 0 ) == 0 ) && ( is_suid(sexec_suid_path) == 0 ) ) {
-                    singularity_message(VERBOSE, "Invoking SUID sexec: %s\n", sexec_suid_path);
 
-                    execv(sexec_suid_path, argv); // Flawfinder: ignore
-                    singularity_abort(255, "Failed to execute sexec binary (%s): %s\n", sexec_suid_path, strerror(errno));
-                } else {
-                    singularity_message(VERBOSE, "Not invoking SUID mode: SUID sexec not installed\n");
-                }
+		if ( is_file(sexec_suid_path) == 0 ) {
+                    if ( ( is_owner(sexec_suid_path, 0 ) == 0 ) && ( is_suid(sexec_suid_path) == 0 ) ) {
+                        singularity_message(VERBOSE, "Invoking SUID sexec: %s\n", sexec_suid_path);
+
+                        execv(sexec_suid_path, argv); // Flawfinder: ignore
+                        singularity_abort(255, "Failed to execute sexec binary (%s): %s\n", sexec_suid_path, strerror(errno));
+                    } else {
+                        singularity_message(VERBOSE, "Not invoking SUID mode: SUID sexec permissions not properly set\n");
+                    }
+		}
+		else {
+		    singularity_message(VERBOSE, "Not invoking SUID mode: SUID sexec not installed\n");
+		}
             } else {
                 singularity_message(VERBOSE, "Not invoking SUID mode: NOSUID mode requested\n");
             }


### PR DESCRIPTION
This is a pull request to add a VERBOSE message that will output the path that sexec binary is searching at for sexec-suid binary. This was brought to light in #267 and should allow easier debugging if this happens again.

Also added separate check if sexec-suid exists to distinguish between improper permissions and an uninstalled binary file.
