### PR TITLE
quick fix so that runscript has permissions u+x even without bootstrap

### DIFF
--- a/libexec/bootstrap/modules-v2/postbootstrap.sh
+++ b/libexec/bootstrap/modules-v2/postbootstrap.sh
@@ -131,6 +131,11 @@ chmod 0755 "$SINGULARITY_ROOTFS/.run"
 
 ldconfig -r "$SINGULARITY_ROOTFS" >/dev/null 2>&1
 
+
+##########################################################################################
+# RUNSCRIPT
+##########################################################################################
+
 if [ -f "$SINGULARITY_BUILDDEF" ]; then
 
 #    #TODO: This needs lots of love...
@@ -162,10 +167,18 @@ if [ -f "$SINGULARITY_BUILDDEF" ]; then
         echo "$runscript_command" > "$SINGULARITY_ROOTFS/singularity"    
     fi
 
-    # If we have a runscript, whether docker, user defined, change permissions    
-    if [ -s "$SINGULARITY_ROOTFS/singularity" ]; then
-        chmod 0755 "$SINGULARITY_ROOTFS/singularity"
-    fi
+fi
+
+# If we have a runscript, whether docker, user defined, change permissions
+if [ -s "$SINGULARITY_ROOTFS/singularity" ]; then
+    chmod 0755 "$SINGULARITY_ROOTFS/singularity"
+fi
+
+#/RUNSCRIPT###############################################################################
+
+
+
+if [ -f "$SINGULARITY_BUILDDEF" ]; then
 
     mount --no-mtab -t proc proc "$SINGULARITY_ROOTFS/proc"
     mount --no-mtab -t sysfs sysfs "$SINGULARITY_ROOTFS/sys"
@@ -225,4 +238,3 @@ if [ -f "$SINGULARITY_BUILDDEF" ]; then
     > "$SINGULARITY_ROOTFS/etc/resolv.conf"
 
 fi
-


### PR DESCRIPTION
Fixes #422 

Changes proposed in this pull request

 - reorganizes the postbootstrap.sh so that the script checks for a runscript, even if a bootstrap was not performed (meaning there is no build definition). This bug resulted from the fact that the change in permissions was inside of this loop, meaning it would work given that the runscript was produced via a bootstrap, but not in the case it was produced via something like:

      singularity run docker://mongo:latest --help

I just tested this on my local machine, and it seems to have fixed the original issue:

      singularity run docker://mongo:latest --help
      (layers download)
      ...
      Adding Docker ENTRYPOINT as Singularity runscript...
      /entrypoint.sh
     Options:

      General options:
        -h [ --help ]                         show this usage information
       --version                             show version information
       -f [ --config ] arg                   configuration file specifying 

I was concerned about order of operations being important in postbootstrap, so I opted to close the first if statement (checking for build def, to create runscript if user specified) and then fix permissions for runscript (so it would work regardless of build definition) and then open the equivalent loop again to finish up the image.

@singularityware-admin
