### PR TITLE
Add/caching and dockerfile

### DIFF
--- a/libexec/python/Makefile.am
+++ b/libexec/python/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = docker
 
 scriptlibexecdir = $(libexecdir)/singularity/python
 
-dist_scriptlibexec_SCRIPTS = cli.py __init__.py utils.py
+dist_scriptlibexec_SCRIPTS = cli.py __init__.py utils.py defaults.py
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -25,7 +25,7 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 from docker.api import get_layer, create_runscript, get_manifest, get_config, get_images
-from utils import extract_tar, change_permissions
+from utils import extract_tar, change_permissions, get_cache
 import argparse
 import os
 import re
@@ -70,6 +70,14 @@ def main():
                         dest='notoken', 
                         action="store_true",
                         help="boolean to specify that the CMD should be included as a runscript (default is not included)", 
+                        default=False)
+
+
+    # Flag to disable cache
+    parser.add_argument("--no-cache", 
+                        dest='disable_cache', 
+                        action="store_true",
+                        help="boolean to specify disabling the cache.", 
                         default=False)
 
     
@@ -154,26 +162,32 @@ def main():
 #  DOWNLOAD LAYERS -------------------------------------------
 # Each is a .tar.gz file, obtained from registry with curl
 
-        # Create a temporary directory for targzs
-        tmpdir = tempfile.mkdtemp()
+        # Get the cache (or temporary one) for docker
+        cache_base = get_cache(subfolder="docker", 
+                               disable_cache = args.disable_cache)
+
         layers = []
 
         for image_id in images:
 
-            # Download the layer
-            targz = get_layer(image_id=image_id,
-                              namespace=namespace,
-                              repo_name=repo_name,
-                              download_folder=tmpdir,
-                              registry=args.registry,
-                              auth=doauth) 
+            # Download the layer, if we don't have it
+            targz = "%s/%s.tar.gz" %(cache_base,image_id)
+ 
+            if not os.path.exists(targz):
+                targz = get_layer(image_id=image_id,
+                                  namespace=namespace,
+                                  repo_name=repo_name,
+                                  download_folder=cache_base,
+                                  registry=args.registry,
+                                  auth=doauth) 
 
             layers.append(targz) # in case we want a list at the end
                                  # @chrisfilo suggestion to try compiling into one tar.gz
 
             # Extract image and remove tar
             extract_tar(targz,singularity_rootfs)
-            os.remove(targz)
+            if args.disable_cache == True:
+                os.remove(targz)
                
      
     # If the user wants to include the CMD as runscript, generate it here
@@ -190,8 +204,9 @@ def main():
             # change permission of runscript to 0755 (default)
             change_permissions("%s/singularity" %(singularity_rootfs))
 
-    # When we finish, change permissions for the entire thing
-    #change_permissions("%s/" %(singularity_rootfs))
+    # When we finish, clean up images
+    if args.disable_cache == True:
+        shutil.rmtree(cache_base)
 
 
 if __name__ == '__main__':

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -91,7 +91,7 @@ def main():
     if args.rootfs != None:
        singularity_rootfs = args.rootfs
     else:
-       singularity_rootfs = os.environ.get("SINGULARITY_ROOTFS",None)
+       singularity_rootfs = os.environ.get("SINGULARITY_ROOTFS", None)
        if singularity_rootfs == None:
            print("ERROR: root file system not specified or defined as environmental variable, exiting!")
            sys.exit(1)

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+'''
+defaults.py: python helper for singularity command line tool. This script stores
+default variables for core python modules for singularity, akin to __init__.py.
+
+Copyright (c) 2016, Vanessa Sochat. All rights reserved. 
+
+"Singularity" Copyright (c) 2016, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ 
+This software is licensed under a customized 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
+ 
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights. As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so. 
+
+'''
+
+import os
+
+SINGULARITY_CACHE = os.path.join(os.environ.get("HOME"),".singularity")

--- a/libexec/python/docker/Makefile.am
+++ b/libexec/python/docker/Makefile.am
@@ -1,6 +1,6 @@
 scriptlibexecdir = $(libexecdir)/singularity/python/docker
 
