### PR TITLE
Final addition of shub endpoint functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ script:
   - sonar-scanner
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_client
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker
-  #- cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_client
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker
-  #- cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub
   - pylint --version
   - cd $TRAVIS_BUILD_DIR/libexec/python && pylint $PWD --errors-only --ignore tests  --disable=E0401,E0611

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -86,7 +86,7 @@ case "$IMPORT_URI" in
     ;;
     shub://*)
         IMAGE_SHUB_ID=`echo "$IMPORT_URI" | sed -e 's@^shub://@@'`
-        exec $SINGULARITY_libexecdir/singularity/python/cli.py --shub $IMAGE_SHUB_ID
+        exec $SINGULARITY_libexecdir/singularity/python/cli.py --shub $IMAGE_SHUB_ID --pull-folder $PWD
     ;;
     http://*|https://*)
         message ERROR "pull is only supported for shub://\n"

--- a/libexec/python/Makefile.am
+++ b/libexec/python/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = docker shub
 scriptlibexecdir = $(libexecdir)/singularity/python
 
 dist_scriptlibexec_SCRIPTS = cli.py
-dist_scriptlibexec_DATA = defaults.py __init__.py logman.py utils.py
+dist_scriptlibexec_DATA = defaults.py __init__.py logman.py shell.py utils.py
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -39,6 +39,8 @@ from docker.api import (
     get_manifest 
 )
 
+from docker.shell import parse_image_uri
+
 from utils import (
     basic_auth_header,
     change_permissions, 
@@ -196,29 +198,10 @@ def run(args):
         # Input Parsing ----------------------------
         # Parse image name, repo name, and namespace
 
-        # First split the docker image name by /
-        image = image.split('/')
-
-        # If there are two parts, we have namespace with repo (and maybe tab)
-        if len(image) == 2:
-            namespace = image[0]
-            image = image[1]
-
-        # Otherwise, we must be using library namespace
-        else:
-            namespace = "library"
-            image = image[0]
-
-        # Now split the docker image name by :
-        image = image.split(':')
-        if len(image) == 2:
-            repo_name = image[0]
-            repo_tag = image[1]
-
-        # Otherwise, assume latest of an image
-        else:
-            repo_name = image[0]
-            repo_tag = "latest"
+        image = parse_image_uri(image=image)
+        namespace = image['namespace']
+        repo_name = image['repo_name']
+        repo_tag = image['repo_tag']
 
         # Tell the user the namespace, repo name and tag
         logger.info("Docker image path: %s/%s:%s", namespace,repo_name,repo_tag)

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -163,8 +163,10 @@ def run(args):
 
     # Does the user want to download a Singularity image?
     if args.shub != None:
-        image_id = int(args.shub)
-        manifest = get_shub_manifest(image_id)
+        image = parse_image_uri(image=args.shub,
+                                uri = "shub://")
+
+        manifest = get_shub_manifest(image)
 
         cache_base = get_cache(subfolder="shub", 
                                disable_cache = args.disable_cache)

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -76,7 +76,14 @@ def get_parser():
     # ID of the Singularity Hub container
     parser.add_option("--shub", 
                       dest='shub', 
-                      help="unique id of the Singularity Hub image", 
+                      help="unique id or name of the Singularity Hub image", 
+                      type=str, 
+                      default=None)
+
+    # Download folder in case of pull, will be used in preference over cache
+    parser.add_option("--pull-folder", 
+                      dest='pull_folder', 
+                      help="Folder to pull image to (only for shub endpoint)", 
                       type=str, 
                       default=None)
 
@@ -166,8 +173,11 @@ def run(args):
     if args.shub != None:
         image = args.shub
         manifest = get_shub_manifest(image)
-        cache_base = get_cache(subfolder="shub", 
-                               disable_cache = args.disable_cache)
+        if args.pull_folder == None:
+            cache_base = get_cache(subfolder="shub", 
+                                   disable_cache = args.disable_cache)
+        else:
+            cache_base = args.pull_folder
 
         # The image name is the md5 hash, download if it's not there
         image_name = get_image_name(manifest)

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -46,6 +46,7 @@ from utils import (
     change_permissions, 
     extract_tar, 
     get_cache, 
+    is_number,
     write_file
 )
 
@@ -163,11 +164,8 @@ def run(args):
 
     # Does the user want to download a Singularity image?
     if args.shub != None:
-        image = parse_image_uri(image=args.shub,
-                                uri = "shub://")
-
+        image = args.shub
         manifest = get_shub_manifest(image)
-
         cache_base = get_cache(subfolder="shub", 
                                disable_cache = args.disable_cache)
 

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -219,11 +219,7 @@ def run(args):
                                 auth=auth)
 
         # Get images from manifest using version 2.0 of Docker Registry API
