### PR TITLE
Lib refactor quick fix to error mesage

### DIFF
--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -32,6 +32,7 @@ perform publicly and display publicly, and to permit other to do so.
 from logman import logger
 import tempfile
 import os
+import pwd
 import sys
 
 def getenv(variable_key,required=False,default=None,silent=False):
@@ -88,7 +89,8 @@ DISABLE_CACHE = convert2boolean(getenv("SINGULARITY_DISABLE_CACHE",
 if DISABLE_CACHE == True:
     SINGULARITY_CACHE = tempfile.mkdtemp()
 else:
-    _cache = os.path.join(os.environ.get("HOME"),".singularity") 
+    userhome = pwd.getpwuid(os.getuid())[5]
+    _cache = os.path.join(userhome,".singularity") 
     SINGULARITY_CACHE = getenv("SINGULARITY_CACHEDIR", default=_cache)
 
 if not os.path.exists(SINGULARITY_CACHE):

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -415,7 +415,7 @@ def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,au
             sys.exit(1)
         os.rename(tmp_file, download_folder)
     except:
-        logger.error("Removing temporary download file %s", tmp_file)
+        logger.error("Error downloading %s. Do you have permission to write to %s?", base, download_folder)
         try:
             os.remove(tmp_file)
         except:

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -405,21 +405,21 @@ def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,au
         # Update user what we are doing
         print("Downloading layer %s" %image_id)
 
-    #try:
-    # Create temporary file with format .tar.gz.tmp.XXXXX
-    fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % download_folder))
-    os.close(fd)
-    response = api_get(base,headers=token,stream=tmp_file)
-    if isinstance(response, HTTPError):
-        logger.error("Error downloading layer %s, exiting.", base)
+    try:
+        # Create temporary file with format .tar.gz.tmp.XXXXX
+        fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % download_folder))
+        os.close(fd)
+        response = api_get(base,headers=token,stream=tmp_file)
+        if isinstance(response, HTTPError):
+            logger.error("Error downloading layer %s, exiting.", base)
+            sys.exit(1)
+        os.rename(tmp_file, download_folder)
+    except:
+        logger.error("Error downloading %s. Do you have permission to write to %s?", base, download_folder)
+        try:
+            os.remove(tmp_file)
+        except:
+            pass
         sys.exit(1)
-    os.rename(tmp_file, download_folder)
-    #except:
-    #    logger.error("Error downloading %s. Do you have permission to write to %s?", base, download_folder)
-    #    try:
-    #        os.remove(tmp_file)
-    #    except:
-    #        pass
-    #    sys.exit(1)
 
     return download_folder

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -405,21 +405,21 @@ def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,au
         # Update user what we are doing
         print("Downloading layer %s" %image_id)
 
-    try:
-        # Create temporary file with format .tar.gz.tmp.XXXXX
-        fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % download_folder))
-        os.close(fd)
-        response = api_get(base,headers=token,stream=tmp_file)
-        if isinstance(response, HTTPError):
-            logger.error("Error downloading layer %s, exiting.", base)
-            sys.exit(1)
-        os.rename(tmp_file, download_folder)
-    except:
-        logger.error("Error downloading %s. Do you have permission to write to %s?", base, download_folder)
-        try:
-            os.remove(tmp_file)
-        except:
-            pass
+    #try:
+    # Create temporary file with format .tar.gz.tmp.XXXXX
+    fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % download_folder))
+    os.close(fd)
+    response = api_get(base,headers=token,stream=tmp_file)
+    if isinstance(response, HTTPError):
+        logger.error("Error downloading layer %s, exiting.", base)
         sys.exit(1)
+    os.rename(tmp_file, download_folder)
+    #except:
+    #    logger.error("Error downloading %s. Do you have permission to write to %s?", base, download_folder)
+    #    try:
+    #        os.remove(tmp_file)
+    #    except:
+    #        pass
+    #    sys.exit(1)
 
     return download_folder

--- a/test.sh.in
+++ b/test.sh.in
@@ -225,15 +225,14 @@ stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 sh -c "cat ${CONTAINERDIR}.tar | singularity import $CONTAINER"
 stest 1 sh -c "sudo singularity import $CONTAINER not_a_file 2>&1 | grep \"unbound variable\""
 stest 0 singularity create -F -s 568 "$CONTAINER"
