### PR TITLE
default python runs now send the singularity output to STDERR

### DIFF
--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -186,7 +186,7 @@ def run(args):
             image_file = download_image(manifest=manifest,
                                         download_folder=cache_base)
         else:
-            print("Image already exists at %s, skipping download." %image_file)
+            sys.stderr.write("Image already exists at %s , skipping download.\n" %image_file)
         logger.info("Singularity Hub Image Download: %s", image_file)
        
         # If singularity_rootfs is provided, write metadata to it

--- a/libexec/python/cli.py
+++ b/libexec/python/cli.py
@@ -186,7 +186,7 @@ def run(args):
             image_file = download_image(manifest=manifest,
                                         download_folder=cache_base)
         else:
-            sys.stderr.write("Image already exists at %s , skipping download.\n" %image_file)
+            sys.stderr.write("# singularity: Image already exists at %s , skipping download.\n" %image_file)
         logger.info("Singularity Hub Image Download: %s", image_file)
        
         # If singularity_rootfs is provided, write metadata to it

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -114,15 +114,15 @@ def download_image(manifest,download_folder=None,extract=True):
     '''    
     image_file = get_image_name(manifest)
 
-    print("Found image %s:%s" %(manifest['name'],manifest['branch']))
-    print("Downloading image... %s" %(image_file))
+    sys.stderr.write("Found image %s:%s\n" %(manifest['name'],manifest['branch']))
+    sys.stderr.write("Downloading image... %s\n" %(image_file))
 
     if download_folder != None:
         image_file = "%s/%s" %(download_folder,image_file)
     url = manifest['image']
     image_file = api_get(url,stream=image_file)
     if extract == True:
-        print("Decompressing", image_file)
+        sys.stderr.write("Decompressing %s\n" %(image_file))
         os.system('gzip -d -f %s' %(image_file))
         image_file = image_file.replace('.gz','')
     return image_file

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -114,15 +114,15 @@ def download_image(manifest,download_folder=None,extract=True):
     '''    
     image_file = get_image_name(manifest)
 
-    sys.stderr.write("Found image %s:%s\n" %(manifest['name'],manifest['branch']))
-    sys.stderr.write("Downloading image... %s\n" %(image_file))
+    sys.stderr.write("# singularity: Found image %s:%s\n" %(manifest['name'],manifest['branch']))
+    sys.stderr.write("# singularity: Downloading image... %s\n" %(image_file))
 
     if download_folder != None:
         image_file = "%s/%s" %(download_folder,image_file)
     url = manifest['image']
     image_file = api_get(url,stream=image_file)
     if extract == True:
-        sys.stderr.write("Decompressing %s\n" %(image_file))
+        sys.stderr.write("# singularity: Decompressing %s\n" %(image_file))
         os.system('gzip -d -f %s' %(image_file))
         image_file = image_file.replace('.gz','')
     return image_file

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -259,7 +259,7 @@ def change_permission(file_path,permission=None):
         try:
             os.chmod(file_path, st.st_mode | permission)
         except:
-            sys.stderr.write("ERROR: Couldn't change permission on ", file_path, "\n")
+            sys.stderr.write("ERROR: Couldn't change permission on %s\n" %file_path)
             sys.exit(1)
     return has_permission(file_path,permission)
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -333,7 +333,7 @@ def get_cache(cache_base=None,subfolder=None,disable_cache=False):
     # Create the cache folder(s), if don't exist
     create_folders(cache_base)
 
-    sys.stderr.write("Cache folder set to %s\n" %cache_base)
+    sys.stderr.write("# singularity: Cache folder set to %s\n" %cache_base)
     return cache_base
 
 
@@ -363,7 +363,7 @@ def extract_tar(archive,output_folder):
 
     # Just use command line, more succinct.
     command = ["tar", args, archive, "-C", output_folder, "--exclude=dev/*"]
-    sys.stderr.write("Extracting %s\n" %(archive))
+    sys.stderr.write("# singularity: Extracting %s\n" %(archive))
 
     retval = run_command(command)
 

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -259,7 +259,7 @@ def change_permission(file_path,permission=None):
         try:
             os.chmod(file_path, st.st_mode | permission)
         except:
-            print("ERROR: Couldn't change permission on ", file_path)
+            sys.stderr.write("ERROR: Couldn't change permission on ", file_path, "\n")
             sys.exit(1)
     return has_permission(file_path,permission)
 
@@ -333,7 +333,7 @@ def get_cache(cache_base=None,subfolder=None,disable_cache=False):
     # Create the cache folder(s), if don't exist
     create_folders(cache_base)
 
-    print("Cache folder set to %s" %cache_base)
+    sys.stderr.write("Cache folder set to %s\n" %cache_base)
     return cache_base
 
 
@@ -363,7 +363,7 @@ def extract_tar(archive,output_folder):
 
     # Just use command line, more succinct.
     command = ["tar", args, archive, "-C", output_folder, "--exclude=dev/*"]
-    print("Extracting %s" %(archive))
+    sys.stderr.write("Extracting %s\n" %(archive))
 
     retval = run_command(command)
 


### PR DESCRIPTION


Fixes #512

Partial fix:  Still doesn't respect the -q, but it now works for STDOUT|STDIN pipes...

Changes proposed in this pull request

 changed a few instances of python print ("blah") to sys.stderr.write ("blah\n")
 -
 -

@singularityware-admin
