### PR TITLE
Enable 'mount slave' by default

### DIFF
--- a/src/lib/ns/mnt/mnt.c
+++ b/src/lib/ns/mnt/mnt.c
@@ -47,7 +47,7 @@ int singularity_ns_mnt_unshare(void) {
     singularity_config_rewind();
     int slave;
 
-    slave = singularity_config_get_bool("mount slave", 0);
+    slave = singularity_config_get_bool("mount slave", 1);
 
     singularity_priv_escalate();
 #ifdef NS_CLONE_FS


### PR DESCRIPTION
We previously set `mount slave = yes` as the default in the config file; this simply changes the code to have the same default value.