### PR TITLE
New container environment file format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -317,6 +317,7 @@ AC_CONFIG_FILES([
    src/lib/file/passwd/Makefile
    src/lib/file/resolvconf/Makefile
    src/lib/file/entrypoint/Makefile
+   src/lib/file/environment/Makefile
    src/lib/mount/Makefile
    src/lib/mount/cwd/Makefile
    src/lib/mount/dev/Makefile

--- a/libexec/defaults/exec
+++ b/libexec/defaults/exec
@@ -1,3 +1,3 @@
 
-. /environment
+. /.env/.metasource
 exec "$@"

--- a/libexec/defaults/run
+++ b/libexec/defaults/run
@@ -1,5 +1,5 @@
 
-. /environment
+. /.env/.metasource
 if test -x /singularity; then
     exec /singularity "$@"
 else

--- a/libexec/defaults/shell
+++ b/libexec/defaults/shell
@@ -1,5 +1,5 @@
 
-. /environment
+. /.env/.metasource
 if test -n "$SHELL" -a -x "$SHELL"; then
     exec "$SHELL" "$@"
 else

--- a/src/lib/action/action.c
+++ b/src/lib/action/action.c
@@ -109,8 +109,6 @@ int singularity_action_do(int argc, char **argv) {
     int tmpstatus;
     int retval = 0;
 
-    singularity_priv_drop_perm();
-
     singularity_message(DEBUG, "Trying to change directory to where we started\n");
     char *target_pwd = envar_path("SINGULARITY_TARGET_PWD");
     if (!target_pwd || (chdir(target_pwd) < 0)) {
@@ -133,6 +131,7 @@ int singularity_action_do(int argc, char **argv) {
     child = singularity_fork();
 
     if ( child == 0 ) {
+        singularity_priv_drop_perm();
         if ( action == ACTION_SHELL ) {
             singularity_message(DEBUG, "Running action: shell\n");
             action_shell_do(argc, argv);

--- a/src/lib/action/action.c
+++ b/src/lib/action/action.c
@@ -35,6 +35,7 @@
 #include "util/util.h"
 #include "lib/message.h"
 #include "lib/privilege.h"
+#include "lib/singularity.h"
 #include "exec/exec.h"
 #include "shell/shell.h"
 #include "run/run.h"
@@ -160,4 +161,5 @@ int singularity_action_do(int argc, char **argv) {
         retval = WEXITSTATUS(tmpstatus);
         singularity_file_environment();
     }
+    return(retval);
 }

--- a/src/lib/action/action.c
+++ b/src/lib/action/action.c
@@ -27,6 +27,9 @@
 #include <linux/limits.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <sys/wait.h>
+#include <poll.h>
+
 
 #include "util/file.h"
 #include "util/util.h"
@@ -101,6 +104,9 @@ int singularity_action_init(void) {
 }
 
 int singularity_action_do(int argc, char **argv) {
+    pid_t child;
+    int tmpstatus;
+    int retval = 0;
 
     singularity_priv_drop_perm();
 
@@ -123,25 +129,35 @@ int singularity_action_do(int argc, char **argv) {
     }
     free(target_pwd);
 
-    if ( action == ACTION_SHELL ) {
-        singularity_message(DEBUG, "Running action: shell\n");
-        action_shell_do(argc, argv);
-    } else if ( action == ACTION_EXEC ) {
-        singularity_message(DEBUG, "Running action: exec\n");
-        action_exec_do(argc, argv);
-    } else if ( action == ACTION_RUN ) {
-        singularity_message(DEBUG, "Running action: run\n");
-        action_run_do(argc, argv);
-    } else if ( action == ACTION_TEST ) {
-        singularity_message(DEBUG, "Running action: test\n");
-        action_test_do(argc, argv);
-    } else if ( action == ACTION_START ) {
-        singularity_message(DEBUG, "Running action: start\n");
-        action_start_do(argc, argv);
-    } else if ( action == ACTION_STOP ) {
-        singularity_message(DEBUG, "Running action: stop\n");
-        action_stop_do(argc, argv);
+    child = singularity_fork();
+
+    if ( child == 0 ) {
+        if ( action == ACTION_SHELL ) {
+            singularity_message(DEBUG, "Running action: shell\n");
+            action_shell_do(argc, argv);
+        } else if ( action == ACTION_EXEC ) {
+            singularity_message(DEBUG, "Running action: exec\n");
+            action_exec_do(argc, argv);
+        } else if ( action == ACTION_RUN ) {
+            singularity_message(DEBUG, "Running action: run\n");
+            action_run_do(argc, argv);
+        } else if ( action == ACTION_TEST ) {
+            singularity_message(DEBUG, "Running action: test\n");
+            action_test_do(argc, argv);
+        } else if ( action == ACTION_START ) {
+            singularity_message(DEBUG, "Running action: start\n");
+            action_start_do(argc, argv);
+        } else if ( action == ACTION_STOP ) {
+            singularity_message(DEBUG, "Running action: stop\n");
+            action_stop_do(argc, argv);
+        }
+        singularity_message(ERROR, "Called singularity_action_do() without singularity_action_init()\n");
+        ABORT(255);
+    } else if ( child > 0 ) {
+        singularity_message(DEBUG, "Waiting on child process to finish to update /.env/.metadata file\n");
+
+        waitpid(child, &tmpstatus, 0);
+        retval = WEXITSTATUS(tmpstatus);
+        singularity_file_environment();
     }
-    singularity_message(ERROR, "Called singularity_action_do() without singularity_action_init()\n");
-    return(-1);
 }

--- a/src/lib/file/Makefile.am
+++ b/src/lib/file/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = passwd group resolvconf entrypoint
+SUBDIRS = passwd group resolvconf entrypoint environment
 
 MAINTAINERCLEANFILES = Makefile.in
 DISTCLEANFILES = Makefile
@@ -11,7 +11,7 @@ AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\
 
 noinst_LTLIBRARIES = libfile.la
 
-libfile_la_LIBADD = passwd/libfilepasswd.la group/libfilegroup.la resolvconf/libfileresolvconf.la entrypoint/libfileentrypoint.la
+libfile_la_LIBADD = passwd/libfilepasswd.la group/libfilegroup.la resolvconf/libfileresolvconf.la entrypoint/libfileentrypoint.la environment/libfileenvironment.la
 libfile_la_SOURCES = file.c file-bind.c
 
 EXTRA_DIST = file-bind.h

--- a/src/lib/file/environment/Makefile.am
+++ b/src/lib/file/environment/Makefile.am
@@ -1,0 +1,12 @@
+MAINTAINERCLEANFILES = Makefile.in 
+DISTCLEANFILES = Makefile
+CLEANFILES = core.* *~ *.la
+
+AM_CFLAGS = -Wall -fpie
+AM_LDFLAGS = -pie
+AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
+
+noinst_LTLIBRARIES = libfileennvironment.la
+libfileenvironment_la_SOURCES = environment.c
+
+EXTRA_DIST = environment.h

--- a/src/lib/file/environment/Makefile.am
+++ b/src/lib/file/environment/Makefile.am
@@ -6,7 +6,7 @@ AM_CFLAGS = -Wall -fpie
 AM_LDFLAGS = -pie
 AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES) $(NO_SETNS)
 
-noinst_LTLIBRARIES = libfileennvironment.la
+noinst_LTLIBRARIES = libfileenvironment.la
 libfileenvironment_la_SOURCES = environment.c
 
 EXTRA_DIST = environment.h

--- a/src/lib/file/environment/environment.c
+++ b/src/lib/file/environment/environment.c
@@ -43,7 +43,6 @@ int singularity_file_environment(void) {
     char *meta_file = strdup("");
     char *buff_line;
     char *buff_line2;
-    char *cwd = get_current_dir_name();
     int rootfs_fd = singularity_rootfs_fd();
     int size = 1; //Starts with 1 to account for single null terminator
     int i;
@@ -74,14 +73,11 @@ int singularity_file_environment(void) {
 
     singularity_message(DEBUG, "Writing to /.env/.metafile:%s\n", meta_file);
 
-    ret = fchdir(rootfs_fd);
-    if ( ( i = fileput(".env/.metasource", meta_file) ) != 0 ) {
+    if ( ( i = fileputat(rootfs_fd, ".env/.metasource", meta_file) ) != 0 ) {
         singularity_message(WARNING, "Unable to write .metasource file: %s\n", strerror(errno));
     }
-    ret = chdir(cwd);
 
     free(namelist);
-    free(cwd);
     free(meta_file);
     return(0);
 }

--- a/src/lib/file/environment/environment.c
+++ b/src/lib/file/environment/environment.c
@@ -18,6 +18,7 @@
  * 
  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -29,13 +30,14 @@
 #include <stdlib.h>
 #include <dirent.h>
 
+
 #include "util/file.h"
 #include "util/util.h"
 #include "lib/message.h"
 #include "lib/file/environment/environment.h"
 
 
-int singularity_file_environment() {
+int singularity_file_environment(void) {
     struct dirent **namelist;
     char *meta_file = strdup("");
     char *buff_line;

--- a/src/lib/file/environment/environment.c
+++ b/src/lib/file/environment/environment.c
@@ -34,6 +34,7 @@
 #include "util/file.h"
 #include "util/util.h"
 #include "lib/message.h"
+#include "lib/singularity.h"
 #include "lib/file/environment/environment.h"
 
 

--- a/src/lib/file/environment/environment.c
+++ b/src/lib/file/environment/environment.c
@@ -74,7 +74,7 @@ int singularity_file_environment(void) {
     singularity_message(DEBUG, "Writing to /.env/.metafile:%s\n", meta_file);
 
     if ( ( i = fileputat(rootfs_fd, ".env/.metasource", meta_file) ) != 0 ) {
-        singularity_message(WARNING, "Unable to write .metasource file: %s\n", strerror(errno));
+        singularity_message(DEBUG, "Unable to write .metasource file: %s\n", strerror(errno));
     }
 
     free(namelist);

--- a/src/lib/file/environment/environment.c
+++ b/src/lib/file/environment/environment.c
@@ -1,0 +1,77 @@
+/* 
+ * Copyright (c) 2016, Michael W. Bauer. All rights reserved.
+ * 
+ * “Singularity” Copyright (c) 2016, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of any
+ * required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ * 
+ * This software is licensed under a customized 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ * 
+ * NOTICE.  This Software was developed under funding from the U.S. Department of
+ * Energy and the U.S. Government consequently retains certain rights. As such,
+ * the U.S. Government has been granted for itself and others acting on its
+ * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+ * to reproduce, distribute copies to the public, prepare derivative works, and
+ * perform publicly and display publicly, and to permit other to do so. 
+ * 
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <limits.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <dirent.h>
+
+#include "util/file.h"
+#include "util/util.h"
+#include "lib/message.h"
+#include "lib/rootfs/rootfs.h"
+
+
+int singularity_file_environment(int rootfs_fd) {
+    struct dirent **namelist;
+    char *meta_file = strdup("");
+    char *buff_line;
+    int size = 1; //Starts with 1 to account for single null terminator
+    int i;
+
+    singularity_message(DEBUG, "Sorting through /.env/ folder and assembling ordered list of files to source\n");
+    
+    if ( scandirat(rootfs_fd, ".env/", &namelist, filter_meta, filter_filenames) < 0 ) {
+        return(-1);
+    }
+    
+    for (i = 0; namelist[i] != NULL; i++) {
+        buff_line = strjoin("source ", namelist[i]->d_name);
+        size = size + strlength(buff_line, 2048) + 1; //+1 for newline
+        if ( (meta_file = (char *)realloc(meta_file, size)) == NULL ) {
+            return(-1);
+        }
+        
+        snprintf(meta_file, size, "%s\n%s", meta_file, buff_line);
+
+        free(buff_line);
+        free(namelist[i]);
+    }
+    fchdir(rootfs_fd);
+    i = fileput(".env/.metasource", meta_file);
+
+    free(meta_file);
+    free(rootfs_path);
+    return(i);
+}
+
+int filter_metafile(const struct dirent *entry) {
+    return( strncmp(entry->d_name, ".metasource", 11) );
+}
+
+int compare_filenames(const struct dirent **a, const struct dirent **b) {
+    return( str2int((*a)->d_name) - str2int((*b)->d_name) );
+}

--- a/src/lib/file/environment/environment.h
+++ b/src/lib/file/environment/environment.h
@@ -22,7 +22,7 @@
 #ifndef __SINGULARITY_FILE_ENVIRONMENT_H_
 #define __SINGULARITY_FILE_ENVIRONMENT_H_
 
-    int singularity_file_environment(int rootfs_fd);
+    int singularity_file_environment();
     int filter_metafile(const struct dirent *entry);
     int compare_filenames(const struct dirent **a, const struct dirent **b);
                                     

--- a/src/lib/file/environment/environment.h
+++ b/src/lib/file/environment/environment.h
@@ -22,7 +22,7 @@
 #ifndef __SINGULARITY_FILE_ENVIRONMENT_H_
 #define __SINGULARITY_FILE_ENVIRONMENT_H_
 
-    int singularity_file_environment();
+    int singularity_file_environment(void);
     int filter_metafile(const struct dirent *entry);
     int compare_filenames(const struct dirent **a, const struct dirent **b);
                                     

--- a/src/lib/file/environment/environment.h
+++ b/src/lib/file/environment/environment.h
@@ -1,0 +1,29 @@
+/* 
+ * Copyright (c) 2016, Michael W. Bauer. All rights reserved.
+ * 
+ * “Singularity” Copyright (c) 2016, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of any
+ * required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ * 
+ * This software is licensed under a customized 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ * 
+ * NOTICE.  This Software was developed under funding from the U.S. Department of
+ * Energy and the U.S. Government consequently retains certain rights. As such,
+ * the U.S. Government has been granted for itself and others acting on its
+ * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+ * to reproduce, distribute copies to the public, prepare derivative works, and
+ * perform publicly and display publicly, and to permit other to do so. 
+ * 
+ */
+
+
+#ifndef __SINGULARITY_FILE_ENVIRONMENT_H_
+#define __SINGULARITY_FILE_ENVIRONMENT_H_
+
+    int singularity_file_environment(int rootfs_fd);
+    int filter_metafile(const struct dirent *entry);
+    int compare_filenames(const struct dirent **a, const struct dirent **b);
+                                    
+#endif /* __SINGULARITY_FILE_ENVIRONMENT_H_ */

--- a/src/lib/file/environment/environment.h
+++ b/src/lib/file/environment/environment.h
@@ -22,6 +22,8 @@
 #ifndef __SINGULARITY_FILE_ENVIRONMENT_H_
 #define __SINGULARITY_FILE_ENVIRONMENT_H_
 
+    #include <dirent.h>
+
     int singularity_file_environment(void);
     int filter_metafile(const struct dirent *entry);
     int compare_filenames(const struct dirent **a, const struct dirent **b);

--- a/src/lib/file/file.c
+++ b/src/lib/file/file.c
@@ -53,6 +53,7 @@ int singularity_file_bootstrap(void) {
     retval += singularity_file_passwd();
     retval += singularity_file_group();
     retval += singularity_file_resolvconf();
+    retval += singularity_file_environment();
     retval += singularity_file_entrypoint("run");
     retval += singularity_file_entrypoint("exec");
     retval += singularity_file_entrypoint("shell");

--- a/src/lib/file/file.c
+++ b/src/lib/file/file.c
@@ -34,6 +34,7 @@
 #include "group/group.h"
 #include "resolvconf/resolvconf.h"
 #include "entrypoint/entrypoint.h"
+#include "environment/environment.h"
 
 
 

--- a/src/lib/image/bootstrap/bootstrap.c
+++ b/src/lib/image/bootstrap/bootstrap.c
@@ -103,12 +103,12 @@ int singularity_bootstrap(char *containerimage, char *bootdef_path) {
         /* Copy runscript, environment, and .test files into container rootfs */
         bootstrap_copy_script("runscript", "/singularity");
         bootstrap_copy_script("test", "/.test");
-        if ( bootstrap_copy_script("environment", "/environment") != 0 ) {
-            singularity_message(VERBOSE, "Copying default environment file instead of user specified environment\n");
-            copy_file(LIBEXECDIR "/singularity/defaults/environment", joinpath(rootfs_path, "/environment"));
+        singularity_message(VERBOSE, "Copying default environment file into /.env/ at lowest priority\n");
+        copy_file(LIBEXECDIR "/singularity/defaults/environment", joinpath(rootfs_path, "/.env/01-default"));
+        chmod(joinpath(rootfs_path, "/.env/01-default"), 0644);
+        if ( bootstrap_copy_script("environment", "/.env/02-userenv") == 0 ) {
+            chmod(joinpath(rootfs_path, "/.env/02-userenv"), 0644);
         }
-        chmod(joinpath(rootfs_path, "/environment"), 0644);
-            
 
         /* Copy/mount necessary files directly into container rootfs */
         if ( singularity_file_bootstrap() < 0 ) {
@@ -215,6 +215,7 @@ int bootstrap_rootfs_install() {
     retval += s_mkpath(joinpath(rootfs_path, "/sys"), 0755);
     retval += s_mkpath(joinpath(rootfs_path, "/tmp"), 1777);
     retval += s_mkpath(joinpath(rootfs_path, "/var/tmp"), 1777);
+    retval += s_mkpath(joinpath(rootfs_path, "/.env"), 0777);
     retval += copy_file("/etc/hosts", joinpath(rootfs_path, "/etc/hosts"));
     retval += copy_file("/etc/resolv.conf", joinpath(rootfs_path, "/etc/resolv.conf"));
     unlink(joinpath(rootfs_path, "/etc/mtab"));

--- a/src/lib/image/bootstrap/bootstrap.c
+++ b/src/lib/image/bootstrap/bootstrap.c
@@ -117,10 +117,7 @@ int singularity_bootstrap(char *containerimage, char *bootdef_path) {
         }
 
         /* Mount necessary folders into container */
-        if ( singularity_mount() < 0 ) {
-            singularity_message(ERROR, "Failed to mount necessary files into container rootfs. Aborting...\n");
-            ABORT(255);
-        }
+        singularity_mount();
 
         /* Run %setup script from host */
         singularity_bootstrap_script_run("setup");

--- a/src/lib/image/bootstrap/bootstrap.c
+++ b/src/lib/image/bootstrap/bootstrap.c
@@ -128,6 +128,9 @@ int singularity_bootstrap(char *containerimage, char *bootdef_path) {
         /* Run %post and %test scripts from inside container */
         singularity_rootfs_chroot();
         singularity_bootstrap_script_run("post");
+
+        /* Generate /.env/.metasource file one last time, in case post/setup changed it */
+        singularity_file_environment();
         action_test_do(0, NULL);
         
         singularity_bootdef_close();

--- a/src/lib/rootfs/rootfs.c
+++ b/src/lib/rootfs/rootfs.c
@@ -233,7 +233,7 @@ int singularity_rootfs_mount(void) {
         singularity_priv_drop();
     }
 
-    rootfs_fd = open(singularity_rootfs_dir(), O_PATH | O_DIRECTORY);
+    rootfs_fd = open(singularity_rootfs_dir(), O_PATH | O_DIRECTORY | O_CLOEXEC);
     singularity_message(DEBUG, "Stored rootfs fd as: %d\n", rootfs_fd);
 
     return(0);
@@ -254,18 +254,22 @@ int singularity_rootfs_check(void) {
 int singularity_rootfs_chroot(void) {
     
     singularity_priv_escalate();
-    singularity_message(VERBOSE, "Entering container file system root: %s\n", joinpath(mount_point, OVERLAY_FINAL));
-    if ( chroot(joinpath(mount_point, OVERLAY_FINAL)) < 0 ) { // Flawfinder: ignore (yep, yep, yep... we know!)
-        singularity_message(ERROR, "Failed to enter container at: %s\n", joinpath(mount_point, OVERLAY_FINAL));
+
+    if ( fchdir(singularity_rootfs_fd()) < 0 ) {
+        singularity_message(ERROR, "Could not chdir to rootfs : %s\n", strerror(errno));
         ABORT(255);
     }
-    singularity_priv_drop();
-
-    singularity_message(DEBUG, "Changing dir to '/' within the new root\n");
-    if ( chdir("/") < 0 ) {
-        singularity_message(ERROR, "Could not chdir after chroot to /: %s\n", strerror(errno));
-        ABORT(1);
+    
+    singularity_message(VERBOSE, "Entering container file system root (fd: %d): %s\n",
+                        singularity_rootfs_fd(), joinpath(mount_point, OVERLAY_FINAL));
+    
+    if ( chroot(".") < 0 ) { // Flawfinder: ignore (yep, yep, yep... we know!)
+        singularity_message(ERROR, "Failed to enter container at (fd: %d): %s\n",
+                            singularity_rootfs_fd(), joinpath(mount_point, OVERLAY_FINAL));
+        ABORT(255);
     }
+    
+    singularity_priv_drop();
 
     return(0);
 }

--- a/src/lib/rootfs/rootfs.c
+++ b/src/lib/rootfs/rootfs.c
@@ -18,6 +18,7 @@
  * 
 */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -53,7 +54,7 @@
 static int module = 0;
 static int overlay_enabled = 0;
 static char *mount_point = NULL;
-
+static int rootfs_fd;
 
 int singularity_rootfs_overlay_enabled(void) {
     singularity_message(DEBUG, "Returning singularity_rootfs_overlay: %d\n", overlay_enabled);
@@ -63,6 +64,11 @@ int singularity_rootfs_overlay_enabled(void) {
 char *singularity_rootfs_dir(void) {
     singularity_message(DEBUG, "Returning singularity_rootfs_dir: %s\n", joinpath(mount_point, OVERLAY_FINAL));
     return(joinpath(mount_point, OVERLAY_FINAL));
+}
+
+int singularity_rootfs_fd(void) {
+    singularity_message(DEBUG, "Returning singularity_rootfs_fd: %d\n", rootfs_fd);
+    return(rootfs_fd);
 }
 
 int singularity_rootfs_init(char *source) {
@@ -226,6 +232,9 @@ int singularity_rootfs_mount(void) {
         }
         singularity_priv_drop();
     }
+
+    rootfs_fd = open(singularity_rootfs_dir(), O_PATH | O_DIRECTORY);
+    singularity_message(DEBUG, "Stored rootfs fd as: %d\n", rootfs_fd);
 
     return(0);
 }

--- a/src/lib/rootfs/rootfs.c
+++ b/src/lib/rootfs/rootfs.c
@@ -256,7 +256,7 @@ int singularity_rootfs_chroot(void) {
     singularity_priv_escalate();
     singularity_message(VERBOSE, "Entering container file system root: %s\n", joinpath(mount_point, OVERLAY_FINAL));
     if ( chroot(joinpath(mount_point, OVERLAY_FINAL)) < 0 ) { // Flawfinder: ignore (yep, yep, yep... we know!)
-        singularity_message(ERROR, "failed enter container at: %s\n", joinpath(mount_point, OVERLAY_FINAL));
+        singularity_message(ERROR, "Failed to enter container at: %s\n", joinpath(mount_point, OVERLAY_FINAL));
         ABORT(255);
     }
     singularity_priv_drop();

--- a/src/lib/rootfs/rootfs.h
+++ b/src/lib/rootfs/rootfs.h
@@ -29,5 +29,6 @@
 
     int singularity_rootfs_overlay_enabled(void);
     char *singularity_rootfs_dir(void);
+    int singularity_rootfs_fd(void);
 
 #endif /* __SINGULARITY_ROOTFS_H_ */

--- a/src/lib/singularity.h
+++ b/src/lib/singularity.h
@@ -125,6 +125,7 @@
     extern int singularity_file_group(void);
     extern int singularity_file_resolvconf(void);
     extern int singularity_file_entrypoint(char *entrypoint_name);
+    extern int singularity_file_environment(void);
 
 
     extern void singularity_sessiondir_init(char *file);

--- a/src/lib/singularity.h
+++ b/src/lib/singularity.h
@@ -83,6 +83,8 @@
     extern int singularity_rootfs_chroot(void);
     // Return the location of the final rootfs directory/mount point
     extern char *singularity_rootfs_dir(void);
+    // Return an open fd of the rootfs_dir
+    extern int singularity_rootfs_fd(void);
     // Check to make sure rootfs is valid
     extern int singularity_rootfs_check(void);
 

--- a/src/sexec.c
+++ b/src/sexec.c
@@ -134,8 +134,7 @@ int main(int argc, char **argv) {
 
     singularity_rootfs_chroot();
 
-    singularity_action_do(argc, argv);
+    return(singularity_action_do(argc, argv));
 
-    return(0);
 
 }

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -358,6 +358,30 @@ int fileput(char *path, char *string) {
     return(0);
 }
 
+int fileputat(int fd, char *path, char *string) {
+    int file_fd;
+    FILE *fp;
+
+    singularity_message(DEBUG, "Called fileputat(%d, %s, %s)\n", fd, path, string);
+    if ( ( file_fd = openat(fd, path, O_CREAT | O_WRONLY | O_TRUNC, 00755) ) < 0 ) {
+        singularity_message(ERROR, "Could not open fd(%d): %s\n", fd, strerror(errno));
+        return(-1);
+    }
+    
+    if ( ( fp = fdopen(file_fd, "w") ) == NULL ) { // Flawfinder: ignore
+        singularity_message(ERROR, "Could not write to %s at %d: %s\n", path, fd, strerror(errno));
+        close(file_fd);
+        return(-1);
+    }
+
+    fprintf(fp, "%s", string);
+    fclose(fp);
+    close(file_fd);
+
+    return(0);
+}
+
+
 char *filecat(char *path) {
     char *ret;
     FILE *fd;

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -364,12 +364,12 @@ int fileputat(int fd, char *path, char *string) {
 
     singularity_message(DEBUG, "Called fileputat(%d, %s, %s)\n", fd, path, string);
     if ( ( file_fd = openat(fd, path, O_CREAT | O_WRONLY | O_TRUNC, 00755) ) < 0 ) {
-        singularity_message(ERROR, "Could not open fd(%d): %s\n", fd, strerror(errno));
+        singularity_message(DEBUG, "Could not open fd(%d): %s\n", fd, strerror(errno));
         return(-1);
     }
     
     if ( ( fp = fdopen(file_fd, "w") ) == NULL ) { // Flawfinder: ignore
-        singularity_message(ERROR, "Could not write to %s at %d: %s\n", path, fd, strerror(errno));
+        singularity_message(DEBUG, "Could not write to %s at %d: %s\n", path, fd, strerror(errno));
         close(file_fd);
         return(-1);
     }

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -36,4 +36,5 @@ int s_rmdir(char *dir);
 int copy_file(char * source, char * dest);
 char *filecat(char *path);
 int fileput(char *path, char *string);
+int fileputat(int fd, char *path, char *string);
 char *basedir(char *dir);


### PR DESCRIPTION
As discussed in #364, #376
Enables proposed solution to #411 

Changes proposed in this pull request

 - Introduces `/.env/` directory in container
   - `.metasource` file, contains a list of all files in `/.env/` directory
   - An arbitrary number of files following the naming convention: `XX-$NAME` where `XX` is a two digit number. Higher numbers take precedence over lower numbers.
 - Default `exec`, `shell`, and `run` entrypoints will source `/.env/.metasource`
 - In `src/lib/action/action.c`, `singularity_action_do()` will fork before executing the entrypoint. After the child process (the container) exits, the parent process will attempt to overwrite the `/.env/.metasource` file. This ensures that if any files were added or removed will also be added or removed from the `/.env/.metasource` file.
 - `src/lib/rootfs/rootfs.c`
     - Stores the filedescriptor of the rootfs directory (opened with O_CLOEXEC)
     - Will now fchdir to the open file descriptor, and then chroot on the current directory
 - In `src/util/file.c`, fileputat() function will write to a file when when given an fd of a directory
 - `sexec.c` will return the value of `singularity_action_do()` to handle the new forking
 - `src/lib/file/environment/environment.c` will handle sorting & creation of the `/.env/.metasource` file

@singularityware-admin

I would like to further convert more of our functions to using filedescriptors, as they are more secure than running on path name alone. I've laid out the groundwork for this in `rootfs.c` by storing the fd and using it for the `singularity_rootfs_chroot()` function. We can further improve our usage of file descriptors by calling fileputat instead of fileput, anytime we would like to write to a file inside the container. Further, it might be a good idea to store the fd of the working directory when singularity is first called, to allow files such as `src/lib/mount/cwd/cwd.c` to access the location from an fd, rather than path or `get_current_directory_name()` (the man page of which recommends instead using fd's).
