### PR TITLE
Use correct variable for secondary groups

### DIFF
--- a/src/lib/runtime/files/group/group.c
+++ b/src/lib/runtime/files/group/group.c
@@ -136,7 +136,7 @@ int _singularity_runtime_files_group(void) {
             struct group *gr = getgrgid(gids[i]);
             if ( gr ) {
                 singularity_message(VERBOSE3, "Found supplementary group membership in: %d\n", gids[i]);
-                singularity_message(VERBOSE2, "Adding user's supplementary group ('%s') info to template group file\n", grent->gr_name);
+                singularity_message(VERBOSE2, "Adding user's supplementary group ('%s') info to template group file\n", gr->gr_name);
                 fprintf(file_fp, "%s:x:%u:%s\n", gr->gr_name, gr->gr_gid, pwent->pw_name);
             } else if ( (errno == 0) || (errno == ESRCH) || (errno == EBADF) || (errno == EPERM) ) {
                 singularity_message(VERBOSE3, "Skipping GID %d as group entry does not exist.\n", gids[i]);


### PR DESCRIPTION
The wrong variable was used.

@singularityware-admin
