### PR TITLE
Removed assumption that certain programs are located in /bin/ for NixOS

### DIFF
--- a/libexec/cli/create.exec
+++ b/libexec/cli/create.exec
@@ -92,7 +92,7 @@ fi
 if [ -f "$SINGULARITY_IMAGE" ]; then
     if [ -n "${OVERWRITE:-}" ]; then
         message 2 "Removing existing file\n"
-        /bin/rm -f "$SINGULARITY_IMAGE"
+        rm -f "$SINGULARITY_IMAGE"
     else
         message ERROR "Image file exists, not overwriting.\n"
         exit 1

--- a/libexec/functions
+++ b/libexec/functions
@@ -22,12 +22,12 @@
 set -u
 
 if [ -z "${SINGULARITY_libexecdir:-}" ]; then
-    /bin/echo "ERROR: SINGULARITY_libexecdir not defined in environment"
+    echo "ERROR: SINGULARITY_libexecdir not defined in environment"
     exit 2
 fi
 
 if [ -z "${MESSAGELEVEL:-}" ]; then
-    /bin/echo "Warning: MESSAGELEVEL is undefined, temporarily setting to '5' (all messages)"
+    echo "Warning: MESSAGELEVEL is undefined, temporarily setting to '5' (all messages)"
     MESSAGELEVEL=5
 fi
 

--- a/libexec/helpers/copy.sh
+++ b/libexec/helpers/copy.sh
@@ -37,4 +37,4 @@ fi
 argc=$(($#))
 argc_1=$(($#-1))
 
-exec /bin/cp "${@:1:$argc_1}" "$SINGULARITY_ROOTFS/${@:$argc}"
+exec cp "${@:1:$argc_1}" "$SINGULARITY_ROOTFS/${@:$argc}"


### PR DESCRIPTION
Fixes #300 

Changes proposed in this pull request

 - Certain scripts in `libexec/*` assumed that programs would be located in `/bin/`. These assumptions are removed

@singularityware-admin

