### PR TITLE
New feature: let singularity execute containers not directly readable by calling user, uses privileged fopen

### DIFF
--- a/docs/Administration.md
+++ b/docs/Administration.md
@@ -68,6 +68,24 @@ $ PREFIX=/opt/singularity
 $ rpmbuild -ta --define="_prefix $PREFIX" --define "_sysconfdir $PREFIX/etc" --define "_defaultdocdir $PREFIX/share" singularity-*.tar.gz
 ```
 
+### Building an DEB directly from source
+
+To build a deb package for Debian/Ubuntu/LinuxMint the first time on on a fresh pull invoke the following commands:
+fakeroot dpkg-buildpackage -b -us -uc
+
+```bash
+$ fakeroot dpkg-buildpackage -b -us -uc # sudo will ask for a password to run the tests
+$ sudo dpkg -i ../singularity-container_2.2-1_amd64.deb
+```
+ 
+Note that the tests will fail if singularity is not already installed on your system. This is the case when you run this procedure for the first time.
+In that case run the following sequence:
+
+```bash
+$ echo "echo SKIPPING TESTS THEYRE BROKEN" > ./test.sh
+$ fakeroot dpkg-buildpackage -nc -b -us -uc # this will run the build without an initial 'make clean'
+```
+
 ## Security
 Once Singularity is installed in it's default configuration you may find that there is a SETUID component installed at `$PREFIX/libexec/singularity/sexec-suid`. The purpose of this is to do the require privilege escalation necessary for Singularity to operate properly. There are a few aspects of Singularity's functionality that require escalated privileges:
 

--- a/docs/Administration.md
+++ b/docs/Administration.md
@@ -68,10 +68,9 @@ $ PREFIX=/opt/singularity
 $ rpmbuild -ta --define="_prefix $PREFIX" --define "_sysconfdir $PREFIX/etc" --define "_defaultdocdir $PREFIX/share" singularity-*.tar.gz
 ```
 
-### Building an DEB directly from source
+### Building a DEB directly from source
 
-To build a deb package for Debian/Ubuntu/LinuxMint the first time on on a fresh pull invoke the following commands:
-fakeroot dpkg-buildpackage -b -us -uc
+To build a deb package for Debian/Ubuntu/LinuxMint invoke the following commands:
 
 ```bash
 $ fakeroot dpkg-buildpackage -b -us -uc # sudo will ask for a password to run the tests
@@ -83,7 +82,7 @@ In that case run the following sequence:
 
 ```bash
 $ echo "echo SKIPPING TESTS THEYRE BROKEN" > ./test.sh
