### PR TITLE
Changed TZ from date +%Z to use info from /etc/localtime.

### DIFF
--- a/etc/init
+++ b/etc/init
@@ -12,10 +12,5 @@ PATH="$PATH:/bin:/sbin:/usr/bin:/usr/sbin"
 # Don't save the shell's HISTFILE
 HISTFILE="/dev/null"
 
-# Set the timezone if it is not already set
-if [ -z "${TZ:-}" ]; then
-    TZ=`strings /etc/localtime | tail -n 1`
-fi
-
-export PATH HISTFILE TZ
+export PATH HISTFILE
 

--- a/etc/init
+++ b/etc/init
@@ -14,7 +14,7 @@ HISTFILE="/dev/null"
 
 # Set the timezone if it is not already set
 if [ -z "${TZ:-}" ]; then
-    TZ=`date +%Z`
+    TZ=`strings /etc/localtime | tail -n 1`
 fi
 
 export PATH HISTFILE TZ


### PR DESCRIPTION
The last line of /etc/localtime works better than +%Z,
This string is longer.  eg PST8PDT,M3.2.0,M11.1.0 instead of PST.  But the
latter doesn't actually have a matching timezone file and thus produce
wrong result.

I ran
TZ_LIST=$(  find /usr/share/zoneinfo -type f -exec tail -1 {} \; )
for TZ in $TZ_LIST; do
   echo $TZ
   date -d "TZ=\"$TZ\"  2016-02-29 13:45"
done
and confimed setting TZ like this produce desired result.

I ran sanity test on CentOS-6 and Ubuntu-14.
Both "echo $TZ" and "date" produced expected result for all 6 time zones of US, and Europe/Zurich.


Fixes #

Changes proposed in this pull request

 - Fix TZ so that date would produce desired result for timezone that doesn't have filenames matching the string from "date +%Z".   Issue was discussed in https://groups.google.com/a/lbl.gov/forum/#!topic/singularity/YWFspd3A_sg

-Tin
