### PR TITLE
adding link to docs repo to encourage contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,5 +163,4 @@ http://dx.doi.org/10.5281/zenodo.60736
 
 
 # Webpage
-We are working on documentation and web pages now, but checkout the work
-in progress: [http://singularity.lbl.gov/](http://singularity.lbl.gov/).
+We have full documentation at [http://singularity.lbl.gov/](http://singularity.lbl.gov/), and [welcome contributions](http://www.github.com/singularityware/singularityware.github.io).


### PR DESCRIPTION
Currently, it's not clear that our docs are hosted on Github (and thus users can contribute), and the current README also presents them as a work in progress. While this is true, I think we would be ok to say "here are the docs! Please contribute!" Is this trivial change ok @gmkurtzer ?

@singularityware-admin
