### PR TITLE
BF: bash_completion.d script has bashisms, so use bash as the shell, not generic posix sh

### DIFF
--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -1,4 +1,4 @@
-#!/bin/sh ## Only here for syntax highlighting
+#!/bin/bash ## Only here for syntax highlighting
 
 _singularity() {
     local cur cmd opts cmd_idx container_idx


### PR DESCRIPTION
Otherwise fails the syntax check (`sh -n`)

@singularityware-admin
