### PR TITLE
updating environment export for docker

### DIFF
--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -115,6 +115,8 @@ def extract_env(manifest):
     if environ is not None:
         if isinstance(environ,list):
             environ = "\n".join(environ)
+        environ = ["export %s" %x for x in environ.split('\n')]
+        environ = "\n".join(environ)
         logger.debug("Found Docker container environment!")    
         environ_file = write_singularity_infos(base_dir=ENV_BASE,
                                                prefix=DOCKER_PREFIX,
@@ -375,7 +377,7 @@ def get_config(manifest,spec="Entrypoint",delim=None):
         if delim is None:
             delim = "\n"
         cmd = delim.join(cmd)
-    logger.info("Found Docker command (%s) %s",spec,cmd)
+    logger.info("Found Docker command (%s) Fg%s",spec,cmd)
     return cmd
 
 

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -377,7 +377,8 @@ def get_config(manifest,spec="Entrypoint",delim=None):
         if delim is None:
             delim = "\n"
         cmd = delim.join(cmd)
-    logger.info("Found Docker command (%s) Fg%s",spec,cmd)
+    logger.info("Found Docker command (%s) %s",spec,cmd)
+
     return cmd
 
 


### PR DESCRIPTION
This is a quick fix to add export VARIABLE=VALUE to the generation of the docker environment. I tested manually with three manifests, but wasn't able to build an image from start to finish because my internet is really bad right now (even kicking me off of my Google instance!)

Fixes #522 

Changes proposed in this pull request

 - adding export to prefix all lines in docker env manifest config

Thanks @flx42 for catching this!

@singularityware-admin
