### PR TITLE
Lib refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,4 +68,4 @@ script:
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_default_cache
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_disable_cache
   - pylint --version
-  - cd $TRAVIS_BUILD_DIR/libexec/python && pylint $PWD --errors-only --ignore tests  --disable=E0401,E0611
+  - cd $TRAVIS_BUILD_DIR/libexec/python && pylint $PWD --errors-only --ignore tests  --disable=E0401,E0611,E1101

--- a/libexec/bootstrap-scripts/deffile-driver-docker.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-docker.sh
@@ -46,6 +46,7 @@ fi
 SINGULARITY_CONTAINER="docker://$FROM"
 export SINGULARITY_CONTAINER
 
+export SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity/labels.json"
 eval "$SINGULARITY_libexecdir/singularity/python/import.py"
 RETVAL=$?
 

--- a/libexec/bootstrap-scripts/deffile-driver-shub.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-shub.sh
@@ -76,7 +76,10 @@ if ! mkdir -p "$SINGULARITY_METADATA_DIR"; then
     ABORT 255
 fi
 
-eval $SINGULARITY_libexecdir/singularity/python/shub/pull.py
+SINGULARITY_CONTAINER="shub://$SINGULARITY_HUB_IMAGE"
+SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity/labels.json"
+export SINGULARITY_CONTAINER SINGULARITY_LABELFILE
+eval $SINGULARITY_libexecdir/singularity/python/import.py
 
 # The python script saves names to files in CONTAINER_DIR, we then pass this image as targz to import
 IMPORT_URI=`cat $SINGULARITY_METADATA_DIR/SINGULARITY_IMAGE`

--- a/libexec/bootstrap-scripts/main-dockerhub.sh
+++ b/libexec/bootstrap-scripts/main-dockerhub.sh
@@ -39,7 +39,8 @@ if [ -z "${SINGULARITY_ROOTFS:-}" ]; then
 fi
 
 SINGULARITY_CONTAINER="$SINGULARITY_BUILDDEF"
-export SINGULARITY_CONTAINER
+SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity/labels.json"
+export SINGULARITY_CONTAINER SINGULARITY_LABELFILE
 
 eval_abort "$SINGULARITY_libexecdir/singularity/bootstrap-scripts/pre.sh"
 eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"

--- a/libexec/bootstrap-scripts/pre.sh
+++ b/libexec/bootstrap-scripts/pre.sh
@@ -49,19 +49,17 @@ if [ -f "$SINGULARITY_BUILDDEF" ]; then
 fi
 
 # Populate the labels.
-S_UUID=`cat /proc/sys/kernel/random/uuid`
-message 1 "Adding label: 'SINGULARITY_CONTAINER_UUID' = '$S_UUID'\n"
-eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" --key "SINGULARITY_CONTAINER_UUID" --value "$S_UUID" --file "$SINGULARITY_ROOTFS/.singularity/labels.json"
+export SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity/labels.json"
 
-message 1 "Adding label: 'SINGULARITY_DEFFILE' = '$SINGULARITY_BUILDDEF'\n"
-eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" --key "SINGULARITY_DEFFILE" --value "$SINGULARITY_BUILDDEF" --file "$SINGULARITY_ROOTFS/.singularity/labels.json"
+S_UUID=`cat /proc/sys/kernel/random/uuid`
+eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" --key "SINGULARITY_CONTAINER_UUID" --value "$S_UUID" --file $SINGULARITY_LABELFILE
+
+eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" --key "SINGULARITY_DEFFILE" --value "$SINGULARITY_BUILDDEF" --file $SINGULARITY_LABELFILE
 
 env | egrep "^SINGULARITY_DEFFILE_" | while read i; do
     KEY=`echo $i | cut -f1 -d =`
     VAL=`echo $i | cut -f2- -d =`
-
-    message 1 "Adding label: '$KEY' = '$VAL'\n"
-    eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" --key "$KEY" --value "$VAL" --file "$SINGULARITY_ROOTFS/.singularity/labels.json"
+    eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" --key "$KEY" --value "$VAL" --file $SINGULARITY_LABELFILE
 
 done
 

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -114,8 +114,7 @@ SHUB_PREFIX = "shub"
 
 _envbase = "%s/env" %(METADATA_BASE)
 ENV_BASE = getenv("SINGULARITY_ENVBASE", default=_envbase)
