### PR TITLE
Use environment of imported Docker images

### DIFF
--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -25,7 +25,8 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 from docker.api import (
-    create_runscript, 
+    create_runscript,
+    create_envfile,
     get_config, 
     get_images,
     get_layer, 
@@ -240,6 +241,9 @@ def run(args):
         if args.disable_cache == True:
             shutil.rmtree(cache_base)
 
+        env = get_config(manifest, 'Env').split("\n")
+        create_envfile(env=env,
+                       base_dir=singularity_rootfs)
 
         logger.info("*** FINISHING DOCKER BOOTSTRAP PYTHON PORTION ****\n")
 

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -51,6 +51,13 @@ def create_runscript(cmd,base_dir):
     output_file = write_file(runscript,content)
     return output_file
 
+def create_envfile(env, base_dir):
+    envfile = "%s/environment" % base_dir
+    with open(envfile, "w") as f:
+        f.write("# Docker image environment\n")
+        for e in env:
+            f.write("export %s\n" % e)
+        f.write('export PS1="Singularity.$SINGULARITY_CONTAINER> "\n')
 
 def get_token(namespace,repo_name,registry=None,auth=None):
     '''get_token uses HTTP basic authentication to get a token for Docker registry API V2 operations


### PR DESCRIPTION
Simple fix for #364: just create a brand new `environment` file, I don't think it's necessary to combine it with the [default bootstrap environment](https://github.com/singularityware/singularity/blob/6932a0f2380885ac984c8d6f81479fc2ecb5787e/libexec/bootstrap/modules-v2/postbootstrap.sh#L68-L79)