### PR TITLE
added an ERRNO==ENOENT clause

### DIFF
--- a/src/lib/file/group/group.c
+++ b/src/lib/file/group/group.c
@@ -139,7 +139,7 @@ int singularity_file_group(void) {
                 singularity_message(VERBOSE3, "Found supplementary group membership in: %d\n", gids[i]);
                 singularity_message(VERBOSE2, "Adding user's supplementary group ('%s') info to template group file\n", grent->gr_name);
                 fprintf(file_fp, "%s:x:%u:%s\n", gr->gr_name, gr->gr_gid, pwent->pw_name);
-            } else if ( (errno == 0) || (errno == ESRCH) || (errno == EBADF) || (errno == EPERM) ) {
+            } else if ( (errno == 0) || (errno == ESRCH) || (errno == EBADF) || (errno == EPERM) || (errno == ENOENT)) {
                 singularity_message(VERBOSE3, "Skipping GID %d as group entry does not exist.\n", gids[i]);
             } else {
                 singularity_message(ERROR, "Failed to lookup GID %d group entry: %s\n", gids[i], strerror(errno));


### PR DESCRIPTION
Fixed an issue with group ids that don't actually exist, such as in the case with AFS and tokens.

Changes proposed in this pull request

 - add the clause (errno==ENOENT) to line 143 in group.c
 -
 -

@singularityware-admin
