### PR TITLE
fixing bug to again support python3 to close #359

### DIFF
--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -74,7 +74,7 @@ def get_token(namespace,repo_name,registry=None,auth=None):
         # No token required for registry.
         return None
 
-    if response.code != 401 or not response.headers.has_key("WWW-Authenticate"):
+    if response.code != 401 or "WWW-Authenticate" not in response.headers:
         logger.error("Authentication error for registry %s, exiting.", registry)
         sys.exit(1)
 


### PR DESCRIPTION
Fixes #359 

Changes proposed in this pull request

 - A quick fix to make singularity python 3 compatible again! See #359 for the error, and confirmation that python 2.7.6 works. Below shows test that it now works, and soon going to write functions to do proper testing on new PRs.


      which python
	/home/vanessa/anaconda3/bin/python
	vanessa@vanessa-ThinkPad-T460s:~/Desktop$ singularity run docker://ubuntu:latestCache folder set to /home/vanessa/Desktop/docker
	Extracting /home/vanessa/Desktop/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
	Extracting /home/vanessa/Desktop/docker/sha256:8ff6f8a9120c54ae6ebde4bea1a4f2bc8170d4a148f5f81eb731be74a071d71e.tar.gz
	Extracting /home/vanessa/Desktop/docker/sha256:cd3d6cd6c0cff04046b5cfc3688e599e56efe9abe35ff59c36fcf469eb289f81.tar.gz

@singularityware-admin

