### PR TITLE
Improve clean_path function

### DIFF
--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -295,10 +295,7 @@ def read_file(filename,mode="r"):
 
 
 def clean_path(path):
-    '''clean_path will strip spaces and extra slashes from the path
+    '''clean_path will canonicalize the path
     :param path: the path to clean
     '''
-    path = path.strip(" ")
-    if path[-1] == "/":
-        path = path[:-1]
-    return path
+    return os.path.realpath(path.strip(" "))


### PR DESCRIPTION
I think this function was trying to canonicalize the path, but in an incomplete way.
It didn't handle the following case:
```
$ export SINGULARITY_CACHEDIR=/
$ singularity import tensorflow docker://tensorflow/tensorflow
Traceback (most recent call last):
  File "/usr/local/libexec/singularity/python/cli.py", line 241, in <module>
    main()
  File "/usr/local/libexec/singularity/python/cli.py", line 185, in main
    disable_cache = args.disable_cache)
  File "/usr/local/libexec/singularity/python/utils.py", line 219, in get_cache
    os.mkdir(cache_base)        
OSError: [Errno 2] No such file or directory: ''
ERROR: Aborting with RETVAL=1
```
This was also a bit ugly:
```
$ export SINGULARITY_CACHEDIR=/usr/../tmp
$ singularity import tensorflow docker://tensorflow/tensorflow
Cache folder set to /usr/../tmp/docker
Extracting /usr/../tmp/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
[...]
```
It's better now, but you still get a `//` here:
```
export SINGULARITY_CACHEDIR=/
root@thor:/home/fabecassis/github/singularity# singularity import tensorflow docker://tensorflow/tensorflow
Cache folder set to //docker
[...]
```
But, I think we can also refactor `get_cache` to only do a single `os.makedirs` then we won't have this problem.