### PR TITLE
updating python tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - make test
   - jdk_switcher use oraclejdk8
   - sonar-scanner
-  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest discover --start-directory tests
-  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest discover --start-directory tests
+  - cd $TRAVIS_BUILD_DIR/libexec/python/tests && ./run_tests_python2.sh
+  - cd $TRAVIS_BUILD_DIR/libexec/python/tests && ./run_tests_python3.sh
   - pylint --version
   - cd $TRAVIS_BUILD_DIR/libexec/python && pylint $PWD --errors-only --ignore tests  --disable=E0401,E0611

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,27 @@ script:
   - make test
   - jdk_switcher use oraclejdk8
   - sonar-scanner
-  - cd $TRAVIS_BUILD_DIR/libexec/python/tests && ./run_tests_python2.sh
-  - cd $TRAVIS_BUILD_DIR/libexec/python/tests && ./run_tests_python3.sh
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_base
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker_import
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker_add
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker_api
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub_import
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub_pull
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub_add
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_custom_cache
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_default_cache
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_disable_cache
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_base
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker_import
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker_add
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker_api
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub_import
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub_pull
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub_add
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_custom_cache
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_default_cache
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_disable_cache
   - pylint --version
   - cd $TRAVIS_BUILD_DIR/libexec/python && pylint $PWD --errors-only --ignore tests  --disable=E0401,E0611

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -65,8 +65,8 @@ def create_runscript(manifest,includecmd=False):
     :param includecmd: overwrite default command (ENTRYPOINT) default is False
     '''
     if METADATA_BASE == None:
-        bot.logger.warning('''METADATA_BASE/SINGULARITY_ROOTFS not defined in environment!
-                           Will not write runscript to file, but return to function call.''')
+        logger.warning('''METADATA_BASE/SINGULARITY_ROOTFS not defined in environment!
+                       Will not write runscript to file, but return to function call.''')
         runscript = None
     else:
         runscript = "%s/runscript" %(METADATA_BASE)

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -47,7 +47,6 @@ from defaults import (
 from logman import logger
 import json
 import re
-import os
 import tempfile
 try:
     from urllib.error import HTTPError
@@ -139,17 +138,6 @@ def extract_labels(manifest):
                                               extension='.txt')
     return labels
 
-
-def get_config(manifest,key):
-    '''get_config returns the content of some key in the manifest "Config"
-    :param manifest: the complete manifest
-    :param key: the key to find
-    '''
-    if "Config" in manifest:
-        if key in manifest["Config"]:
-            if len(manifest["Config"][key] > 0):
-                return manifest["Config"][key]
-    return None
 
 
 def get_configs(manifest,keys):

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -64,7 +64,12 @@ def create_runscript(manifest,includecmd=False):
     :param manifest: the manifest to use to get the runscript
     :param includecmd: overwrite default command (ENTRYPOINT) default is False
     '''
-    runscript = "%s/runscript" %(METADATA_BASE)
+    if METADATA_BASE == None:
+        bot.logger.warning('''METADATA_BASE/SINGULARITY_ROOTFS not defined in environment!
+                           Will not write runscript to file, but return to function call.''')
+        runscript = None
+    else:
+        runscript = "%s/runscript" %(METADATA_BASE)
     cmd = None
 
     # Does the user want to use the CMD instead of ENTRYPOINT?
@@ -91,9 +96,10 @@ def create_runscript(manifest,includecmd=False):
             cmd = 'exec %s "$@"' %(cmd)
         cmd = "#!/bin/sh\n\n%s" %(cmd)
         logger.info("Generating runscript at %s",runscript)
-        output_file = write_file(runscript,cmd)
-        return output_file
-
+        if runscript != None:
+            output_file = write_file(runscript,cmd)
+            return output_file
+        return runscript
     print("No Docker CMD or ENTRYPOINT found, skipping runscript generation.")
     return cmd
 

