### PR TITLE
Implement basic authentication for Docker registries

### DIFF
--- a/libexec/bootstrap/modules-v2/build-docker.sh
+++ b/libexec/bootstrap/modules-v2/build-docker.sh
@@ -85,19 +85,12 @@ fi
 
 
 ### Does the registry require authentication?
-SINGULARITY_DOCKER_AUTH=`singularity_key_get "Token" "$SINGULARITY_BUILDDEF"`
-if [ -n "${SINGULARITY_DOCKER_AUTH:-}" ]; then
-    message 1 "Token: $SINGULARITY_DOCKER_AUTH\n"
-
-    # A command of "no" means don't add token auth header
-    if [ "$SINGULARITY_DOCKER_AUTH" == "no" ]; then
-        SINGULARITY_DOCKER_AUTH="--no-token"
-
-    # Anything else, we do authentication
-    else
-        SINGULARITY_DOCKER_AUTH=""
-    fi
-
+SINGULARITY_DOCKER_USERNAME=`singularity_key_get "Username" "$SINGULARITY_BUILDDEF"`
+SINGULARITY_DOCKER_PASSWORD=`singularity_key_get "Password" "$SINGULARITY_BUILDDEF"`
+if [ -n "${SINGULARITY_DOCKER_USERNAME:-}" ] && [ -n "${SINGULARITY_DOCKER_PASSWORD:-}" ]; then
+    message 1 "Username: $SINGULARITY_DOCKER_USERNAME\n"
+    message 1 "Password: [hidden]\n"
+    SINGULARITY_DOCKER_AUTH="--username $SINGULARITY_DOCKER_USERNAME --password $SINGULARITY_DOCKER_PASSWORD"
 else
     SINGULARITY_DOCKER_AUTH=""   
 fi

--- a/libexec/helpers/image-import.sh
+++ b/libexec/helpers/image-import.sh
@@ -54,7 +54,7 @@ fi
 case "$IMPORT_URI" in
     docker://*)
         CONTAINER_NAME=`echo "$IMPORT_URI" | sed -e 's@^docker://@@'`
-        SINGULARITY_IMPORT_GET="$SINGULARITY_libexecdir/singularity/python/cli.py --rootfs '$SINGULARITY_ROOTFS' --docker '$CONTAINER_NAME' --cmd"
+        SINGULARITY_IMPORT_GET="$SINGULARITY_libexecdir/singularity/python/cli.py --rootfs '$SINGULARITY_ROOTFS' --docker '$CONTAINER_NAME' ${SINGULARITY_DOCKER_REGISTRY:-} ${SINGULARITY_DOCKER_AUTH:-}"
     ;;
     http://*|https://*)
         SINGULARITY_IMPORT_GET="curl -L -k '$IMPORT_URI'"

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -31,6 +31,7 @@ import subprocess
 import sys
 import tempfile
 import tarfile
+import base64
 try:
     from urllib.parse import urlencode
     from urllib.request import urlopen, Request
@@ -147,7 +148,6 @@ def api_get(url,data=None,default_header=True,headers=None,stream=None,return_re
 
     # If we have an HTTPError, try to follow the response
     except HTTPError as error:
-        logger.error("HTTPError %s", error)        
         return error
 
     # Does the call just want to return the response?
@@ -167,6 +167,10 @@ def api_get(url,data=None,default_header=True,headers=None,stream=None,return_re
 
     return stream
 
+def basic_auth_header(username, password):
+    credentials = base64.b64encode("%s:%s" % (username, password))
+    auth = {"Authorization": "Basic %s" % credentials}
+    return auth
 
 ############################################################################
 ## COMMAND LINE OPERATIONS #################################################


### PR DESCRIPTION
There are a few problems currently:
- The Docker registry to use cannot be modified for `singularity import`
- The `--no-token` option is tricky. A token might be necessary for a registry, even if you don't need an account. We should attempt without a token, then try to get a token if we receive a 401.
- Basic authentication is not supported, so I don't think there is a way to fetch private repos.
- Token caching might not be a good idea: the token might expire when downloading large images over a slow connection. I think it's safer to get a new token per layer, and it makes the code simpler imo.

To specify the registry for `singularity import`:
```
export SINGULARITY_DOCKER_REGISTRY='--registry myrepo'
export SINGULARITY_DOCKER_AUTH='--username fabecassis --password [mygreatpassword]'
```
Having to export the password as an environment variable might not be great, I'm open to better suggestions. Maybe an authentication file like Docker does.

I tested my patch with “singularity import” on the following:
- DockerHub: a public and a private repo
- Google Container Registry: gcr.io/tensorflow (public)
- Githost.io (GitLab): a private repo 

It seemed to work, please test!
