### PR TITLE
Fix failed import exit

### DIFF
--- a/libexec/functions
+++ b/libexec/functions
@@ -1,23 +1,23 @@
 #!/bin/bash
-# 
+#
 # Copyright (c) 2015-2016, Gregory M. Kurtzer. All rights reserved.
-# 
+#
 # “Singularity” Copyright (c) 2016, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
-# 
+#
 # This software is licensed under a customized 3-clause BSD license.  Please
 # consult LICENSE file distributed with the sources of this project regarding
 # your rights to use or distribute this software.
-# 
+#
 # NOTICE.  This Software was developed under funding from the U.S. Department of
 # Energy and the U.S. Government consequently retains certain rights. As such,
 # the U.S. Government has been granted for itself and others acting on its
 # behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 # to reproduce, distribute copies to the public, prepare derivative works, and
-# perform publicly and display publicly, and to permit other to do so. 
-# 
-# 
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
 
 set -u
 
@@ -262,7 +262,7 @@ parse_opts() {
                 shift
                 continue
             ;;
-            *)  
+            *)
                 NEWOPTS="$NEWOPTS $@"
                 break
             ;;

--- a/libexec/helpers/image-import.sh
+++ b/libexec/helpers/image-import.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
-# 
+#
 # Copyright (c) 2015-2016, Gregory M. Kurtzer. All rights reserved.
-# 
+#
 # “Singularity” Copyright (c) 2016, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
-# 
+#
 # This software is licensed under a customized 3-clause BSD license.  Please
 # consult LICENSE file distributed with the sources of this project regarding
 # your rights to use or distribute this software.
-# 
+#
 # NOTICE.  This Software was developed under funding from the U.S. Department of
 # Energy and the U.S. Government consequently retains certain rights. As such,
 # the U.S. Government has been granted for itself and others acting on its
 # behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 # to reproduce, distribute copies to the public, prepare derivative works, and
-# perform publicly and display publicly, and to permit other to do so. 
-# 
-# 
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
 
 
 ## Basic sanity
@@ -96,6 +96,12 @@ case "$IMPORT_URI" in
 esac
 
 eval "$SINGULARITY_IMPORT_GET ${SINGULARITY_IMPORT_SPLAT:-}"
+
+ret_val=$?
+if [ $ret_val != 0 ];then
+    ABORT $ret_val
+fi
+
 eval "$SINGULARITY_libexecdir/singularity/bootstrap/main.sh"
 
 exit $?

--- a/test.sh.in
+++ b/test.sh.in
@@ -1,23 +1,23 @@
 #!/bin/bash
-# 
+#
 # Copyright (c) 2015-2016, Gregory M. Kurtzer. All rights reserved.
-# 
+#
 # "Singularity" Copyright (c) 2016, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
-# 
+#
 # This software is licensed under a customized 3-clause BSD license.  Please
 # consult LICENSE file distributed with the sources of this project regarding
 # your rights to use or distribute this software.
-# 
+#
 # NOTICE.  This Software was developed under funding from the U.S. Department of
 # Energy and the U.S. Government consequently retains certain rights. As such,
 # the U.S. Government has been granted for itself and others acting on its
 # behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 # to reproduce, distribute copies to the public, prepare derivative works, and
-# perform publicly and display publicly, and to permit other to do so. 
-# 
-# 
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
 
 
 prefix="@prefix@"
@@ -210,6 +210,9 @@ stest 0 sudo rm -f "$CONTAINER"
 stest 0 sudo singularity create -s 568 "$CONTAINER"
 stest 0 sh -c "cat ${CONTAINERDIR}.tar | sudo singularity import $CONTAINER"
 stest 1 sh -c "sudo singularity import $CONTAINER not_a_file 2>&1 | grep "unbound variable""
+stest 1 sudo singularity import ${CONTAINER} http://fake_singularity_url
+stest 1 sudo singularity import ${CONTAINER} docker://not_a_docker_container/nope_nope_singularity
+stest 1 sh -c "sudo singularity import ${CONTAINER} docker://not_a_docker_container/nope_nope_singularity | grep 'ERROR: Container does not contain the valid minimum requirement of /bin/sh'"
 
 
 /bin/echo
@@ -229,7 +232,7 @@ stest 1 singularity exec $CONTAINERDIR ping localhost -c 1
 /bin/echo "Checking target UID mode"
 stest 0 sh -c "sudo SINGULARITY_TARGET_GID=`id -g` SINGULARITY_TARGET_UID=`id -u` singularity exec $CONTAINER whoami | grep -q `id -un`"
 
- 
+
 #TODO: The following tests must be conditional based on host capabilities
 /bin/echo
 /bin/echo "Disabling setuid config flag"


### PR DESCRIPTION
Fixes #307 

Changes proposed in this pull request

- Fix failed import error handling.

Previously an import command that failed to retrieve its image (via
docker or http/s) would carry on and run bootstrap anyway, this change
fixes that so we exit with the return code of the retrieval.

@singularityware-admin
