### PR TITLE
Flx42 docker image environment

### DIFF
--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -25,7 +25,8 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 from docker.api import (
-    create_runscript, 
+    create_runscript,
+    create_envfile,
     get_config, 
     get_images,
     get_layer, 
@@ -240,6 +241,9 @@ def run(args):
         if args.disable_cache == True:
             shutil.rmtree(cache_base)
 
+        env = get_config(manifest, 'Env').split("\n")
+        create_envfile(env=env,
+                       base_dir=singularity_rootfs)
 
         logger.info("*** FINISHING DOCKER BOOTSTRAP PYTHON PORTION ****\n")
 

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -2,7 +2,7 @@
 
 '''
 
-bootstrap.py: python helper for Singularity command line tool
+cli.py: python helper for Singularity command line tool
 
 Copyright (c) 2016, Vanessa Sochat. All rights reserved. 
 
@@ -241,8 +241,8 @@ def run(args):
         if args.disable_cache == True:
             shutil.rmtree(cache_base)
 
-        env = get_config(manifest, 'Env').split("\n")
-        create_envfile(env=env,
+        # environment is added to ~/environment in the image
+        create_envfile(manifest=manifest,
                        base_dir=singularity_rootfs)
 
         logger.info("*** FINISHING DOCKER BOOTSTRAP PYTHON PORTION ****\n")

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 '''
 
 api.py: Docker helper functions for Singularity in Python
@@ -51,13 +49,34 @@ def create_runscript(cmd,base_dir):
     output_file = write_file(runscript,content)
     return output_file
 
-def create_envfile(env, base_dir):
-    envfile = "%s/environment" % base_dir
+
+def create_envfile(base_dir,env=None,manifest=None):
+    '''create_envfile will generate a file called environment
+    in the base_dir of an image
+    :param base_dir: the base_dir to write the file to
+    :param manifest: the manifest to generate the Env for.
+    :param env: a list of environment variables to export, if manifest
+    is not provided
+    '''
+    if env == None:
+        if manifest == None:
+            logger.error("env or manifest must be provided, exiting")
+            sys.exit(1)    
+        env = get_config(manifest, 'Env').split("\n")
+
+    # A user providing an environment not split by '/n' --> error
+    if not isinstance(env,list):
+        env = [env]
+
+    envfile = "%s/environment" %(base_dir)
+    logger.info("Generating environment file %s",envfile)
     with open(envfile, "w") as f:
         f.write("# Docker image environment\n")
         for e in env:
             f.write("export %s\n" % e)
         f.write('export PS1="Singularity.$SINGULARITY_CONTAINER> "\n')
+    return envfile
+
 
 def get_token(namespace,repo_name,registry=None,auth=None):
     '''get_token uses HTTP basic authentication to get a token for Docker registry API V2 operations

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -51,6 +51,13 @@ def create_runscript(cmd,base_dir):
     output_file = write_file(runscript,content)
     return output_file
 
+def create_envfile(env, base_dir):
+    envfile = "%s/environment" % base_dir
+    with open(envfile, "w") as f:
+        f.write("# Docker image environment\n")
+        for e in env:
+            f.write("export %s\n" % e)
+        f.write('export PS1="Singularity.$SINGULARITY_CONTAINER> "\n')
 
 def get_token(namespace,repo_name,registry=None,auth=None):
     '''get_token uses HTTP basic authentication to get a token for Docker registry API V2 operations

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -285,7 +285,8 @@ class TestUtils(TestCase):
         tmpfile = tempfile.mkstemp()[1]
         os.remove(tmpfile)
         write_json(good_json,tmpfile)
-        content = json.load(open(tmpfile,'r'))
+        with open(tmpfile,'r') as filey:
+            content = json.load(filey)
         self.assertTrue(isinstance(content,dict))
         self.assertTrue("Wakkawakkawakka" in content)
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 '''
 utils.py: python helper for singularity command line tool
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -282,9 +282,8 @@ def write_file(filename,content,mode="w"):
     and properly close the file
     '''
     logger.info("Writing file %s with mode %s.",filename,mode)
-    filey = open(filename,mode)
-    filey.writelines(content)
-    filey.close()
+    with open(filename,mode) as filey:
+        filey.writelines(content)
     return filename
 
 
@@ -295,12 +294,11 @@ def write_json(json_obj,filename,mode="w",print_pretty=True):
     :param pretty_print: if True, will use nicer formatting   
     '''
     logger.info("Writing json file %s with mode %s.",filename,mode)
-    filey = open(filename,mode)
-    if print_pretty == True:
-        filey.writelines(json.dumps(json_obj, indent=4, separators=(',', ': ')))
-    else:
-        filey.writelines(json.dumps(json_obj))
-    filey.close()
+    with open(filename,mode) as filey:
+        if print_pretty == True:
+            filey.writelines(json.dumps(json_obj, indent=4, separators=(',', ': ')))
+        else:
+            filey.writelines(json.dumps(json_obj))
     return filename
 
 
@@ -309,9 +307,9 @@ def read_file(filename,mode="r"):
     and properly close the file
     '''
     logger.info("Reading file %s with mode %s.",filename,mode)
-    filey = open(filename,mode)
-    content = filey.readlines()
-    filey.close()
+ 
+    with open(filename,mode) as filey:
+        content = filey.readlines()
     return content
 
 


### PR DESCRIPTION
Fixes #369 and closes #364 

Changes proposed in this pull request

 - adding tests for environment creation function
 - adjusting function to allow user to provide manifest or env, with the env taking preference
 - if user provides a string (eg, gives an env without splitting by newline) we check for this

@gmkurtzer there will be a print of the environment files in the tests - could you please check to see if the PS1 part looks ok? I'm not sure what that variable is, or why there is an extra `>` at the end.
@flx42 please review as well!

@singularityware-admin
