### PR TITLE
python abort image extraction failure

### DIFF
--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -266,7 +266,10 @@ def run(args):
             layers.append(targz) # in case we want a list at the end
 
             # Extract image and remove tar
-            extract_tar(targz,singularity_rootfs)
+            output = extract_tar(targz,singularity_rootfs)
+            if output is None:
+                logger.error("Error extracting image: %s", targz)
+                sys.exit(1)
             if args.disable_cache == True:
                 os.remove(targz)
                

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -264,7 +264,7 @@ class TestUtils(TestCase):
         for dirname in [extract_dir,creation_dir]:
             shutil.rmtree(dirname)
 
-        print("Case 1: Testing tar...")
+        print("Case 2: Testing tar...")
         creation_dir = tempfile.mkdtemp()
         archive,files = create_test_tar(creation_dir,compressed=False)
 
@@ -275,6 +275,15 @@ class TestUtils(TestCase):
         extracted_files = [x.replace(extract_dir,'') for x in glob("%s/tmp/*" %(extract_dir))]
         [self.assertTrue(x in files) for x in extracted_files]
         
+
+        print("Case 3: Testing that extract_tar returns None on error...")
+        creation_dir = tempfile.mkdtemp()
+        archive,files = create_test_tar(creation_dir,compressed=False)
+        extract_dir = tempfile.mkdtemp()
+        shutil.rmtree(extract_dir)
+        output = extract_tar(archive=archive,
+                             output_folder=extract_dir)
+        self.assertEqual(output,None)
 
 
     def test_write_read_files(self):

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -200,11 +200,14 @@ def run_command(cmd):
     try:
         logger.info("Running command %s with subprocess", " ".join(cmd))
         process = subprocess.Popen(cmd,stdout=subprocess.PIPE)
-        output, err = process.communicate()
     except OSError as error:
         logger.error("Error with subprocess: %s, returning None",error)
         return None
-    
+
+    output = process.communicate()[0]
+    if process.returncode != 0:
+        return None
+
     return output
 
 


### PR DESCRIPTION
Fixes #358 and adds one quick test to @flx42 PR to exit if extraction fails. The calling function will receive the failed status and is responsible for exiting, and `extract_tar` will just ensure that None is returned with any error.

Changes proposed in this pull request

 - adding test for None given failed extraction

@singularityware-admin
