### PR TITLE
Flx42 python add http cleanup

### DIFF
--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -68,27 +68,44 @@ class TestUtils(TestCase):
     def test_add_http(self):
         '''test_add_http ensures that http is added to a url
         '''
-        print("Case 1: adding https to url with nothing specified...")
 
         from utils import add_http
-        url = 'registry.docker.io'
+        url_http = 'http://registry.docker.io'
+        url_https = 'https://registry.docker.io'
+
+        print("Case 1: adding https to url with nothing specified...")
 
         # Default is https
+        url = 'registry.docker.io'
         http = add_http(url)
-        self.assertEqual("https://%s"%url,http)
+        self.assertEqual(url_https,http)
 
         # http
         print("Case 2: adding http to url with nothing specified...")
         http = add_http(url,use_https=False)
-        self.assertEqual("http://%s"%url,http)
+        self.assertEqual(url_http,http)
 
         # This should not change. Note - is url is http, stays http
         print("Case 3: url already has https, should not change...")
         url = 'https://registry.docker.io'
         http = add_http(url)
-        self.assertEqual(url,http)
+        self.assertEqual(url_https,http)
 
-        #TODO: add test to change http to https
+        # This should not change. Note - is url is http, stays http
+        print("Case 4: url already has http, should not change...")
+        url = 'http://registry.docker.io'
+        http = add_http(url,use_https=False)
+        self.assertEqual(url_http,http)
+
+        print("Case 5: url has http, should change to https")
+        url = 'http://registry.docker.io'
+        http = add_http(url)
+        self.assertEqual(url_https,http)
+
+        print("Case 6: url has https, should change to http")
+        url = 'https://registry.docker.io'
+        http = add_http(url,use_https=False)
+        self.assertEqual(url_http,http)
 
 
     def test_headers(self):

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -229,11 +229,11 @@ class TestUtils(TestCase):
         # Create and close a temporary tar.gz
         print("Case 1: Testing tar.gz...")
         creation_dir = tempfile.mkdtemp()
-        targz,files = create_test_tar(creation_dir)
+        archive,files = create_test_tar(creation_dir)
 
         # Extract to different directory
         extract_dir = tempfile.mkdtemp()