--- a/libexec/python/docker/import.py
+++ b/libexec/python/docker/import.py
@@ -41,7 +41,7 @@ sys.path.append('..')
 from main import IMPORT
 from shell import get_image_uri
 from utils import (
-    basic_auth_header,
+    basic_auth_header
 )
 
 from defaults import getenv

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -45,6 +45,7 @@ from api import (
 
 from logman import logger
 import json
+import shutil
 import re
 import os
 import tempfile

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -18,9 +18,10 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),"docker")))
 
 from logman import logger
-from docker.api import get_tags
 
 from defaults import (
     API_BASE as default_registry,
@@ -49,7 +50,6 @@ def get_image_uri(image):
         image_uri = match[0].lower()
         logger.debug("Found uri %s",image_uri)
     return image_uri
-
 
 
 def parse_image_uri(image,uri=None):
@@ -115,18 +115,3 @@ def parse_image_uri(image,uri=None):
             sys.exit(1)
 
     return parsed
-
-
-def get_tags_shell(image,uri):
-    '''get_tags_shell is a wrapper to run docker.api.get_tags with additional parsing
-    of the input string. It is assumed that a tag is not provided.
-    :image: the image name to be parsed by parse_image_uri
-    '''
-    parsed = parse_image_uri(image,uri)
-    repo_name = parsed['repo_name']
-    namespace = parsed['namespace']
-    registry = parsed['registry']
-
-    return get_tags(namespace=namespace,
-                    repo_name=repo_name,
-                    registry=registry)

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -134,22 +134,26 @@ def download_image(manifest,download_folder=None,extract=True):
 
 
 # Various Helpers ---------------------------------------------------------------------------------
-def get_image_name(manifest,extension='img.gz',use_commit=True):
+def get_image_name(manifest,extension='img.gz',use_hash=False):
     '''get_image_name will return the image name for a manifest
     :param manifest: the image manifest with 'image' as key with download link
-    :param use_commit: use the commit id to name the image (default) otherwise use md5sum
+    :param use_hash: use the image hash instead of name
     '''
-    image_url = os.path.basename(unquote(manifest['image']))
-    image_name = re.findall(".+[.]%s" %(extension),image_url)
-    if len(image_name) > 0:
-        image_name = image_name[0]
-        if use_commit == True:
-            image_name = "%s.img.gz" %(manifest["version"])            
-        logger.info("Singularity Hub Image: %s", image_name)
-        return image_name
+    if not use_hash:
+        image_name = "%s-%s.%s" %(manifest['name'].replace('/','-'),
+                                  manifest['branch'].replace('/','-'),
+                                  extension)
     else:
-        logger.error("Singularity Hub Image not found with expected extension %s, exiting.",extension)
-        sys.exit(1)
+        image_url = os.path.basename(unquote(manifest['image']))
+        image_name = re.findall(".+[.]%s" %(extension),image_url)
+        if len(image_name) > 0:
+            image_name = image_name[0]
+        else:
+            logger.error("Singularity Hub Image not found with expected extension %s, exiting.",extension)
+            sys.exit(1)
+            
+    logger.info("Singularity Hub Image: %s", image_name)
+    return image_name
 
 
 def extract_metadata(manifest):

--- a/libexec/python/shub/main.py
+++ b/libexec/python/shub/main.py
@@ -49,7 +49,7 @@ import os
 import tempfile
 
 
-def PULL(image,pull_folder=None):
+def PULL(image,pull_folder=None,layerfile=None):
     '''PULL will retrieve a Singularity Hub image and download to the local file
     system, to the variable specified by SINGULARITY_PULL_FOLDER.
     :param image: the singularity hub image name
@@ -77,6 +77,10 @@ def PULL(image,pull_folder=None):
                  'manifest': manifest,
                  'cache_base': cache_base,
                  'image': image }
+
+    if layerfile != None:
+        logger.debug("Writing Singularity Hub image path to %s", layerfile)
+        write_file(layerfile,additions['image_file'],mode="w")
 
     return additions
 

--- a/libexec/python/shub/pull.py
+++ b/libexec/python/shub/pull.py
@@ -7,7 +7,7 @@ pull.py: wrapper for "pull" for Singularity Hub command line tool.
 ENVIRONMENTAL VARIABLES that are found for this executable:
 
 
-   SINGULARITY_HUB_IMAGE: maps to container name: shub://vsoch/singularity-images
+   SINGULARITY_CONTAINER: maps to container name: shub://vsoch/singularity-images
    SINGULARITY_ROOTFS: the root file system location
    SINGULARITY_HUB_PULL_FOLDER: maps to location to pull folder to
    SINGULARITY_METADATA_DIR: if defined, will write paths to file pulled here

--- a/libexec/python/shub/pull.py
+++ b/libexec/python/shub/pull.py
@@ -38,11 +38,6 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
 sys.path.append('..')
 
-from defaults import (
-    DISABLE_CACHE,
-    getenv
-)
-
 from shub.main import PULL
 from shell import get_image_uri
 from logman import logger
@@ -55,7 +50,8 @@ def main():
     This makes it possible to set up a parser in test cases
     '''
     logger.info("\n*** STARTING SINGULARITY HUB PYTHON PULL ****")
-    
+    from defaults import LAYERFILE DISABLE_CACHE getenv
+
     # What image is the user asking for?
     container = getenv("SINGULARITY_CONTAINER", required=True)
     pull_folder = getenv("SINGULARITY_HUB_PULL_FOLDER")
@@ -65,7 +61,8 @@ def main():
     if image_uri == "shub://":
 
        additions = PULL(image=container,
-                        pull_folder=pull_folder)
+                        pull_folder=pull_folder,
+                        layerfile=LAYERFILE)
 
     else:
         logger.error("uri %s is not currently supported for pull. Exiting.",image_uri)

