### PR TITLE
Update/docker registry api get_images

### DIFF
--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -187,7 +187,8 @@ def run(args):
                                 auth=auth)
 
         # Get images from manifest using version 2.0 of Docker Registry API
-        images = get_images(manifest=manifest,
+        images = get_images(repo_name=repo_name,
+                            namespace=namespace,
                             registry=args.registry,
                             auth=auth)
         

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -194,7 +194,10 @@ def get_manifest(repo_name,namespace,repo_tag="latest",registry=None,auth=None,h
 
     # Add ['Accept'] header to specify version 2 of manifest
     if headers != None:
-        token.update(headers)
+        if token != None:
+            token.update(headers)
+        else:
+            token = headers
 
     response = api_get(base,headers=token,default_header=True)
     try:

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -137,7 +137,6 @@ class TestUtils(TestCase):
         new_header = {"cookies":"nom"}
         headers = parse_headers(default_header=True,
                                 headers=new_header)
-        print(headers)
         for field in ["Accept","Content-Type","cookies"]:
             self.assertTrue(field in headers)
 

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -137,6 +137,7 @@ class TestUtils(TestCase):
         new_header = {"cookies":"nom"}
         headers = parse_headers(default_header=True,
                                 headers=new_header)
+        print(headers)
         for field in ["Accept","Content-Type","cookies"]:
             self.assertTrue(field in headers)
 

--- a/libexec/python/tests/test_docker.py
+++ b/libexec/python/tests/test_docker.py
@@ -130,20 +130,13 @@ class TestApi(TestCase):
         '''
         from docker.api import get_images
         from docker.api import get_manifest
-        print("Case 1: Ask for images without providing manifest")
+        print("Case 1: Ask for images")
         images = get_images(repo_name = self.repo_name,
                             namespace = self.namespace)
         self.assertTrue(isinstance(images,list))
         self.assertTrue(len(images)>1)
 
-        # Get manifest for same repo should return same images
-        print("Case 2: Ask for images with provided manifest")
-        manifest = get_manifest(repo_name = self.repo_name,
-                                namespace = self.namespace)
-        images_manifest = get_images(manifest=manifest)
-        [self.assertEqual(images[x],images_manifest[x]) for x in range(len(images))]
-
-        print("Case 3: Ask for images from custom registry")
+        print("Case 2: Ask for images from custom registry")
         images = get_images(repo_name = 'tensorflow',
                             namespace = 'tensorflow',
                             registry = 'gcr.io')

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -103,15 +103,17 @@ def parse_headers(default_header,headers=None):
 
     if default_header == True:
         if headers != None:
-            header.update(headers)
+            final_headers = header.copy()
+            final_headers.update(headers)
         else:
-            headers = header
+            final_headers = header
 
     else:
+        final_headers = headers
         if headers == None:
-            headers = dict() 
+            final_headers = dict() 
 
-    return headers
+    return final_headers
 
 
 def api_get(url,data=None,default_header=True,headers=None,stream=None,return_response=False):

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -103,7 +103,7 @@ def parse_headers(default_header,headers=None):
 
     if default_header == True:
         if headers != None:
-            headers.update(header)
+            header.update(headers)
         else:
             headers = header
 


### PR DESCRIPTION
Fixes #382 

This PR will use the updated schema 2 endpoint to obtain a manifest to pull images from the registry in order base --> child. For example, here is the reported pull by @jmstover before the fix:

```bash
INFO:python:Adding digest sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
INFO:python:Adding digest sha256:cd1890e69bd64ae2f7c68fcfd2c44b006fb46efa437c480f5350d335cd4ab771
INFO:python:Adding digest sha256:3e62cf0fa9bc550d2353a23d186416e5a16efbad1932bee99bb9138a480296f9
INFO:python:Adding digest sha256:2bccc34703d47763cca99cb080f262b372c305346853c4096711a4f0da58fc56
INFO:python:Adding digest sha256:8d6b7c57d3ff588a9a993583b8794596cc9e169427b25329130a6584ef3eea6e
INFO:python:Adding digest sha256:7911183054129118d6df59f99fd6681f86ae94cc8cdf23fb318f4009c3b7e489
INFO:python:Adding digest sha256:f7cf2c8316ae754707656c6eaa688e3b0c9ddbeb4b9b98b9a1c2bf1edfb3b2d4
INFO:python:Adding digest sha256:951040916ca34ecc97bbe1dce49294d8bf8828ffa6540dfa1e59ee18307fcdab
INFO:python:Adding digest sha256:fe629c04d1148cd188b4bd869c083ef36caadb6ebc7eb1f0c87c0ea5932130af
INFO:python:Adding digest sha256:0b25ca541a8b3b3128ff8df5d9bb92e2051e907d208d5c2c01b2fea7ce395593
INFO:python:Adding digest sha256:9163f0d1336e9da4e160be470f24e22f5f03a9963c5f67b5c034f5803f94fda2
INFO:python:Adding digest sha256:ac18bb72f0eacaad47a8e1a919db78b9801263266b111110ccdb53cf99e4cadb
INFO:python:Adding digest sha256:63f2fe4291079511a8c24ea2b08a593ffc3826fca0519622f92d2bd3dab517a8
INFO:python:Adding digest sha256:a236d32b835b99c29bfcf801163781f30a35f5907bdbcac0cf3ec5b056e95306
INFO:python:Adding digest sha256:694658681c8a77ad5fd501de74339d8f29a038134164feb5d3755c524510e373
INFO:python:Adding digest sha256:2fa2ee5b62e9ea7da6e434e5cf625b2bf4ad80153b3e73f06f039cb7912d03c7
INFO:python:Adding digest sha256:06e33d905fee3d6293b8fa4012ac5e93942d9b9314f8888be97f59af6ed1b923
INFO:python:Adding digest sha256:336f6e105bc20420026cade0c4cf8d98d9f4123343c5d4eaecca4a977e3133fc
INFO:python:Adding digest sha256:3ffadd8cf926664abc373d20f6a8d3a56600926e00edb671a909e6c3950b361d
INFO:python:Adding digest sha256:223a2c0531d489ad71710e0ddaf4cf66d5cbd1b4aeb7a7840b38001d48b3e203
INFO:python:Adding digest sha256:6ebac0c8a1bb8f2c1ce17b74922611f3f57ccadd9370d8f5e2329972e86cd1f8
INFO:python:Adding digest sha256:6b133709d8d5b59e1e86eaee3963a1bca1980d99d09dfa26d2542a71f5b7bdd6
INFO:python:Adding digest sha256:6b24dc0e5e9867b594d8e2718f9e3efa5ed4556a4203ce965d02c3f8466d297c
INFO:python:Adding digest sha256:a62784d6bd518295fdf6fbf39cffc7ef2a061782805d9900c4e70100f597445a
INFO:python:Adding digest sha256:08d48e6f1cff259389732d35307bb877215fa28867cdaff50c1dbd6e0b993c1f
```
and after the fix the first layer (the previous last layer) is now the first. I'm not sure about the rest, but it's been half a day since that output was generated, so likely there have been changes?

```bash
Cache folder set to /home/vanessa/.singularity/docker
Downloading layer sha256:08d48e6f1cff259389732d35307bb877215fa28867cdaff50c1dbd6e0b993c1f
Extracting /home/vanessa/.singularity/docker/sha256:08d48e6f1cff259389732d35307bb877215fa28867cdaff50c1dbd6e0b993c1f.tar.gz
Downloading layer sha256:17d3b1026ce4ce98307ca6afcba4031a3c6babbc8afd41db02ee4c31abc6e250
Extracting /home/vanessa/.singularity/docker/sha256:17d3b1026ce4ce98307ca6afcba4031a3c6babbc8afd41db02ee4c31abc6e250.tar.gz
```

note that there is still the permissions issue that needs to be resolved for layer download - after these layers I get years of permission errors.

Here is ubuntu (before the fix):

```bash
INFO:python:Adding digest sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
INFO:python:Adding digest sha256:9332eaf1a55b72fb779d2f249b65855c623c8ce7be83c822b7d80115ef5a3af3
INFO:python:Adding digest sha256:47b5e16c0811b08c1cf3198fa5ac0b920946ac538a0a0030627d19763e2fa212
INFO:python:Adding digest sha256:e931b117db38a05b9d0bbd28ca99a0abe5236a0026d88b3db804f520e59977ec
INFO:python:Adding digest sha256:8f9757b472e7962a4304d4af61630e2cde66129218135b4093a43b9db8942c34
INFO:python:Adding digest sha256:af49a5ceb2a56a8232402f5868cdb13dfdae5d66a62955a73e647e16e9f30a63
```

And after the fix

```bash
singularity shell docker://ubuntu
Cache folder set to /home/vanessa/.singularity/docker
Downloading layer sha256:af49a5ceb2a56a8232402f5868cdb13dfdae5d66a62955a73e647e16e9f30a63
Extracting /home/vanessa/.singularity/docker/sha256:af49a5ceb2a56a8232402f5868cdb13dfdae5d66a62955a73e647e16e9f30a63.tar.gz
Downloading layer sha256:8f9757b472e7962a4304d4af61630e2cde66129218135b4093a43b9db8942c34
Extracting /home/vanessa/.singularity/docker/sha256:8f9757b472e7962a4304d4af61630e2cde66129218135b4093a43b9db8942c34.tar.gz
Downloading layer sha256:e931b117db38a05b9d0bbd28ca99a0abe5236a0026d88b3db804f520e59977ec
Extracting /home/vanessa/.singularity/docker/sha256:e931b117db38a05b9d0bbd28ca99a0abe5236a0026d88b3db804f520e59977ec.tar.gz
Downloading layer sha256:47b5e16c0811b08c1cf3198fa5ac0b920946ac538a0a0030627d19763e2fa212
Extracting /home/vanessa/.singularity/docker/sha256:47b5e16c0811b08c1cf3198fa5ac0b920946ac538a0a0030627d19763e2fa212.tar.gz
Downloading layer sha256:9332eaf1a55b72fb779d2f249b65855c623c8ce7be83c822b7d80115ef5a3af3
Extracting /home/vanessa/.singularity/docker/sha256:9332eaf1a55b72fb779d2f249b65855c623c8ce7be83c822b7d80115ef5a3af3.tar.gz
Singularity: Invoking an interactive shell within container...
```

It doesn't totally seem to be a flip, but according to what is expected in the manifest json image response, this is the right way to go about it. For example, here is the manifest obtained for ubuntu:

```bash
ut[97]: 
{'config': {'digest': 'sha256:4ca3a192ff2a5b7e225e81dc006b6379c10776ed3619757a65608cb72de0a7f6',
  'mediaType': 'application/vnd.docker.container.image.v1+json',
  'size': 3621},
 'layers': [{'digest': 'sha256:af49a5ceb2a56a8232402f5868cdb13dfdae5d66a62955a73e647e16e9f30a63',
   'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
   'size': 50096701},
  {'digest': 'sha256:8f9757b472e7962a4304d4af61630e2cde66129218135b4093a43b9db8942c34',
   'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
   'size': 824},
  {'digest': 'sha256:e931b117db38a05b9d0bbd28ca99a0abe5236a0026d88b3db804f520e59977ec',
   'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
   'size': 518},
  {'digest': 'sha256:47b5e16c0811b08c1cf3198fa5ac0b920946ac538a0a0030627d19763e2fa212',
   'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
   'size': 682},
  {'digest': 'sha256:9332eaf1a55b72fb779d2f249b65855c623c8ce7be83c822b7d80115ef5a3af3',
   'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
   'size': 162}],
 'mediaType': 'application/vnd.docker.distribution.manifest.v2+json',
 'schemaVersion': 2}
```

@singularityware-admin