-dist_scriptlibexec_SCRIPTS = api.py __init__.py
+dist_scriptlibexec_SCRIPTS = api.py __init__.py converter.py
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -2,7 +2,7 @@
 
 '''
 
-docker.py: Docker helper functions for Singularity in Python
+api.py: Docker helper functions for Singularity in Python
 
 Copyright (c) 2016, Vanessa Sochat. All rights reserved. 
 

--- a/libexec/python/docker/converter.py
+++ b/libexec/python/docker/converter.py
@@ -23,6 +23,8 @@ perform publicly and display publicly, and to permit other to do so.
 
 '''
 
+import json
+import os
 import re
 import sys
 sys.path.append('..') # parent directory
@@ -61,7 +63,6 @@ def parse_env(env):
                     value = "%s %s" %(value,contender)
         exports.append(join_env(name,value))
         return "\n".join(exports)
-
     # otherwise, the rule is one per line
     else: 
         name,value = re.split(' ',env,1)
@@ -77,7 +78,14 @@ def join_env(name,value):
 
 def parse_cmd(cmd):
     '''parse_cmd will parse a Dockerfile CMD command to a singularity appropriate one
-    eg: CMD /code/run_uwsgi.sh --> exec /code/run_uwsgi.sh
+    eg: CMD /code/run_uwsgi.sh --> /code/run_uwsgi.sh.
+    '''
+    return "%s" %(cmd)
+
+
+def parse_entry(cmd):
+    '''parse_entry will parse a Dockerfile ENTRYPOINT command to a singularity appropriate one
+    eg: ENTRYPOINT /code/run_uwsgi.sh --> exec /code/run_uwsgi.sh.
     '''
     return "exec %s" %(cmd)
 
@@ -90,33 +98,59 @@ def parse_copy(copy_str):
     return "cp %s" %(copy_str)
 
 
-def parse_add(add)
+def parse_http(url,destination):
+    '''parse_http will get the filename of an http address, and return a statement
+    to download it to some location
+    '''
+    file_name = os.path.basename(url)
+    download_path = "%s/%s" %(to_thing,file_name)
+    return "curl %s -o %s" %(url,download_path)
+
+
+def parse_targz(targz,destination):
+    '''parse_targz will return a commnd to extract a targz file to a destination.
+    '''
+    return "tar -xzvf %s %s" %(targz,destination)
+
+
+def parse_zip(zipfile,destination):
+    '''parse_zipfile will return a commnd to unzip a file to a destination.
+    '''
+    return "unzip %s %s" %(targz,destination)
+
+
+def parse_add(add):
     '''parse_add will copy multiple files from one location to another. This likely will need
     tweaking, as the files might need to be mounted from some location before adding to
     the image. The add command is done for an entire directory.
     :param add: the command to parse
     '''
     from_thing,to_thing = add.split(" ")
-
-    # If it's a url or http address, then we need to use wget/curl to get it
-    if re.search("^http",from_thing):
-        return "curl %s -o %s" %(from_thing,to_thing)
-
     # People like to use dots for PWD.
     if from_thing == ".":
         from_thing = os.getcwd()
     if to_thing == ".":
         to_thing = os.getcwd()
-
+    # If it's a url or http address, then we need to use wget/curl to get it
+    if re.search("^http",from_thing):
+        return parse_http(url=from_thing,
+                          destination=to_thing)
+    # If it's a tar.gz, then we are supposed to uncompress
+    if re.search(".tar.gz$",from_thing):
+        return parse_targz(targz=from_thing,
+                           destination=to_thing)
+    # If it's .zip, then we are supposed to unzip it
+    if re.search(".zip$",from_thing):
+        return parse_zip(zipfile=from_thing,
+                         destination=to_thing)
     # Is from thing a directory or something else?
     if os.path.isdir(from_thing):
         return "cp -R %s %s" %(from_thing,to_thing)
+    else:
+        return "cp %s %s" %(from_thing,to_thing)
 
-    print("Cannot determine add command for %s, skipping" %(add))     
-    return ""
 
