### PR TITLE
[python] adding additional tests for the docker functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,6 @@ script:
   - jdk_switcher use oraclejdk8
   - sonar-scanner
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_client
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_client
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -226,7 +226,7 @@ def get_config(manifest,spec="Entrypoint"):
     # Standard is to include commands like ['/bin/sh']
     if isinstance(cmd,list):
         cmd = "\n".join(cmd)
-    logger.info("Found Docker command (CMD) %s", cmd)
+    logger.info("Found Docker command (%s) %s",spec,cmd)
     return cmd
 
 

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -24,6 +24,7 @@ perform publicly and display publicly, and to permit other to do so.
 import os
 import re
 import sys
+import tarfile
 sys.path.append('..') # directory with client
 
 from unittest import TestCase
@@ -217,8 +218,62 @@ class TestUtils(TestCase):
         shutil.rmtree(tmpdir)
 
 
-    #TODO: need to test api_get
+    def test_extract_tar(self):
+        '''test_extract_tar will test extraction of a tar.gz file
+        '''
+        print("Testing utils.extract_tar...")
+
+        # First create a temporary tar file
+        from utils import extract_tar
+        from glob import glob
+        import tarfile 
         
+        # Create and close a temporary tar.gz
+        print("Case 1: Testing tar.gz...")
+        creation_dir = tempfile.mkdtemp()
+        targz,files = create_test_tar(creation_dir)
+
+        # Extract to different directory
+        extract_dir = tempfile.mkdtemp()
+        extract_tar(targz=targz,
+                    output_folder=extract_dir)
+        extracted_files = [x.replace(extract_dir,'') for x in glob("%s/tmp/*" %(extract_dir))]
+        [self.assertTrue(x in files) for x in extracted_files]
+        
+        # Clean up
+        for dirname in [extract_dir,creation_dir]:
+            shutil.rmtree(dirname)
+
+        print("Case 1: Testing tar...")
+        creation_dir = tempfile.mkdtemp()
+        targz,files = create_test_tar(creation_dir,compressed=False)
+
+        # Extract to different directory
+        extract_dir = tempfile.mkdtemp()
+        extract_tar(targz=targz,
+                    output_folder=extract_dir)
+        extracted_files = [x.replace(extract_dir,'') for x in glob("%s/tmp/*" %(extract_dir))]
+        [self.assertTrue(x in files) for x in extracted_files]
+        
+
+
+    #TODO: need to test api_get
+    #TODO: need to test api_get_pagination
+        
+# Supporting Test Functions
+def create_test_tar(tmpdir,compressed=True):
+    targz = "%s/toodles.tar.gz" %tmpdir
+    if compressed == False:
+        targz = "%s/toodles.tar" %tmpdir
+    mode = "w:gz"
+    if compressed == False:
+        mode = "w"
+    print("Creating %s" %(targz))
+    tar = tarfile.open(targz, mode)
+    files = [tempfile.mkstemp()[1] for x in range(3)]
+    [tar.add(x) for x in files]
+    tar.close()
+    return targz,files
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -40,7 +40,6 @@ class TestClient(TestCase):
 
     def setUp(self):
         print("\n---START----------------------------------------")
-        self.parser = get_parser()
 
     def tearDown(self):
         print("---END------------------------------------------")
@@ -49,7 +48,8 @@ class TestClient(TestCase):
         '''test_singularity_rootfs ensures that --rootfs is required
         '''
         print("Testing --rootfs command...")
-        args = self.parser.parse_args([])
+        parser = get_parser()
+        args = parser.parse_args([])
         with self.assertRaises(SystemExit) as cm:
             run(args)
         self.assertEqual(cm.exception.code, 1)
@@ -58,9 +58,11 @@ class TestClient(TestCase):
 class TestUtils(TestCase):
 
     def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
         print("\n---START----------------------------------------")
 
     def tearDown(self):
+        shutil.rmtree(self.tmpdir)
         print("---END------------------------------------------")
 
     def test_add_http(self):
@@ -198,9 +200,7 @@ class TestUtils(TestCase):
 
         from utils import change_permissions
         from stat import ST_MODE
-        
-        tmpdir = tempfile.mkdtemp()
-        tmpfile = '%s/.mooza' %(tmpdir)
+        tmpfile = '%s/.mooza' %(self.tmpdir)
         os.system('touch %s' %(tmpfile))
 
         # 664
@@ -214,8 +214,6 @@ class TestUtils(TestCase):
         change_permissions(tmpfile,permission="0644")  
         new_permissions = oct(os.stat(tmpfile)[ST_MODE])[-3:]
         self.assertTrue(new_permissions,'664')
