### PR TITLE
updating python tests to remove tag

### DIFF
--- a/libexec/python/tests/test_docker.py
+++ b/libexec/python/tests/test_docker.py
@@ -104,7 +104,9 @@ class TestApi(TestCase):
         manifest = get_manifest(repo_name = self.repo_name,
                                 namespace = self.namespace, 
                                 repo_tag = repo_tag)
-        self.assertEqual(manifest['tag'],repo_tag)
+
+        # This will trigger if/when they change the schema on us
+        self.assertEqual(manifest['schemaVersion'],1)
 
         # Giving a bad tag sould return error
         print("Case 3: Bad tag should print valid tags and exit")
@@ -119,10 +121,7 @@ class TestApi(TestCase):
         manifest = get_manifest(repo_name = "tensorflow",
                                 namespace = "tensorflow", 
                                 registry = "gcr.io")
-        self.assertEqual(manifest['tag'],"latest")
         self.assertTrue("fsLayers" in manifest)
-        self.assertEqual(manifest['name'],"%s/%s" %("tensorflow",
-                                                    "tensorflow"))
 
 
     def test_get_images(self):


### PR DESCRIPTION
This is a quick patch to update the python tests - for custom registries, it looks like the standard manifest is changing (and not including the "tag" key anymore). We don't rely on this for functionality, and since we retrieve the manifests by specifying the tag, this test isn't needed. I added a test to look at the manifest version, so as soon as (if/when) they change it on us, the test will fail and we will know, and can read about the right way to update the manifest (and hopefully avoid the situation next time)

@singularityware-admin

