### PR TITLE
Check curl status in busybox bootstrap module

### DIFF
--- a/examples/legacy/busybox.def
+++ b/examples/legacy/busybox.def
@@ -1,5 +1,5 @@
 DistType "busybox"
-MirrorURL "https://www.busybox.net/downloads/binaries/busybox-x86_64"
+MirrorURL "https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64"
 
 Setup
 Bootstrap

--- a/libexec/bootstrap/modules-v2/build-busybox.sh
+++ b/libexec/bootstrap/modules-v2/build-busybox.sh
@@ -48,7 +48,7 @@ fi
 
 MIRROR=`singularity_key_get "MirrorURL" "$SINGULARITY_BUILDDEF"`
 if [ -z "${MIRROR:-}" ]; then
-    MIRROR="https://www.busybox.net/downloads/binaries/busybox-x86_64"
+    MIRROR="https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64"
 fi
 
 

--- a/libexec/bootstrap/modules-v2/build-busybox.sh
+++ b/libexec/bootstrap/modules-v2/build-busybox.sh
@@ -59,7 +59,12 @@ echo "root:!:0:0:root:/root:/bin/sh" > "$SINGULARITY_ROOTFS/etc/passwd"
 echo " root:x:0:" > "$SINGULARITY_ROOTFS/etc/group"
 echo "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4" > "$SINGULARITY_ROOTFS/etc/hosts"
 
-curl "$MIRROR" > "$SINGULARITY_ROOTFS/bin/busybox"
+curl -f "$MIRROR" > "$SINGULARITY_ROOTFS/bin/busybox"
+
+if [ $? -ne 0 ]; then
+    message ERROR "Failed fetching MirrorURL: $MIRROR\n"
+    exit 1
+fi
 
 chmod 0755 "$SINGULARITY_ROOTFS/bin/busybox"
 

--- a/test.sh.in
+++ b/test.sh.in
@@ -134,6 +134,11 @@ stest 0 sudo singularity create -s 568 "$CONTAINER"
 stest 0 sudo singularity bootstrap "$CONTAINER" "$STARTDIR/examples/docker.def"
 stest 0 sudo rm -rf "$CONTAINER"
 stest 0 sudo singularity create -s 568 "$CONTAINER"
+stest 0 sh -c "sed "$STARTDIR/examples/busybox.def" -e 's|^MirrorURL:.*|MirrorURL: https://fake_mirror_url|' > "$TEMPDIR/busybox-busted-mirror.def""
+stest 255 singularity bootstrap "$CONTAINER" "$TEMPDIR/busybox-busted-mirror.def"
+stest 0 sh -c "sudo singularity bootstrap "$CONTAINER" "$TEMPDIR/busybox-busted-mirror.def" 2>&1 | grep -i 'failed fetching mirrorurl'"
+stest 0 sudo rm -rf "$CONTAINER"
+stest 0 sudo singularity create -s 568 "$CONTAINER"
 # We will need a setuid binary (ping) for the NO_NEW_PRIVS test below.
 stest 0 sed -i "$STARTDIR/examples/centos.def" -e 's|#InstallPkgs yum vim-minimal|InstallPkgs iputils|'
 stest 0 sudo singularity bootstrap "$CONTAINER" "$STARTDIR/examples/busybox.def"


### PR DESCRIPTION
Fixes https://github.com/singularityware/singularity/pull/438#issuecomment-270187567

Changes proposed in this pull request

 - Fix default busybox MirrorURL (it moved recently)
 - Update busybox bootstrap module to check return value of curl and communicate failure to user

@singularityware-admin
