### PR TITLE
fix environment settings

### DIFF
--- a/etc/init
+++ b/etc/init
@@ -2,6 +2,7 @@
 
 # Environment modules if set, cause errors in containers
 unset module
+unset ml
 
 # Bash env has been known to cause issues in containers
 unset BASH_ENV


### PR DESCRIPTION
Using an Ubuntu container build with examples/ubuntu.def and running it on a hpc environment with lmod gives the following error:
/bin/bash: BASH_FUNC_ml(): line 0: syntax error near unexpected token `)'
/bin/bash: BASH_FUNC_ml(): line 0: `BASH_FUNC_ml() () {  eval $($LMOD_DIR/ml_cmd "$@")'
/bin/bash: error importing function definition for `BASH_FUNC_ml'

It seems that environment variable BASH_FUNC_ml() should not be set, just as BASH_FUNC_module()
Unsetting ml fixed the problem for me.

Changes proposed in this pull request
 - also unset ml

@singularityware-admin