--- a/libexec/python/shub/pull.py
+++ b/libexec/python/shub/pull.py
@@ -50,7 +50,7 @@ def main():
     This makes it possible to set up a parser in test cases
     '''
     logger.info("\n*** STARTING SINGULARITY HUB PYTHON PULL ****")
-    from defaults import LAYERFILE DISABLE_CACHE getenv
+    from defaults import LAYERFILE, DISABLE_CACHE, getenv
 
     # What image is the user asking for?
     container = getenv("SINGULARITY_CONTAINER", required=True)

--- a/libexec/python/tests/run_tests_python2.sh
+++ b/libexec/python/tests/run_tests_python2.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+python2 -m unittest test_base
+python2 -m unittest test_docker_import
+python2 -m unittest test_docker_add
+python2 -m unittest test_docker_api
+
+python2 -m unittest test_shub_import
+python2 -m unittest test_shub_pull
+python2 -m unittest test_shub_add
+python2 -m unittest test_shub
+
+python2 -m unittest test_custom_cache
+python2 -m unittest test_default_cache
+python2 -m unittest test_disable_cache

--- a/libexec/python/tests/run_tests_python3.sh
+++ b/libexec/python/tests/run_tests_python3.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+python3 -m unittest test_base
+python3 -m unittest test_docker_import
+python3 -m unittest test_docker_add
+python3 -m unittest test_docker_api
+
+python3 -m unittest test_shub_import
+python3 -m unittest test_shub_pull
+python3 -m unittest test_shub_add
+python3 -m unittest test_shub
+
+python3 -m unittest test_custom_cache
+python3 -m unittest test_default_cache
+python3 -m unittest test_disable_cache

--- a/libexec/python/tests/test_base.py
+++ b/libexec/python/tests/test_base.py
@@ -437,14 +437,14 @@ class TestUtils(TestCase):
                                             prefix=prefix,
                                             start_number=start_number,
                                             content=content)
-        self.assertEqual(info_file,"%s/%s%s" %(base_dir,prefix,start_number))
+        self.assertEqual(info_file,"%s/%s-%s" %(base_dir,prefix,start_number))
 
         print("Case 3: Adding another equivalent prefix should return next")
         info_file = write_singularity_infos(base_dir=base_dir,
                                             prefix=prefix,
                                             start_number=start_number,
                                             content=content)
-        self.assertEqual(info_file,"%s/%s%s" %(base_dir,prefix,start_number+1))
+        self.assertEqual(info_file,"%s/%s-%s" %(base_dir,prefix,start_number+1))
         
         print("Case 4: Files have correct content.")
         with open(info_file,'r') as filey:

--- a/libexec/python/tests/test_docker_add.py
+++ b/libexec/python/tests/test_docker_add.py
@@ -1,6 +1,6 @@
 '''
 
