### PR TITLE
fixing docker command and runscript specification

### DIFF
--- a/libexec/bootstrap/modules-v2/postbootstrap.sh
+++ b/libexec/bootstrap/modules-v2/postbootstrap.sh
@@ -158,7 +158,7 @@ if [ -f "$SINGULARITY_BUILDDEF" ]; then
 
     # If the command is not empty, write to file.
     if [ ! -z "$runscript_command" ]; then
-        cat $runscript_command > "$SINGULARITY_ROOTFS/singularity"    
+        cat "$runscript_command" > "$SINGULARITY_ROOTFS/singularity"    
     fi
 
     # If we have a runscript, whether docker, user defined, change permissions    

--- a/libexec/bootstrap/modules-v2/postbootstrap.sh
+++ b/libexec/bootstrap/modules-v2/postbootstrap.sh
@@ -158,6 +158,7 @@ if [ -f "$SINGULARITY_BUILDDEF" ]; then
 
     # If the command is not empty, write to file.
     if [ ! -z "$runscript_command" ]; then
+        echo "User defined %runscript found! Taking priority."
         echo "$runscript_command" > "$SINGULARITY_ROOTFS/singularity"    
     fi
 

--- a/libexec/bootstrap/modules-v2/postbootstrap.sh
+++ b/libexec/bootstrap/modules-v2/postbootstrap.sh
@@ -152,11 +152,18 @@ if [ -f "$SINGULARITY_BUILDDEF" ]; then
 #    done
 
     ### CREATE RUNSCRIPT
-    singularity_section_get "runscript" "$SINGULARITY_BUILDDEF" > "$SINGULARITY_ROOTFS/singularity"
+
+    # First priority goes to runscript defined in build file
+    runscript_command=$(singularity_section_get "runscript" "$SINGULARITY_BUILDDEF")
+
+    # If the command is not empty, write to file.
+    if [ ! -z "$runscript_command" ]; then
+        cat $runscript_command > "$SINGULARITY_ROOTFS/singularity"    
+    fi
+
+    # If we have a runscript, whether docker, user defined, change permissions    
     if [ -s "$SINGULARITY_ROOTFS/singularity" ]; then
         chmod 0755 "$SINGULARITY_ROOTFS/singularity"
-    else
-        rm -f "$SINGULARITY_ROOTFS/singularity"
     fi
 
     mount -t proc proc "$SINGULARITY_ROOTFS/proc"

--- a/libexec/bootstrap/modules-v2/postbootstrap.sh
+++ b/libexec/bootstrap/modules-v2/postbootstrap.sh
@@ -158,7 +158,7 @@ if [ -f "$SINGULARITY_BUILDDEF" ]; then
 
     # If the command is not empty, write to file.
     if [ ! -z "$runscript_command" ]; then