-
-        shutil.rmtree(tmpdir)
 
 
     def test_extract_tar(self):

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -28,6 +28,8 @@ sys.path.append('..') # directory with client
 
 from unittest import TestCase
 from cli import get_parser, run
+import shutil
+import tempfile
 
 VERSION = sys.version_info[0]
 
@@ -63,7 +65,7 @@ class TestUtils(TestCase):
     def test_add_http(self):
         '''test_add_http ensures that http is added to a url
         '''
-        print("Testing utils.add_http...")
+        print("Case 1: adding https to url with nothing specified...")
 
         from utils import add_http
         url = 'registry.docker.io'
@@ -73,10 +75,12 @@ class TestUtils(TestCase):
         self.assertEqual("https://%s"%url,http)
 
         # http
+        print("Case 2: adding http to url with nothing specified...")
         http = add_http(url,use_https=False)
         self.assertEqual("http://%s"%url,http)
 
         # This should not change. Note - is url is http, stays http
+        print("Case 3: url already has https, should not change...")
         url = 'https://registry.docker.io'
         http = add_http(url)
         self.assertEqual(url,http)
@@ -93,15 +97,18 @@ class TestUtils(TestCase):
         from utils import basic_auth_header
         
         # If we don't give headers, and no default, should get {} 
+        print("Case 1: Don't give headers, return empty dictionary")
         empty_dict = parse_headers(default_header=False)
         self.assertEqual(empty_dict,dict())
 
         # If we ask for default, should get something back
+        print("Case 2: ask for default headers...")
         headers = parse_headers(default_header=True)
         for field in ["Accept","Content-Type"]:
             self.assertTrue(field in headers)
 
         # Can we add a header?
+        print("Case 3: add a custom header")
         new_header = {"cookies":"nom"}
         headers = parse_headers(default_header=True,
                                 headers=new_header)
@@ -110,6 +117,7 @@ class TestUtils(TestCase):
 
 
         # Basic auth header