-        images = get_images(repo_name=repo_name,
-                            namespace=namespace,
-                            registry=args.registry,
-                            auth=auth)
-        
+        images = get_images(manifest=manifest)
        
         #  DOWNLOAD LAYERS -------------------------------------------
         # Each is a .tar.gz file, obtained from registry with curl

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -39,7 +39,7 @@ from docker.api import (
     get_manifest 
 )
 
-from docker.shell import parse_image_uri
+from shell import parse_image_uri
 
 from utils import (
     basic_auth_header,
@@ -198,7 +198,7 @@ def run(args):
         # Input Parsing ----------------------------
         # Parse image name, repo name, and namespace
 
-        image = parse_image_uri(image=image)
+        image = parse_image_uri(image=image,uri="docker://")
         namespace = image['namespace']
         repo_name = image['repo_name']
         repo_tag = image['repo_tag']

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -18,10 +18,10 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 import sys
-sys.path.append('..') # parent directory
 
 from logman import logger
 from docker.api import get_tags
+from utils import is_number
 import json
 import re
 import os
@@ -41,6 +41,11 @@ def parse_image_uri(image,uri,default_namespace=None):
     # First split the docker image name by /
     image = image.replace(uri,'')
     image = image.split('/')
+
+    # If the user provided a number (unique id for an image), return it
+    if is_number(image) == True:
+        logger.info("Numeric image ID %s%s found.", uri, image)
+        return int(image)
 
     # If there are two parts, we have namespace with repo (and maybe tab)
     if len(image) >= 2:

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -1,0 +1,86 @@
+'''
+shell.py: Docker shell parsing functions for Singularity in Python
+Copyright (c) 2017, Vanessa Sochat. All rights reserved. 
+"Singularity" Copyright (c) 2016, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ 
+This software is licensed under a customized 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
+ 
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights. As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so. 
+'''
+
+import sys
+sys.path.append('..') # parent directory
+
+from logman import logger
+from docker.api import get_tags
+import json
+import re
+import os
+
+
+def parse_image_uri(image,uri,default_namespace=None):
+    '''parse_image_uri will return a json structure with a repo name, tag, and
+    namespace.
+    :param image: the string provided on command line for the image name, eg: ubuntu:latest
+    :param uri: the uri (eg, docker:// to remove)
+    :default_namespace: if not provided, will use "library"
+    :returns parsed: a json structure with repo_name, repo_tag, and namespace
+    '''
+    if default_namespace == None:
+        default_namespace = "library"
+
+    # First split the docker image name by /
+    image = image.replace(uri,'')
+    image = image.split('/')
+
+    # If there are two parts, we have namespace with repo (and maybe tab)
+    if len(image) >= 2:
+        namespace = image[0]
+        image = image[1]
+
+    # Otherwise, we must be using library namespace
+    else:
+        namespace = default_namespace
+        image = image[0]
+
+    # Now split the docker image name by :
+    image = image.split(':')
+    if len(image) == 2:
+        repo_name = image[0]
+        repo_tag = image[1]
+
+    # Otherwise, assume latest of an image
+    else:
+        repo_name = image[0]
+        repo_tag = "latest"
+
+    logger.info("Repo Name: %s", repo_name)
+    logger.info("Repo Tag: %s", repo_tag)
+    logger.info("Namespace: %s", namespace)
+
+    parsed = {'repo_name':repo_name,
+              'repo_tag':repo_tag,
+              'namespace':namespace }
+    return parsed
+
+
+def get_tags_shell(image,uri,default_namespace=None):
+    '''get_tags_shell is a wrapper to run docker.api.get_tags with additional parsing
+    of the input string. It is assumed that a tag is not provided.
+    :image: the image name to be parsed by parse_image_uri
+    '''
+    parsed = parse_image_uri(image,uri,default_namespace=None)
+    repo_name = parsed['repo_name']
+    namespace = parsed['namespace']
+
+    return get_tags(namespace=namespace,
+                    repo_name=repo_name)

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -51,7 +51,6 @@ def parse_image_uri(image,uri=None,default_namespace=None):
 
     image = image.split('/')
 
-
     # If there are two parts, we have namespace with repo (and maybe tab)
     if len(image) >= 2:
         namespace = image[0]

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -27,25 +27,30 @@ import re
 import os
 
 
-def parse_image_uri(image,uri,default_namespace=None):
+def parse_image_uri(image,uri=None,default_namespace=None):
     '''parse_image_uri will return a json structure with a repo name, tag, and
     namespace.
     :param image: the string provided on command line for the image name, eg: ubuntu:latest
-    :param uri: the uri (eg, docker:// to remove)
+    :param uri: the uri (eg, docker:// to remove), default uses ""
     :default_namespace: if not provided, will use "library"
     :returns parsed: a json structure with repo_name, repo_tag, and namespace
     '''
     if default_namespace == None:
         default_namespace = "library"
 
+    if uri == None:
+        uri = ""
+
     # First split the docker image name by /
     image = image.replace(uri,'')
-    image = image.split('/')
 
     # If the user provided a number (unique id for an image), return it
     if is_number(image) == True:
         logger.info("Numeric image ID %s%s found.", uri, image)
         return int(image)
+
+    image = image.split('/')
+
 
     # If there are two parts, we have namespace with repo (and maybe tab)
     if len(image) >= 2:

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -29,8 +29,9 @@ sys.path.append('..') # parent directory
 from utils import (
     add_http,
     api_get, 
+    is_number,
     read_file,
-    write_file 
+    write_file
 )
 from logman import logger
 import json
@@ -76,16 +77,20 @@ def authenticate(domain=None,token_folder=None):
 # Docker Registry Version 2.0 Functions - IN USE
 
 
-def get_manifest(image_id,registry=None):
+def get_manifest(image,registry=None):
     '''get_image will return a json object with image metadata, based on a unique id.
-    :param image_id: the image_id
+    :param image: the image name, either an id, or a repo name, tag, etc.
     :param registry: the registry (hub) to use, if not defined, default is used
     '''
     if registry == None:
         registry = api_base
     registry = add_http(registry) # make sure we have a complete url
 
-    base = "%s/containers/%s" %(registry,image_id)
+    # Numeric images have slightly different endpoint from named
+    if is_number(image) == True:
+        base = "%s/containers/%s" %(registry,image)
+    else:
+        base = "%s/container/%s" %(registry,image)
 
     # ---------------------------------------------------------------
     # If we eventually have private images, need to authenticate here       

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -114,7 +114,7 @@ def download_image(manifest,download_folder=None,extract=True):
     '''    
     image_file = get_image_name(manifest)
 
-    print("Found image %s" %(manifest['name']))
+    print("Found image %s:%s" %(manifest['name'],manifest['branch']))
     print("Downloading image... %s" %(image_file))
 
     if download_folder != None:

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -214,6 +214,26 @@ class TestUtils(TestCase):
         self.assertTrue(os.path.exists(cache))
 
 
+    def test_is_number(self):
+        '''test_is_number should return True for any string or
+        number that turns to a number, and False for everything else
+        '''
+        print("Testing utils.is_number...")
+
+        from utils import is_number
+
+        print("Case 1: Testing string and float numbers returns True")
+        self.assertTrue(is_number("4"))
+        self.assertTrue(is_number(4))
+        self.assertTrue(is_number("2.0"))
+        self.assertTrue(is_number(2.0))
+
+        print("Case 2: Testing repo names, tags, commits, returns False")
+        self.assertFalse(is_number("vsoch/singularity-images"))
+        self.assertFalse(is_number("vsoch/singularity-images:latest"))
+        self.assertFalse(is_number("44ca6e7c6c35778ab80b34c3fc940c32f1810f39"))
+
+
     def test_change_permission(self):
         '''test_change_permissions will make sure that we can change
         permissions of a file
@@ -225,14 +245,16 @@ class TestUtils(TestCase):
         tmpfile = '%s/.mooza' %(self.tmpdir)
         os.system('touch %s' %(tmpfile))
 
-        # 664
+        print("Case 1: Base permissions are 644")
         permissions = oct(os.stat(tmpfile)[ST_MODE])[-3:]
         self.assertTrue(permissions,'664')
-        # to 755
+
+        print("Case 2: Permissions are changed to 755")
         change_permissions(tmpfile,permission=755)  
         new_permissions = oct(os.stat(tmpfile)[ST_MODE])[-3:]
         self.assertTrue(new_permissions,'755')
-        # and back
+
+        print("Case 2: Permissions are changed back to 644")
         change_permissions(tmpfile,permission=644)  
         new_permissions = oct(os.stat(tmpfile)[ST_MODE])[-3:]
         self.assertTrue(new_permissions,'664')

--- a/libexec/python/tests/test_client.py
+++ b/libexec/python/tests/test_client.py
@@ -106,6 +106,7 @@ class TestShell(TestCase):
         self.assertTrue(digest['namespace'] == 'library')
         self.assertTrue(digest['repo_name'] == self.repo_name)
 
+
         print("Case 7: Changing default namespace should not use library.")
         image_name = "%s:%s" %(self.repo_name,self.tag)
         digest = parse_image_uri(image=image_name,default_namespace="meow")

--- a/libexec/python/tests/test_shub.py
+++ b/libexec/python/tests/test_shub.py
@@ -90,6 +90,7 @@ class TestApi(TestCase):
         from shub.api import get_image_name, get_manifest
         manifest = get_manifest(image_id=self.image_id)
         
+        
         print("Case 1: return an image name using the commit id")
         image_name = get_image_name(manifest)
         self.assertEqual('f57e631a0434c31f0b4fa5276a314a6d8a672a55.img.gz',

--- a/libexec/python/tests/test_shub.py
+++ b/libexec/python/tests/test_shub.py
@@ -27,6 +27,7 @@ sys.path.append('..') # directory with singularity, etc.
 
 from unittest import TestCase
 from utils import read_file
+from glob import glob
 import shutil
 import tempfile
 
@@ -38,7 +39,9 @@ class TestApi(TestCase):
 
 
     def setUp(self):
-        self.image_id = 8
+        self.image_id = 24 # https://singularity-hub.org/collections/12/
+        self.user_name = "vsoch"
+        self.repo_name = "singularity-images"
         self.tmpdir = tempfile.mkdtemp()
         print("\n---START----------------------------------------")
 
@@ -54,8 +57,8 @@ class TestApi(TestCase):
         from shub.api import get_manifest
         print("Case 1: Testing retrieval of singularity-hub manifest")
         manifest = get_manifest(self.image_id)
-        keys = ['files', 'name', 'image', 'collection', 
-                'id', 'version', 'spec']
+        keys = ['files', 'version', 'collection', 'branch', 
+                'name', 'id', 'metrics', 'spec', 'image']
         [self.assertTrue(x in manifest) for x in keys]
         self.assertTrue(manifest['id']==self.image_id)
 
@@ -67,33 +70,62 @@ class TestApi(TestCase):
         '''
         from shub.api import download_image, get_manifest
         print("Case 1: Specifying a directory downloads to it")
-        manifest = get_manifest(image_id=self.image_id)
+        manifest = get_manifest(image=self.image_id)
         image = download_image(manifest,
                                download_folder=self.tmpdir)
         self.assertEqual(os.path.dirname(image),self.tmpdir)
+        
+        print("Case 2: Image should be named based on commit.")
+        image_name = os.path.splitext(os.path.basename(image))[0]
+        self.assertEqual(image_name,manifest['version'])
         os.remove(image)
 
-        print("Case 2: Not specifying a directory downloads to PWD")
+        print("Case 3: Not specifying a directory downloads to PWD")
         os.chdir(self.tmpdir)
         image = download_image(manifest)
         self.assertEqual(os.getcwd(),self.tmpdir)
+        self.assertTrue(image in glob("*"))
         os.remove(image)
 
-        print("Case 3: Image should not be extracted.")
+        print("Case 4: Image should not be extracted.")
         image = download_image(manifest,extract=False)
         self.assertTrue(image.endswith('.img.gz'))        
+
+    def test_uri(self):
+        '''test_uri will make sure that the endpoint returns the equivalent
+        image for all different uri options
+        '''
+        from shub.api import get_image_name, get_manifest
+        manifest = get_manifest(image=self.image_id)
+        image_name = get_image_name(manifest)
+                
+        print("Case 1: ask for image and ask for master branch (tag)")
+        manifest = get_manifest(image="%s/%s:master" %(self.user_name,self.repo_name))
+        self.assertEqual(image_name,get_image_name(manifest))
+
+        print("Case 2: ask for different tag (mongo)")
+        manifest = get_manifest(image="%s/%s:mongo" %(self.user_name,self.repo_name))
+        mongo = get_image_name(manifest)
+        self.assertFalse(image_name == mongo)
+
+        print("Case 3: ask for image without tag (should be latest across tags, mongo)")
+        manifest = get_manifest(image="%s/%s" %(self.user_name,self.repo_name))
+        self.assertEqual(mongo,get_image_name(manifest))
+
+        print("Case 4: ask for latest tag (should be latest across tags, mongo)")
+        manifest = get_manifest(image="%s/%s:latest" %(self.user_name,self.repo_name))
+        self.assertEqual(mongo,get_image_name(manifest))
 
 
     def test_get_image_name(self):
         '''test_get_image_name will return the image name from the manifest
         '''
         from shub.api import get_image_name, get_manifest
-        manifest = get_manifest(image_id=self.image_id)
-        
-        
+        manifest = get_manifest(image=self.image_id)
+                
         print("Case 1: return an image name using the commit id")
         image_name = get_image_name(manifest)
-        self.assertEqual('f57e631a0434c31f0b4fa5276a314a6d8a672a55.img.gz',
+        self.assertEqual('6d3715a982865863ff20e8783014522edf1240e4.img.gz',
                          image_name)
 
         print("Case 2: ask for invalid extension")
@@ -106,7 +138,7 @@ class TestApi(TestCase):
         image_name = get_image_name(manifest,
                                     use_commit=False)
         print(image_name)
-        self.assertEqual('be4b9ba8fc22525d2ee2b27846513d42.img.gz',image_name)
+        self.assertEqual('32394f413f46f070e76cc07308f0e791.img.gz',image_name)
 
 
 if __name__ == '__main__':

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -180,14 +180,14 @@ def basic_auth_header(username, password):
     :param password: the password
     '''
     s = "%s:%s" % (username, password)
-    logger.debug("AUTH: Input username/password:", s)
+    logger.debug("AUTH: Input username/password: %s", s)
     if sys.version_info[0] >= 3:
         s = bytes(s, 'utf-8')
         credentials = base64.b64encode(s).decode('utf-8')
     else:
         credentials = base64.b64encode(s)
     auth = {"Authorization": "Basic %s" % credentials}
-    logger.debug("AUTH Final", auth)
+    logger.debug("AUTH Final %s", auth)
     return auth
 
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -180,7 +180,6 @@ def basic_auth_header(username, password):
     :param password: the password
     '''
     s = "%s:%s" % (username, password)
-    logger.debug("AUTH: Input username/password: %s", s)
     if sys.version_info[0] >= 3:
         s = bytes(s, 'utf-8')
         credentials = base64.b64encode(s).decode('utf-8')

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -172,6 +172,7 @@ def api_get(url,data=None,default_header=True,headers=None,stream=None,return_re
 
     return stream
 
+
 def basic_auth_header(username, password):
     '''basic_auth_header will return a base64 encoded header object to
     generate a token
@@ -212,6 +213,17 @@ def run_command(cmd):
 
     return output
 
+
+def is_number(image):
+    '''is_number determines if the user is providing a singularity hub
+    number (meaning the id of an image to download) vs a full name)
+    :param image: the image name, after the uri is removed (shub://)
+    '''
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
 
 
 ############################################################################

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -179,12 +179,14 @@ def basic_auth_header(username, password):
     :param password: the password
     '''
     s = "%s:%s" % (username, password)
+    logger.debug("AUTH: Input username/password:", s)
     if sys.version_info[0] >= 3:
         s = bytes(s, 'utf-8')
         credentials = base64.b64encode(s).decode('utf-8')
     else:
         credentials = base64.b64encode(s)
     auth = {"Authorization": "Basic %s" % credentials}
+    logger.debug("AUTH Final", auth)
     return auth
 
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -220,7 +220,7 @@ def is_number(image):
     :param image: the image name, after the uri is removed (shub://)
     '''
     try:
-        float(s)
+        float(image)
         return True
     except ValueError:
         return False

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -186,7 +186,6 @@ def basic_auth_header(username, password):
     else:
         credentials = base64.b64encode(s)
     auth = {"Authorization": "Basic %s" % credentials}
-    logger.debug("AUTH Final %s", auth)
     return auth
 
 


### PR DESCRIPTION
Fixes #434 #441 

This PR will add full functionality to all singularity hub endpoints (or ways to specify an image, including):

 - `shub://51` (unique id), the current implementation
 - `shub://vsoch/singularity-images` (namespace and repo name, tag defaults to master-->latest)
 - `shub://vsoch/singularity-images:latest` (specification of latest across all images)
 - `shub://vsoch/singularity-images:master` (specification of a tag)

I am going to wait to add official tests that pull images directly, as the database is going to be migrated to one more robust soon (and I will make permanent, official testing images at that time), but here is the functionality on command line:

Here is asking for an image based on username (akin to namespace) and repo name:

	vanessa@vanessa-ThinkPad-T460s:~/Desktop$ singularity shell shub://vsoch/singularity-images
	Cache folder set to /home/vanessa/.singularity/shub
	Found image vsoch/singularity-images:mongo
	Downloading image... 1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img.gz
	Decompressing /home/vanessa/.singularity/shub/1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img.gz
	Singularity: Invoking an interactive shell within container...
	Singularity.1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img> $ exit

Now we ask for the same image, but based on unique id:

	vanessa@vanessa-ThinkPad-T460s:~/Desktop$ singularity shell shub://55
	Cache folder set to /home/vanessa/.singularity/shub
	Found image vsoch/singularity-images:mongo
	Downloading image... 1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img.gz
	Decompressing /home/vanessa/.singularity/shub/1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img.gz
	Singularity: Invoking an interactive shell within container...
	Singularity.1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img> $ exit

Now we ask for a different image, the master branch (previous was branch "mongo")

	vanessa@vanessa-ThinkPad-T460s:~/Desktop$ singularity shell shub://vsoch/singularity-images:master
	Cache folder set to /home/vanessa/.singularity/shub
	Found image vsoch/singularity-images:master
	Downloading image... ce85ef57b5e9edf402f96b69d6ca44a6ce3adc91.img.gz
	Decompressing /home/vanessa/.singularity/shub/ce85ef57b5e9edf402f96b69d6ca44a6ce3adc91.img.gz
	Singularity: Invoking an interactive shell within container...
	Singularity.ce85ef57b5e9edf402f96b69d6ca44a6ce3adc91.img> $ exit

Asking for latest should return the latest image across tags (branches) which is mongo:

	vanessa@vanessa-ThinkPad-T460s:~/Desktop$ singularity shell shub://vsoch/singularity-images:latest
	Cache folder set to /home/vanessa/.singularity/shub
	Found image vsoch/singularity-images:mongo
	Downloading image... 1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img.gz
	Decompressing /home/vanessa/.singularity/shub/1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img.gz
	Singularity: Invoking an interactive shell within container...
	Singularity.1a4e2f28855f7e08dbe0fd969cb8372ffe005b4f.img> $ 

Changes proposed in this pull request

 - addition of all `shub://` uri endpoints so user's don't have to look up unique ids for images, and can specify easy-to-remember repo names. The previous specification of a particular image id is also still supported.
 - removing the redundant call to the docker API to retrieve the manifest twice, first to retrieve it, and then to get image with it.
 - Adding the parsing of the docker image name into a function, in anticipation of having command line completion (another PR).
- adding tests for the above functions

@singularityware-admin
