### PR TITLE
It4innovations local server docker

### DIFF
--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -88,7 +88,7 @@ def parse_image_uri(image,uri=None):
     # If there are three parts, we have port and tag
     if len(image) == 3:
         repo_tag = image[2]
-        image = image[0] + ":" + image[1]
+        image = "%s:%s" %(image[0],image[1])
 
     # If there are two parts, we have port or tag
     elif len(image) == 2:
@@ -98,7 +98,7 @@ def parse_image_uri(image,uri=None):
             image = image[0]
         # Otherwise we have a port and we merge the path
         else:
-            image = image[0] + ":" + image[1]
+            image = "%s:%s" %(image[0],image[1])
             repo_tag = default_tag
     else:
         image = image[0]

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -85,11 +85,21 @@ def parse_image_uri(image,uri=None):
     image = image.replace(uri,'')
     image = image.split(':')
 
-    # If there are two parts, we have a tag
-    if len(image) == 2:
-        repo_tag = image[1]
-        image = image[0]
+    # If there are three parts, we have port and tag
+    if len(image) == 3:
+        repo_tag = image[2]
+        image = image[0] + ":" + image[1]
 
+    # If there are two parts, we have port or tag
+    elif len(image) == 2:
+        # If there isn't a slash in second part, we have a tag
+        if image[1].find("/") == -1:
+            repo_tag = image[1]
+            image = image[0]
+        # Otherwise we have a port and we merge the path
+        else:
+            image = image[0] + ":" + image[1]
+            repo_tag = default_tag
     else:
         image = image[0]
         repo_tag = default_tag

--- a/libexec/python/tests/test_base.py
+++ b/libexec/python/tests/test_base.py
@@ -151,6 +151,22 @@ class TestShell(TestCase):
         self.assertTrue(digest['registry'] == 'meow')
         self.assertTrue(digest['namespace'] == 'mix')
 
+        print("Case 9: Registry with port with tag")
+        image_name = "catdog://meow:0000/mix/%s:%s" %(self.repo_name,self.tag)
+        digest = parse_image_uri(image_name,uri="catdog://")
+        self.assertTrue(digest['registry'] == 'meow:0000')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 10: Registry with port without tag")
+        image_name = "catdog://meow:0000/mix/%s" %(self.repo_name)
+        digest = parse_image_uri(image_name,uri="catdog://")
+        self.assertTrue(digest['registry'] == 'meow:0000')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == 'latest')
+
 
 class TestUtils(TestCase):
 


### PR DESCRIPTION
Parsing of docker url is extended to support custom port on registry.

e.g. docker://<registy>:<port>/<namespace>/<repo>

This PR includes #525, plus a few tests for the new uri. 

Changes proposed in this pull request

- adding ability to parse a port from a `docker://` uri
- tests for this

@singularityware-admin