-
-def parse_workdir(workdir)
+def parse_workdir(workdir):
     '''parse_workdir will simply cd to the working directory
     '''
     return "cd %s" %(workdir)
@@ -125,35 +159,69 @@ def parse_workdir(workdir)
 def get_mapping():
     '''get_mapping returns a dictionary mapping from a Dockerfile command to a Singularity
     build spec section. Note - this currently ignores lines that we don't know what to do with
-    in the context of Singularity (eg, EXPOSE, LABEL, USER, VOLUME, STOPSIGNAL)
+    in the context of Singularity (eg, EXPOSE, LABEL, USER, VOLUME, STOPSIGNAL, escape,
+    MAINTAINER)
+
+    :: note
+    each KEY of the mapping should be a command start in the Dockerfile (eg, RUN)
+    for each corresponding value, there should be a dictionary with the following:
+    
+        - section: the Singularity build file section to write the new command to
+        - fun: any function to pass the output through before writing to the section (optional)
+        - json: Boolean, if the section can optionally have json (eg a list)
+
+    I'm not sure the subtle differences between add and copy, other than copy doesn't support
+    external files. It should suffice for our purposes (for now) to use the same function 
+    (parse_add) until evidence for a major difference is determined.
     '''
     #  Docker : Singularity
-    add_command = {"section": "%post", "fun": parse_copy }  
-    copy_command = {"section": "%post", "fun": parse_copy }  
-    cmd_command = {"section": "%runscript", "fun": parse_cmd }  
-    env_command = {"section": "%post", "fun": parse_env } 
-    from_command = {"section": "From"}
-    run_command = {"section": "%post"}       
-    workdir_command = {"section": "%post", "fun": parse_workdir }  
+    add_command = {"section": "%post","fun": parse_add, "json": True }
+    copy_command = {"section": "%post", "fun": parse_add, "json": True }  
+    cmd_command = {"section": "%runscript", "fun": parse_cmd, "json": True }  
+    env_command = {"section": "%post", "fun": parse_env, "json": False }
+    from_command = {"section": "From", "json": False }
+    run_command = {"section": "%post", "json": True}       
+    workdir_command = {"section": "%post","fun": parse_workdir, "json": False }  
+    entry_command = {"section": "%post", "fun": parse_entry, "json": True }
 
     return {"ADD": add_command,
+            "COPY":copy_command,
+            "CMD":cmd_command,
+            "ENTRYPOINT":entry_command,
             "ENV": env_command,
             "FROM": from_command,
+            "RUN":run_command,
             "WORKDIR":workdir_command}
            
-    # STOPPING FOR TODAY - remainder of parsing functions need to be written, tested,
-    # and the mapping finished, and then the mapping used in organize_sections!
+    
 
-
-def dockerfile_to_singularity(dockerfile_path, output_dir):
+def dockerfile_to_singularity(dockerfile_path, output_dir=None):
     '''dockerfile_to_singularity will return a Singularity build file based on
-    a provided Dockerfile
+    a provided Dockerfile. If output directory is not specified, the string
+    will be returned. Otherwise, a file called Singularity will be written to 
+    output_dir
     :param dockerfile_path: the path to the Dockerfile
     :param output_dir: the output directory to write the Singularity file to
     '''
     if os.path.basename(dockerfile_path) == "Dockerfile":
         spec = read_file(dockerfile_path)
+        # Use a common mapping
+        mapping = get_mapping()
+   
+        # Put into dict of keys (section titles) and list of commands (values)
+        sections = organize_sections(lines=spec,
+                                     mapping=mapping)
 
+        # We have to, by default, add the Docker bootstrap
+        sections["bootstrap"] = ["docker"]
+
+        # Put into one string based on "order" variable in mapping
+        build_file = print_sections(sections=sections,
+                                    mapping=mapping)
+        if output_dir != None:
+            write_file("%s/Singularity" %(output_dir),build_file)
+            print("Singularity spec written to %s" %(output_dir))
+        return build_file
 
     # If we make it here, something didn't work
     return sys.exit(1)