-        cat "$runscript_command" > "$SINGULARITY_ROOTFS/singularity"    
+        echo "$runscript_command" > "$SINGULARITY_ROOTFS/singularity"    
     fi
 
     # If we have a runscript, whether docker, user defined, change permissions    

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -24,7 +24,15 @@ perform publicly and display publicly, and to permit other to do so.
 
 '''
 
-from docker.api import get_layer, create_runscript, get_manifest, get_config, get_images
+from docker.api import (
+    create_runscript, 
+    get_config, 
+    get_images,
+    get_layer, 
+    get_token,
+    get_manifest 
+)
+
 from utils import extract_tar, change_permissions, get_cache
 from logman import logger
 import argparse
@@ -178,6 +186,11 @@ def main():
 
         layers = []
 
+        # Let's get a token to use across image downloads
+        token = get_token(repo_name=repo_name,
+                          namespace=namespace,
+                          permission="pull")
+
         for image_id in images:
 
             # Download the layer, if we don't have it
@@ -189,7 +202,8 @@ def main():
                                   repo_name=repo_name,
                                   download_folder=cache_base,
                                   registry=args.registry,
-                                  auth=doauth) 
+                                  auth=doauth,
+                                  token=token) 
 
             layers.append(targz) # in case we want a list at the end
                                  # @chrisfilo suggestion to try compiling into one tar.gz

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -61,7 +61,7 @@ def main():
     parser.add_argument("--cmd", 
                         dest='includecmd', 
                         action="store_true",
-                        help="boolean to specify that the CMD should be included as a runscript (default is not included)", 
+                        help="boolean to specify that CMD should be used instead of ENTRYPOINT as the runscript.", 
                         default=False)
 
 
@@ -93,7 +93,7 @@ def main():
     if args.notoken == True:
        doauth = False
 
-    # Does the user want to include the CMD as runscript?
+    # Does the user want to override default Entrypoint and use CMD as runscript?
     includecmd = args.includecmd
 
     # Do we have a docker image specified?
@@ -178,21 +178,18 @@ def main():
      
     # If the user wants to include the CMD as runscript, generate it here
     if includecmd == True:
+        spec="Cmd"
+    else:
+        spec="Entrypoint"
 
-        cmd = get_config(manifest) # default is spec="Cmd"
+    cmd = get_config(manifest,spec=spec)
 
-        # Only add runscript if command is defined
-        if cmd != None:
-            print("Adding Docker CMD as Singularity runscript...")
-            runscript = create_runscript(cmd=cmd,
-                                         base_dir=singularity_rootfs)
-
-            # change permission of runscript to 0755 (default)
-            change_permissions("%s/singularity" %(singularity_rootfs))
-
-    # When we finish, change permissions for the entire thing
-    #change_permissions("%s/" %(singularity_rootfs))
-
+    # Only add runscript if command is defined
+    if cmd != None:
+        print("Adding Docker %s as Singularity runscript..." %(spec.upper()))
+        print(cmd)
+        runscript = create_runscript(cmd=cmd,
+                                     base_dir=singularity_rootfs)
 
 if __name__ == '__main__':
     main()

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -40,7 +40,7 @@ def create_runscript(cmd,base_dir):
     :param base_dir: the base directory to write the runscript to
     '''
     runscript = "%s/singularity" %(base_dir)
-    content = "#!/bin/sh\n\n%s" %(cmd)
+    content = '#!/bin/sh\n\nexec %s "$@"' %(cmd)
     output_file = write_file(runscript,content)
     return output_file
 
@@ -170,10 +170,10 @@ def get_manifest(repo_name,namespace,repo_tag="latest",registry=None,auth=True):
     return response
 
 
-def get_config(manifest,spec="Cmd"):
-    '''get_config returns a particular spec (default is Cmd) from a manifest obtained with get_manifest.
+def get_config(manifest,spec="Entrypoint"):
+    '''get_config returns a particular spec (default is Entrypoint) from a manifest obtained with get_manifest.
     :param manifest: the manifest obtained from get_manifest
-    :param spec: the key of the spec to return, default is "Cmd"
+    :param spec: the key of the spec to return, default is "Entrypoint"
     '''
   
     cmd = None

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -40,7 +40,7 @@ def create_runscript(cmd,base_dir):
     :param base_dir: the base directory to write the runscript to
     '''
     runscript = "%s/singularity" %(base_dir)
-    content = '#!/bin/sh\n\nexec %s "$@"' %(cmd)
+    content = 'exec %s "$@"' %(cmd)
     output_file = write_file(runscript,content)
     return output_file
 

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -104,8 +104,9 @@ def get_images(repo_name=None,namespace=None,manifest=None,repo_tag="latest",reg
     if 'fsLayers' in manifest:
         for fslayer in manifest['fsLayers']:
             if 'blobSum' in fslayer:
-                logger.info("Adding digest %s",fslayer['blobSum'])
-                digests.append(fslayer['blobSum'])
+                if fslayer['blobSum'] not in digests:
+                    logger.info("Adding digest %s",fslayer['blobSum'])
+                    digests.append(fslayer['blobSum'])
     return digests
     
 
@@ -202,7 +203,7 @@ def get_config(manifest,spec="Entrypoint"):
     return cmd
 
 
-def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,auth=True):
+def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,auth=True,token=None):
     '''get_layer will download an image layer (.tar.gz) to a specified download folder.
     :param image_id: the (full) image id to get the manifest for, required
     :param namespace: the namespace (eg, "library")
@@ -210,6 +211,7 @@ def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,au
     :param download_folder: if specified, download to folder. Otherwise return response with raw data (not recommended)
     :param registry: the docker registry to use (default will use registry-1.docker.io
     :param auth: does the API require obtaining an authentication Token? (default True)
+    :param token: a token to pass to the api to get a layer (optional)
     '''
     if registry == None:
         registry = api_base
