### PR TITLE
Drop privileges in parent threads

### DIFF
--- a/src/lib/fork.c
+++ b/src/lib/fork.c
@@ -30,6 +30,7 @@
 #include <sys/wait.h>
 
 
+#include "lib/ns/ns.h"
 #include "lib/privilege.h"
 #include "lib/message.h"
 #include "util/util.h"
@@ -248,7 +249,9 @@ pid_t singularity_fork(void) {
         // At this point, we have nothing to do but wait on some external action.
         // We should never again need to increase our privileges.  Drop privs
         // permanently and then indicate the child can proceed.
-        singularity_priv_drop_perm();
+        if (singularity_ns_user_configured() < 0) {
+            singularity_priv_drop_perm();
+        }
         signal_go_ahead(0);
 
         do {

--- a/src/lib/ns/ns.h
+++ b/src/lib/ns/ns.h
@@ -33,6 +33,7 @@
 
     extern int singularity_ns_user_unshare(void);
     extern int singularity_ns_user_enabled(void);
+    extern int singularity_ns_user_configured(void);
 
     extern int singularity_ns_join(pid_t attach_pid);
 

--- a/src/lib/rootfs/dir/dir.c
+++ b/src/lib/rootfs/dir/dir.c
@@ -82,7 +82,7 @@ int rootfs_dir_mount(void) {
         singularity_message(ERROR, "Could not mount container directory %s->%s: %s\n", source_dir, mount_point, strerror(errno));
         return 1;
     }
-    if ( singularity_priv_userns_enabled() != 1 ) {
+    if ( singularity_priv_userns_enabled() < 0 ) {
         if ( mount(NULL, mount_point, NULL, MS_BIND|MS_NOSUID|MS_REC|MS_REMOUNT, NULL) < 0 ) {
             singularity_message(ERROR, "Could not bind read only %s: %s\n", mount_point, strerror(errno));
             ABORT(255);
@@ -91,7 +91,7 @@ int rootfs_dir_mount(void) {
     singularity_priv_drop();
 
     if ( read_write <= 0 ) {
-        if ( singularity_ns_user_enabled() <= 0 ) {
+        if ( singularity_ns_user_enabled() < 0 ) {
             singularity_priv_escalate();
             singularity_message(VERBOSE2, "Making mount read only: %s\n", mount_point);
             if ( mount(NULL, mount_point, NULL, MS_BIND|MS_NOSUID|MS_REC|MS_REMOUNT|MS_RDONLY, NULL) < 0 ) {

--- a/src/lib/singularity.h
+++ b/src/lib/singularity.h
@@ -53,6 +53,7 @@
     // Unshare the user namespace (if supported by platform itself)
     extern int singularity_ns_user_unshare(void);
     extern int singularity_ns_user_enabled(void);
+    extern int singularity_ns_user_configured(void);
 
 
     // IMAGE


### PR DESCRIPTION
Partial fix for #384

This forces the child process (post-fork) to delay until the parent has confirmed it has permanently dropped all privileges.

When testing, I additionally noticed that the exit status is incorrect when the payload is terminated by a signal; that is fixed here.

@singularityware-admin
