### PR TITLE
Second attempt at enabling pylint support. (#335)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ addons:
   sonarqube: true
   apt:
     packages:
-      - oracle-java8-installer
+      #- oracle-java8-installer
       - flawfinder
+      - pylint
 
 env:
   global:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,9 +3,7 @@ sonar.projectKey=singularityware:singularity
 sonar.projectName=Singularity
 sonar.projectVersion=2.2
 
-sonar.sources=src
-
-sonar.language=c
+sonar.sources=src,libexec
 
 sonar.cfamily.build-wrapper-output=bw-outputs
 


### PR DESCRIPTION
Fixes #335

This installs pylint and makes the project not C-specific, which should be sufficient to get a python code analysis going.

Trying again with the branch already in-repo.