### PR TITLE
updating tests and cli.py to use optparse

### DIFF
--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -46,7 +46,7 @@ def get_parser():
 
 
     parser = optparse.OptionParser(description='bootstrap Docker images for Singularity containers',
-                                   usage="usage: %prog [options] filename",
+                                   usage="usage: %prog [options]",
                                    version="%prog 2.2")
 
 

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -35,7 +35,7 @@ from docker.api import (
 
 from utils import extract_tar, get_cache, basic_auth_header
 from logman import logger
-import argparse
+import optparse
 import os
 import re
 import shutil
@@ -44,54 +44,58 @@ import tempfile
 
 def get_parser():
 
-    parser = argparse.ArgumentParser(description="bootstrap Docker images for Singularity containers")
+
+    parser = optparse.OptionParser(description='bootstrap Docker images for Singularity containers',
+                                   usage="usage: %prog [options] filename",
+                                   version="%prog 1.0")
+
 
     # Name of the docker image, required
-    parser.add_argument("--docker", 
-                        dest='docker', 
-                        help="name of Docker image to bootstrap, in format library/ubuntu:latest", 
-                        type=str, 
-                        default=None)
+    parser.add_option("--docker", 
+                      dest='docker', 
+                      help="name of Docker image to bootstrap, in format library/ubuntu:latest", 
+                      type=str, 
+                      default=None)
 
     # root file system of singularity image
-    parser.add_argument("--rootfs", 
-                        dest='rootfs', 
-                        help="the path for the root filesystem to extract to", 
-                        type=str, 
-                        default=None)
+    parser.add_option("--rootfs", 
+                      dest='rootfs', 
+                      help="the path for the root filesystem to extract to", 
+                      type=str, 
+                      default=None)
 
     # Docker registry (default is registry-1.docker.io
-    parser.add_argument("--registry", 
-                        dest='registry', 
-                        help="the registry path to use, to replace registry-1.docker.io", 
-                        type=str, 
-                        default=None)
+    parser.add_option("--registry", 
+                      dest='registry', 
+                      help="the registry path to use, to replace registry-1.docker.io", 
+                      type=str, 
+                      default=None)
 
 
     # Flag to add the Docker CMD as a runscript
-    parser.add_argument("--cmd", 
-                        dest='includecmd', 
-                        action="store_true",
-                        help="boolean to specify that CMD should be used instead of ENTRYPOINT as the runscript.", 
-                        default=False)
+    parser.add_option("--cmd", 
+                      dest='includecmd', 
+                      action="store_true",
+                      help="boolean to specify that CMD should be used instead of ENTRYPOINT as the runscript.", 
+                      default=False)
 
-    parser.add_argument("--username",
-                        dest='username',
-                        help="username for registry authentication",
-                        default=None)
+    parser.add_option("--username",
+                      dest='username',
+                      help="username for registry authentication",
+                      default=None)
 
-    parser.add_argument("--password",
-                        dest='password',
-                        help="password for registry authentication",
-                        default=None)
+    parser.add_option("--password",
+                      dest='password',
+                      help="password for registry authentication",
+                      default=None)
 
 
     # Flag to disable cache
-    parser.add_argument("--no-cache", 
-                        dest='disable_cache', 
-                        action="store_true",
-                        help="boolean to specify disabling the cache.", 
-                        default=False)
+    parser.add_option("--no-cache", 
+                      dest='disable_cache', 
+                      action="store_true",
+                      help="boolean to specify disabling the cache.", 
+                      default=False)
 
     return parser
 
@@ -104,7 +108,7 @@ def main():
     parser = get_parser()
     
     try:
-        args = parser.parse_args()
+        (args,options) = parser.parse_args()
     except:
         logger.error("Input args to %s improperly set, exiting.", os.path.abspath(__file__))
         parser.print_help()

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -47,7 +47,7 @@ def get_parser():
 
     parser = optparse.OptionParser(description='bootstrap Docker images for Singularity containers',
                                    usage="usage: %prog [options] filename",
-                                   version="%prog 1.0")
+                                   version="%prog 2.2")
 
 
     # Name of the docker image, required

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -49,7 +49,7 @@ class TestClient(TestCase):
         '''
         print("Testing --rootfs command...")
         parser = get_parser()
-        args = parser.parse_args([])
+        (args,options) = parser.parse_args([])
         with self.assertRaises(SystemExit) as cm:
             run(args)
         self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
Fixes #389 #391 

Changes proposed in this pull request

 - changes argparse to optparse, since it is supported in older version of RHEL (6?) The package is deprecated but still valid for Python 3, so we will likely be able to transition back to argparse and (hopefully) not need to support RHEL 6 anymore
 
 I still need to find and change the code for the python executable for the config parser - if it hasn't been merged yet it will need to wait for another pr!

@singularityware-admin

