### PR TITLE
Restore 'expected' signal handling rules for the payload.

### DIFF
--- a/src/lib/ns/pid/pid.c
+++ b/src/lib/ns/pid/pid.c
@@ -93,6 +93,13 @@ int singularity_ns_pid_unshare(void) {
     // PID namespace requires a fork to activate!
     singularity_fork_run();
 
+    // At this point, we are now PID 1; when we later exec the payload, it will also be PID 1.
+    // Unfortunately, PID 1 in Linux has special signal handling rules (the _only_ signal that
+    // will terminate the process is SIGKILL; all other signals are ignored).  Hence, we fork
+    // one more time.  This makes PID 1 a shim process and the payload process PID 2 (meaning
+    // that the payload gets the "normal" signal handling rules it would expect).
+    singularity_fork_run();
+
     return(0);
 }
 


### PR DESCRIPTION

@singularityware-admin

Without this, the payload process - when PID namespaces are used -
gets PID 1 rules for signal handling.  This can lead to surprising
results for end-users.

This utilizes an additional `sexec` process inside the PID namespace as a shim process for signal handling.