### PR TITLE
Fix /bin/bash HISTFILE bug

### DIFF
--- a/etc/init
+++ b/etc/init
@@ -10,7 +10,7 @@ unset BASH_ENV
 PATH="$PATH:/bin:/sbin:/usr/bin:/usr/sbin"
 
 # Don't save the shell's HISTFILE
-HISTFILE="/dev/null"
+HISTFILE=""
 
 export PATH HISTFILE
 


### PR DESCRIPTION
When running singularity shell as root with bash, we encounter a bug with HISTFILE pointing to /dev/null when HISTSIZE limit is reached.

Steps to reproduce as root:

`# ls -la /dev/null`
`crw-rw-rw- 1 root root 1, 3 Mar 15 10:30 /dev/null`

`# singularity shell -s /bin/bash image.img`
`singularity> # export HISTSIZE=1`
`singularity> # exit`

`# ls -la /dev/null`
`-rw------- 1 root root 0 Mar 15 10:30 /dev/null`

when HISTSIZE limit is reached /dev/null become a regular file and could impact other applications which redirect output/error streams to /dev/null, by example our SGE batch scheduler stopped working.

Solved by setting empty HISTFILE environment variable or by unsetting it

@singularityware-admin