+stest 0 singularity import ${CONTAINER} docker://centos
+stest 0 singularity exec ${CONTAINER} test -f /etc/redhat-release
+stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sudo singularity import ${CONTAINER} http://fake_singularity_url
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sudo singularity import ${CONTAINER} docker://not_a_docker_container/nope_nope_singularity
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sh -c "sudo singularity import ${CONTAINER} docker://not_a_docker_container/nope_nope_singularity | grep 'ERROR: Container does not contain the valid minimum requirement of /bin/sh'"
-stest 0 singularity create -F -s 568 "$CONTAINER"
-stest 0 singularity import ${CONTAINER} docker://centos
-stest 0 singularity exec ${CONTAINER} test -f /etc/redhat-release
-
 
 /bin/echo
 /bin/echo "Checking directory mode"

--- a/test.sh.in
+++ b/test.sh.in
@@ -228,6 +228,8 @@ stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 singularity import ${CONTAINER} docker://centos
 stest 0 singularity exec ${CONTAINER} test -f /etc/redhat-release
 stest 0 singularity create -F -s 568 "$CONTAINER"
+echo "What is the permission of SINGULARITY_CACHE?"
+stat /home/travis/.singularity/docker
 stest 1 sudo singularity import ${CONTAINER} http://fake_singularity_url
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sudo singularity import ${CONTAINER} docker://not_a_docker_container/nope_nope_singularity

--- a/test.sh.in
+++ b/test.sh.in
@@ -225,7 +225,7 @@ stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 sh -c "cat ${CONTAINERDIR}.tar | singularity import $CONTAINER"
 stest 1 sh -c "sudo singularity import $CONTAINER not_a_file 2>&1 | grep \"unbound variable\""
 stest 0 singularity create -F -s 568 "$CONTAINER"
-export SINGULARITY_DISABLE_CACHE="yes" && stest 0 singularity import ${CONTAINER} docker://centos
+export SINGULARITY_CACHEDIR="/tmp/.singularity" && stest 0 singularity import ${CONTAINER} docker://centos
 stest 0 singularity exec ${CONTAINER} test -f /etc/redhat-release
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sudo singularity import ${CONTAINER} http://fake_singularity_url

--- a/test.sh.in
+++ b/test.sh.in
@@ -225,7 +225,7 @@ stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 sh -c "cat ${CONTAINERDIR}.tar | singularity import $CONTAINER"
 stest 1 sh -c "sudo singularity import $CONTAINER not_a_file 2>&1 | grep \"unbound variable\""
 stest 0 singularity create -F -s 568 "$CONTAINER"
-export SINGULARITY_CACHEDIR="/tmp/.singularity" && stest 0 singularity import ${CONTAINER} docker://centos
+stest 0 singularity import ${CONTAINER} docker://centos
 stest 0 singularity exec ${CONTAINER} test -f /etc/redhat-release
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sudo singularity import ${CONTAINER} http://fake_singularity_url

--- a/test.sh.in
+++ b/test.sh.in
@@ -224,12 +224,12 @@ stest 0 sudo chmod 0644 ${CONTAINERDIR}.tar
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 sh -c "cat ${CONTAINERDIR}.tar | singularity import $CONTAINER"
 stest 1 sh -c "sudo singularity import $CONTAINER not_a_file 2>&1 | grep \"unbound variable\""
+echo "What is the permission of SINGULARITY_CACHE?"
+stat /home/travis/.singularity/docker
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 singularity import ${CONTAINER} docker://centos
 stest 0 singularity exec ${CONTAINER} test -f /etc/redhat-release
 stest 0 singularity create -F -s 568 "$CONTAINER"
-echo "What is the permission of SINGULARITY_CACHE?"
-stat /home/travis/.singularity/docker
 stest 1 sudo singularity import ${CONTAINER} http://fake_singularity_url
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sudo singularity import ${CONTAINER} docker://not_a_docker_container/nope_nope_singularity

--- a/test.sh.in
+++ b/test.sh.in
@@ -224,10 +224,8 @@ stest 0 sudo chmod 0644 ${CONTAINERDIR}.tar
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 sh -c "cat ${CONTAINERDIR}.tar | singularity import $CONTAINER"
 stest 1 sh -c "sudo singularity import $CONTAINER not_a_file 2>&1 | grep \"unbound variable\""
-echo "What is the permission of SINGULARITY_CACHE?"
-stat /home/travis/.singularity/docker
 stest 0 singularity create -F -s 568 "$CONTAINER"
-stest 0 singularity import ${CONTAINER} docker://centos
+export SINGULARITY_DISABLE_CACHE="yes" && stest 0 singularity import ${CONTAINER} docker://centos
 stest 0 singularity exec ${CONTAINER} test -f /etc/redhat-release
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sudo singularity import ${CONTAINER} http://fake_singularity_url


### PR DESCRIPTION
In the case that the layer download fails due to permission issue, the temporary file will be undefined, and further, the likely cause of this error is a permissions issue where the user is trying to write (to the cache) so we should ask him/her about this.