### PR TITLE
Fix unbound variable in image import.

### DIFF
--- a/libexec/helpers/image-import.sh
+++ b/libexec/helpers/image-import.sh
@@ -76,7 +76,7 @@ case "$IMPORT_URI" in
     ;;
     *)
         if [ ! -f "$IMPORT_URI" ]; then
-            message ERROR "File not found: $LOCAL_FILE\n"
+            message ERROR "File not found: $IMPORT_URI\n"
             ABORT 1
         fi
         SINGULARITY_IMPORT_GET="cat $IMPORT_URI"

--- a/test.sh.in
+++ b/test.sh.in
@@ -209,6 +209,7 @@ stest 0 sudo chmod 0644 ${CONTAINERDIR}.tar
 stest 0 sudo rm -f "$CONTAINER"
 stest 0 sudo singularity create -s 568 "$CONTAINER"
 stest 0 sh -c "cat ${CONTAINERDIR}.tar | sudo singularity import $CONTAINER"
+stest 1 sh -c "sudo singularity import $CONTAINER not_a_file 2>&1 | grep "unbound variable""
 
 
 /bin/echo


### PR DESCRIPTION
Changes proposed in this pull request

 - Fix unbound variable in image import.

@singularityware-admin

When importing via a file path and not specifying `file:///` as the
protocol the `LOCAL_FILE` variable is not defined resulting in an
`unbound variable` error.

This replaces the use of `LOCAL_FILE` with `IMPORT_URI`.