@@ -165,13 +233,83 @@ def organize_sections(lines,mapping=None):
     :param lines: the raw lines from the Dockerfile
     :mapping: a dictionary mapping Docker commands to Singularity sections
     '''
+    if mapping == None:
+        mapping = get_mapping()
+    sections = dict()
+    startre = "|".join(["^%s" %x for x in mapping.keys()])
+    command = None
+    name = None
+    while len(lines) > 0:
+        line = lines.pop(0)
+        # Do we have a new line/section?
+        if re.search(startre,line):
+            # Parse the last section, and start over
+            if command != None and name != None:
+                sections = parse_section(name=name,
+                                         command=command,
+                                         mapping=mapping,
+                                         sections=sections)
+                name,command = line.split(" ",1)
+        # We have a continuation of the last command or an empty line
+        else:
+            command = "%s %s" %(command,line)
 
-    #TODO: read in lines until we reach the next section.
-    # If section isn't in list, or is, parse to one or the other (FOR: RUN,CMD)
-    # send entire section to be parsed and put (as a unit) into an object
+    return sections
+
+def parse_section(sections,name,command,mapping=None):
+    '''parse_section will take a command that has lookup key "name" as a key in "mapping"
+    and add a line to the list of each in sections that will be rendered into a Singularity
+    build file.
+    :param sections: the current sections, a dictionary of keys (singularity section titles)
+    and a list of lines.
+    :param name: the name of the section to add
+    :param command: the command to parse:
+    :param mapping: the mapping object to use
+    '''
+    if mapping == None:
+        mapping = get_mapping()
+    if name in mapping:
+        build_section = mapping[name]['section']
+        # Can the command potentially be json (a list?)
+        if mapping[name]['json']:
+            try:
+                command = " ".join(json.loads(command))
+            except:
+                pass 
+        # Do we need to pass it through a function first?
+        if 'fun' in mapping[name]:
+            command = mapping[name]['fun'](command)
+        # Add to our dictionary of sections!
+        if build_section not in sections:
+            sections[build_section] = [command]
+        else:
+            sections[build_section].append(command)
+    return sections
 
 
-def sniff_command(line):
-    '''sniff_command will return the command type and command for one or more lines
-    :param line: the line to read
+def print_sections(sections,mapping=None):
+    '''print_sections will take a sections object (dict with section names and
+    list of commands) and parse into a common string, to output to file or return
+    to user.
+    :param sections: output from organize_sections
+    :mapping: a dictionary mapping Docker commands to Singularity sections
+    '''
+    if mapping == None:
+        mapping = get_mapping()
+    finished_spec = ""
+    ordering = ['bootstrap',"From","%runscript","%post"]
 
+    for section in ordering:
+
+        # Was the section found in the file?
+        if section in sections:
+            if not re.search("^%",section):
+                # A single command, intended to go after a colon (yaml)
+                content = "".join(sections[section])
+                finished_spec = "%s\n%s:%s" %(finished_spec,section,content)
+            else:
+                # A list of things to join, after the section header
+                content = "".join(sections[section])
+                finished_spec = "%s\n%s\n%s" %(finished_spec,section,content)
+
+    return finished_spec

