### PR TITLE
Add SLURM integration plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ src/.libs/
 src/lib*.la
 src/*.o
 src/*.lo
+src/singularity_spank.la
 
 src/*/.deps/
 src/*/.libs/

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ src/.libs/
 src/lib*.la
 src/*.o
 src/*.lo
-src/singularity_spank.la
+src/slurm/singularity_spank.la
 
 src/*/.deps/
 src/*/.libs/

--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,7 @@ AS_IF([test "x$with_slurm" != "xno"],
     ]
 )
 AM_CONDITIONAL([WITH_SLURM], [test "$with_slurm" = "yes"])
+AC_SUBST(with_slurm)
 
 
 AC_MSG_CHECKING([if suid should be enabled])

--- a/configure.ac
+++ b/configure.ac
@@ -329,6 +329,7 @@ AC_CONFIG_FILES([
    src/lib/mount/userbinds/Makefile
    src/lib/mount/scratch/Makefile
    src/util/Makefile
+   src/slurm/Makefile
    etc/Makefile
    bin/Makefile
    bin/singularity

--- a/configure.ac
+++ b/configure.ac
@@ -247,13 +247,27 @@ AC_MSG_CHECKING([if slurm integration should be built])
 AC_ARG_WITH([slurm],
             AS_HELP_STRING([--with-slurm], [Enable build of slurm integration]),
            )
-AS_IF([test "x$with_slurm" != "xno"], [
-    AC_MSG_RESULT([yes])
-    BUILD_SLURM="libsingularity_spank.la"
-], [
-    AC_MSG_RESULT([no])
-    BUILD_SLURM=""
-])
+AS_IF([test "x$with_slurm" != "xno"],
+    [
+        AC_CHECK_HEADER([slurm/spank.h],
+            [AC_MSG_RESULT([yes])
+             with_slurm="yes"
+            ],
+            [AS_IF([test "$with_slurm" = "yes"],
+                   [AC_MSG_ERROR([SLURM support requested, but slurm/spank.h header not found.])],
+                   [ AC_MSG_RESULT([no])
+                     with_slurm="no"
+                   ]
+            ])
+        )
+    ],
+    [
+        AC_MSG_RESULT([no])
+        with_slurm="no"
+    ]
+)
+AM_CONDITIONAL([WITH_SLURM], [test "$with_slurm" = "yes"])
+
 
 AC_MSG_CHECKING([if suid should be enabled])
 AC_ARG_ENABLE([suid],

--- a/configure.ac
+++ b/configure.ac
@@ -217,7 +217,6 @@ AC_ARG_WITH([userns],
             [SINGULARITY_DEFINES="$SINGULARITY_DEFINES -DSINGULARITY_USERNS"]
            )
 
-
 AC_CHECK_FUNCS(setns, [
                       ], [
                           NO_SETNS="-DNO_SETNS"
@@ -244,7 +243,17 @@ fi
 AC_SUBST(OVERLAY_FS)
 AC_SUBST(SINGULARITY_DEFINES)
 
-
+AC_MSG_CHECKING([if slurm integration should be built])
+AC_ARG_WITH([slurm],
+            AS_HELP_STRING([--with-slurm], [Enable build of slurm integration]),
+           )
+AS_IF([test "x$with_slurm" != "xno"], [
+    AC_MSG_RESULT([yes])
+    BUILD_SLURM="libsingularity_spank.la"
+], [
+    AC_MSG_RESULT([no])
+    BUILD_SLURM=""
+])
 
 AC_MSG_CHECKING([if suid should be enabled])
 AC_ARG_ENABLE([suid],

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -42,6 +42,7 @@ Development files for Singularity
 %package slurm
 Summary: Singularity plugin for SLURM
 Group: System Environment/Libraries
+Requires: singularity = %{version}-%{release}
 
 %description slurm
 The Singularity plugin for SLURM allows jobs to be started within

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -1,5 +1,13 @@
 %{!?_rel:%{expand:%%global _rel 0.1}}
 
+# This allows us to pick up the default value from the configure
+%define with_slurm @with_slurm@
+%if "%{with_slurm}" == "yes"
+%define slurm 1
+%else
+%define slurm 0
+%endif
+
 Summary: Application and environment virtualization
 Name: singularity
 Version: @PACKAGE_VERSION@
@@ -11,6 +19,12 @@ URL: http://singularity.lbl.gov/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
+
+%if %slurm
+# NOTE: doing a direct file dependency because experience has shown there are a few
+# site-local RPMs that have random pieces missing.
+BuildRequires: /usr/include/slurm/spank.h
+%endif
 
 %description
 Singularity provides functionality to build the smallest most minimal
@@ -24,12 +38,35 @@ Group: System Environment/Development
 %description devel
 Development files for Singularity
 
+%if %slurm
+%package slurm
+Summary: Singularity plugin for SLURM
+Group: System Environment/Libraries
+
+%description slurm
+The Singularity plugin for SLURM allows jobs to be started within
+a container.  This provides a simpler interface to the user (they
+don't have to be aware of the singularity executable) and doesn't
+require a setuid binary.
+%endif
+
+
 %prep
 %setup
 
 
 %build
-%configure 
+if [ ! -f configure ]; then
+  ./autogen.sh
+fi
+
+%configure \
+%if %slurm
+  --with-slurm
+%else
+  --without-slurm
+%endif
+
 %{__make} %{?mflags}
 
 
@@ -74,6 +111,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/lib*.a
 %{_includedir}/*.h
 
+
+%files slurm
+%defattr(-, root, root)
+%{_libdir}/slurm/singularity.so
 
 
 %changelog

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,7 +35,12 @@ image_bind_LDADD = lib/libsingularity.la
 get_section_SOURCES = get-section.c util/util.c util/file.c
 get_section_LDADD = lib/libsingularity.la
 
-
+plugindir = $(libdir)/slurm
+#plugin_LTLIBRARIES = $(BUILD_SLURM)
+plugin_LTLIBRARIES = singularity_spank.la
+singularity_spank_la_SOURCES = slurm/singularity.c
+singularity_spank_la_LIBADD = lib/libsingularity.la
+singularity_spank_la_LDFLAGS = -module -no-undefined -avoid-version -export-symbols-regex '^slurm_spank_|^plugin_'
 
 #sexec_nosuid_CPPFLAGS = -DSINGULARITY_NOSUID=1 -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
 #bootstrap_CPPFLAGS = -DLIBEXECDIR=\"$(libexecdir)\"
@@ -43,7 +48,7 @@ get_section_LDADD = lib/libsingularity.la
 
 #dist_suidPROGRAM_INSTALL = ${INSTALL} -m 640
 
-install-data-hook: make_suid
+install-data-hook: make_suid cleanup_plugin
 
 make_suid:
 	@if test `id -ru` = "0" -a "x$(BUILD_SUID)" = "xsexec-suid"; then \
@@ -51,6 +56,16 @@ make_suid:
 		/bin/chown root:root $(DESTDIR)$(libexecdir)/singularity/sexec-suid; \
 		echo " /bin/chmod 4755 $(DESTDIR)$(libexecdir)/singularity/sexec-suid"; \
 		/bin/chmod 4755 $(DESTDIR)$(libexecdir)/singularity/sexec-suid; \
+	fi
+
+cleanup_plugin:
+	@if test -e "$(DESTDIR)$(plugindir)/singularity_spank.so"; then \
+		echo "cp $(DESTDIR)$(plugindir)/singularity_spank.so $(DESTDIR)$(plugindir)/backup_singularity_spank"; \
+		cp "$(DESTDIR)$(plugindir)/singularity_spank.so" "$(DESTDIR)$(plugindir)/backup_singularity_spank"; \
+		echo "rm -f $(DESTDIR)$(plugindir)/singularity_spank.*"; \
+		rm -f "$(DESTDIR)$(plugindir)/"singularity_spank.*; \
+		echo "mv $(DESTDIR)$(plugindir)/backup_singularity_spank $(DESTDIR)$(plugindir)/singularity_spank.so"; \
+		mv "$(DESTDIR)$(plugindir)/backup_singularity_spank" "$(DESTDIR)$(plugindir)/singularity.so"; \
 	fi
 
 EXTRA_DIST = config.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,11 +36,13 @@ get_section_SOURCES = get-section.c util/util.c util/file.c
 get_section_LDADD = lib/libsingularity.la
 
 plugindir = $(libdir)/slurm
-#plugin_LTLIBRARIES = $(BUILD_SLURM)
+
+if WITH_SLURM
 plugin_LTLIBRARIES = singularity_spank.la
 singularity_spank_la_SOURCES = slurm/singularity.c
 singularity_spank_la_LIBADD = lib/libsingularity.la
 singularity_spank_la_LDFLAGS = -module -no-undefined -avoid-version -export-symbols-regex '^slurm_spank_|^plugin_'
+endif
 
 #sexec_nosuid_CPPFLAGS = -DSINGULARITY_NOSUID=1 -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
 #bootstrap_CPPFLAGS = -DLIBEXECDIR=\"$(libexecdir)\"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = lib util
+SUBDIRS = lib util slurm
 
 MAINTAINERCLEANFILES = Makefile.in config.h config.h.in
 DISTCLEANFILES = Makefile
@@ -35,22 +35,13 @@ image_bind_LDADD = lib/libsingularity.la
 get_section_SOURCES = get-section.c util/util.c util/file.c
 get_section_LDADD = lib/libsingularity.la
 
-plugindir = $(libdir)/slurm
-
-if WITH_SLURM
-plugin_LTLIBRARIES = singularity_spank.la
-singularity_spank_la_SOURCES = slurm/singularity.c
-singularity_spank_la_LIBADD = lib/libsingularity_internal.la
-singularity_spank_la_LDFLAGS = -module -no-undefined -avoid-version -export-symbols-regex '^slurm_spank_|^plugin_'
-endif
-
 #sexec_nosuid_CPPFLAGS = -DSINGULARITY_NOSUID=1 -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
 #bootstrap_CPPFLAGS = -DLIBEXECDIR=\"$(libexecdir)\"
 #ftrace_CPPFLAGS = -DARCH_$(SINGULARITY_ARCH)
 
 #dist_suidPROGRAM_INSTALL = ${INSTALL} -m 640
 
-install-data-hook: make_suid cleanup_plugin
+install-data-hook: make_suid
 
 make_suid:
 	@if test `id -ru` = "0" -a "x$(BUILD_SUID)" = "xsexec-suid"; then \
@@ -58,16 +49,6 @@ make_suid:
 		/bin/chown root:root $(DESTDIR)$(libexecdir)/singularity/sexec-suid; \
 		echo " /bin/chmod 4755 $(DESTDIR)$(libexecdir)/singularity/sexec-suid"; \
 		/bin/chmod 4755 $(DESTDIR)$(libexecdir)/singularity/sexec-suid; \
-	fi
-
-cleanup_plugin:
-	@if test -e "$(DESTDIR)$(plugindir)/singularity_spank.so"; then \
-		echo "cp $(DESTDIR)$(plugindir)/singularity_spank.so $(DESTDIR)$(plugindir)/backup_singularity_spank"; \
-		cp "$(DESTDIR)$(plugindir)/singularity_spank.so" "$(DESTDIR)$(plugindir)/backup_singularity_spank"; \
-		echo "rm -f $(DESTDIR)$(plugindir)/singularity_spank.*"; \
-		rm -f "$(DESTDIR)$(plugindir)/"singularity_spank.*; \
-		echo "mv $(DESTDIR)$(plugindir)/backup_singularity_spank $(DESTDIR)$(plugindir)/singularity_spank.so"; \
-		mv "$(DESTDIR)$(plugindir)/backup_singularity_spank" "$(DESTDIR)$(plugindir)/singularity.so"; \
 	fi
 
 EXTRA_DIST = config.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,7 +40,7 @@ plugindir = $(libdir)/slurm
 if WITH_SLURM
 plugin_LTLIBRARIES = singularity_spank.la
 singularity_spank_la_SOURCES = slurm/singularity.c
-singularity_spank_la_LIBADD = lib/libsingularity.la
+singularity_spank_la_LIBADD = lib/libsingularity_internal.la
 singularity_spank_la_LDFLAGS = -module -no-undefined -avoid-version -export-symbols-regex '^slurm_spank_|^plugin_'
 endif
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -7,13 +7,18 @@ AM_CFLAGS = -Wall -fpie -fPIC
 AM_LDFLAGS = -pie
 AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
 
+noinst_LTLIBRARIES = libsingularity_internal.la
+libsingularity_internal_la_LIBADD = ns/libns.la rootfs/librootfs.la action/libaction.la mount/libmount.la file/libfile.la
+libsingularity_internal_la_SOURCES = singularity.c privilege.c message.c util.c file.c sessiondir.c config_parser.c fork.c loop-control.c image-util.c
+libsingularity_internal_la_CFLAGS = $(AM_CFLAGS) # This fixes duplicate sources in library and progs
+
 include_HEADERS = singularity.h
 lib_LTLIBRARIES = libsingularity.la
 
-libsingularity_la_LIBADD = ns/libns.la rootfs/librootfs.la action/libaction.la mount/libmount.la file/libfile.la
-libsingularity_la_SOURCES = singularity.c privilege.c message.c util.c file.c sessiondir.c config_parser.c fork.c loop-control.c image-util.c
+libsingularity_la_SOURCES =
+libsingularity_la_LIBADD = libsingularity_internal.la
 libsingularity_la_LDFLAGS = -version-info 1:0:0 
-libsingularity_la_CFLAGS = $(AM_CFLAGS) # This fixes duplicate sources in library and progs
+libsingularity_la_CFLAGS = $(AM_CFLAGS)
 
 EXTRA_DIST = config_parser.h fork.h image-util.h loop-control.h message.h privilege.h sessiondir.h singularity.h
 

--- a/src/lib/message.c
+++ b/src/lib/message.c
@@ -35,7 +35,7 @@ int messagelevel = -1;
 
 extern const char *__progname;
 
-void init(void) {
+static void message_init(void) {
     char *messagelevel_string = getenv("MESSAGELEVEL"); // Flawfinder: ignore (need to get string, validation in atol())
 
     openlog("Singularity", LOG_CONS | LOG_NDELAY, LOG_LOCAL0);
@@ -67,7 +67,7 @@ void _singularity_message(int level, const char *function, const char *file, int
     va_end (args);
 
     if ( messagelevel == -1 ) {
-        init();
+        message_init();
     }
 
     while( ( ! isalpha(file[0]) ) && ( file[0] != '\0') ) {

--- a/src/lib/singularity.h
+++ b/src/lib/singularity.h
@@ -18,6 +18,7 @@
  * 
 */
 
