### PR TITLE
Fix for Debian distros on aarch64

### DIFF
--- a/libexec/bootstrap/modules-v2/build-debootstrap.sh
+++ b/libexec/bootstrap/modules-v2/build-debootstrap.sh
@@ -57,6 +57,8 @@ if [ "$ARCH" == "x86_64" ]; then
     ARCH=amd64
 elif [ "$ARCH" == "ppc64le" ]; then
     ARCH=ppc64el
+elif [ "$ARCH" == "aarch64" ]; then
+    ARCH=arm64
 fi
 
 


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request

 - Change the identified architecture from 'aarch64' to 'arm64' for debootstrap.

@singularityware-admin
