### PR TITLE
BF: var/singularity -> var/lib/singularity to please FHS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ install-perms:
 	@echo
 
 install-data-hook:
-	install -d -m 0755 $(DESTDIR)$(localstatedir)/singularity/mnt
+	install -d -m 0755 $(DESTDIR)$(localstatedir)/lib/singularity/mnt
 
 
 ACLOCAL_AMFLAGS = -I m4

--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -125,11 +125,11 @@ mount slave = yes
 
 
 # CONTAINER DIR: [STRING]
-# DEFAULT: /var/singularity/mnt
+# DEFAULT: /var/lib/singularity/mnt
 # This path specifies the location to use for mounting the container, overlays
 # and other necessary file systems for the container. Note, this location
 # absolutely must be local on this host.
-container dir = /var/singularity/mnt
+container dir = /var/lib/singularity/mnt
 
 
 # SESSIONDIR PREFIX: [STRING]
@@ -137,7 +137,7 @@ container dir = /var/singularity/mnt
 # This specifies the prefix for the session directory. Appended to this string
 # is an identification string unique to each user and container. Note, this
 # location absolutely must be local on this host. If the default location of
-# /tmp/ does not work for your system, /var/singularity/sessions maybe a
+# /tmp/ does not work for your system, /var/lib/singularity/sessions maybe a
 # better option.
-#sessiondir prefix = /var/singularity/sessions/
+#sessiondir prefix = /var/lib/singularity/sessions/
 

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -86,8 +86,8 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0755, root, root) %dir %{_sysconfdir}/singularity
 %attr(0644, root, root) %config(noreplace) %{_sysconfdir}/singularity/*
 %dir %{_libexecdir}/singularity
-%dir %{_localstatedir}/singularity
-%dir %{_localstatedir}/singularity/mnt
+%dir %{_localstatedir}/lib/singularity
+%dir %{_localstatedir}/lib/singularity/mnt
 %attr(4755, root, root) %{_libexecdir}/singularity/sexec-suid
 %{_libexecdir}/singularity/bootstrap
 %{_libexecdir}/singularity/cli

--- a/src/lib/rootfs/rootfs.c
+++ b/src/lib/rootfs/rootfs.c
@@ -80,8 +80,8 @@ int singularity_rootfs_init(char *source) {
     singularity_message(DEBUG, "Figuring out where to mount Singularity container\n");
 
     if ( ( mount_point = singularity_config_get_value("container dir") ) == NULL ) {
-        singularity_message(DEBUG, "Using default container path of: /var/singularity/mnt\n");
-        mount_point = strdup("/var/singularity/mnt");
+        singularity_message(DEBUG, "Using default container path of: /var/lib/singularity/mnt\n");
+        mount_point = strdup("/var/lib/singularity/mnt");
     }
     singularity_message(VERBOSE3, "Set image mount path to: %s\n", mount_point);
 


### PR DESCRIPTION
Debian lintian tool has rightfully complained:

`E: singularity-container: non-standard-dir-in-var var/singularity/`

which is indeed the case.  FHS (http://www.pathname.com/fhs/pub/fhs-2.3.html#THEVARHIERARCHY) defines a list of directories to be commonly found directly under /var, and I thought that it would be better to comply with that to not pollute name space there

@singularityware-admin

