### PR TITLE
changing second character to newline to fix parsing bug. Seems to work!

### DIFF
--- a/src/lib/image/bootstrap/bootdef_parser.c
+++ b/src/lib/image/bootstrap/bootdef_parser.c
@@ -105,12 +105,11 @@ char *singularity_bootdef_get_value(char *key) {
     }
 
     line = (char *)malloc(MAX_LINE_LEN);
-
     while ( fgets(line, MAX_LINE_LEN, bootdef_fp) ) {
         if ( ( bootdef_key = strtok(line, ":") ) != NULL ) {
             chomp(bootdef_key);
             if ( strcasecmp(bootdef_key, key) == 0 ) {
-                if ( ( bootdef_value = strdup(strtok(NULL, ":")) ) != NULL ) {
+                if ( ( bootdef_value = strdup(strtok(NULL, "\n")) ) != NULL ) {
                     chomp(bootdef_value);
                     singularity_message(VERBOSE2, "Got bootstrap definition key %s(: '%s')\n", key, bootdef_value);
                     return(bootdef_value);


### PR DESCRIPTION
Not sure if this is reasonable, but after trying different stuff it seemed that the issue was using another `:` in `strtok`. I changed it to newline, and this seemed to fix the issue. What isn't clear to me is why it was chosen in the first place (is there some format of line like : : : that uses it?).

@singularityware-admin