-test_docker_import.py: Docker testing functions for Singularity in Python
+test_docker_add.py: Docker testing functions for Singularity in Python
 
 Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
 
@@ -38,9 +38,9 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s DOCKER IMPORT TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s DOCKER ADD TESTING START ***" %(VERSION))
 
-class TestImport(TestCase):
+class TestAdd(TestCase):
 
     def setUp(self):
         self.namespace = 'library'
@@ -52,7 +52,6 @@ class TestImport(TestCase):
         os.environ["SINGULARITY_CONTAINER"] = "docker://ubuntu:latest" 
         os.environ["SINGULARITY_ROOTFS"] = self.tmpdir
         os.mkdir('%s/.singularity' %(self.tmpdir))
-        os.mkdir('%s/.singularity/env' %(self.tmpdir))
 
         print("\n---START----------------------------------------")
 
@@ -60,10 +59,10 @@ class TestImport(TestCase):
         shutil.rmtree(self.tmpdir)
         print("---END------------------------------------------")
 
-    def test_IMPORT(self):
-        '''test_import will test the IMPORT function
+    def test_ADD(self):
+        '''test_ADD will test the ADD function
         '''
-        script_path = "%s/docker/import.py" %(self.here)
+        script_path = "%s/docker/add.py" %(self.here)
         if VERSION == 2:
             testing_command = ["python2",script_path]
         else:
@@ -75,6 +74,7 @@ class TestImport(TestCase):
                   'return_code':t[1]}
         print(result['message'])
         self.assertEqual(result['return_code'],0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_shub.py
+++ b/libexec/python/tests/test_shub.py
@@ -76,20 +76,15 @@ class TestApi(TestCase):
         image = download_image(manifest,
                                download_folder=self.tmpdir)
         self.assertEqual(os.path.dirname(image),self.tmpdir)
-        
-        print("Case 2: Image should be named based on commit.")
-        image_name = os.path.splitext(os.path.basename(image))[0]
-        self.assertEqual(image_name,manifest['version'])
-        os.remove(image)
-
-        print("Case 3: Not specifying a directory downloads to PWD")
+       
+        print("Case 2: Not specifying a directory downloads to PWD")
         os.chdir(self.tmpdir)
         image = download_image(manifest)
         self.assertEqual(os.getcwd(),self.tmpdir)
         self.assertTrue(image in glob("*"))
         os.remove(image)
 
-        print("Case 4: Image should not be extracted.")
+        print("Case 3: Image should not be extracted.")
         image = download_image(manifest,extract=False)
         self.assertTrue(image.endswith('.img.gz'))        
 
@@ -125,22 +120,18 @@ class TestApi(TestCase):
         from shub.api import get_image_name, get_manifest
         manifest = get_manifest(image=self.image_id)
                 
-        print("Case 1: return an image name using the commit id")
+        print("Case 1: return an image name corresponding to repo")
         image_name = get_image_name(manifest)
-        self.assertEqual('6d3715a982865863ff20e8783014522edf1240e4.img.gz',
+        self.assertEqual('vsoch-singularity-images-master.img.gz',
                          image_name)
 
-        print("Case 2: ask for invalid extension")
+        print("Case 2: ask for hash, but with invalid extension")
         with self.assertRaises(SystemExit) as cm:
             image_name = get_image_name(manifest,
-                                        extension='.bz2')
+                                        extension='.bz2',
+                                        use_hash=True)
         self.assertEqual(cm.exception.code, 1)
 
-        print("Case 3: don't use commit (use md5 sum on generation)")
-        image_name = get_image_name(manifest,
-                                    use_commit=False)
-        print(image_name)
-        self.assertEqual('9e46ba8be1e10b1a2812844ac8072259.img.gz',image_name)
 
 
 if __name__ == '__main__':

--- a/libexec/python/tests/test_shub.py
+++ b/libexec/python/tests/test_shub.py
@@ -44,6 +44,7 @@ class TestApi(TestCase):
         self.repo_name = "singularity-images"
         self.tmpdir = tempfile.mkdtemp()
         os.environ['SINGULARITY_ROOTFS'] = self.tmpdir
+        os.mkdir('%s/.singularity' %(self.tmpdir))
         print("\n---START----------------------------------------")
 
     def tearDown(self):

--- a/libexec/python/tests/test_shub_add.py
+++ b/libexec/python/tests/test_shub_add.py
@@ -1,6 +1,6 @@
 '''
 
