### PR TITLE
Use fixed image offset of zero for SquashFS images

### DIFF
--- a/src/lib/loop-control.h
+++ b/src/lib/loop-control.h
@@ -22,6 +22,7 @@
 #ifndef __SINGULARITY_LOOP_CONTROL_
 #define __SINGULARITY_LOOP_CONTROL_
 
+    char *singularity_loop_bind_with_offset(FILE *image_fp, int image_offset);
     char *singularity_loop_bind(FILE *image_fp);
     int singularity_loop_free(char *loop_dev);
 

--- a/src/lib/rootfs/squashfs/squashfs.c
+++ b/src/lib/rootfs/squashfs/squashfs.c
@@ -96,7 +96,7 @@ int rootfs_squashfs_mount(void) {
     }
 
     singularity_message(DEBUG, "Binding image to loop device\n");
-    if ( ( loop_dev = singularity_loop_bind(image_fp) ) == NULL ) {
+    if ( ( loop_dev = singularity_loop_bind_with_offset(image_fp, 0) ) == NULL ) {
         singularity_message(ERROR, "There was a problem bind mounting the image\n");
         ABORT(255);
     }


### PR DESCRIPTION
SquashFS images can contain a 0x0a byte within the first 64 bytes, so the current header/offset detection yields wrong results for some SquashFS files, resulting in failure to mount the image.

Fixes #430 

Could this (or a similar solution) be backported to the 2.x branch as well?