--- a/libexec/python/docker/converter.py
+++ b/libexec/python/docker/converter.py
@@ -125,29 +125,37 @@ def parse_add(add):
     the image. The add command is done for an entire directory.
     :param add: the command to parse
     '''
-    from_thing,to_thing = add.split(" ")
+    # In the case that there are newlines or comments
+    command,rest = add.split('\n',1)
+    from_thing,to_thing = command.split(" ")
+
     # People like to use dots for PWD.
     if from_thing == ".":
         from_thing = os.getcwd()
     if to_thing == ".":
         to_thing = os.getcwd()
+
     # If it's a url or http address, then we need to use wget/curl to get it
     if re.search("^http",from_thing):
-        return parse_http(url=from_thing,
-                          destination=to_thing)
+        result = parse_http(url=from_thing,
+                           destination=to_thing)
+
     # If it's a tar.gz, then we are supposed to uncompress
     if re.search(".tar.gz$",from_thing):
-        return parse_targz(targz=from_thing,
-                           destination=to_thing)
+        result = parse_targz(targz=from_thing,
+                             destination=to_thing)
+
     # If it's .zip, then we are supposed to unzip it
     if re.search(".zip$",from_thing):
-        return parse_zip(zipfile=from_thing,
+        result = parse_zip(zipfile=from_thing,
                          destination=to_thing)
+
     # Is from thing a directory or something else?
     if os.path.isdir(from_thing):
-        return "cp -R %s %s" %(from_thing,to_thing)
+        result = "cp -R %s %s" %(from_thing,to_thing)
     else:
-        return "cp %s %s" %(from_thing,to_thing)
+        result = "cp %s %s" %(from_thing,to_thing)
+    return "%s\n%s" %(result,rest)
 
 
 def parse_workdir(workdir):
@@ -249,7 +257,7 @@ def organize_sections(lines,mapping=None):
                                          command=command,
                                          mapping=mapping,
                                          sections=sections)
-                name,command = line.split(" ",1)
+            name,command = line.split(" ",1)
         # We have a continuation of the last command or an empty line
         else:
             command = "%s %s" %(command,line)

--- a/libexec/python/docker/converter.py
+++ b/libexec/python/docker/converter.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+
+'''
+
+converted.py: Parse a Dockerfile into a Singularity spec file
+
+Copyright (c) 2016, Vanessa Sochat. All rights reserved. 
+
+"Singularity" Copyright (c) 2016, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ 
+This software is licensed under a customized 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
+ 
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights. As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so. 
+
+'''
+
+import re
+import sys
+sys.path.append('..') # parent directory
+
+from utils import write_file, read_file
+import json
+
+# Parsing functions ---------------------------------------------------------------
+
+def parse_env(env):
+    '''parse_env will parse a Dockerfile ENV command to a singularity appropriate one
+    eg: ENV PYTHONBUFFER 1 --> export PYTHONBUFFER=1
+    ::note  This has to handle multiple exports per line. In the case of having an =,
+    It could be that we have more than one pair of variables. If no equals, then
+    we probably don't. See:
+    see: https://docs.docker.com/engine/reference/builder/#/env
+    '''
+    # If the user has "=" then we can have more than one export per line
+    exports = []
+    name = None
+    value = None
+    if re.search("=",env):
+        pieces = [p for p in re.split("( |\\\".*?\\\"|'.*?')", env) if p.strip()]
+        while len(pieces) > 0:
+            contender = pieces.pop(0)
+            # If there is an equal, we've found a name
+            if re.search("=",contender):
+                if name != None:
+                    exports.append(join_env(name,value))
+                name = contender         
+                value = None
+            else:
+                if value == None:
+                    value = contender
+                else:
+                    value = "%s %s" %(value,contender)
+        exports.append(join_env(name,value))
+        return "\n".join(exports)
+
+    # otherwise, the rule is one per line
+    else: 
+        name,value = re.split(' ',env,1)
+        return "export %s=%s" %(name,value)
+    
+
+def join_env(name,value):
+    # If it's the end of the string, we don't want a space
+    if re.search("=$",name):
+        return "export %s%s" %(name,value)
+    return "export %s %s" %(name,value)
+
+
+def parse_cmd(cmd):
+    '''parse_cmd will parse a Dockerfile CMD command to a singularity appropriate one
+    eg: CMD /code/run_uwsgi.sh --> exec /code/run_uwsgi.sh
+    '''
+    return "exec %s" %(cmd)
+
+
+def parse_copy(copy_str):
+    '''parse_copy will copy a file from one location to another. This likely will need
+    tweaking, as the files might need to be mounted from some location before adding to
+    the image.
+    '''
+    return "cp %s" %(copy_str)
+
+
+def parse_add(add)
+    '''parse_add will copy multiple files from one location to another. This likely will need
+    tweaking, as the files might need to be mounted from some location before adding to
+    the image. The add command is done for an entire directory.
+    :param add: the command to parse
+    '''
+    from_thing,to_thing = add.split(" ")
+
+    # If it's a url or http address, then we need to use wget/curl to get it
+    if re.search("^http",from_thing):
+        return "curl %s -o %s" %(from_thing,to_thing)
+
+    # People like to use dots for PWD.
+    if from_thing == ".":
+        from_thing = os.getcwd()
+    if to_thing == ".":
+        to_thing = os.getcwd()
+
+    # Is from thing a directory or something else?
+    if os.path.isdir(from_thing):
+        return "cp -R %s %s" %(from_thing,to_thing)
+
+    print("Cannot determine add command for %s, skipping" %(add))     
+    return ""
+
+
+def parse_workdir(workdir)
+    '''parse_workdir will simply cd to the working directory
+    '''
+    return "cd %s" %(workdir)
+
+
+def get_mapping():
+    '''get_mapping returns a dictionary mapping from a Dockerfile command to a Singularity
+    build spec section. Note - this currently ignores lines that we don't know what to do with
+    in the context of Singularity (eg, EXPOSE, LABEL, USER, VOLUME, STOPSIGNAL)
+    '''
+    #  Docker : Singularity
+    add_command = {"section": "%post", "fun": parse_copy }  
+    copy_command = {"section": "%post", "fun": parse_copy }  
+    cmd_command = {"section": "%runscript", "fun": parse_cmd }  
+    env_command = {"section": "%post", "fun": parse_env } 
+    from_command = {"section": "From"}
+    run_command = {"section": "%post"}       
+    workdir_command = {"section": "%post", "fun": parse_workdir }  
+
+    return {"ADD": add_command,
+            "ENV": env_command,
+            "FROM": from_command,
+            "WORKDIR":workdir_command}
+           
+    # STOPPING FOR TODAY - remainder of parsing functions need to be written, tested,
+    # and the mapping finished, and then the mapping used in organize_sections!
+
+
+def dockerfile_to_singularity(dockerfile_path, output_dir):
+    '''dockerfile_to_singularity will return a Singularity build file based on
+    a provided Dockerfile
+    :param dockerfile_path: the path to the Dockerfile
+    :param output_dir: the output directory to write the Singularity file to
+    '''
+    if os.path.basename(dockerfile_path) == "Dockerfile":
+        spec = read_file(dockerfile_path)
+
+
+    # If we make it here, something didn't work
+    return sys.exit(1)
+
+
+def organize_sections(lines,mapping=None):
+    '''organize_sections will break apart lines from a Dockerfile, and put into 
+    appropriate Singularity sections.
+    :param lines: the raw lines from the Dockerfile
+    :mapping: a dictionary mapping Docker commands to Singularity sections
+    '''
+
+    #TODO: read in lines until we reach the next section.
+    # If section isn't in list, or is, parse to one or the other (FOR: RUN,CMD)
+    # send entire section to be parsed and put (as a unit) into an object
+
+
+def sniff_command(line):
+    '''sniff_command will return the command type and command for one or more lines
+    :param line: the line to read
+

