### PR TITLE
removing IncludeCmd from docker example

### DIFF
--- a/examples/docker.def
+++ b/examples/docker.def
@@ -6,7 +6,6 @@
 
 BootStrap: docker
 From: ubuntu:latest
-IncludeCmd: yes
 
 %runscript
     echo "This is what happens when you run the container..."


### PR DESCRIPTION

Changes proposed in this pull request

 - removing IncludeCmd from docker example, as it's not the recommended thing to do.
 
@singularityware-admin

