### PR TITLE
Support for overriding variables inside the container at runtime

### DIFF
--- a/src/lib/action/action.c
+++ b/src/lib/action/action.c
@@ -87,7 +87,7 @@ int singularity_env_override(char * prefix) {
 }
 
 int singularity_action_init(void) {
-    char *env_prefix = envar("SINGULARITY_ENV_PREFIX", "", 32);
+    char *env_prefix = envar("SINGULARITY_ENV_PREFIX", "_", 32);
     if ( env_prefix == NULL ) {
         env_prefix = "_SENV";
     }

--- a/src/lib/action/action.c
+++ b/src/lib/action/action.c
@@ -94,6 +94,8 @@ int singularity_action_init(void) {
     unsetenv("SINGULARITY_ENV_PREFIX");
     singularity_env_override(env_prefix);
 
+    free(env_prefix);
+
     char *command = envar("SINGULARITY_COMMAND", "", 10);
     singularity_message(DEBUG, "Checking on action to run\n");
 

--- a/src/lib/action/action.c
+++ b/src/lib/action/action.c
@@ -87,14 +87,7 @@ int singularity_env_override(char * prefix) {
 }
 
 int singularity_action_init(void) {
-    char *env_prefix = envar("SINGULARITY_ENV_PREFIX", "_", 32);
-    if ( env_prefix == NULL ) {
-        env_prefix = "_SENV";
-    }
-    unsetenv("SINGULARITY_ENV_PREFIX");
-    singularity_env_override(env_prefix);
-
-    free(env_prefix);
+    singularity_env_override("SENV");
 
     char *command = envar("SINGULARITY_COMMAND", "", 10);
     singularity_message(DEBUG, "Checking on action to run\n");

--- a/src/lib/singularity.h
+++ b/src/lib/singularity.h
@@ -99,6 +99,8 @@
     extern int singularity_action_init(void);
     // Do the requested action
     extern int singularity_action_do(int agc, char **argv);
+    // Export proxied unsecure ld variables to container
+    extern int singularity_proxy_unsecvars(void);
 
 
     // MOUNT

--- a/src/lib/singularity.h
+++ b/src/lib/singularity.h
@@ -99,8 +99,8 @@
     extern int singularity_action_init(void);
     // Do the requested action
     extern int singularity_action_do(int agc, char **argv);
-    // Export proxied unsecure ld variables to container
-    extern int singularity_proxy_unsecvars(void);
+    // Override container environment
+    extern int singularity_env_override(char * prefix);
 
 
     // MOUNT

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -299,3 +299,13 @@ char *get_homedir(struct passwd *pw_in) {
 
     return homedir;
 }
+
+void slice_str(const char * str, char * buffer, size_t start, size_t end)
+{
+    size_t j = 0;
+    size_t i;
+    for ( i = start; i <= end; ++i ) {
+        buffer[j++] = str[i];
+    }
+    buffer[j] = 0;
+}

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -55,6 +55,7 @@ int str2int(const char *input_str, long int *output_num);
 
 struct passwd;
 char *get_homedir(struct passwd *pw);
+void slice_str(const char * str, char * buffer, size_t start, size_t end);
 
 #define ABORT(a) do {singularity_message(ABRT, "Retval = %d\n", a); exit(a);} while (0)
 

--- a/test.sh.in
+++ b/test.sh.in
@@ -32,6 +32,30 @@ SINGULARITY_sysconfdir="$sysconfdir"
 SINGULARITY_localstatedir="$localstatedir"
 SINGULARITY_PATH="$bindir"
 
+UNSEC_VARS="
+GCONV_PATH
+GETCONF_DIR
+HOSTALIASES
+LD_AUDIT
+LD_DEBUG
+LD_DEBUG_OUTPUT
+LD_DYNAMIC_WEAK
+LD_LIBRARY_PATH
+LD_ORIGIN_PATH
+LD_PRELOAD
+LD_PROFILE
+LD_SHOW_AUXV
+LD_USE_LOAD_BIAS
+LOCALDOMAIN
+LOCPATH
+MALLOC_TRACE
+NIS_PATH
+NLSPATH
+RESOLV_HOST_CONF
+RES_OPTIONS
+TMPDIR
+TZDIR
+"
 
 ALL_COMMANDS="exec run shell start stop test bootstrap copy create expand export import mount"
 
@@ -348,6 +372,13 @@ stest 1 singularity exec /tmp/container.img echo "hello world"
 stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|protected image mode = group|protected image mode = none|'
 stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|allow user image = no|allow user image = yes|'
 
+/bin/echo
+/bin/echo "Testing unsecured variable proxying"
+for UNSEC_VAR in $UNSEC_VARS; do
+    PREFIXED_UNSEC_VAR="CONTAINER_$UNSEC_VAR"
+    stest 1 sh -c "$UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
+    stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
+done
 
 /bin/echo
 /bin/echo "Cleaning up"

--- a/test.sh.in
+++ b/test.sh.in
@@ -380,9 +380,10 @@ for UNSEC_VAR in $UNSEC_VARS; do
     stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
     export SINGULARITY_ENV_PREFIX="SOME_OTHER_PREFIX"
     PREFIXED_UNSEC_VAR="${SINGULARITY_ENV_PREFIX}_${UNSEC_VAR}"
-    echo PREFIXED_UNSEC_VAR
     stest 1 sh -c "$UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
     stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
+    unset PREFIXED_UNSEC_VAR
+    unset SINGULARITY_ENV_PREFIX
 done
 
 /bin/echo

--- a/test.sh.in
+++ b/test.sh.in
@@ -375,15 +375,10 @@ stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's
 /bin/echo
 /bin/echo "Testing environment override"
 for UNSEC_VAR in $UNSEC_VARS; do
-    PREFIXED_UNSEC_VAR="_SENV_$UNSEC_VAR"
-    stest 1 sh -c "$UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
-    stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
-    export SINGULARITY_ENV_PREFIX="SOME_OTHER_PREFIX"
-    PREFIXED_UNSEC_VAR="${SINGULARITY_ENV_PREFIX}_${UNSEC_VAR}"
+    PREFIXED_UNSEC_VAR="SENV_$UNSEC_VAR"
     stest 1 sh -c "$UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
     stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
     unset PREFIXED_UNSEC_VAR
-    unset SINGULARITY_ENV_PREFIX
 done
 
 /bin/echo

--- a/test.sh.in
+++ b/test.sh.in
@@ -378,6 +378,11 @@ for UNSEC_VAR in $UNSEC_VARS; do
     PREFIXED_UNSEC_VAR="_SENV_$UNSEC_VAR"
     stest 1 sh -c "$UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
     stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
+    export SINGULARITY_ENV_PREFIX="SOME_OTHER_PREFIX"
+    PREFIXED_UNSEC_VAR="${SINGULARITY_ENV_PREFIX}_${UNSEC_VAR}"
+    echo PREFIXED_UNSEC_VAR
+    stest 1 sh -c "$UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
+    stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
 done
 
 /bin/echo

--- a/test.sh.in
+++ b/test.sh.in
@@ -373,9 +373,9 @@ stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's
 stest 0 sudo sed -i "$SINGULARITY_sysconfdir/singularity/singularity.conf" -e 's|allow user image = no|allow user image = yes|'
 
 /bin/echo
-/bin/echo "Testing unsecured variable proxying"
+/bin/echo "Testing environment override"
 for UNSEC_VAR in $UNSEC_VARS; do
-    PREFIXED_UNSEC_VAR="CONTAINER_$UNSEC_VAR"
+    PREFIXED_UNSEC_VAR="_SENV_$UNSEC_VAR"
     stest 1 sh -c "$UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
     stest 0 sh -c "$PREFIXED_UNSEC_VAR=test singularity exec $CONTAINER env | grep $UNSEC_VAR=test"
 done


### PR DESCRIPTION
Fixes #411

This allows users to explicitly override environment variables within the container via `SENV_` prefixed environment variables. This prefix gets stripped and the result gets set within the containers's environment. This is especially useful for proxying [unsecure variables stripped by ld for suid/sgid executables ](https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=sysdeps/generic/unsecvars.h;hb=HEAD)  to the container:
```
$ whoami
test
$ export LD_LIBRARY_PATH=/test/path
$ singularity exec cuda75.img env | grep LD_LIBRARY_PATH
$ export SENV_LD_LIBRARY_PATH=/test/path
$ singularity exec cuda75.img env | grep LD_LIBRARY_PATH
LD_LIBRARY_PATH=/test/path
```

 - adds a `singularity_env_override` method to `src/lib/action/action.c` called by `singularity_action_init` that looks for env variables that start with prefix, strips the prefix, and sets the resulting key/value inside the container.

@singularityware-admin
