### PR TITLE
Extended permission model for image access

### DIFF
--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -17,8 +17,30 @@ allow setuid = yes
 # Should we allow users to request the PID namespace?
 allow pid ns = yes
 
+# ALLOW USER IMAGE: [BOOL]
+# DEFAULT: yes
+# Should we allow users to run images they own?  If set to 'no', then the image
+# can only be executed through 'protected image mode' (see below).
+#
+# Note that if 'allow user image' is no and 'protected image mode' is none,
+# then no image file may be used.
+allow user image = yes
 
-# ENABLE OVERLAY: [BOOL]
+
+# PROTECTED IMAGE MODE: [STRING]
+# DEFAULT: none
+# The 'protected image mode' allows users to start singularity inside images
+# that they do not own.  There are three allowed modes:
+# - none: Protected image mode is disabled.  Users must own any image they run.
+# - group: The image file must be readable by the user 'singularity' AND the
+#          invoking user must be in the same group as the image file.
+# - user: The image file must be readable by the user 'singularity'.
+# The name of the user 'singularity' can be controlled via the
+# 'singularity user' option below.
+protected image mode = none
+
+
+# # ENABLE OVERLAY: [BOOL]
 # DEFAULT: yes
 # Enabling this option will make it possible to specify bind paths to locations
 # that do not currently exist within the container. Some limitations still exist
@@ -140,4 +162,15 @@ container dir = /var/singularity/mnt
 # /tmp/ does not work for your system, /var/singularity/sessions maybe a
 # better option.
 #sessiondir prefix = /var/singularity/sessions/
+
+
+# SINGULARITY USER: [STRING]
+# DEFAULT: singularity
+# The protected image mode will restrict Singularity images to those owned by
+# the 'singularity user'; this option allows admins to change the username we
+# use as a test.
+#
+# If user namespaces are enabled, the singularity user setting is ignored and
+# instead the invoking user is utilized for all access privilege checks.
+singularity user = singularity
 

--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -19,8 +19,9 @@ allow pid ns = yes
 
 # ALLOW USER IMAGE: [BOOL]
 # DEFAULT: yes
-# Should we allow users to run images they own?  If set to 'no', then the image
-# can only be executed through 'protected image mode' (see below).
+# Should we allow users to run images they can access according to normal
+# filesystem privileges?  If set to 'no', then the image can only be executed
+# through 'protected image mode' (see below).
 #
 # Note that if 'allow user image' is no and 'protected image mode' is none,
 # then no image file may be used.
@@ -29,12 +30,17 @@ allow user image = yes
 
 # PROTECTED IMAGE MODE: [STRING]
 # DEFAULT: none
-# The 'protected image mode' allows users to start singularity inside images
-# that they do not own.  There are three allowed modes:
-# - none: Protected image mode is disabled.  Users must own any image they run.
+# The 'protected image mode' allows users to launch singularity with images
+# that they cannot access according to filesystem privileges.
+# There are three allowed modes:
+# - none: Protected image mode is disabled.  The typical filesystem rules
+#         are applied.
 # - group: The image file must be readable by the user 'singularity' AND the
 #          invoking user must be in the same group as the image file.
 # - user: The image file must be readable by the user 'singularity'.
+# In both 'group' and 'user' cases, the image must be either owned by the
+# singularity user or be owned by the singularity user's primary group.
+#
 # The name of the user 'singularity' can be controlled via the
 # 'singularity user' option below.
 protected image mode = none

--- a/src/get-section.c
+++ b/src/get-section.c
@@ -64,7 +64,7 @@ int main(int argc, char ** argv) {
         ABORT(255);
     }
 