-$ fakeroot dpkg-buildpackage -nc -b -us -uc # this will run the build without an initial 'make clean'
+$ fakeroot dpkg-buildpackage -nc -b -us -uc # this will continue the previous build without an initial 'make clean'
 ```
 
 ## Security

--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -17,6 +17,11 @@ allow setuid = yes
 # Should we allow users to request the PID namespace?
 allow pid ns = yes
 
+# ALLOW PRIVILEGED FOPEN: [BOOL]
+# DEFAULT: no
+# Should singularity try to fopen container images in privileged mode
+# if the calling user does not have sufficient permissions?
+allow privileged fopen = no
 
 # ENABLE OVERLAY: [BOOL]
 # DEFAULT: yes
@@ -140,4 +145,11 @@ container dir = /var/singularity/mnt
 # /tmp/ does not work for your system, /var/singularity/sessions maybe a
 # better option.
 #sessiondir prefix = /var/singularity/sessions/
+
+# CONTAINER GROUP: [STRING]
+# DEFAULT: Undefined
+# Specifies a group a container must belong to in order to be executable by singularity.
+# The calling user is not required to belong to that group but the container must have the group executable or group readable permission set.
+# This feature requires 'allow privileged fopen' to be set.
+#container group = singularity
 

--- a/src/lib/rootfs/image/image.c
+++ b/src/lib/rootfs/image/image.c
@@ -87,6 +87,12 @@ int rootfs_image_init(char *source, char *mount_dir) {
         if ( ( image_fp = fopen(source, "r") ) != NULL ) { // Flawfinder: ignore
             singularity_message(VERBOSE, "Opened image (read only, without privileges) %s\n", source);
         } else {
+            singularity_config_rewind();
+            if ( singularity_config_get_bool("allow privileged fopen", 0) == 0 ) {
+                singularity_message(ERROR, "Privileged fopen is not enabled in config\n" );
+                ABORT(255);
+            }
+
             singularity_priv_escalate();
             if ( ( image_fp = fopen(source, "r") ) == NULL ) { // Flawfinder: ignore
 	            singularity_message(ERROR, "Could not open image (read only, with privileges) %s: %s\n", source, strerror(errno));

--- a/src/lib/rootfs/image/image.c
+++ b/src/lib/rootfs/image/image.c
@@ -28,6 +28,7 @@
 #include <sys/mount.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <grp.h>
 
 #include "util/file.h"
 #include "util/util.h"
@@ -50,6 +51,10 @@ static int read_write = 0;
 
 int rootfs_image_init(char *source, char *mount_dir) {
     singularity_message(DEBUG, "Inializing container rootfs image subsystem\n");
+    struct group *file_grp;
+    struct group *config_grp;
+    struct stat image_stat;
+    char *config_gname;
 
     if ( image_fp != NULL ) {
         singularity_message(WARNING, "Called image_open, but image already open!\n");
@@ -79,9 +84,58 @@ int rootfs_image_init(char *source, char *mount_dir) {
         }
         read_write = 1;
     } else {
-        if ( ( image_fp = fopen(source, "r") ) == NULL ) { // Flawfinder: ignore
-            singularity_message(ERROR, "Could not open image (read only) %s: %s\n", source, strerror(errno));
-            ABORT(255);
+        if ( ( image_fp = fopen(source, "r") ) != NULL ) { // Flawfinder: ignore
+            singularity_message(VERBOSE, "Opened image (read only, without privileges) %s\n", source);
+        } else {
+            singularity_priv_escalate();
+            if ( ( image_fp = fopen(source, "r") ) == NULL ) { // Flawfinder: ignore
+	            singularity_message(ERROR, "Could not open image (read only, with privileges) %s: %s\n", source, strerror(errno));
+                ABORT(255);
+            }
+
+            singularity_message(VERBOSE, "Opened image (read only, with privileges) %s\n", source);
+
+            if ( fstat(fileno(image_fp), &image_stat) != 0 ) {
+                singularity_message(ERROR, "Could not obtain stat on image %s: %s\n", source, strerror(errno));
+                ABORT(255);
+            }
+
+            if ( ( file_grp = getgrgid(image_stat.st_gid) ) == NULL ) {
+                singularity_message(ERROR, "Could not obtain gid of image %s: %s\n", source, strerror(errno));
+                ABORT(255);
+            }
+            singularity_priv_drop();
+
+            singularity_config_rewind();
+            do {
+                config_gname = singularity_config_get_value("container group");
+
+                if ( ( has_perm(4, image_stat) == 0 ) || ( has_perm(1, image_stat) == 0 ) ) {
+                    singularity_message(VERBOSE, "Image is accessible by calling user\n");
+                    break;
+                } else {
+                    if ( config_gname == NULL ) {
+                        singularity_message(ERROR, "Calling user does not have proper permissions to access image, aborting...\n");
+                        ABORT(255);
+                    }
+
+                    if ( (config_grp = getgrnam(config_gname)) == NULL ) {
+                        singularity_message(WARNING, "Unusable container group %s\n", config_gname);
+                        continue;
+                    }
+                    if ( config_grp->gr_gid == file_grp->gr_gid )  {
+                        if ( (( image_stat.st_mode & 11 )== 0) && ((image_stat.st_mode & 44 ) == 0) ) {
+                            singularity_message(ERROR, "Image does not have proper container group permissions to access image, aborting...\n");
+                            ABORT(255);
+                        } else {
+                            singularity_message(VERBOSE, "Image access is permitted by container group %s specified in config\n", config_gname);
+                            break;
+                        }
+                    }
+                }
+            } while( config_gname != NULL );
+
+
         }
     }
 

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -40,6 +40,29 @@
 #include "lib/message.h"
 #include "lib/privilege.h"
 
+int has_perm(int level, struct stat file_stat) {
+    int i;
+
+    if ( singularity_priv_getuid() == file_stat.st_uid ) {
+        if ( file_stat.st_mode & (level * 100) ) {
+            return(0);
+        }
+    }
+
+    for( i = 0; i < singularity_priv_getgidcount(); i++ ) {
+        if ( singularity_priv_getgids()[i] == file_stat.st_gid )
+            if ( file_stat.st_mode & (level * 10) ) {
+	        return(0);
+            }
+        }
+
+    if ( file_stat.st_mode & (level * 1) ) {
+        return(0);
+    }
+
+    return(-1);
+}
+
 char *file_id(char *path) {
     struct stat filestat;
     char *ret;

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -19,6 +19,7 @@
  */
 
 
+int has_perm(int level, struct stat file_stat);
 char *file_id(char *path);
 int is_file(char *path);
 int is_fifo(char *path);


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request

 - new cfg option to enable/disable privileged fopens in image.c
 - new cfg options to define container groups (groups of containers singularity can execute via privileged fopen)
 - new behaviour is as follows:
1.) try to open container.image as calling user (needs 'r' permission)
2.) if failed: check if privileged fopen is allowed
if yes: 
 get fh
 get stat(fh)
 if user(fh) has 'r' or 'x' permission OR
 if group(fh) == group(calling_user) && group has 'r' or 'x' permission OR
 if other(fh) has 'x' permission OR
 if (group(fh) is in a group enabled by 'group container' && group has 'r' or 'x' permission
 SUCCEED

else FAIL

Please tell me if you accept the implementation and if not what needs to be fixed in order to be acceptable. As soon as you give your okay I will write docs/tests.
Thanks: )

@singularityware-admin