@@ -220,11 +222,11 @@ def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,au
     logger.info("Downloading layers from %s", base)
     
     # To get the image layers, we need a valid token to read the repo
-    token = None
     if auth == True:
-        token = get_token(repo_name=repo_name,
-                          namespace=namespace,
-                          permission="pull")
+        if token == None:
+            token = get_token(repo_name=repo_name,
+                              namespace=namespace,
+                              permission="pull")
 
     if download_folder != None:
         download_folder = "%s/%s.tar.gz" %(download_folder,image_id)

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -232,7 +232,7 @@ def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,au
         download_folder = "%s/%s.tar.gz" %(download_folder,image_id)
 
         # Update user what we are doing
-        logger.info("Downloading layer %s", image_id)
+        print("Downloading layer %s" %image_id)
 
     return api_get(base,headers=token,stream=download_folder)
     

--- a/libexec/python/logman.py
+++ b/libexec/python/logman.py
@@ -35,12 +35,12 @@ def get_logging_level():
         level = logging.ERROR
 
     #define WARNING -2
-    elif MESSAGELEVEL == -2:
+    elif MESSAGELEVEL in [1,-2]:
         level = logging.WARNING
 
     #define LOG -1
     #define INFO 1
-    elif MESSAGELEVEL in [1,-1]:
+    elif MESSAGELEVEL == -1:
         level = logging.INFO
 
     #define VERBOSE 2

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -223,7 +223,7 @@ def get_cache(cache_base=None,subfolder=None,disable_cache=False):
         cache_base = "%s/%s" %(cache_base,subfolder)
         if not os.path.exists(cache_base):
             os.mkdir(cache_base)
-    logger.info("Cache folder set to %s", cache_base)
+    print("Cache folder set to %s" %cache_base)
     return cache_base
 
 
@@ -252,7 +252,7 @@ def extract_tar(targz,output_folder):
     '''
     # Just use command line, more succinct.
     command = ["tar","-xzf",targz,"-C",output_folder,"--exclude=dev/*"]
-    logger.info("Extracting %s", " ".join(command))
+    print("Extracting %s" %(targz))
     return run_command(command) 
 
 


### PR DESCRIPTION
Fixes #316 

Changes proposed in this pull request

 - Makes the default behavior (if nothing specified) to use ENTRYPOINT as an executable. There is a weird distinction between CMD and ENTRYPOINT, but [I believe Entrypoint](http://stackoverflow.com/questions/21553353/what-is-the-difference-between-cmd-and-entrypoint-in-a-dockerfile) is more suited to the executable, and should be the default. If the user specifies IncludeCmd then it changes to use the CMD from in the manifest.
 - The runscript message was printing to save, but wasn't actually saving to the container. The reason was because the code in postbootstrap.sh dumped the output from trying to get the runscript from the boostrap spec (even if it was empty) into a singularity file, and then deleted the file if it was empty. The behavior should be:

1. if there is a runscript defined in the bootstrap, write it to file. This takes priority over Docker, etc.
2. if there is no runscript defined in the bootstrap spec, the default uses the Dockerfile ENTRYPOINT
3. if the user specifies includeCmd, then use the CMD argument instead.

- I also removed unneeded changing of permissions in the docker cli.py, as the runscript permissions are handled by postbootstrap after.
- The original script to create_runscript originally appended the /bin/sh as the executor, but we should not bias, and so I removed this so it looks like:

     exec /usr/local/run.sh "$@"

The above is basically the command from the runscript, prefixed by exec, followed by "$@"  to capture any other input arguments from the user.

@singularityware-admin

