### PR TITLE
Fix format string vulnerability in message handler.

### DIFF
--- a/src/lib/message.c
+++ b/src/lib/message.c
@@ -106,7 +106,7 @@ void _singularity_message(int level, const char *function, const char *file_in, 
         char syslog_string[540]; // Flawfinder: ignore (512 max message length + 28'ish chars for header)
         snprintf(syslog_string, 540, "%s (U=%d,P=%d)> %s", __progname, geteuid(), getpid(), message); // Flawfinder: ignore
 
-        syslog(syslog_level, syslog_string, strlength(syslog_string, 1024)); // Flawfinder: ignore (format is internally defined)
+        syslog(syslog_level, "%s", syslog_string, strlength(syslog_string, 1024)); // Flawfinder: ignore (format is internally defined)
     }
 
     if ( level <= messagelevel ) {


### PR DESCRIPTION
Steps to reproduce:

export SINGULARITY_IMAGE=%n
singularity shell

result in:
*** %n in writable segment detected ***
Abandon (core dumped)

expected result:
ERROR  : Illegal input character '%' in: 'SINGULARITY_IMAGE=%n'
ABORT  : Retval = 255

glibc have some protection against format string vulnerabilites depending of compilation optimization options, so it should be safe without the fix but in case of old glibc or different libc ...