-        extract_tar(targz=targz,
+        extract_tar(archive=archive,
                     output_folder=extract_dir)
         extracted_files = [x.replace(extract_dir,'') for x in glob("%s/tmp/*" %(extract_dir))]
         [self.assertTrue(x in files) for x in extracted_files]
@@ -244,11 +244,11 @@ class TestUtils(TestCase):
 
         print("Case 1: Testing tar...")
         creation_dir = tempfile.mkdtemp()
-        targz,files = create_test_tar(creation_dir,compressed=False)
+        archive,files = create_test_tar(creation_dir,compressed=False)
 
         # Extract to different directory
         extract_dir = tempfile.mkdtemp()
-        extract_tar(targz=targz,
+        extract_tar(archive=archive,
                     output_folder=extract_dir)
         extracted_files = [x.replace(extract_dir,'') for x in glob("%s/tmp/*" %(extract_dir))]
         [self.assertTrue(x in files) for x in extracted_files]
@@ -305,18 +305,18 @@ class TestUtils(TestCase):
         
 # Supporting Test Functions
 def create_test_tar(tmpdir,compressed=True):
-    targz = "%s/toodles.tar.gz" %tmpdir
+    archive = "%s/toodles.tar.gz" %tmpdir
     if compressed == False:
-        targz = "%s/toodles.tar" %tmpdir
+        archive = "%s/toodles.tar" %tmpdir
     mode = "w:gz"
     if compressed == False:
         mode = "w"
-    print("Creating %s" %(targz))
-    tar = tarfile.open(targz, mode)
+    print("Creating %s" %(archive))
+    tar = tarfile.open(archive, mode)
     files = [tempfile.mkstemp()[1] for x in range(3)]
     [tar.add(x) for x in files]
     tar.close()
-    return targz,files
+    return archive,files
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -107,6 +107,11 @@ class TestUtils(TestCase):
         http = add_http(url,use_https=False)
         self.assertEqual(url_http,http)
 
+        print("Case 7: url should have trailing slash stripped")
+        url = 'https://registry.docker.io/'
+        http = add_http(url,use_https=False)
+        self.assertEqual(url_http,http)
+
 
     def test_headers(self):
         '''test_add_http ensures that http is added to a url

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -36,7 +36,7 @@ try:
     from urllib.error import HTTPError
 except ImportError:
     from urllib import urlencode
-    import urlparse
+    from urlparse import urlparse
     from urllib2 import urlopen, Request, HTTPError
 
 # Python less than version 3 must import OSError

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -24,7 +24,6 @@ from defaults import SINGULARITY_CACHE
 from logman import logger
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -259,19 +258,19 @@ def change_permissions(path,permission="0755",recursive=True):
         return run_command(cmd)
 
 
-def extract_tar(targz,output_folder):
-    '''extract_tar will extract a tar.gz to a specified output folder
-    :param targz: the tar.gz file to extract
+def extract_tar(archive,output_folder):
+    '''extract_tar will extract a tar archive to a specified output folder
+    :param archive: the archive file to extract
     :param output_folder: the output folder to extract to
     '''
     # If extension is .tar.gz, use -xzf
     args = '-xf'
-    if re.search('.tar.gz$',targz):
+    if archive.endswith(".tar.gz"):
         args = '-xzf'
 
     # Just use command line, more succinct.
-    command = ["tar", args, targz, "-C", output_folder, "--exclude=dev/*"]
-    print("Extracting %s" %(targz))
+    command = ["tar", args, archive, "-C", output_folder, "--exclude=dev/*"]
+    print("Extracting %s" %(archive))
 
     # Should we return a list of extracted files? Current returns empty string
     return run_command(command)

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -61,7 +61,7 @@ def add_http(url,use_https=True):
     parsed = urlparse(url)
     # Returns tuple with(scheme,netloc,path,params,query,fragment)
 
-    return "%s%s" %(scheme,"".join(parsed[1:]))
+    return "%s%s" %(scheme,"".join(parsed[1:]).rstrip('/'))
 
 
 def api_get_pagination(url):

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -57,13 +57,13 @@ def add_http(url,use_https=True):
     prefix = "https://"
     if use_https == False:
         prefix="http://"
-    
+
     # Does the url have http?
-    if re.search('^http*',url) == None:
+    if not url.startswith('http'):
         url = "%s%s" %(prefix,url)
 
     # Always remove extra slash
-    url = url.strip('/')
+    url = url.rstrip('/')
 
     return url
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -31,11 +31,12 @@ import tempfile
 import tarfile
 import base64
 try:
-    from urllib.parse import urlencode
+    from urllib.parse import urlencode, urlparse
     from urllib.request import urlopen, Request
     from urllib.error import HTTPError
 except ImportError:
     from urllib import urlencode
+    import urlparse
     from urllib2 import urlopen, Request, HTTPError
 
 # Python less than version 3 must import OSError
@@ -53,18 +54,15 @@ def add_http(url,use_https=True):
     :param url: the url to add the prefix to
     :param use_https: should we default to https? default is True
     '''
-    prefix = "https://"
+    scheme = "https://"
     if use_https == False:
-        prefix="http://"
+        scheme="http://"
 
-    # Does the url have http?
-    if not url.startswith('http'):
-        url = "%s%s" %(prefix,url)
+    parsed = urlparse(url)
+    # Returns tuple with(scheme,netloc,path,params,query,fragment)
 
-    # Always remove extra slash
-    url = url.rstrip('/')
+    return "%s%s" %(scheme,"".join(parsed[1:]))
 
-    return url
 
 def api_get_pagination(url):
    '''api_pagination is a wrapper for "api_get" that will also handle pagination


### PR DESCRIPTION
Fixes #356 and integrates and closes #356 to integrate @flx42 contributions to the functions

Changes proposed in this pull request

 - add_http function reliably returns the correct URI asked for the by the user, given that http, https, or no URI are supplied. It does this by using `urlparse` to parse the url and add the extension to what is requested to the rest. 
 - the tests have been updated to test for all these cases

@singularityware-admin
