### PR TITLE
Correctly handle format strings and null-terminate.

### DIFF
--- a/src/lib/image/bootstrap/bootstrap.c
+++ b/src/lib/image/bootstrap/bootstrap.c
@@ -19,6 +19,7 @@
  */
 
 #include <errno.h>
+#include <limits.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
@@ -188,8 +189,10 @@ int bootstrap_module_init() {
             free(module_name);
             return( singularity_bootstrap_docker() );
         } else {
-            fork_args[0] = (char *)malloc(2048);
-            snprintf(fork_args[0], 2048, LIBEXECDIR "/singularity/bootstrap/modules-v2/build-%s.sh", module_name);
+            fork_args[0] = (char *)malloc(PATH_MAX);
+            if (snprintf(fork_args[0], PATH_MAX, LIBEXECDIR "/singularity/bootstrap/modules-v2/build-%s.sh", module_name) >= PATH_MAX) {
+                singularity_message(ERROR, "Compiled setting for LIBEXECDIR too long.\n");
+            }
             fork_args[1] = NULL;
             
             free(module_name);

--- a/src/lib/message.c
+++ b/src/lib/message.c
@@ -118,23 +118,23 @@ void _singularity_message(int level, const char *function, const char *file_in, 
     }
 
     if ( level <= messagelevel ) {
-        char *header_string = NULL;
+        char header_string[95];
 
         if ( messagelevel >= DEBUG ) {
-            char *debug_string = (char *) malloc(25);
-            char *location_string = (char *) malloc(60);
-            char *tmp_header_string = (char *) malloc(80);
-            header_string = (char *) malloc(80);
+            char debug_string[25];
+            char location_string[60];
+            char tmp_header_string[86];
             snprintf(location_string, 60, "%s:%d:%s()", file, line, function); // Flawfinder: ignore
+            location_string[59] = '\0';
             snprintf(debug_string, 25, "[U=%d,P=%d]", geteuid(), getpid()); // Flawfinder: ignore
-            snprintf(tmp_header_string, 80, "%-18s %s", debug_string, location_string); // Flawfinder: ignore
-            snprintf(header_string, 80, "%-7s %-62s: ", prefix, tmp_header_string); // Flawfinder: ignore
-            free(debug_string);
-            free(location_string);
-            free(tmp_header_string);
+            debug_string[24] = '\0';
+            snprintf(tmp_header_string, 86, "%-18s %s", debug_string, location_string); // Flawfinder: ignore
+            tmp_header_string[85] = '\0';
+            snprintf(header_string, 95, "%-7s %-62s: ", prefix, tmp_header_string); // Flawfinder: ignore
+            header_string[94] = '\0';
         } else {
-            header_string = (char *) malloc(11);
             snprintf(header_string, 10, "%-7s: ", prefix); // Flawfinder: ignore
+            header_string[9] = '\0';
         }
 
         if ( level == INFO && messagelevel == INFO ) {
@@ -147,7 +147,6 @@ void _singularity_message(int level, const char *function, const char *file_in, 
             fprintf(stderr, "%s%s", header_string, message);
         }
 
-        free(header_string);
         fflush(stdout);
         fflush(stderr);
 

--- a/src/lib/rootfs/rootfs.c
+++ b/src/lib/rootfs/rootfs.c
@@ -182,7 +182,10 @@ int singularity_rootfs_mount(void) {
 #ifdef SINGULARITY_OVERLAYFS
         int overlay_options_len = strlength(rootfs_source, PATH_MAX) + strlength(overlay_upper, PATH_MAX) + strlength(overlay_work, PATH_MAX) + 50;
         char *overlay_options = (char *) malloc(overlay_options_len);
-        snprintf(overlay_options, overlay_options_len, "lowerdir=%s,upperdir=%s,workdir=%s", rootfs_source, overlay_upper, overlay_work); // Flawfinder: ignore
+        if (snprintf(overlay_options, overlay_options_len, "lowerdir=%s,upperdir=%s,workdir=%s", rootfs_source, overlay_upper, overlay_work) >= overlay_options_len) {
+            singularity_message(ERROR, "Overly-long path names for OverlayFS configuration.\n");
+            ABORT(255);
+        }
 
         singularity_priv_escalate();
         singularity_message(DEBUG, "Mounting overlay tmpfs: %s\n", overlay_mount);

--- a/src/lib/sessiondir.c
+++ b/src/lib/sessiondir.c
@@ -55,7 +55,7 @@ char *singularity_sessiondir_init(char *file) {
         struct stat filestat;
         uid_t uid = singularity_priv_getuid();
 
-        sessiondir = (char *) malloc(sizeof(char) * PATH_MAX);
+        sessiondir = (char *) malloc(PATH_MAX);
 
         singularity_message(DEBUG, "Checking Singularity configuration for 'sessiondir prefix'\n");
 
@@ -65,9 +65,15 @@ char *singularity_sessiondir_init(char *file) {
         }
 
         if ( ( sessiondir_prefix = envar_path("SINGULARITY_SESSIONDIR") ) != NULL ) {
-            snprintf(sessiondir, sizeof(char) * PATH_MAX, "%s/singularity-session-%d.%d.%lu", sessiondir_prefix, (int)uid, (int)filestat.st_dev, (long unsigned)filestat.st_ino); // Flawfinder: ignore
+            if (snprintf(sessiondir, PATH_MAX, "%s/singularity-session-%d.%d.%lu", sessiondir_prefix, (int)uid, (int)filestat.st_dev, (long unsigned)filestat.st_ino) >= PATH_MAX) { // Flawfinder: ignore
+                singularity_message(ERROR, "Overly-long session directory specified.\n");
+                ABORT(255);
+            }
         } else if ( ( sessiondir_prefix = strdup(singularity_config_get_value(SESSIONDIR_PREFIX)) ) != NULL ) {
-            snprintf(sessiondir, sizeof(char) * PATH_MAX, "%s%d.%d.%lu", sessiondir_prefix, (int)uid, (int)filestat.st_dev, (long unsigned)filestat.st_ino); // Flawfinder: ignore
+            if (snprintf(sessiondir, PATH_MAX, "%s%d.%d.%lu", sessiondir_prefix, (int)uid, (int)filestat.st_dev, (long unsigned)filestat.st_ino) >= PATH_MAX) { // Flawfinder: ignore
+                singularity_message(ERROR, "Overly-long session directory specified.\n");
+                ABORT(255);
+            }
         } else {
             singularity_message(ERROR, "Programming error - default for %s returned NULL.\n", sessiondir_prefix);
             ABORT(255);

--- a/src/slurm/singularity.c
+++ b/src/slurm/singularity.c
@@ -55,7 +55,7 @@ static int setup_container_environment(spank_t spank) {
         slurm_error("Failed to get job's target UID");
         return -1;
     }
-    if (INT_MAX_STRING_SIZE == snprintf(job_uid_str, INT_MAX_STRING_SIZE, "%u", job_uid)) { // Flawfinder: ignore
+    if (INT_MAX_STRING_SIZE <= snprintf(job_uid_str, INT_MAX_STRING_SIZE, "%u", job_uid)) { // Flawfinder: ignore
         slurm_error("Failed to serialize job's UID to string");
         return -1;
     }
@@ -65,7 +65,7 @@ static int setup_container_environment(spank_t spank) {
         slurm_error("Failed to get job's target GID");
         return -1;
     }
-    if (INT_MAX_STRING_SIZE == snprintf(job_gid_str, INT_MAX_STRING_SIZE, "%u", job_gid)) { // Flawfinder: ignore
+    if (INT_MAX_STRING_SIZE <= snprintf(job_gid_str, INT_MAX_STRING_SIZE, "%u", job_gid)) { // Flawfinder: ignore
         slurm_error("Failed to serialize job's GID to string");
         return -1;
     }

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -140,8 +140,12 @@ char *joinpath(const char * path1, const char * path2_in) {
         path2++;
     }
 
-    ret = (char *) malloc(strlength(tmp_path1, PATH_MAX) + strlength(path2, PATH_MAX) + 2);
-    snprintf(ret, strlength(tmp_path1, PATH_MAX) + strlen(path2) + 2, "%s/%s", tmp_path1, path2); // Flawfinder: ignore
+    size_t ret_pathlen = strlength(tmp_path1, PATH_MAX) + strlength(path2, PATH_MAX) + 2;
+    ret = (char *) malloc(ret_pathlen);
+    if (snprintf(ret, ret_pathlen, "%s/%s", tmp_path1, path2) >= ret_pathlen) { // Flawfinder: ignore
+        singularity_message(ERROR, "Overly-long path name.\n");
+        ABORT(255);
+    }
 
     return(ret);
 }
@@ -151,7 +155,10 @@ char *strjoin(char *str1, char *str2) {
     int len = strlength(str1, 2048) + strlength(str2, 2048) + 1;
 
     ret = (char *) malloc(len);
-    snprintf(ret, len, "%s%s", str1, str2); // Flawfinder: ignore
+    if (snprintf(ret, len, "%s%s", str1, str2) >= len) { // Flawfinder: ignore
+       singularity_message(ERROR, "Overly-long string encountered.\n");
+       ABORT(255);
+    }
 
     return(ret);
 }


### PR DESCRIPTION
Make sure we don't utilize user-controlled input as a format string.

Verify we null-terminate fixed-length strings when `snprintf` hits the character limit.


@singularityware-admin
