### PR TITLE
Make ABORT macro require a semi-colon.

### DIFF
--- a/src/util/util.h
+++ b/src/util/util.h
@@ -54,7 +54,7 @@ int str2int(const char *input_str, long int *output_num);
 struct passwd;
 char *get_homedir(struct passwd *pw);
 
-#define ABORT(a) {singularity_message(ABRT, "Retval = %d\n", a); exit(a);}
+#define ABORT(a) do {singularity_message(ABRT, "Retval = %d\n", a); exit(a);} while (0)
 
 
 #endif


### PR DESCRIPTION
Fixes SonarQube-detected code warnings.

Previously, `ABORT(1);` was actually multiple statements, meaning:

```
if (1)
   ABORT(1);
else
   return 0;
```

was not valid C as there are two statements between `if` and `else`.

This removes the extra empty statement; as a side-effect,`ABORT(1)`
is no longer valid (that pattern was used nowhere in the codebase).