-_labelbase = "%s/labels" %(METADATA_BASE)
-LABEL_BASE = getenv("SINGULARITY_LABELBASE", default=_labelbase)
+LABELFILE = getenv("SINGULARITY_LABELFILE")
 
 
 #######################################################################

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -34,13 +34,14 @@ from utils import (
     write_singularity_infos
 )
 
+from helpers.json.main import ADD
+
 from defaults import (
     API_BASE,
     API_VERSION,
     DOCKER_NUMBER,
     DOCKER_PREFIX,
     ENV_BASE,
-    LABEL_BASE,
     METADATA_BASE,
     RUNSCRIPT_COMMAND_ASIS
 )
@@ -111,7 +112,7 @@ def extract_env(manifest):
     :param manifest: the manifest to use
     '''
     environ = get_config(manifest,'Env')
-    if environ != None:
+    if environ is not None:
         if isinstance(environ,list):
             environ = "\n".join(environ)
         logger.debug("Found Docker container environment!")    
@@ -123,20 +124,23 @@ def extract_env(manifest):
     return environ
 
 
-def extract_labels(manifest):
+def extract_labels(manifest,labelfile=None,prefix=None):
     '''extract_labels will write a file of key value pairs including
     maintainer, and labels.
     :param manifest: the manifest to use
+    :param labelfile: if defined, write to labelfile (json)
+    :param prefix: an optional prefix to add to the names
     '''
+    if prefix is None:
+        prefix = ""
+
     labels = get_config(manifest,'Labels')
-    if labels != None and len(labels) != 0:
-        labels = json.dumps(labels)
+    if labels is not None and len(labels) is not 0:
         logger.debug("Found Docker container labels!")    
-        labels_file = write_singularity_infos(base_dir=LABEL_BASE,
-                                              prefix=DOCKER_PREFIX,
-                                              start_number=DOCKER_NUMBER,
-                                              content=labels,
-                                              extension='txt')
+        if labelfile is not None:
+            for key,value in labels.items():
+                key = "%s%s" %(prefix,key)
+                value = ADD(key,value,labelfile)
     return labels
 
 
@@ -403,7 +407,7 @@ def get_layer(image_id,namespace,repo_name,download_folder=None,registry=None,au
 
     # Download the layer atomically
     finished_download = download_stream_atomically(url=base,
-                                                   file_name=download_base,
+                                                   file_name=download_folder,
                                                    headers=token)
 
 

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -49,7 +49,7 @@ import os
 import tempfile
 
 
-def IMPORT(image,rootfs,auth=None,includecmd=False):
+def IMPORT(image,rootfs,auth=None,includecmd=False,labelfile=None):
     '''run is the main script that will obtain docker layers, runscript information (either entrypoint
     or cmd), and environment, and either return the list of files to extract (in case of add 
     :param image: the docker image to add
@@ -95,7 +95,10 @@ def IMPORT(image,rootfs,auth=None,includecmd=False):
 
     # Extract environment and labels
     extract_env(additions['manifest'])
-    extract_labels(additions['manifest'])
+    if labelfile is not None:
+        extract_labels(manifest=additions['manifest'],
+                       labelfile=labelfile,
+                       prefix="DOCKER_")
 
     # When we finish, clean up images
     logger.info("*** FINISHING DOCKER IMPORT PYTHON PORTION ****\n")
@@ -157,8 +160,7 @@ def ADD(image,auth=None,layerfile=None):
         layers.append(targz) # in case we want a list at the end
 
     # If the user wants us to write the layers to file, do it.
-    if layerfile != None:
-
+    if layerfile is not None:
         logger.debug("Writing Docker layers files to %s", layerfile)
         write_file(layerfile,"\n".join(layers),mode="w")
 

--- a/libexec/python/helpers/json/main.py
+++ b/libexec/python/helpers/json/main.py
@@ -80,7 +80,8 @@ def ADD(key,value,jsonfile,force=False):
     '''ADD will write or update a key in a json file
     '''
     key = format_keyname(key)
-    logger.debug("ADD %s from %s",jsonfile)
+    print("Adding label: '%s' = '%s'" %(key,value))
+    logger.debug("ADD %s from %s",key,jsonfile)
     if os.path.exists(jsonfile):    
         contents = read_json(jsonfile)
         if key in contents:
@@ -88,7 +89,7 @@ def ADD(key,value,jsonfile,force=False):
             if force == True:
                 contents[key] = value
             else:
-                logger.error('%s found in %s and overwrite set to %s, exiting.',key,jsonfile,force)
+                logger.error('%s found in %s and overwrite set to %s.',key,jsonfile,force)
                 sys.exit(1)
         else:
             contents[key] = value

--- a/libexec/python/import.py
+++ b/libexec/python/import.py
@@ -70,7 +70,7 @@ def main():
         logger.info("\n*** STARTING DOCKER IMPORT PYTHON  ****")    
 
         from utils import  basic_auth_header
-        from defaults import SINGULARITY_ROOTFS, LAYERFILE
+        from defaults import SINGULARITY_ROOTFS, LAYERFILE, LABELFILE
 
         username = getenv("SINGULARITY_DOCKER_USERNAME") 
         password = getenv("SINGULARITY_DOCKER_PASSWORD",silent=True)
@@ -85,7 +85,8 @@ def main():
 
             IMPORT(auth=auth,
                    image=container,
-                   rootfs=SINGULARITY_ROOTFS)
+                   rootfs=SINGULARITY_ROOTFS,
+                   labelfile=LABELFILE)
 
 
         else:
@@ -111,10 +112,11 @@ def main():
 
         logger.info("\n*** STARTING SINGULARITY HUB IMPORT PYTHON  ****")    
 
-        from defaults import LAYERFILE
+        from defaults import LAYERFILE, LABELFILE
         from shub.main import IMPORT
         IMPORT(image=container,
-               layerfile=LAYERFILE)
+               layerfile=LAYERFILE,
+               labelfile=LABELFILE)
 
     else:
         logger.error("uri %s is not a currently supported uri for docker import. Exiting.",image_uri)

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -38,10 +38,10 @@ from utils import (
     write_singularity_infos
 )
 
+from helpers.json.main import ADD
+
 from defaults import (
-    SHUB_API_BASE, 
-    SHUB_PREFIX, 
-    LABEL_BASE
+    SHUB_API_BASE
 )
 
 from logman import logger
@@ -161,20 +161,26 @@ def get_image_name(manifest,extension='img.gz',use_hash=False):
     return image_name
 
 
-def extract_metadata(manifest):
+def extract_metadata(manifest,labelfile=None,prefix=None):
     '''extract_metadata will write a file of metadata from shub
     :param manifest: the manifest to use
     '''
+    if prefix is None:
+        prefix = ""
+    prefix = prefix.upper()
 
-    # The only metadata we don't need to keep is the spec
     metadata = manifest.copy()