-test_docker_import.py: Docker testing functions for Singularity in Python
+test_shub_add.py: Singularity Hub testing functions for Singularity in Python
 
 Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
 
@@ -38,21 +38,18 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s DOCKER IMPORT TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s SINGULARITY HUB ADD TESTING START ***" %(VERSION))
 
 class TestImport(TestCase):
 
     def setUp(self):
-        self.namespace = 'library'
-        self.repo_name = 'ubuntu'
         self.tmpdir = tempfile.mkdtemp()
         self.here = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))        
 
         # Variables are obtained from environment
-        os.environ["SINGULARITY_CONTAINER"] = "docker://ubuntu:latest" 
+        os.environ["SINGULARITY_CONTAINER"] = "shub://vsoch/singularity-images" 
         os.environ["SINGULARITY_ROOTFS"] = self.tmpdir
         os.mkdir('%s/.singularity' %(self.tmpdir))
-        os.mkdir('%s/.singularity/env' %(self.tmpdir))
 
         print("\n---START----------------------------------------")
 
@@ -60,10 +57,11 @@ class TestImport(TestCase):
         shutil.rmtree(self.tmpdir)
         print("---END------------------------------------------")
 
-    def test_IMPORT(self):
-        '''test_import will test the IMPORT function
+
+    def test_ADD(self):
+        '''test_ADD will test the ADD function
         '''
-        script_path = "%s/docker/import.py" %(self.here)
+        script_path = "%s/shub/add.py" %(self.here)
         if VERSION == 2:
             testing_command = ["python2",script_path]
         else:
@@ -75,6 +73,7 @@ class TestImport(TestCase):
                   'return_code':t[1]}
         print(result['message'])
         self.assertEqual(result['return_code'],0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_shub_import.py
+++ b/libexec/python/tests/test_shub_import.py
@@ -1,6 +1,6 @@
 '''
 
-test_docker_import.py: Docker testing functions for Singularity in Python
+test_shub_import.py: Singularity Hub testing functions for Singularity in Python
 
 Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
 
@@ -38,21 +38,19 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s DOCKER IMPORT TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s SINGULARITY HUB IMPORT TESTING START ***" %(VERSION))
 
 class TestImport(TestCase):
 
     def setUp(self):
-        self.namespace = 'library'
-        self.repo_name = 'ubuntu'
         self.tmpdir = tempfile.mkdtemp()
         self.here = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))        
 
         # Variables are obtained from environment
-        os.environ["SINGULARITY_CONTAINER"] = "docker://ubuntu:latest" 
+        os.environ["SINGULARITY_CONTAINER"] = "shub://vsoch/singularity-images" 
         os.environ["SINGULARITY_ROOTFS"] = self.tmpdir
         os.mkdir('%s/.singularity' %(self.tmpdir))
-        os.mkdir('%s/.singularity/env' %(self.tmpdir))
+        os.mkdir('%s/.singularity/labels' %(self.tmpdir))
 
         print("\n---START----------------------------------------")
 
@@ -60,10 +58,11 @@ class TestImport(TestCase):
         shutil.rmtree(self.tmpdir)
         print("---END------------------------------------------")
 
+
     def test_IMPORT(self):