+#include <stdio.h>
 
 #ifndef __SINGULARITY_H_
 #define __SINGULARITY_H_

--- a/src/slurm/Makefile.am
+++ b/src/slurm/Makefile.am
@@ -1,0 +1,23 @@
+
+plugindir = $(libdir)/slurm
+
+if WITH_SLURM
+plugin_LTLIBRARIES = singularity_spank.la
+singularity_spank_la_SOURCES = singularity.c
+singularity_spank_la_LIBADD = ../lib/libsingularity_internal.la
+singularity_spank_la_LDFLAGS = -module -no-undefined -avoid-version -export-symbols-regex '^slurm_spank_|^plugin_'
+endif
+
+install-data-hook: cleanup_plugin
+
+cleanup_plugin:
+	@if test -e "$(DESTDIR)$(plugindir)/singularity_spank.so"; then \
+		echo "cp $(DESTDIR)$(plugindir)/singularity_spank.so $(DESTDIR)$(plugindir)/backup_singularity_spank"; \
+		cp "$(DESTDIR)$(plugindir)/singularity_spank.so" "$(DESTDIR)$(plugindir)/backup_singularity_spank"; \
+		echo "rm -f $(DESTDIR)$(plugindir)/singularity_spank.*"; \
+		rm -f "$(DESTDIR)$(plugindir)/"singularity_spank.*; \
+		echo "mv $(DESTDIR)$(plugindir)/backup_singularity_spank $(DESTDIR)$(plugindir)/singularity_spank.so"; \
+		mv "$(DESTDIR)$(plugindir)/backup_singularity_spank" "$(DESTDIR)$(plugindir)/singularity.so"; \
+	fi
+
+