-    del metadata['files']
-    del metadata['spec']
-    metadata = json.dumps(metadata)
-    metadata_file = write_singularity_infos(base_dir=LABEL_BASE,
-                                            prefix=SHUB_PREFIX,
-                                            start_number=1,
-                                            content=metadata,
-                                            extension='json')
-    logger.debug("Saving Singularity Hub metadata to %s",metadata_file)    
+    remove_fields = ['files','spec','metrics']
+    for remove_field in remove_fields:
+        if remove_field in metadata:
+            del metadata[remove_field]
+
+    if labelfile is not None:
+        for key,value in metadata.items():
+            key = "%s%s" %(prefix,key)
+            value = ADD(key=key,
+                        value=value,
+                        jsonfile=labelfile)
+
+        logger.debug("Saving Singularity Hub metadata to %s",labelfile)    
     return metadata

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -31,6 +31,7 @@ sys.path.append('..') # parent directory
 from utils import (
     add_http,
     api_get, 
+    download_stream_atomically,
     is_number,
     read_file,
     write_file,
@@ -125,7 +126,11 @@ def download_image(manifest,download_folder=None,extract=True):
     if download_folder != None:
         image_file = "%s/%s" %(download_folder,image_file)
     url = manifest['image']
-    image_file = api_get(url,stream=image_file)
+
+    # Download image file atomically, streaming
+    image_file = download_stream_atomically(url=url,
+                                            file_name=image_file)
+
     if extract == True:
         print("Decompressing %s" %image_file)
         os.system('gzip -d -f %s' %(image_file))

--- a/libexec/python/shub/main.py
+++ b/libexec/python/shub/main.py
@@ -41,6 +41,8 @@ from utils import (
     write_file
 )
 
+from defaults import SHUB_PREFIX
+
 from logman import logger
 import json
 import re
@@ -85,7 +87,7 @@ def PULL(image,download_folder=None,layerfile=None):
 
 
 
-def IMPORT(image,layerfile):
+def IMPORT(image,layerfile,labelfile=None):
     '''IMPORT takes one more step than ADD, returning the image written to a layerfile
     plus metadata written to the metadata base in rootfs.
     :param image: the singularity hub image name
@@ -93,5 +95,7 @@ def IMPORT(image,layerfile):
     manifest = PULL(image,layerfile=layerfile)
 
     # Write metadata to base    
-    manifest['metadata'] = extract_metadata(manifest['manifest'])
+    manifest['metadata'] = extract_metadata(manifest=manifest['manifest'],
+                                            labelfile=labelfile,
+                                            prefix="%s_" %SHUB_PREFIX)
     return manifest

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -176,6 +176,34 @@ def api_get(url,data=None,default_header=True,headers=None,stream=None,return_re
     return stream
 
 
+
+def download_stream_atomically(url,file_name,headers=None):
+    '''download stream atomically will stream to a temporary file, and
+    rename only upon successful completion. This is to ensure that
+    errored downloads are not found as complete in the cache
+    :param file_name: the file name to stream to
+    :param url: the url to stream from
+    :param headers: additional headers to add to the get (default None)
+    '''
+    try:
+        fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % file_name)) # file_name.tmp.XXXXXX
+        os.close(fd)
+        response = api_get(base,headers=headers,stream=tmp_file)
+        if isinstance(response, HTTPError):
+            logger.error("Error downloading %s, exiting.", url)
+            sys.exit(1)
+        os.rename(tmp_file, file_name)
+    except:
+        download_folder = os.path.dirname(os.path.abspath(file_name))
+        logger.error("Error downloading %s. Do you have permission to write to %s?", base, download_folder)
+        try:
+            os.remove(tmp_file)
+        except:
+            pass
+        sys.exit(1)
+    return file_name
+
+
 def basic_auth_header(username, password):
     '''basic_auth_header will return a base64 encoded header object to
     generate a token
@@ -342,6 +370,7 @@ def create_folders(path):
             sys.exit(1)
 
 
+
 def extract_tar(archive,output_folder):
     '''extract_tar will extract a tar archive to a specified output folder
     :param archive: the archive file to extract
@@ -363,6 +392,7 @@ def extract_tar(archive,output_folder):
 
     # Should we return a list of extracted files? Current returns empty string
     return retval
+
 
 
 def write_file(filename,content,mode="w"):

--- a/libexec/python/utils.py
+++ b/libexec/python/utils.py
@@ -188,14 +188,14 @@ def download_stream_atomically(url,file_name,headers=None):
     try:
         fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % file_name)) # file_name.tmp.XXXXXX
         os.close(fd)
-        response = api_get(base,headers=headers,stream=tmp_file)
+        response = api_get(url,headers=headers,stream=tmp_file)
         if isinstance(response, HTTPError):
             logger.error("Error downloading %s, exiting.", url)
             sys.exit(1)
         os.rename(tmp_file, file_name)
     except:
         download_folder = os.path.dirname(os.path.abspath(file_name))
-        logger.error("Error downloading %s. Do you have permission to write to %s?", base, download_folder)
+        logger.error("Error downloading %s. Do you have permission to write to %s?", url, download_folder)
         try:
             os.remove(tmp_file)
         except:


### PR DESCRIPTION
Fixes #513 

Changes proposed in this pull request

 - I added a shared [download_stream_atomically](https://github.com/vsoch/singularity/blob/lib-refactor/libexec/python/utils.py#L180) function (used by docker and shub) to download images and layers, which will not rename the file until it is complete to fix #513 
 - For all of the exec scripts I exported the `SINGULARITY_LABELFILE` first so it could be found by python
 - I moved your print statements into the python function, so all calls to use this function will have consistent printing.
- each of LABELS for docker and shub are prefixed by `DOCKER_` and `SHUB_` respectively. This will reduce potential name conflicts (although nothing is overwritten) and make it clear where the labels originated from. For shub, I removed all of the metadata minus the collection and container ID (so they can find it via the singularity hub api and the information isn't redundant).
- I realize we don't have an official function for import of a singularity hub image, but I changed the call to import in the case that we can have one soon :) The functionality is equivalent to pull, but import does pull and then extracts the metadata.

The bootstrap with labels looks like this:

	sudo singularity bootstrap tmp.img Singularity 
	Building from bootstrap definition recipe
	Adding label: 'SINGULARITY_CONTAINER_UUID' = 'd2b8dcc8-af73-4349-92e4-2a83f461c839'
	Adding label: 'SINGULARITY_DEFFILE' = 'Singularity'
	Adding label: 'SINGULARITY_DEFFILE_BOOTSTRAP' = 'docker'
	Adding label: 'SINGULARITY_DEFFILE_FROM' = 'wikiwi/docker-build'
	Cache folder set to /root/.singularity/docker
	Extracting /root/.singularity/docker/sha256:7d028cf3fe54f3087a34f1d93f8dd725226a5c0183692d0f7147d1ccad36410d.tar.gz
	Extracting /root/.singularity/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
	Extracting /root/.singularity/docker/sha256:1d7e81cdc08bf6db6ce70280f4a26fd660b07f70e97802ee414af0155f46a3ea.tar.gz
	Extracting /root/.singularity/docker/sha256:81ca7ec69872bf4ff8a3ffb899d32ff46a9e5eec6fc69aed7ad580552d3ffa02.tar.gz
	Extracting /root/.singularity/docker/sha256:10fb2f450fdc80d99e84f607c24917360bdbf360fe7329867de8322425c22624.tar.gz
	Extracting /root/.singularity/docker/sha256:49e2842bdfdf9757b6fb042a914386833eb89594a0f6643fc8a7ca8e925dd58c.tar.gz
	Extracting /root/.singularity/docker/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58.tar.gz
	Adding Docker ENTRYPOINT as Singularity runscript...
	docker-entrypoint.sh
	Adding label: 'DOCKER_ORG_LABEL_SCHEMA_NAME' = 'docker-build'
	Adding label: 'DOCKER_ORG_LABEL_SCHEMA_VCS_URL' = 'https://github.com/wikiwi/docker-build'
	Adding label: 'DOCKER_IO_WIKIWI_LICENSE' = 'MIT'
	Adding label: 'DOCKER_ORG_LABEL_SCHEMA_VENDOR' = 'wikiwi.io'
	Adding base Singularity environment to container
	Finalizing Singularity container
	vanessa@vanessa-ThinkPad-T460s:~/Desktop$ singularity exec tmp.img cat /.singularity/labels.json
	{
	    "DOCKER_ORG_LABEL_SCHEMA_VENDOR": "wikiwi.io",
	    "SINGULARITY_DEFFILE_BOOTSTRAP": "docker",
	    "DOCKER_ORG_LABEL_SCHEMA_VCS_URL": "https://github.com/wikiwi/docker-build",
	    "SINGULARITY_DEFFILE": "Singularity",
	    "SINGULARITY_DEFFILE_FROM": "wikiwi/docker-build",
	    "SINGULARITY_CONTAINER_UUID": "d2b8dcc8-af73-4349-92e4-2a83f461c839",
	    "DOCKER_ORG_LABEL_SCHEMA_NAME": "docker-build",
	    "DOCKER_IO_WIKIWI_LICENSE": "MIT"
	}

@singularityware-admin