--- a/libexec/python/docker/converter.py
+++ b/libexec/python/docker/converter.py
@@ -30,6 +30,7 @@ import sys
 sys.path.append('..') # parent directory
 
 from utils import write_file, read_file
+from logman import logger
 import json
 
 # Parsing functions ---------------------------------------------------------------
@@ -232,6 +233,7 @@ def dockerfile_to_singularity(dockerfile_path, output_dir=None):
         return build_file
 
     # If we make it here, something didn't work
+    logger.error("Could not find %s, exiting.", dockerfile_path)
     return sys.exit(1)
 
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -223,7 +223,7 @@ def get_cache(cache_base=None,subfolder=None,disable_cache=False):
         cache_base = "%s/%s" %(cache_base,subfolder)
         if not os.path.exists(cache_base):
             os.mkdir(cache_base)
-    print("Cache folder set to %s" %(cache_base))
+    logger.info("Cache folder set to %s", cache_base)
     return cache_base
 
 


### PR DESCRIPTION
Fixes #312 and #283 

Changes proposed in this pull request

- The first part of this PR is adding a cache for docker layers (see details below)
- The second component is adding a python module to convert a Dockerfile to Singularity file (or string), as promised. The use case for this is when a user wants to generate a Singularity image from a Dockerfile they have locally, as not all images are available on the hub (eg, those in progress, private). See details below.

