### PR TITLE
Fix runscript parsing error

### DIFF
--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -40,7 +40,7 @@ def create_runscript(cmd,base_dir):
     :param base_dir: the base directory to write the runscript to
     '''
     runscript = "%s/singularity" %(base_dir)
-    content = "!#/bin/sh\n\n%s" %(cmd)
+    content = "#!/bin/sh\n\n%s" %(cmd)
     output_file = write_file(runscript,content)
     return output_file
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -215,7 +215,7 @@ def extract_tar(targz,output_folder):
     return run_command(["tar","-xzf",targz,"-C",output_folder,"--exclude=dev/*"]) 
 
 
-def write_file(filename,content,mode="wb"):
+def write_file(filename,content,mode="w"):
     '''write_file will open a file, "filename" and write content, "content"
     and properly close the file
     '''
@@ -240,7 +240,7 @@ def write_json(json_obj,filename,mode="w",print_pretty=True):
     return filename
 
 
-def read_file(filename,mode="rb"):
+def read_file(filename,mode="r"):
     '''write_file will open a file, "filename" and write content, "content"
     and properly close the file
     '''


### PR DESCRIPTION
The current runscript is being encoded incorrectly in python3, thanks to the updates with bytes. This makes the default write_file function mode "w" instead of "wb" and also fixes the incorrect shabang ordering of the runscript.