+        print("Case 4: basic_auth_header - ask for custom authentication header")
         auth = basic_auth_header(username='vanessa',
                                  password='pancakes')
         self.assertEqual(auth['Authorization'],
@@ -125,10 +133,12 @@ class TestUtils(TestCase):
         from utils import run_command
         
         # An error should return None
+        print("Case 1: Command errors returns None ")
         none  = run_command(['exec','whaaczasd'])
         self.assertEqual(none,None)
 
         # A success should return console output
+        print("Case 2: Command success returns output")
         hello  = run_command(['echo','hello'])
         if not isinstance(hello,str): # python 3 support
             hello = hello.decode('utf-8')
@@ -144,29 +154,34 @@ class TestUtils(TestCase):
         from utils import get_cache
         
         # If there is no cache_base, we should get default
+        print("Case 1: No cache base returns default")
         home = os.environ['HOME']
         cache = get_cache()
         self.assertEqual("%s/.singularity" %home,cache)
         self.assertTrue(os.path.exists(cache))
 
         # If we give a base, we should get that base instead
+        print("Case 2: custom specification of cache base")
         cache_base = '%s/cache' %(home)
         cache = get_cache(cache_base=cache_base)
         self.assertEqual(cache_base,cache)
         self.assertTrue(os.path.exists(cache))
 
         # If we specify a subfolder, we should get that added
+        print("Case 3: Ask for subfolder in cache base")
         subfolder = 'docker'
         cache = get_cache(subfolder=subfolder)
         self.assertEqual("%s/.singularity/%s" %(home,subfolder),cache)
         self.assertTrue(os.path.exists(cache))
 
         # If we disable the cache, we should get temporary directory
+        print("Case 4: Disable the cache (uses /tmp)")
         cache = get_cache(disable_cache=True)
         self.assertTrue(os.path.exists(cache))
         self.assertTrue(re.search("tmp",cache)!=None)
 
         # If environmental variable set, should use that
+        print("Case 5: cache base obtained from environment")
         SINGULARITY_CACHEDIR = '%s/cache' %(home)
         os.environ['SINGULARITY_CACHEDIR'] = SINGULARITY_CACHEDIR
         cache = get_cache()
@@ -183,21 +198,23 @@ class TestUtils(TestCase):
         from utils import change_permissions
         from stat import ST_MODE
         
-        os.system('touch .mooza')
+        tmpdir = tempfile.mkdtemp()
+        tmpfile = '%s/.mooza' %(tmpdir)
+        os.system('touch %s' %(tmpfile))
 
         # 664
-        permissions = oct(os.stat(".mooza")[ST_MODE])[-3:]
+        permissions = oct(os.stat(tmpfile)[ST_MODE])[-3:]
         self.assertTrue(permissions,'664')
         # to 755
-        change_permissions(".mooza",permission="0755")  
-        new_permissions = oct(os.stat(".mooza")[ST_MODE])[-3:]
+        change_permissions(tmpfile,permission="0755")  
+        new_permissions = oct(os.stat(tmpfile)[ST_MODE])[-3:]
         self.assertTrue(new_permissions,'755')
         # and back
-        change_permissions(".mooza",permission="0644")  
-        new_permissions = oct(os.stat(".mooza")[ST_MODE])[-3:]
+        change_permissions(tmpfile,permission="0644")  
+        new_permissions = oct(os.stat(tmpfile)[ST_MODE])[-3:]
         self.assertTrue(new_permissions,'664')
 
-        os.remove('.mooza')
+        shutil.rmtree(tmpdir)
 
 
     #TODO: need to test api_get

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -257,6 +257,51 @@ class TestUtils(TestCase):
         
 
 
+    def test_write_read_files(self):
+        '''test_write_read_files will test the functions write_file and read_file
+        '''
+        print("Testing utils.write_file...")
+        from utils import write_file
+        import json
+        tmpfile = tempfile.mkstemp()[1]
+        os.remove(tmpfile)
+        write_file(tmpfile,"hello!")
+        self.assertTrue(os.path.exists(tmpfile))        
+
+        print("Testing utils.read_file...")
+        from utils import read_file
+        content = read_file(tmpfile)[0]
+        self.assertEqual("hello!",content)
+
+        from utils import write_json
+        print("Testing utils.write_json...")
+        print("Case 1: Providing bad json")
+        bad_json = {"Wakkawakkawakka'}":[{True},"2",3]}
+        tmpfile = tempfile.mkstemp()[1]
+        os.remove(tmpfile)        
+        with self.assertRaises(TypeError) as cm:
+            write_json(bad_json,tmpfile)
+
+        print("Case 2: Providing good json")        
+        good_json = {"Wakkawakkawakka":[True,"2",3]}
+        tmpfile = tempfile.mkstemp()[1]
+        os.remove(tmpfile)
+        write_json(good_json,tmpfile)
+        content = json.load(open(tmpfile,'r'))
+        self.assertTrue(isinstance(content,dict))
+        self.assertTrue("Wakkawakkawakka" in content)
+
+
+    def test_clean_path(self):
+        '''test_clean_path will test the clean_path function
+        '''
+        print("Testing utils.clean_path...")
+        from utils import clean_path
+        ideal_path = '/home/vanessa/Desktop/stuff'
+        self.assertEqual(clean_path('/home/vanessa/Desktop/stuff/'),ideal_path)
+        self.assertEqual(clean_path('/home/vanessa/Desktop/stuff//'),ideal_path)
+        self.assertEqual(clean_path('/home/vanessa//Desktop/stuff/'),ideal_path)
+
     #TODO: need to test api_get
     #TODO: need to test api_get_pagination
         

--- a/libexec/python/tests/test_docker.py
+++ b/libexec/python/tests/test_docker.py
@@ -173,7 +173,7 @@ class TestApi(TestCase):
         '''test_get_config will obtain parameters from the DOcker configuration json
         '''
         from docker.api import get_config
-        from docker.api import get_manfiest
+        from docker.api import get_manifest
 
         # Default should return entrypoint
         print("Case 1: Ask for default command (Entrypoint)")

--- a/libexec/python/tests/test_docker.py
+++ b/libexec/python/tests/test_docker.py
@@ -1,0 +1,194 @@
+'''
+
+test_docker.py: Docker testing functions for Singularity in Python
+
+Copyright (c) 2016, Vanessa Sochat. All rights reserved. 
+
+"Singularity" Copyright (c) 2016, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ 
+This software is licensed under a customized 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
+ 
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights. As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so. 
+
+'''
+
+import os
+import sys
+sys.path.append('..') # directory with docker
+
+from unittest import TestCase
+from utils import read_file
+import tempfile
+
+VERSION = sys.version_info[0]
+
+print("*** PYTHON VERSION %s CLIENT TESTING START ***" %(VERSION))
+
+class TestApi(TestCase):
+
+
+    def setUp(self):
+        self.namespace = 'library'
+        self.repo_name = 'ubuntu'
+        print("\n---START----------------------------------------")
+
+    def tearDown(self):
+        print("---END------------------------------------------")
+
+    def test_create_runscript(self):
+        '''test_create_runscript should ensure that a runscript is generated
+        with some command
+        '''
+        from docker.api import create_runscript
+        cmd = "echo 'Hello World'"
+        base_dir = tempfile.mkdtemp()
+        runscript = create_runscript(cmd=cmd,
+                                     base_dir=base_dir)
+        self.assertTrue(os.path.exists(runscript))
+        generated_cmd = read_file(runscript)[0]
+        # Commands are always in format exec [] "$@"
+        # 'exec echo \'Hello World\' "$@"'
+        self.assertEqual('exec %s "$@"' %cmd,generated_cmd)
+
+
+    def test_get_token(self):
+        '''test_get_token will obtain a token from the Docker registry for a namepspace
+        and repo. 
+        '''
+        from docker.api import get_token
+        print("Case 1: Ask when we don't need token returns None")
+        token = get_token(namespace = 'tensorflow',
+                          repo_name = 'tensorflow',
+                          registry = 'gcr.io')
+        self.assertEqual(token,None)
+        print("Case 2: Ask when we do need token returns token header")
+        token = get_token(namespace = self.namespace,
+                          repo_name = self.repo_name)
+        self.assertTrue("Authorization" in token)
+        self.assertTrue(len(token["Authorization"])==1437)
+
+        #TODO: test here for different registry auth challenge?
+
+
+    def test_get_manifest(self):
+        '''test_get_manifest will obtain a library/repo manifest
+        '''
+        from docker.api import get_manifest
+        print("Case 1: Obtain manifest for %s/%s" %(self.namespace,
+                                                    self.repo_name))
+
+        manifest = get_manifest(repo_name = self.repo_name,
+                                namespace = self.namespace)
+
+        # Default tag should be latest
+        self.assertEqual(manifest['tag'],"latest")
+        self.assertTrue("fsLayers" in manifest)
+        self.assertEqual(manifest['name'],"%s/%s" %(self.namespace,
+                                                    self.repo_name))
+
+        repo_tag = "14.04"
+        print("Case 2: Obtain manifest with custom tag %s" %repo_tag)
+        manifest = get_manifest(repo_name = self.repo_name,
+                                namespace = self.namespace, 
+                                repo_tag = repo_tag)
+        self.assertEqual(manifest['tag'],repo_tag)
+
+        # Giving a bad tag sould return error
+        print("Case 3: Bad tag should print valid tags and exit")
+        with self.assertRaises(SystemExit) as cm:
+            manifest = get_manifest(repo_name = self.repo_name,
+                                    namespace = self.namespace, 
+                                    repo_tag = "mmm.avocado")
+        self.assertEqual(cm.exception.code, 1)
+
+        # Should work for custom registries
+        print("Case 4: Obtain manifest from custom registry")
+        manifest = get_manifest(repo_name = "tensorflow",
+                                namespace = "tensorflow", 
+                                registry = "gcr.io")
+        self.assertEqual(manifest['tag'],"latest")
+        self.assertTrue("fsLayers" in manifest)
+        self.assertEqual(manifest['name'],"%s/%s" %("tensorflow",
+                                                    "tensorflow"))
+
+
+    def test_get_images(self):
+        '''test_get_images will obtain a list of images
+        '''
+        from docker.api import get_images
+        from docker.api import get_manifest
+        print("Case 1: Ask for images without providing manifest")
+        images = get_images(repo_name = self.repo_name,
+                            namespace = self.namespace)
+        self.assertTrue(isinstance(images,list))
+        self.assertTrue(len(images)>1)
+
+        # Get manifest for same repo should return same images
+        print("Case 2: Ask for images with provided manifest")
+        manifest = get_manifest(repo_name = self.repo_name,
+                                namespace = self.namespace)
+        images_manifest = get_images(manifest=manifest)
+        [self.assertEqual(images[x],images_manifest[x]) for x in range(len(images))]
+
+        print("Case 3: Ask for images from custom registry")
+        images = get_images(repo_name = 'tensorflow',
+                            namespace = 'tensorflow',
+                            registry = 'gcr.io')
+        self.assertTrue(isinstance(images,list))
+        self.assertTrue(len(images)>1)
+
+
+    def test_get_tags(self):
+        '''test_get_tags will obtain a list of tags
+        '''
+        from docker.api import get_tags
+
+        print("Case 1: Ask for tags from standard %s/%s" %(self.namespace,
+                                                           self.repo_name))
+        tags = get_tags(repo_name = self.repo_name,
+                        namespace = self.namespace)
+        self.assertTrue(isinstance(tags,list))
+        self.assertTrue(len(tags)>1)
+        [self.assertTrue(x in tags) for x in ['xenial','latest','trusty','yakkety']]
+
+        print("Case 2: Ask for tags from custom registry")
+        tags = get_tags(repo_name = 'tensorflow',
+                        namespace = 'tensorflow',
+                        registry = 'gcr.io')
+        self.assertTrue(isinstance(tags,list))
+        self.assertTrue(len(tags)>1)
+        [self.assertTrue(x in tags) for x in ['latest','latest-gpu']]
+  
+
+    def test_get_config(self):
+        '''test_get_config will obtain parameters from the DOcker configuration json
+        '''
+        from docker.api import get_config
+        from docker.api import get_manfiest
+
+        # Default should return entrypoint
+        print("Case 1: Ask for default command (Entrypoint)")
+        manifest = get_manifest(repo_name = self.repo_name,
+                                namespace = self.namespace)
+        entrypoint = get_config(manifest=manifest)
+
+        # Ubuntu latest should have None
+        self.assertEqual(entrypoint,None)
+        
+        print("Case 2: Ask for custom command (Cmd)")
+        entrypoint = get_config(manifest=manifest,
+                                spec="Cmd")
+        self.assertEqual(entrypoint,'/bin/bash')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -24,6 +24,7 @@ perform publicly and display publicly, and to permit other to do so.
 
 from defaults import SINGULARITY_CACHE
 from logman import logger
+import json
 import os
 import re
 import shutil
@@ -298,9 +299,9 @@ def write_json(json_obj,filename,mode="w",print_pretty=True):
     logger.info("Writing json file %s with mode %s.",filename,mode)
     filey = open(filename,mode)
     if print_pretty == True:
-        filey.writelines(simplejson.dumps(json_obj, indent=4, separators=(',', ': ')))
+        filey.writelines(json.dumps(json_obj, indent=4, separators=(',', ': ')))
     else:
-        filey.writelines(simplejson.dumps(json_obj))
+        filey.writelines(json.dumps(json_obj))
     filey.close()
     return filename
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -265,10 +265,17 @@ def extract_tar(targz,output_folder):
     :param targz: the tar.gz file to extract
     :param output_folder: the output folder to extract to
     '''
+    # If extension is .tar.gz, use -xzf
+    args = '-xf'
+    if re.search('.tar.gz$',targz):
+        args = '-xzf'
+
     # Just use command line, more succinct.
-    command = ["tar","-xzf",targz,"-C",output_folder,"--exclude=dev/*"]
+    command = ["tar", args, targz, "-C", output_folder, "--exclude=dev/*"]
     print("Extracting %s" %(targz))
-    return run_command(command) 
+
+    # Should we return a list of extracted files? Current returns empty string
+    return run_command(command)
 
 
 def write_file(filename,content,mode="w"):

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -173,25 +173,15 @@ def basic_auth_header(username, password):
     :param username: the username
     :param password: the password
     '''
-    credentials = "%s:%s" % (username, password)   
-    credentials = check_encoding(credentials)
-    credentials = base64.b64encode(credentials)
-
-    if isinstance(credentials,bytes):
-        credentials = credentials.decode('utf-8')
+    s = "%s:%s" % (username, password)
+    if sys.version_info[0] >= 3:
+        s = bytes(s, 'utf-8')
+        credentials = base64.b64encode(s).decode('utf-8')
+    else:
+        credentials = base64.b64encode(s)
     auth = {"Authorization": "Basic %s" % credentials}
     return auth
 
-
-def check_encoding(string):
-    '''check_encoding will check for a string, and if so, encode in utf-8. In
-    python 2.x this does not much, but in 3.x it makes sure we have a bytes
-    object
-    :param string: the string to check
-    '''
-    if isinstance(string,str):
-        return string.encode('utf-8')
-    return string
 
 ############################################################################
 ## COMMAND LINE OPERATIONS #################################################


### PR DESCRIPTION
This will add the additional docker tests for the python functions

Changes proposed in this pull request

 - Addition of tests in libexec/python/tests/test_docker.py
 - Adding test commands to circle.yml for docker, for each of python 2 and 3
-  Adding prints with details of testing Case (eg, "Case 1:...)
-  Adding support to extract_tar function to tell if compressed (or not) based on file name
-  Fixed print statement of command extracted in get_config (was hard coded to be CMD, now can be custom / user defined)

@singularityware-admin
