### PR TITLE
Correct the typo 'avaialble' in the verbose output.

### DIFF
--- a/src/lib/loop-control.c
+++ b/src/lib/loop-control.c
@@ -130,7 +130,7 @@ char *singularity_loop_bind(FILE *image_fp) {
 
     }
 
-    singularity_message(VERBOSE, "Found avaialble loop device: %s\n", loop_dev);
+    singularity_message(VERBOSE, "Found available loop device: %s\n", loop_dev);
 
     singularity_message(DEBUG, "Setting loop device flags\n");
     if ( ioctl(fileno(loop_fp), LOOP_SET_STATUS64, &lo64) < 0 ) {


### PR DESCRIPTION
Currently a typo exists in the verbose messages.
e.g.

` VERBOSE: Found avaialble loop device: /dev/loop0`

 This PR fixes this. 

@singularityware-admin

