### PR TITLE
updating shub tests to support image ids in new database

### DIFF
--- a/libexec/python/tests/test_shub.py
+++ b/libexec/python/tests/test_shub.py
@@ -39,7 +39,7 @@ class TestApi(TestCase):
 
 
     def setUp(self):
-        self.image_id = 24 # https://singularity-hub.org/collections/12/
+        self.image_id = 60 # https://singularity-hub.org/collections/12/
         self.user_name = "vsoch"
         self.repo_name = "singularity-images"
         self.tmpdir = tempfile.mkdtemp()
@@ -138,7 +138,7 @@ class TestApi(TestCase):
         image_name = get_image_name(manifest,
                                     use_commit=False)
         print(image_name)
-        self.assertEqual('32394f413f46f070e76cc07308f0e791.img.gz',image_name)
+        self.assertEqual('9e46ba8be1e10b1a2812844ac8072259.img.gz',image_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a quick update to the testing script for shub, basically updating the image ID and commit to support a different image being used for testing. Again, apologies about this change - I had expected the images to be set for good, and found out this morning we needed to use a different storage class... and one that was not transferrable from the old one! Booya.

@singularityware-admin
