### PR TITLE
Fix various static analysis warnings.

### DIFF
--- a/src/get-section.c
+++ b/src/get-section.c
@@ -44,7 +44,7 @@ int main(int argc, char ** argv) {
     int toggle_section = 0;
     int retval = 1;
     FILE *input;
-    char *line = (char *)malloc(MAX_LINE_LEN);;
+    char *line = (char *)malloc(MAX_LINE_LEN);
 
     if ( argc < 3 ) {
         printf("USAGE: %s [section] [file]\n", argv[0]);
@@ -75,6 +75,8 @@ int main(int argc, char ** argv) {
             printf("%s", line);
         }
     }
-
+    fclose(input);
+    free(section);
+    free(file);
     return(retval);
 }

--- a/src/lib/action/start/start.c
+++ b/src/lib/action/start/start.c
@@ -102,6 +102,7 @@ void action_start_do(int argc, char **argv) {
         }
     }
     fclose(comm);
+    free(line);
 
     singularity_message(VERBOSE, "Namespace process exiting...\n");
     exit(0);

--- a/src/lib/config_parser.c
+++ b/src/lib/config_parser.c
@@ -117,6 +117,7 @@ char *singularity_config_get_value(char *key) {
                 if ( ( config_value = strdup(strtok(NULL, "=")) ) != NULL ) {
                     chomp(config_value);
                     singularity_message(VERBOSE2, "Got config key %s (= '%s')\n", key, config_value);
+                    free(line);
                     return(config_value);
                 }
             }

--- a/src/lib/file/file.c
+++ b/src/lib/file/file.c
@@ -43,6 +43,6 @@ int singularity_file(void) {
     retval += singularity_file_group();
     retval += singularity_file_resolvconf();
 
-    return(0);
+    return (retval);
 }
 

--- a/src/lib/file/passwd/passwd.c
+++ b/src/lib/file/passwd/passwd.c
@@ -90,13 +90,7 @@ int singularity_file_passwd(void) {
         ABORT(255);
     }
 
-    singularity_message(DEBUG, "Opening the template passwd file: %s\n", tmp_file);
-    if ( ( file_fp = fopen(tmp_file, "a") ) == NULL ) { // Flawfinder: ignore
-        singularity_message(ERROR, "Could not open template passwd file %s: %s\n", tmp_file, strerror(errno));
-        ABORT(255);
-    }
-
-    singularity_message(VERBOSE, "Creating template passwd file and appending user data\n");
+    singularity_message(VERBOSE, "Creating template passwd file and appending user data: %s\n", tmp_file);
     if ( ( file_fp = fopen(tmp_file, "a") ) == NULL ) { // Flawfinder: ignore
         singularity_message(ERROR, "Could not open template passwd file %s: %s\n", tmp_file, strerror(errno));
         ABORT(255);

--- a/src/lib/fork.c
+++ b/src/lib/fork.c
@@ -96,7 +96,7 @@ pid_t singularity_fork(void) {
         sigprocmask(SIG_SETMASK, &blocked_mask, &old_mask);
 
         struct sigaction action;
-        action.sa_sigaction = handle_signal;
+        action.sa_sigaction = &handle_signal;
         action.sa_flags = SA_SIGINFO|SA_RESTART;
         // All our handlers are signal safe.
         action.sa_mask = empty_mask;
@@ -131,7 +131,7 @@ pid_t singularity_fork(void) {
             singularity_message(ERROR, "Failed to install SIGUSR2 signal handler: %s\n", strerror(errno));
             ABORT(255);
         }
-        action.sa_sigaction = handle_sigchld;
+        action.sa_sigaction = &handle_sigchld;
         if ( -1 == sigaction(SIGCHLD, &action, NULL) ) {
             singularity_message(ERROR, "Failed to install SIGCHLD signal handler: %s\n", strerror(errno));
             ABORT(255);

--- a/src/lib/mount/mount-util.c
+++ b/src/lib/mount/mount-util.c
@@ -36,7 +36,7 @@
 int check_mounted(char *mountpoint) {
     int retval = -1;
     FILE *mounts;
-    char *line = (char *)malloc(MAX_LINE_LEN);;
+    char *line = (char *)malloc(MAX_LINE_LEN);
     char *rootfs_dir = singularity_rootfs_dir();
 
     singularity_message(DEBUG, "Opening /proc/mounts\n");


### PR DESCRIPTION
More minor tweaks from SonarQube:

- Close file descriptors and free memory on error paths.
- Remove unnecessary empty statements.
- Pass function pointer address, not value.  This one is probably a end-user-visible bug (possibly we had broken Unix signal forwarding?)!