### PR TITLE
Read only userbinds rebased

### DIFF
--- a/libexec/cli/exec.help
+++ b/libexec/cli/exec.help
@@ -4,9 +4,12 @@ This command will allow you to execute any program within the given
 container image.
 
 EXEC OPTIONS:
-    -B/--bind <spec>    A user-bind path specification.  spec can either be a
-                        path or a src:dest pair, specifying the bind mount to
-                        perform (can be called multiple times)
+    -B/--bind <spec>    A user-bind path specification.  spec has the format
+                        src[:dest[:opts]], where src and dest are outside and
+                        inside paths.  If dest is not given, it is set equal
+                        to src.  opts may be specified as 'ro' (read-only) or
+                        'rw' (read/write, which is the default). This option
+                        can be called multiple times.
     -c/--contain        This option disables the automatic sharing of writable
                         filesystems on your host (e.g. $HOME and /tmp).
     -C/--containall     Contain not only file systems, but also PID and IPC 

--- a/libexec/cli/run.help
+++ b/libexec/cli/run.help
@@ -9,9 +9,12 @@ runscript.
 
 
 RUN OPTIONS:
-    -B/--bind <spec>    A user-bind path specification.  spec can either be a
-                        path or a src:dest pair, specifying the bind mount to
-                        perform (can be called multiple times)
+    -B/--bind <spec>    A user-bind path specification.  spec has the format
+                        src[:dest[:opts]], where src and dest are outside and
+                        inside paths.  If dest is not given, it is set equal
+                        to src.  opts may be specified as 'ro' (read-only) or
+                        'rw' (read/write, which is the default). This option
+                        can be called multiple times.
     -c/--contain        This option disables the automatic sharing of writable
                         filesystems on your host (e.g. $HOME and /tmp).
     -C/--containall     Contain not only file systems, but also PID and IPC

--- a/libexec/cli/shell.help
+++ b/libexec/cli/shell.help
@@ -7,9 +7,12 @@ by default writable.
 
 
 SHELL OPTIONS:
-    -B/--bind <spec>    A user-bind path specification.  spec can either be a
-                        path or a src:dest pair, specifying the bind mount to
-                        perform (can be called multiple times)
+    -B/--bind <spec>    A user-bind path specification.  spec has the format
+                        src[:dest[:opts]], where src and dest are outside and
+                        inside paths.  If dest is not given, it is set equal
+                        to src.  opts may be specified as 'ro' (read-only) or
+                        'rw' (read/write, which is the default). This option
+                        can be called multiple times.
     -c/--contain        This option disables the automatic sharing of writable
                         filesystems on your host (e.g. $HOME and /tmp).
     -C/--containall     Contain not only file systems, but also PID and IPC


### PR DESCRIPTION
Fixes #451

Changes proposed in this pull request

 - Allow specifying additional --bind option ":ro" to perform a read-only bind mount.

@singularityware-admin