--- a/src/slurm/README.md
+++ b/src/slurm/README.md
@@ -1,0 +1,39 @@
+
+Singularity plugin for SLURM
+============================
+
+This plugin allows users to execute their SLURM jobs within a Singularity container without
+having to execute Singularity directly.  This assists in simplifying the invocation of the
+container and hiding the implementation details.
+
+To enable the plugin, add the following line to the SLURM plugin configuration (`/etc/slurm/plugstack.conf`):
+
+```
+required singularity.so
+```
+
+This works if Singularity is installed as a system package.  If the install prefix is `/opt/singularity`, then
+one would have:
+
+```
+required /opt/singularity/lib/slurm/singularity.so
+```
+
+Note that the sysadmin may provide a default image that will be utilized if the user doesn't provide one:
+
+```
+required singularity.so default_image=/cvmfs/cernvm-prod.cern.ch/cvm3
+```
+
+Finally, a user may select their image through the `--image` optional argument:
+
+```
+srun --image=/cvmfs/cms.cern.ch/rootfs/x86_64/centos7/latest ls -lh /
+```
+
+Within a batch file:
+
+```
+#SBATCH --image=/cvmfs/cms.cern.ch/rootfs/x86_64/centos7/latest ls -lh /
+```
+

--- a/src/slurm/singularity.c
+++ b/src/slurm/singularity.c
@@ -141,6 +141,7 @@ static int setup_container(spank_t spank) {
     // At this point, the current process is in the runtime container environment.
     // Return control flow back to SLURM: when execv is invoked, it'll be done from
     // within the container.
+    singularity_priv_escalate();
 
     return(0);
 }