-    singularity_message(DEBUG, "Iterating through file looking for sections matching: \%%s\n", section);
+    singularity_message(DEBUG, "Iterating through file looking for sections matching: %s\n", section);
     while ( fgets(line, MAX_LINE_LEN, input) != NULL ) {
         if ( strncmp(line, strjoin("%", section), strlength(section, 128) + 1) == 0 ) {
             toggle_section = 1;

--- a/src/get-section.c
+++ b/src/get-section.c
@@ -64,7 +64,7 @@ int main(int argc, char ** argv) {
         ABORT(255);
     }
 
-    singularity_message(DEBUG, "Iterating through file looking for sections matching: %s\n", section);
+    singularity_message(DEBUG, "Iterating through file looking for sections matching: %%%s\n", section);
     while ( fgets(line, MAX_LINE_LEN, input) != NULL ) {
         if ( strncmp(line, strjoin("%", section), strlength(section, 128) + 1) == 0 ) {
             toggle_section = 1;

--- a/src/lib/config_parser.c
+++ b/src/lib/config_parser.c
@@ -129,6 +129,11 @@ char *singularity_config_get_value(char *key) {
     return(NULL);
 }
 
+char *singularity_config_get_value_default(char *key, const char *def) {
+    char *value = singularity_config_get_value(key);
+    return value ? value : strdup(def);
+}
+
 /*
  * Gets the associated boolean value of key from config_fp. Passes
  * key into singularity_get_config_value() and then checks if that

--- a/src/lib/config_parser.h
+++ b/src/lib/config_parser.h
@@ -27,6 +27,7 @@
     void singularity_config_rewind(void);
 
     char *singularity_config_get_value(char *key);
+    char *singularity_config_get_value_default(char *key, const char *def);
     int singularity_config_get_bool(char *key, int def);
 
 #endif /* __SINGULARITY_CONFIG_H_ */

--- a/src/lib/message.h
+++ b/src/lib/message.h
@@ -33,7 +33,7 @@
     #define VERBOSE3 4
     #define DEBUG 5
 
-    void _singularity_message(int level, const char *function, const char *file, int line, char *format, ...);
+    void _singularity_message(int level, const char *function, const char *file, int line, char *format, ...) __attribute__ ((__format__(printf, 5, 6)));
 
     #define singularity_message(a,b...) _singularity_message(a, __func__, __FILE__, __LINE__, b)
 

--- a/src/lib/privilege.h
+++ b/src/lib/privilege.h
@@ -33,4 +33,10 @@
     void singularity_priv_userns_ready(void);
     int singularity_priv_userns_enabled(void);
 
+    // Escalate privileges to the 'singularity' user.
+    void singularity_priv_escalate_singularity(void);
+
+    // Returns 1 if invoking user is a member of `gid`, 0 otherwise
+    int singularity_priv_has_gid(gid_t gid);
+
 #endif /* __PRIVILEGE_H_ */

--- a/src/lib/privilege.h
+++ b/src/lib/privilege.h
@@ -39,4 +39,10 @@
     // Returns 1 if invoking user is a member of `gid`, 0 otherwise
     int singularity_priv_has_gid(gid_t gid);
 
+    // Returns the UID of the singularity user.
+    uid_t singularity_priv_singularity_uid();
+
+    // Returns the GID of the singularity user.
+    gid_t singularity_priv_singularity_gid();
+
 #endif /* __PRIVILEGE_H_ */

--- a/test.sh.in
+++ b/test.sh.in
@@ -77,6 +77,12 @@ sudo true
 . ./libexec/functions
 
 /bin/echo
+/bin/echo "Adding users and groups for a test."
+stest 0 sudo groupadd test_singularity2
+stest 0 sudo useradd singularity
+stest 0 sudo useradd test_singularity -G test_singularity2 -d /tmp
+
+/bin/echo
 /bin/echo "SINGULARITY_TMPDIR=$TEMPDIR"
 /bin/echo
 
@@ -291,6 +297,40 @@ else
     /bin/echo
     /bin/echo "Skipping user bind mount tests, overlay FS support is not enabled"
 fi
+
+
+/bin/echo
+/bin/echo "Testing protected mode"
+cp "$CONTAINER" /tmp/container.img
+stest 0 sudo chown singularity:test_singularity /tmp/container.img
+stest 0 sudo chmod 644 /tmp/container.img
+stest 0 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chmod 640 /tmp/container.img
+stest 0 sudo chown singularity: /tmp/container.img
+stest 1 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|protected image mode = none|protected image mode = user|'
+stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|allow user image = yes|allow user image = no|'
+stest 0 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chown root:singularity /tmp/container.img
+stest 0 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chown root: /tmp/container.img
+stest 1 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|protected image mode = user|protected image mode = group|'
+stest 0 sudo chmod 600 /tmp/container.img
+stest 0 sudo chown singularity: /tmp/container.img
+stest 1 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chown singularity:test_singularity /tmp/container.img
+stest 0 sudo -u test_singularity singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chown singularity:test_singularity2 /tmp/container.img
+stest 0 sudo -u test_singularity singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chown singularity:root /tmp/container.img
+stest 1 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chown `id -u -n`: /tmp/container.img
+# This should fail in the future - commented out for now as it succeeds.
+# stest 1 singularity exec /tmp/container.img echo "hello world"
+# Restore state
+stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|protected image mode = group|protected image mode = none|'
+stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|allow user image = no|allow user image = yes|'
 
 
 /bin/echo

--- a/test.sh.in
+++ b/test.sh.in
@@ -325,9 +325,10 @@ stest 0 sudo chown singularity:test_singularity2 /tmp/container.img
 stest 0 sudo -u test_singularity singularity exec /tmp/container.img echo "hello world"
 stest 0 sudo chown singularity:root /tmp/container.img
 stest 1 singularity exec /tmp/container.img echo "hello world"
+# Make sure there is singularity user or group ownership of image, even if it is world-readable.
 stest 0 sudo chown `id -u -n`: /tmp/container.img
-# This should fail in the future - commented out for now as it succeeds.
-# stest 1 singularity exec /tmp/container.img echo "hello world"
+stest 0 sudo chmod 644 /tmp/container.img
+stest 1 singularity exec /tmp/container.img echo "hello world"
 # Restore state
 stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|protected image mode = group|protected image mode = none|'
 stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|allow user image = no|allow user image = yes|'


### PR DESCRIPTION
This PR introduces two new features for _read-only_ containers (writable containers are unaffected):

1.  "Protected mode".  Allows access to images readable by a dedicated user account.   This has three possible settings
      * `none` (default): This feature is disabled.
      * `group`: The image must be readable by the dedicated user account *and* its group ownership must overlap with the invoking user's.  So, if user `bbockelm` is in group `foo` and `bar`, then the user would be able to access an image with mode `600` and ownership `singularity:foo`, `singularity:bar`, but not `singularity:baz`.
      * `user`: The image must be readable by the dedicated user account.  Given the user `bbockelm` above, they would be able to access an image mode `600` and ownership `singularity:baz` or mode `640` and ownership `root:singularity`.
      The dedicated user account is named `singularity` by default(when switching to this account, we set to the corresponding UID and primary GID).
2.  A boolean flag (`allow user image`) on whether users can provide their own images (defaults to `yes`).  When disabled, user-provided images (i.e., anything readable by the invoking user) are not allowed.

The default configuration values leave the permission model unchanged from the current code.

A few example use cases:
* Sysadmin only wants `singularity` to execute images she provides for the user.  In that case, set `allow user image = no` and `protected user mode = user`.
* Admin wants to provide a group-ownership based model for the users she maintains.  Users in group `physics` should not access the images available to group `chemistry`.  In that case, set `protected user mode = group`.
   * As a follow-up, we could put together a more fine-grained model that a user is only allowed to execute a fixed command inside the image (would prevent the user from doing arbitrary reads of the software inside the image).
* Admin wants only users belonging to a given group to create `singularity` images.  Set `allow user image = no` and `protected user mode = user`, and add these users to the `singularity` group.
   * In this case, users put their images in a publicly-accessible directory and allow other users to execute them.