-        '''test_import will test the IMPORT function
+        '''test_IMPORT will test the IMPORT function
         '''
-        script_path = "%s/docker/import.py" %(self.here)
+        script_path = "%s/shub/import.py" %(self.here)
         if VERSION == 2:
             testing_command = ["python2",script_path]
         else:
@@ -75,6 +74,7 @@ class TestImport(TestCase):
                   'return_code':t[1]}
         print(result['message'])
         self.assertEqual(result['return_code'],0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_shub_pull.py
+++ b/libexec/python/tests/test_shub_pull.py
@@ -49,6 +49,7 @@ class TestImport(TestCase):
         # Variables are obtained from environment
         os.environ["SINGULARITY_CONTAINER"] = "shub://vsoch/singularity-images" 
         os.environ["SINGULARITY_HUB_PULL_FOLDER"] = self.tmpdir
+        os.environ["SINGULARITY_LAYERFILE"] = "%s/.layers" %self.tmpdir
 
         print("\n---START----------------------------------------")
 

--- a/libexec/python/tests/test_shub_pull.py
+++ b/libexec/python/tests/test_shub_pull.py
@@ -1,6 +1,6 @@
 '''
 
-test_docker_import.py: Docker testing functions for Singularity in Python
+test_shub_pull.py: Singularity Hub testing functions for Singularity in Python
 
 Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
 
@@ -38,21 +38,17 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s DOCKER IMPORT TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s SINGULARITY HUB PULL TESTING START ***" %(VERSION))
 
 class TestImport(TestCase):
 
     def setUp(self):
-        self.namespace = 'library'
-        self.repo_name = 'ubuntu'
         self.tmpdir = tempfile.mkdtemp()
         self.here = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))        
 
         # Variables are obtained from environment
-        os.environ["SINGULARITY_CONTAINER"] = "docker://ubuntu:latest" 
-        os.environ["SINGULARITY_ROOTFS"] = self.tmpdir
-        os.mkdir('%s/.singularity' %(self.tmpdir))
-        os.mkdir('%s/.singularity/env' %(self.tmpdir))
+        os.environ["SINGULARITY_CONTAINER"] = "shub://vsoch/singularity-images" 
+        os.environ["SINGULARITY_HUB_PULL_FOLDER"] = self.tmpdir
 
         print("\n---START----------------------------------------")
 
@@ -60,10 +56,11 @@ class TestImport(TestCase):
         shutil.rmtree(self.tmpdir)
         print("---END------------------------------------------")
 
-    def test_IMPORT(self):
-        '''test_import will test the IMPORT function
+
+    def test_PULL(self):
+        '''test_PULL will test the PULL function
         '''
-        script_path = "%s/docker/import.py" %(self.here)
+        script_path = "%s/shub/pull.py" %(self.here)
         if VERSION == 2:
             testing_command = ["python2",script_path]
         else:
@@ -75,6 +72,7 @@ class TestImport(TestCase):
                   'return_code':t[1]}
         print(result['message'])
         self.assertEqual(result['return_code'],0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should at least be a start to fixing up the python tests. There were a few issues:

- the actual testing for the import/add/pull for both of docker and shub weren't written. It looks like I started and then promptly forgot, so I've added a few completely new files. This is a more challenging test case because the intended use is to call from command line but we are running tests from within python. They also expect environment variables to be defined, and folders to be created. To address this, I do these exports/creations upon setup, and then use subprocess to pipe commands to the command line (as the real calling singularity would) and then check for an exit code of 0. I also print the terminal output for the viewer in case it's needed.
- I fixed a few imports / header details
- the runscript function was updated to not need a base directory (as it gets it from the environment) and this wasn't updated in the tests. I also saw a potential bug if the user tried using the function without defining the `SINGULARITY_METADATA_FOLDER` in the environment - it would try to write to a path like 

      /None/.singularity/runscript

So I do a check for this first. If the metadata folder is not defined, it returns the runscript as a string (and gives the user a warning).

Finally, I moved all the tests into a bash script to be run instead of using the unittest discovery tool. The reason is pretty silly, although I don't see a workaround for it other than calling the commands separately. To test a lot of the functions that require changing environment variables, it means we need totally separate python processes. The cache functions were failing because we had set them to be something upon init, and then our changes didn't take effect.This method works for me locally so I'm hoping it works on travis.

I'll push updates to address any/all total failures, lol.

@singularityware-admin