## Cache for Docker Layers
Currently, when a Docker image is bootstrapped, meaning layers are pulled from the registry and dumped into an image, we download and then remove them. This works fine, but the software should have the ability to cache layers, to either save time, or some other context where the download isn't available. To this end, to the python code I have added the following functionality:

- The environment variable `SINGULARITY_CACHE` determines the base of the cache directory.
- If not defined, the default (set in [defaults.py](https://github.com/vsoch/singularity/blob/add/caching-and-dockerfile/libexec/python/defaults.py#L28) is to use a hidden folder called `.singularity` in the user's home directory. 

### Notes on the default `SINGULARITY_CACHE`
I must be careful with the term USER, as when it is run by root that becomes root's home, and the user doesn't actually see it. This is why this variable should likely be defined/exported as the true user's home (not sure how, but it would need to happen before the python script is called) OR we set the default to be somewhere else). The problems I see with having the cache be in some install folder is that it can be lost given a new install, but maybe this isn't an issue. Definitely open (and hoping for) suggestions here!

- Next, with anticipation of wanting to cache other kinds of image layers and things, the function to [get_cache](https://github.com/vsoch/singularity/blob/add/caching-and-dockerfile/libexec/python/utils.py#L194) takes an optional subfolder, and it is defined to be "docker" in the command line client that handles the operation:

        cache_base = get_cache(subfolder="docker", 
                               disable_cache = args.disable_cache)

### Ability to disable cache
Finally, you will notice the `disable_cache` variable, which comes in as a command line argument for the client script. The default is set to False, and I would suggest we also set a default somewhere in the core software that can be tweaked by the user/admin setup. This is currently [called via bash](https://github.com/vsoch/singularity/blob/add/caching-and-dockerfile/libexec/bootstrap/modules-v2/build-docker.sh#L119) in the `build-docker.sh` script, and given this current setup, would be passed as an environmental / command line variable. Again, given that someone is transitioning the entirety of bootstrap to C, I didn't touch this part. When this is parsed out, let me know and the python portion can be adjusted appropriately.


## Dockerfile to Singularity file
This part of the PR will add a new module file, [converter.py](https://github.com/vsoch/singularity/blob/add/caching-and-dockerfile/libexec/python/docker/converter.py), to the python/docker folder. It currently is not "plugged in" anywhere to the singularity core software, as it is my understanding that the bootstrap is being converted to C, however this PR will add the functionality to be available to the core when it's ready. This will need a lot of testing with different Dockerfiles, because when you've seen one Dockerfile... you've seen one Dockerfile :) I went off of their [standard spec here](https://docs.docker.com/engine/reference/builder/) and [have provided here](https://gist.github.com/vsoch/4192e93b0597bee9610ece87e42edf5d) example Dockerfile and the generated Singularity file, along with how to test the code:

      # How to test Dockerfile --> Singularity generation
      # checkout the caching-and-dockerfile branch from https://github.com/vsoch/singularity
      # cd singularity/libexec/python/docker

      # Here in python

      from converter import dockerfile_to_singularity  
      import tempfile

      # You can specify an output directory, to save a file called "Singularity"
      output_dir = tempfile.mkdtemp() # (optional)
      dockerfile = "/home/vanessa/Documents/Dropbox/Code/singularity/singularity-hub/Dockerfile"
      singularity_spec = dockerfile_to_singularity(dockerfile_path=dockerfile,
                                                                           output_dir=output_dir)

      ## -- End pasted text --
      # Singularity spec written to /tmp/tmpe7gnhe9k
 
## Next steps
Given that the second part of the PR is not integrated into the software, we likely don't need extensive testing until it's added and available on the command line. If others want / are able to do testing like the above, it would be greatly appreciated, but no harm will come if it's not perfectly suited for every use case yet. 

The first part of the PR, the cache, is very important so that I can next add an endpoint for Singularity Hub, and those images to be cached. Additionally, this PR will need to be updated with logging, when #311 is merged. Thanks in advance for good discussion and feedback! Save me some stickers at SC :)

@singularityware-admin