@@ -149,7 +150,6 @@ static int setup_container(spank_t spank) {
 static int determine_image(int val, const char *optarg, int remote)
 {
     if (val) {}  // Suppresses unused error...
-    if (remote) { return 0;}
     // TODO: could do some basic path validation here in order to prevent an ABORT() later.
     job_image = strdup(optarg);
 

--- a/src/slurm/singularity.c
+++ b/src/slurm/singularity.c
@@ -1,0 +1,201 @@
+/* 
+ * Copyright (c) 2015-2016, Gregory M. Kurtzer. All rights reserved.
+ * 
+ * “Singularity” Copyright (c) 2016, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of any
+ * required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ * 
+ * This software is licensed under a customized 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ * 
+ * NOTICE.  This Software was developed under funding from the U.S. Department of
+ * Energy and the U.S. Government consequently retains certain rights. As such,
+ * the U.S. Government has been granted for itself and others acting on its
+ * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+ * to reproduce, distribute copies to the public, prepare derivative works, and
+ * perform publicly and display publicly, and to permit other to do so. 
+ * 
+ */
+
+#define _GNU_SOURCE 1
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <string.h>
+
+#include "config.h"
+#include "lib/singularity.h"
+#include "util/util.h"
+#include "util/file.h"
+
+#include "slurm/spank.h"
+
+SPANK_PLUGIN(singularity, 1);
+
+#ifndef SYSCONFDIR
+#define SYSCONFDIR "/etc"
+#endif
+
+#define INT_MAX_STRING_SIZE 30
+
+// These should only be set post-fork and before exec;
+// this means reading / writing to these should be thread-safe.
+static char job_uid_str[INT_MAX_STRING_SIZE];
+static char job_gid_str[INT_MAX_STRING_SIZE];
+static char *job_cwd = NULL;
+static char *job_image = NULL;
+
+static int setup_container_environment(spank_t spank) {
+
+    uid_t job_uid = -1;
+    if (ESPANK_SUCCESS != spank_get_item(spank, S_JOB_UID, &job_uid)) {
+        slurm_error("Failed to get job's target UID");
+        return -1;
+    }
+    if (INT_MAX_STRING_SIZE == snprintf(job_uid_str, INT_MAX_STRING_SIZE, "%u", job_uid)) {
+        slurm_error("Failed to serialize job's UID to string");
+        return -1;
+    }
+    setenv("SINGULARITY_TARGET_UID", job_uid_str, 1);
+    gid_t job_gid = -1;
+    if (ESPANK_SUCCESS != spank_get_item(spank, S_JOB_GID, &job_gid)) {
+        slurm_error("Failed to get job's target GID");
+        return -1;
+    }
+    if (INT_MAX_STRING_SIZE == snprintf(job_gid_str, INT_MAX_STRING_SIZE, "%u", job_gid)) {
+        slurm_error("Failed to serialize job's GID to string");
+        return -1;
+    }
+    setenv("SINGULARITY_TARGET_GID", job_gid_str, 1);
+
+    job_cwd = get_current_dir_name();
+    if (!job_cwd) {
+        slurm_error("Failed to determine job's correct PWD: %s", strerror(errno));
+        return -1;
+    }
+    setenv("SINGULARITY_TARGET_PWD", job_cwd, 1);
+
+    if (!job_image) {
+        slurm_error("Unable to determine job's image file.");
+        return -1;
+    }
+    setenv("SINGULARITY_IMAGE", job_image, 1);
+
+    return 0;
+}
+
+static int setup_container_cwd() {
+    singularity_message(DEBUG, "Trying to change directory to where we started\n");
+    char *target_pwd = envar_path("SINGULARITY_TARGET_PWD");
+    if (!target_pwd || (chdir(target_pwd) < 0)) {
+        singularity_message(ERROR, "Failed to change into correct directory (%s) inside container.", target_pwd ? target_pwd : "UNKNOWN");
+        return -1;
+    }
+    free(target_pwd);
+    return 0;
+}
+
+static int setup_container(spank_t spank) {
+    int rc;
+
+    if ( (rc = setup_container_environment(spank)) != 0) { return rc; }
+    printf("Finished container env setup.\n");
+
+    // Before we do anything, check privileges and drop permission
+    singularity_priv_init();
+    singularity_priv_drop();
+
+    singularity_message(VERBOSE, "Running SLURM/Singularity integration plugin\n");
+
+    singularity_config_open(joinpath(SYSCONFDIR, "/singularity/singularity.conf"));
+
+    singularity_config_rewind();
+
+    char *image;
+    if ( ( image = envar_path("SINGULARITY_IMAGE") ) == NULL ) {
+        singularity_message(ERROR, "SINGULARITY_IMAGE not defined!\n");
+    }
+
+    singularity_rootfs_init(image);
+    singularity_sessiondir_init(image);
+
+    free(image);
+
+    singularity_ns_unshare();
+
+    singularity_rootfs_mount();
+
+    singularity_rootfs_check();
+
+    singularity_file();
+
+    singularity_mount();
+
+    singularity_rootfs_chroot();
+
+    if ( (rc = setup_container_cwd()) < 0) {return rc;}
+
+    // At this point, the current process is in the runtime container environment.
+    // Return control flow back to SLURM: when execv is invoked, it'll be done from
+    // within the container.
+
+    return(0);
+}
+
+// TODO: When run on the submit host, we should evaluate the URL and create/cache docker images as necessary.
+static int determine_image(int val, const char *optarg, int remote)
+{
+    if (val) {}  // Suppresses unused error...
+    if (remote) { return 0;}
+    // TODO: could do some basic path validation here in order to prevent an ABORT() later.
+    job_image = strdup(optarg);
+
+    return job_image == NULL;
+}
+
+/// SPANK plugin functions.
+
+int slurm_spank_init(spank_t spank, int ac, char **av)
+{
+    struct spank_option image_opt;
+    memset(&image_opt, '\0', sizeof(image_opt));
+    image_opt.name = "image";
+    image_opt.arginfo = "[path]";
+    image_opt.usage = "Specify a path to a Singularity image, directory tree, or Docker image";
+    image_opt.has_arg = 1;
+    image_opt.val = 0;
+    image_opt.cb = determine_image;
+    if (ESPANK_SUCCESS != spank_option_register(spank, &image_opt)) {
+        slurm_error("singularity: Unable to register a new option.");
+        return -1;
+    }
+
+    // Make this a no-op except when starting the task.
+    if (spank_context() == S_CTX_ALLOCATOR || (spank_remote(spank) != 1)) {
+        return 0;
+    }
+
+    int i;
+    for (i = 0; i < ac; i++) {
+        if (strncmp ("default_image=", av[i], 14) == 0) {
+            const char *optarg = av[i] + 14;
+            job_image = strdup(optarg);
+        } else {
+            slurm_error ("singularity: Invalid option: %s", av[i]);
+        }
+    }
+
+    return 0;
+}
+
+int slurm_spank_task_init_privileged(spank_t spank, int ac, char *argv[])
+{
+    if (job_image) {
+        return setup_container(spank);
+    }
+    return 0;
+}
+


### PR DESCRIPTION
This PR creates a SLURM plugin.  With this installed, a user can add an `--image` argument such as:

```
srun --image /cvmfs/cms.cern.ch/rootfs/x86_64/centos7/latest/ /usr/bin/ls /opt
```

With this, `singularity` does not need to be explicitly called by the user - instead, the user can just state the intent and have the batch system figure it out.

This utilizes the "SPANK" API provided by SLURM.  SPANK allows us to call code as root, after forking but prior to `exec`ing the job -- but does not allow us to actually prefix the job with a call to `singularity` (manipulating the `argv` string).  Hence, we must do the image and namespace initialization inside the plugin instead of as part of the `singularity` executable.  While this is more complex, it _does_ eliminate the need to have a `setuid` binary.

This contains support for file- and directory-based images.  Docker can be done as part of the followup.
