### PR TITLE
Extended parsing of docker url

### DIFF
--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -85,11 +85,21 @@ def parse_image_uri(image,uri=None):
     image = image.replace(uri,'')
     image = image.split(':')
 
-    # If there are two parts, we have a tag
-    if len(image) == 2:
-        repo_tag = image[1]
-        image = image[0]
+    # If there are three parts, we have port and tag
+    if len(image) == 3:
+        repo_tag = image[2]
+        image = image[0] + ":" + image[1]
 
+    # If there are two parts, we have port or tag
+    elif len(image) == 2:
+        # If there isn't a slash in second part, we have a tag
+        if image[1].find("/") == -1:
+            repo_tag = image[1]
+            image = image[0]
+        # Otherwise we have a port and we merge the path
+        else:
+            image = image[0] + ":" + image[1]
+            repo_tag = default_tag
     else:
         image = image[0]
         repo_tag = default_tag


### PR DESCRIPTION
Parsing of docker url is extended to support custom port on registry.

e.g. docker://\<registy\>:\<port\>/\<namespace\>/\<repo\>

Fixes #515

Changes proposed in this pull request

 -
 -
 -

@singularityware-admin
