### PR TITLE
Simplification of logger

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -256,7 +256,7 @@ if test x"$PYTHON_CHECK" != x"yes" ; then
     AC_MSG_ERROR([Please install python before installing.])
 else
 
-    PYTHON_MODULES="base64 datetime glob hashlib io json logging pickle pwd re shutil subprocess stat sys tarfile tempfile"
+    PYTHON_MODULES="base64 datetime glob hashlib io json pickle pwd re shutil subprocess stat sys tarfile tempfile"
     for PYTHON_MODULE in $PYTHON_MODULES; do
         AC_MSG_CHECKING([for the $PYTHON_MODULE python module])
 	    python_module_result=`python -c "import $PYTHON_MODULE" 2>&1`

--- a/etc/configure_transform.py
+++ b/etc/configure_transform.py
@@ -44,13 +44,13 @@ def get_parser():
 def main():
     '''parse configuration options and produce configuration output file
     '''
-    bot.logger.info("\n*** STARTING PYTHON CONFIGURATION HELPER ****")
+    bot.info("\n*** STARTING PYTHON CONFIGURATION HELPER ****")
     parser = get_parser()
 
     try:
         (args,options) = parser.parse_args()
     except:
-        bot.logger.error("Input args to %s improperly set, exiting.", os.path.abspath(__file__))
+        bot.error("Input args to %s improperly set, exiting." %os.path.abspath(__file__))
         parser.print_help()
         sys.exit(1)
 
@@ -112,7 +112,7 @@ def configure(args):
     write_file(outfile,data)
     os.rename(outfile, args.outfile)
 
-    bot.logger.info("*** FINISHED PYTHON CONFIGURATION HELPER ****\n")
+    bot.info("*** FINISHED PYTHON CONFIGURATION HELPER ****\n")
 
 
 if __name__ == '__main__':

--- a/libexec/cli/singularity.help
+++ b/libexec/cli/singularity.help
@@ -20,7 +20,10 @@ CONTAINER USAGE COMMANDS:
     test          Execute any test code defined within container
 
 CONTAINER USAGE OPTIONS:
-    -H  --home    Specify $HOME to mount 
+   -H  --home     Specify $HOME to mount 
+   -e  --cleanenv Remove host environment from container
+   -i  --ipc      Run container in a new IPC namespace
+
 
 CONTAINER MANAGEMENT COMMANDS (requires root):
     bootstrap     Bootstrap a new Singularity image from scratch

--- a/libexec/cli/singularity.help
+++ b/libexec/cli/singularity.help
@@ -20,7 +20,7 @@ CONTAINER USAGE COMMANDS:
     test          Execute any test code defined within container
 
 CONTAINER USAGE OPTIONS:
-    see singularity <command> help
+    see singularity help <command>
 
 CONTAINER MANAGEMENT COMMANDS (requires root):
     bootstrap     Bootstrap a new Singularity image from scratch

--- a/libexec/cli/singularity.help
+++ b/libexec/cli/singularity.help
@@ -19,6 +19,9 @@ CONTAINER USAGE COMMANDS:
     shell         Run a Bourne shell within container
     test          Execute any test code defined within container
 
+CONTAINER USAGE OPTIONS:
+    see singularity <command> help
+
 CONTAINER MANAGEMENT COMMANDS (requires root):
     bootstrap     Bootstrap a new Singularity image from scratch
     copy          Copy files from your host into the container

--- a/libexec/cli/singularity.help
+++ b/libexec/cli/singularity.help
@@ -19,12 +19,6 @@ CONTAINER USAGE COMMANDS:
     shell         Run a Bourne shell within container
     test          Execute any test code defined within container
 
-CONTAINER USAGE OPTIONS:
-   -H  --home     Specify $HOME to mount 
-   -e  --cleanenv Remove host environment from container
-   -i  --ipc      Run container in a new IPC namespace
-
-
 CONTAINER MANAGEMENT COMMANDS (requires root):
     bootstrap     Bootstrap a new Singularity image from scratch
     copy          Copy files from your host into the container

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -55,7 +55,7 @@ class ApiConnection(object):
                 headers[key] = value
 
         header_names = ",".join(list(headers.keys()))
-        bot.logger.debug("Headers found: %s",header_names)
+        bot.debug("Headers found: %s" %header_names)
         self.headers = headers
 
 
@@ -73,7 +73,7 @@ class ApiConnection(object):
         default is None (will not stream)
         :returns response: the requests response object, or stream
         '''
-        bot.logger.debug("GET %s", url)
+        bot.debug("GET %s" %url)
 
         # If we use default headers, start with client's
         request_headers = dict()
@@ -136,7 +136,7 @@ class ApiConnection(object):
                 try:
                     filey.write(chunk)
                 except: # PermissionError
-                    bot.logger.error("Cannot write to %s, exiting",stream)
+                    bot.error("Cannot write to %s, exiting" %stream)
                     sys.exit(1)
 
         return stream
@@ -171,12 +171,12 @@ class ApiConnection(object):
             os.close(fd)
             response = self.get(url,headers=headers,stream=tmp_file)
             if isinstance(response, HTTPError):
-                bot.logger.error("Error downloading %s, exiting.", url)
+                bot.error("Error downloading %s, exiting." %url)
                 sys.exit(1)
             os.rename(tmp_file, file_name)
         except:
             download_folder = os.path.dirname(os.path.abspath(file_name))
-            bot.logger.error("Error downloading %s. Do you have permission to write to %s?", url, download_folder)
+            bot.error("Error downloading %s. Do you have permission to write to %s?" %(url, download_folder))
             try:
                 os.remove(tmp_file)
             except:

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -44,16 +44,16 @@ def getenv(variable_key,required=False,default=None,silent=False):
     '''
     variable = os.environ.get(variable_key, default)
     if variable == None and required:
-        bot.logger.error("Cannot find environment variable %s, exiting.",variable_key)
+        bot.error("Cannot find environment variable %s, exiting." %variable_key)
         sys.exit(1)
 
     if silent:
-        bot.logger.debug("%s found",variable_key)
+        bot.debug("%s found",variable_key)
     else:
         if variable is not None:
-            bot.logger.debug("%s found as %s",variable_key,variable)
+            bot.debug("%s found as %s" %(variable_key,variable))
         else:
-            bot.logger.debug("%s not defined (None)",variable_key)
+            bot.debug("%s not defined (None)" %variable_key)
 
     return variable 
 

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -48,12 +48,12 @@ def getenv(variable_key,required=False,default=None,silent=False):
         sys.exit(1)
 
     if silent:
-        bot.debug("%s found" %variable_key)
+        bot.verbose2("%s found" %variable_key)
     else:
         if variable is not None:
-            bot.debug("%s found as %s" %(variable_key,variable))
+            bot.verbose2("%s found as %s" %(variable_key,variable))
         else:
-            bot.debug("%s not defined (None)" %variable_key)
+            bot.verbose2("%s not defined (None)" %variable_key)
 
     return variable 
 

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -48,7 +48,7 @@ def getenv(variable_key,required=False,default=None,silent=False):
         sys.exit(1)
 
     if silent:
-        bot.debug("%s found",variable_key)
+        bot.debug("%s found" %variable_key)
     else:
         if variable is not None:
             bot.debug("%s found as %s" %(variable_key,variable))

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -432,7 +432,7 @@ def extract_metadata_tar(manifest,image_name,include_env=True,
 
 
     if len(files) > 0:
-        output_folder = get_cache(subfolder="docker",quiet=True)
+        output_folder = get_cache(subfolder="metadata", quiet=True)
         tar_file = create_tar(files,output_folder)      
     else:
         bot.logger.warning("No environment, labels files, or runscript will be included.")

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -124,13 +124,13 @@ class DockerApiConnection(ApiConnection):
             return None
 
         if response.code != 401 or "Www-Authenticate" not in response.headers:
-            bot.logger.error("Authentication error, exiting.")
+            bot.error("Authentication error, exiting.")
             sys.exit(1)
 
         challenge = response.headers["Www-Authenticate"]
         match = re.match('^Bearer\s+realm="(.+)",service="(.+)",scope="(.+)",?', challenge)
         if not match:
-            bot.logger.error("Unrecognized authentication challenge, exiting.")
+            bot.error("Unrecognized authentication challenge, exiting.")
             sys.exit(1)
 
         realm = match.group(1)
@@ -149,7 +149,7 @@ class DockerApiConnection(ApiConnection):
             self.token = token
             self.update_headers(token)
         except:
-            bot.logger.error("Error getting token for repository %s/%s, exiting.", self.namespace,self.repo_name)
+            bot.error("Error getting token for repository %s/%s, exiting." %(self.namespace,self.repo_name))
             sys.exit(1)
 
 
@@ -169,7 +169,7 @@ class DockerApiConnection(ApiConnection):
                 self.manifest = self.get_manifest()
 
             else:
-                bot.logger.error("No namespace and repo name OR manifest provided, exiting.")
+                bot.error("No namespace and repo name OR manifest provided, exiting.")
                 sys.exit(1)
 
         digests = read_digests(self.manifest)
@@ -190,7 +190,7 @@ class DockerApiConnection(ApiConnection):
         registry = add_http(registry) # make sure we have a complete url
 
         base = "%s/%s/%s/%s/tags/list" %(registry,self.api_version,self.namespace,self.repo_name)
-        bot.logger.debug("Obtaining tags: %s", base)
+        bot.debug("Obtaining tags: %s" %base)
 
         # We use get_tags for a testing endpoint in update_token
         response = self.get(base)
@@ -201,7 +201,7 @@ class DockerApiConnection(ApiConnection):
             response = json.loads(response)
             return response['tags']
         except:
-            bot.logger.error("Error obtaining tags: %s", base)
+            bot.error("Error obtaining tags: %s" %base)
             sys.exit(1)
 
 
@@ -220,7 +220,7 @@ class DockerApiConnection(ApiConnection):
             base = "%s/%s" %(base,self.version)
         else:
             base = "%s/%s" %(base,self.repo_tag)
-        bot.logger.debug("Obtaining manifest: %s", base)
+        bot.debug("Obtaining manifest: %s" %base)
     
         headers = self.headers
         if old_version == True:
@@ -234,7 +234,7 @@ class DockerApiConnection(ApiConnection):
             tags = self.get_tags()
             print("\n".join(tags))
             repo_uri = "%s/%s:%s" %(self.namespace,self.repo_name,self.repo_tag)
-            bot.logger.error("Error getting manifest for %s, exiting.", repo_uri)
+            bot.error("Error getting manifest for %s, exiting." %repo_uri)
             sys.exit(1)
 
         return response
@@ -251,13 +251,13 @@ class DockerApiConnection(ApiConnection):
 
         # The <name> variable is the namespace/repo_name
         base = "%s/%s/%s/%s/blobs/%s" %(registry,self.api_version,self.namespace,self.repo_name,image_id)
-        bot.logger.debug("Downloading layers from %s", base)
+        bot.debug("Downloading layers from %s" %base)
     
         if download_folder is not None:
             download_folder = "%s/%s.tar.gz" %(download_folder,image_id)
 
             # Update user what we are doing
-            bot.logger.info("Downloading layer %s", image_id)
+            bot.info("Downloading layer %s" %image_id)
 
         # Download the layer atomically, step 1
         fd, tar_download = tempfile.mkstemp(prefix=("%s.download." % download_folder))
@@ -307,7 +307,7 @@ class DockerApiConnection(ApiConnection):
                 if delim is None:
                     delim = "\n"
                 cmd = delim.join(cmd)
-            bot.logger.info("Found Docker config (%s) %s",spec,cmd)
+            bot.info("Found Docker config (%s) %s" %(spec,cmd))
 
         else:
             if "config" in manifest:
@@ -330,22 +330,22 @@ def read_digests(manifest):
     if 'layers' in manifest:
         layer_key = 'layers'
         digest_key = 'digest'
-        bot.logger.debug('Image manifest version 2.2 found.')
+        bot.debug('Image manifest version 2.2 found.')
 
     # https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md#example-manifest
     elif 'fsLayers' in manifest:
         layer_key = 'fsLayers'
         digest_key = 'blobSum'
-        bot.logger.debug('Image manifest version 2.1 found.')
+        bot.debug('Image manifest version 2.1 found.')
 
     else:
-        bot.logger.error('Improperly formed manifest, layers or fsLayers must be present')
+        bot.error('Improperly formed manifest, layers or fsLayers must be present')
         sys.exit(1)
 
     for layer in manifest[layer_key]:
         if digest_key in layer:
             if layer[digest_key] not in digests:
-                bot.logger.debug("Adding digest %s",layer[digest_key])
+                bot.debug("Adding digest %s" %layer[digest_key])
                 digests.append(layer[digest_key])
     return digests
     
@@ -372,8 +372,8 @@ def extract_runscript(manifest,includecmd=False):
             break
 
     if cmd is not None:
-        bot.logger.debug("Adding Docker %s as Singularity runscript..." %(command.upper()))
-        bot.logger.debug(cmd)
+        bot.debug("Adding Docker %s as Singularity runscript..." %(command.upper()))
+        bot.debug(cmd)
 
         # If the command is a list, join. (eg ['/usr/bin/python','hello.py']
         if isinstance(cmd,list):
@@ -384,7 +384,7 @@ def extract_runscript(manifest,includecmd=False):
         cmd = "#!/bin/sh\n\n%s" %(cmd)
         return cmd
 
-    bot.logger.debug("No Docker CMD or ENTRYPOINT found, skipping runscript generation.")
+    bot.debug("No Docker CMD or ENTRYPOINT found, skipping runscript generation.")
     return cmd
 
 
@@ -403,7 +403,7 @@ def extract_metadata_tar(manifest,image_name,include_env=True,
         if include_env:               
             environ = extract_env(manifest)
             if environ not in [None,""]:
-                bot.logger.debug('Adding Docker environment to metadata tar')
+                bot.debug('Adding Docker environment to metadata tar')
                 template = get_template('tarinfo')
                 template['name'] = './%s/env/%s-%s.sh' %(METADATA_FOLDER_NAME,
                                                          DOCKER_NUMBER,
@@ -417,14 +417,14 @@ def extract_metadata_tar(manifest,image_name,include_env=True,
             if labels is not None:
                 if isinstance(labels,dict):
                     labels = json.dumps(labels)
-                bot.logger.debug('Adding Docker labels to metadata tar')
+                bot.debug('Adding Docker labels to metadata tar')
                 template = get_template('tarinfo')
                 template['name'] = "./%s/labels.json" %METADATA_FOLDER_NAME
                 template['content'] = labels
                 files.append(template)
 
         if runscript is not None:
-            bot.logger.debug('Adding Docker runscript to metadata tar')
+            bot.debug('Adding Docker runscript to metadata tar')
             template = get_template('tarinfo')
             template['name'] = "./%s/runscript" %METADATA_FOLDER_NAME
             template['content'] = runscript
@@ -435,7 +435,7 @@ def extract_metadata_tar(manifest,image_name,include_env=True,
         output_folder = get_cache(subfolder="metadata", quiet=True)
         tar_file = create_tar(files,output_folder)      
     else:
-        bot.logger.warning("No environment, labels files, or runscript will be included.")
+        bot.warning("No environment, labels files, or runscript will be included.")
     return tar_file
 
 
@@ -449,7 +449,7 @@ def extract_env(manifest):
             environ = "\n".join(environ)
         environ = ["export %s" %x for x in environ.split('\n')]
         environ = "\n".join(environ)
-        bot.logger.debug("Found Docker container environment!")    
+        bot.debug("Found Docker container environment!")    
     return environ
 
 
@@ -482,7 +482,7 @@ def extract_labels(manifest,labelfile=None,prefix=None):
 
     labels = get_config(manifest,'Labels')
     if labels is not None and len(labels) is not 0:
-        bot.logger.debug("Found Docker container labels!")    
+        bot.debug("Found Docker container labels!")    
         if labelfile is not None:
             for key,value in labels.items():
                 key = "%s%s" %(prefix,key)
@@ -515,7 +515,7 @@ def get_config(manifest,spec="Entrypoint",delim=None):
         if delim is None:
             delim = "\n"
         cmd = delim.join(cmd)
-    bot.logger.debug("Found Docker command (%s) %s",spec,cmd)
+    bot.debug("Found Docker command (%s) %s" %(spec,cmd))
 
     return cmd
 

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -190,7 +190,7 @@ class DockerApiConnection(ApiConnection):
         registry = add_http(registry) # make sure we have a complete url
 
         base = "%s/%s/%s/%s/tags/list" %(registry,self.api_version,self.namespace,self.repo_name)
-        bot.debug("Obtaining tags: %s" %base)
+        bot.verbose("Obtaining tags: %s" %base)
 
         # We use get_tags for a testing endpoint in update_token
         response = self.get(base)
@@ -220,7 +220,7 @@ class DockerApiConnection(ApiConnection):
             base = "%s/%s" %(base,self.version)
         else:
             base = "%s/%s" %(base,self.repo_tag)
-        bot.debug("Obtaining manifest: %s" %base)
+        bot.verbose("Obtaining manifest: %s" %base)
     
         headers = self.headers
         if old_version == True:
@@ -251,7 +251,7 @@ class DockerApiConnection(ApiConnection):
 
         # The <name> variable is the namespace/repo_name
         base = "%s/%s/%s/%s/blobs/%s" %(registry,self.api_version,self.namespace,self.repo_name,image_id)
-        bot.debug("Downloading layers from %s" %base)
+        bot.verbose("Downloading layers from %s" %base)
     
         if download_folder is not None:
             download_folder = "%s/%s.tar.gz" %(download_folder,image_id)
@@ -307,7 +307,7 @@ class DockerApiConnection(ApiConnection):
                 if delim is None:
                     delim = "\n"
                 cmd = delim.join(cmd)
-            bot.info("Found Docker config (%s) %s" %(spec,cmd))
+            bot.verbose("Found Docker config (%s) %s" %(spec,cmd))
 
         else:
             if "config" in manifest:
@@ -372,7 +372,7 @@ def extract_runscript(manifest,includecmd=False):
             break
 
     if cmd is not None:
-        bot.debug("Adding Docker %s as Singularity runscript..." %(command.upper()))
+        bot.verbose3("Adding Docker %s as Singularity runscript..." %(command.upper()))
         bot.debug(cmd)
 
         # If the command is a list, join. (eg ['/usr/bin/python','hello.py']
@@ -403,7 +403,7 @@ def extract_metadata_tar(manifest,image_name,include_env=True,
         if include_env:               
             environ = extract_env(manifest)
             if environ not in [None,""]:
-                bot.debug('Adding Docker environment to metadata tar')
+                bot.verbose3('Adding Docker environment to metadata tar')
                 template = get_template('tarinfo')
                 template['name'] = './%s/env/%s-%s.sh' %(METADATA_FOLDER_NAME,
                                                          DOCKER_NUMBER,
@@ -417,14 +417,14 @@ def extract_metadata_tar(manifest,image_name,include_env=True,
             if labels is not None:
                 if isinstance(labels,dict):
                     labels = json.dumps(labels)
-                bot.debug('Adding Docker labels to metadata tar')
+                bot.verbose3('Adding Docker labels to metadata tar')
                 template = get_template('tarinfo')
                 template['name'] = "./%s/labels.json" %METADATA_FOLDER_NAME
                 template['content'] = labels
                 files.append(template)
 
         if runscript is not None:
-            bot.debug('Adding Docker runscript to metadata tar')
+            bot.verbose3('Adding Docker runscript to metadata tar')
             template = get_template('tarinfo')
             template['name'] = "./%s/runscript" %METADATA_FOLDER_NAME
             template['content'] = runscript
@@ -449,7 +449,7 @@ def extract_env(manifest):
             environ = "\n".join(environ)
         environ = ["export %s" %x for x in environ.split('\n')]
         environ = "\n".join(environ)
-        bot.debug("Found Docker container environment!")    
+        bot.verbose3("Found Docker container environment!")    
     return environ
 
 
@@ -482,7 +482,7 @@ def extract_labels(manifest,labelfile=None,prefix=None):
 
     labels = get_config(manifest,'Labels')
     if labels is not None and len(labels) is not 0:
-        bot.debug("Found Docker container labels!")    
+        bot.verbose3("Found Docker container labels!")    
         if labelfile is not None:
             for key,value in labels.items():
                 key = "%s%s" %(prefix,key)
@@ -515,7 +515,7 @@ def get_config(manifest,spec="Entrypoint",delim=None):
         if delim is None:
             delim = "\n"
         cmd = delim.join(cmd)
-    bot.debug("Found Docker command (%s) %s" %(spec,cmd))
+    bot.verbose3("Found Docker command (%s) %s" %(spec,cmd))
 
     return cmd
 

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -53,7 +53,7 @@ def SIZE(image,auth=None,contentfile=None):
     (one per layer) corresponding with the layers that will be downloaded for image
     '''
     bot.debug("Starting Docker SIZE, will get size from manifest")
-    bot.debug("Docker image: %s" %image)
+    bot.verbose("Docker image: %s" %image)
     client = DockerApiConnection(image=image,auth=auth)
     size = client.get_size()
     if contentfile is not None:
@@ -68,13 +68,13 @@ def IMPORT(image,auth=None,layerfile=None):
     :param layerfile: The file to write layers to extract into
     '''
     bot.debug("Starting Docker IMPORT, includes environment, runscript, and metadata.")
-    bot.debug("Docker image: %s" %image)
+    bot.verbose("Docker image: %s" %image)
 
     # Does the user want to override default of using ENTRYPOINT?
     if INCLUDE_CMD:
-        bot.debug("Specified Docker CMD as %runscript.")
+        bot.verbose2("Specified Docker CMD as %runscript.")
     else:
-        bot.debug("Specified Docker ENTRYPOINT as %runscript.")
+        bot.verbose2("Specified Docker ENTRYPOINT as %runscript.")
 
 
     # Input Parsing ----------------------------
@@ -122,11 +122,11 @@ def IMPORT(image,auth=None,layerfile=None):
                                     client.assemble_uri(),
                                     runscript=runscript)
 
-    bot.debug('Tar file with Docker env and labels: %s' %(tar_file))
+    bot.verbose2('Tar file with Docker env and labels: %s' %(tar_file))
 
     # Write all layers to the layerfile
     if layerfile is not None:
-        bot.debug("Writing Docker layers files to %s" %layerfile)
+        bot.verbose3("Writing Docker layers files to %s" %layerfile)
         write_file(layerfile,"\n".join(layers),mode="w")
         if tar_file is not None:
             write_file(layerfile,"\n%s" %tar_file,mode="a")

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -52,8 +52,8 @@ def SIZE(image,auth=None,contentfile=None):
     '''size is intended to be run before an import, to return to the contentfile a list of sizes
     (one per layer) corresponding with the layers that will be downloaded for image
     '''
-    bot.logger.debug("Starting Docker SIZE, will get size from manifest")
-    bot.logger.debug("Docker image: %s", image)
+    bot.debug("Starting Docker SIZE, will get size from manifest")
+    bot.debug("Docker image: %s" %image)
     client = DockerApiConnection(image=image,auth=auth)
     size = client.get_size()
     if contentfile is not None:
@@ -67,14 +67,14 @@ def IMPORT(image,auth=None,layerfile=None):
     :param auth: if needed, an authentication header (default None)
     :param layerfile: The file to write layers to extract into
     '''
-    bot.logger.debug("Starting Docker IMPORT, includes environment, runscript, and metadata.")
-    bot.logger.debug("Docker image: %s", image)
+    bot.debug("Starting Docker IMPORT, includes environment, runscript, and metadata.")
+    bot.debug("Docker image: %s" %image)
 
     # Does the user want to override default of using ENTRYPOINT?
     if INCLUDE_CMD:
-        bot.logger.debug("Specified Docker CMD as %runscript.")
+        bot.debug("Specified Docker CMD as %runscript.")
     else:
-        bot.logger.debug("Specified Docker ENTRYPOINT as %runscript.")
+        bot.debug("Specified Docker ENTRYPOINT as %runscript.")
 
 
     # Input Parsing ----------------------------
@@ -88,7 +88,7 @@ def IMPORT(image,auth=None,layerfile=None):
 
     if client.version is not None:
         docker_image_uri = "%s@%s" %(docker_image_uri,client.version)
-    bot.logger.info(docker_image_uri)
+    bot.info(docker_image_uri)
 
 
     # IMAGE METADATA -------------------------------------------
@@ -122,11 +122,11 @@ def IMPORT(image,auth=None,layerfile=None):
                                     client.assemble_uri(),
                                     runscript=runscript)
 
-    bot.logger.debug('Tar file with Docker env and labels: %s' %(tar_file))
+    bot.debug('Tar file with Docker env and labels: %s' %(tar_file))
 
     # Write all layers to the layerfile
     if layerfile is not None:
-        bot.logger.debug("Writing Docker layers files to %s", layerfile)
+        bot.debug("Writing Docker layers files to %s" %layerfile)
         write_file(layerfile,"\n".join(layers),mode="w")
         if tar_file is not None:
             write_file(layerfile,"\n%s" %tar_file,mode="a")
@@ -140,6 +140,6 @@ def IMPORT(image,auth=None,layerfile=None):
                   "cache_base":cache_base,
                   "metadata": tar_file }
 
-    bot.logger.debug("*** FINISHING DOCKER IMPORT PYTHON PORTION ****\n")
+    bot.debug("*** FINISHING DOCKER IMPORT PYTHON PORTION ****\n")
 
     return additions

--- a/libexec/python/helpers/json/add.py
+++ b/libexec/python/helpers/json/add.py
@@ -90,7 +90,7 @@ def main():
                    force=args.force)
 
     else:
-        bot.logger.error("--key and --file and --value must be defined for ADD. Exiting")
+        bot.error("--key and --file and --value must be defined for ADD. Exiting")
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/libexec/python/helpers/json/delete.py
+++ b/libexec/python/helpers/json/delete.py
@@ -75,7 +75,7 @@ def main():
        success = DELETE(key=args.key,
                         jsonfile=args.file)
     else:
-        bot.logger.error("--key and --file must be defined for DELETE. Exiting")
+        bot.error("--key and --file must be defined for DELETE. Exiting")
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/libexec/python/helpers/json/dump.py
+++ b/libexec/python/helpers/json/dump.py
@@ -67,7 +67,7 @@ def main():
        dump = DUMP(args.file)
 
     else:
-        bot.logger.error("--file must be defined for DUMP. Exiting")
+        bot.error("--file must be defined for DUMP. Exiting")
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/libexec/python/helpers/json/get.py
+++ b/libexec/python/helpers/json/get.py
@@ -75,7 +75,7 @@ def main():
        value = GET(key=args.key,
                    jsonfile=args.file)
     else:
-        bot.logger.error("--key and --file must be defined for GET. Exiting")
+        bot.error("--key and --file must be defined for GET. Exiting")
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/libexec/python/helpers/json/main.py
+++ b/libexec/python/helpers/json/main.py
@@ -41,9 +41,9 @@ def DUMP(jsonfile):
     '''DUMP will return the entire layfile as text, key value pairs
     :param jsonfile_path: the path to the jsonfile
     '''
-    bot.logger.debug("Reading %s to prepare dump to STDOUT",jsonfile)
+    bot.debug("Reading %s to prepare dump to STDOUT" %jsonfile)
     if not os.path.exists(jsonfile):
-        bot.logger.error("Cannot find %s, exiting.",jsonfile)
+        bot.error("Cannot find %s, exiting." %jsonfile)
         sys.exit(1)
     
     contents = read_json(jsonfile)
@@ -60,18 +60,18 @@ def GET(key,jsonfile):
     '''GET will return a key from the jsonfile, if it exists. If it doesn't, returns None.
     '''
     key = format_keyname(key)
-    bot.logger.debug("GET %s from %s",jsonfile)
+    bot.debug("GET %s from %s" %jsonfile)
     if not os.path.exists(jsonfile):
-        bot.logger.error("Cannot find %s, exiting.",jsonfile)
+        bot.error("Cannot find %s, exiting." %jsonfile)
         sys.exit(1)
     
     contents = read_json(jsonfile)
     if key in contents:
         value = contents[key]
         print(value)
-        bot.logger.debug('%s is %s',key,value)
+        bot.debug('%s is %s' %(key,value))
     else:
-        bot.logger.error("%s is not defined in file. Exiting",key)
+        bot.error("%s is not defined in file. Exiting" %key)
         sys.exit(1)
     return value
 
@@ -80,22 +80,22 @@ def ADD(key,value,jsonfile,force=False):
     '''ADD will write or update a key in a json file
     '''
     key = format_keyname(key)
-    bot.logger.debug("Adding label: '%s' = '%s'", key, value)
-    bot.logger.debug("ADD %s from %s",key,jsonfile)
+    bot.debug("Adding label: '%s' = '%s'" %(key, value))
+    bot.debug("ADD %s from %s",key,jsonfile)
     if os.path.exists(jsonfile):    
         contents = read_json(jsonfile)
         if key in contents:
-            bot.logger.debug('Warning, %s is already set. Overwrite is set to %s',key,force)
+            bot.debug('Warning, %s is already set. Overwrite is set to %s' %(key,force))
             if force == True:
                 contents[key] = value
             else:
-                bot.logger.error('%s found in %s and overwrite set to %s.',key,jsonfile,force)
+                bot.error('%s found in %s and overwrite set to %s.' %(key,jsonfile,force))
                 sys.exit(1)
         else:
             contents[key] = value
     else:
         contents = {key:value}
-    bot.logger.debug('%s is %s',key,value)
+    bot.debug('%s is %s' %(key,value))
     write_json(contents,jsonfile)
     return value
 
@@ -104,9 +104,9 @@ def DELETE(key,jsonfile):
     '''DELETE will remove a key from a json file
     '''
     key = format_keyname(key)
-    bot.logger.debug("DELETE %s from %s",jsonfile)
+    bot.debug("DELETE %s from %s" %jsonfile)
     if not os.path.exists(jsonfile):
-        bot.logger.error("Cannot find %s, exiting.",jsonfile)
+        bot.error("Cannot find %s, exiting." %jsonfile)
         sys.exit(1)
     
     contents = read_json(jsonfile)
@@ -115,11 +115,11 @@ def DELETE(key,jsonfile):
         if len(contents) > 0:
             write_json(contents,jsonfile)
         else:
-            bot.logger.debug('%s is empty, deleting.',jsonfile)
+            bot.debug('%s is empty, deleting.' %jsonfile)
             os.remove(jsonfile)
         return True
     else:    
-        bot.logger.debug('Warning, %s not found in %s',jsonfile)
+        bot.debug('Warning, %s not found in %s' %jsonfile)
         return False
 
 

--- a/libexec/python/helpers/json/main.py
+++ b/libexec/python/helpers/json/main.py
@@ -60,7 +60,7 @@ def GET(key,jsonfile):
     '''GET will return a key from the jsonfile, if it exists. If it doesn't, returns None.
     '''
     key = format_keyname(key)
-    bot.debug("GET %s from %s" %jsonfile)
+    bot.debug("GET %s from %s" %(key,jsonfile))
     if not os.path.exists(jsonfile):
         bot.error("Cannot find %s, exiting." %jsonfile)
         sys.exit(1)
@@ -81,7 +81,7 @@ def ADD(key,value,jsonfile,force=False):
     '''
     key = format_keyname(key)
     bot.debug("Adding label: '%s' = '%s'" %(key, value))
-    bot.debug("ADD %s from %s",key,jsonfile)
+    bot.debug("ADD %s from %s" %(key,jsonfile))
     if os.path.exists(jsonfile):    
         contents = read_json(jsonfile)
         if key in contents:
@@ -104,7 +104,7 @@ def DELETE(key,jsonfile):
     '''DELETE will remove a key from a json file
     '''
     key = format_keyname(key)
-    bot.debug("DELETE %s from %s" %jsonfile)
+    bot.debug("DELETE %s from %s" %(key,jsonfile))
     if not os.path.exists(jsonfile):
         bot.error("Cannot find %s, exiting." %jsonfile)
         sys.exit(1)
@@ -119,7 +119,7 @@ def DELETE(key,jsonfile):
             os.remove(jsonfile)
         return True
     else:    
-        bot.debug('Warning, %s not found in %s' %jsonfile)
+        bot.debug('Warning, %s not found in %s' %(key,jsonfile))
         return False
 
 

--- a/libexec/python/import.py
+++ b/libexec/python/import.py
@@ -65,12 +65,12 @@ def main():
 
     if image_uri == "docker://":
 
-        bot.logger.debug("\n*** STARTING DOCKER IMPORT PYTHON  ****")    
+        bot.debug("\n*** STARTING DOCKER IMPORT PYTHON  ****")    
 
         from sutils import basic_auth_header
         from defaults import LAYERFILE
 
-        bot.logger.debug("Docker layers and (env,labels,runscript) will be written to: %s", LAYERFILE)
+        bot.debug("Docker layers and (env,labels,runscript) will be written to: %s" %LAYERFILE)
         username = getenv("SINGULARITY_DOCKER_USERNAME") 
         password = getenv("SINGULARITY_DOCKER_PASSWORD",silent=True)
 
@@ -91,7 +91,7 @@ def main():
 
     elif image_uri == "shub://":
 
-        bot.logger.debug("\n*** STARTING SINGULARITY HUB IMPORT PYTHON  ****")    
+        bot.debug("\n*** STARTING SINGULARITY HUB IMPORT PYTHON  ****")    
 
         from defaults import LAYERFILE, LABELFILE
         from shub.main import IMPORT
@@ -100,7 +100,7 @@ def main():
                labelfile=LABELFILE)
 
     else:
-        bot.logger.error("uri %s is not a currently supported uri for import. Exiting.",image_uri)
+        bot.error("uri %s is not a currently supported uri for import. Exiting." %image_uri)
         sys.exit(1)
 
 

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -120,7 +120,7 @@ class SingularityMessage:
             prefix = ""
 
         # Add the prefix 
-        message = "%s\%s" %(prefix,message)
+        message = "%s%s" %(prefix,message)
 
         if not message.endswith('\n'):
             message = "%s\n" %message

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -119,6 +119,9 @@ class SingularityMessage:
         else:
             prefix = ""
 
+        # Add the prefix 
+        message = "%s\%s" %(prefix,message)
+
         if not message.endswith('\n'):
             message = "%s\n" %message
 

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -140,7 +140,7 @@ class SingularityMessage:
         self.history.append(message)
 
 
-    def get_logs(join_newline=True):
+    def get_logs(self,join_newline=True):
         ''''get_logs will return the complete history, joined by newline
         (default) or as is.
         '''

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -20,9 +20,17 @@ VERBOSE is equivalent to VERBOSE1 (this is mirroring the C code)
 and for each level, calling it corresponds to calling the class'
 function for it. E.g., DEBUG --> bot.debug('This is the message!')
 
-The following levels are to stdout:
+The following levels are to stderr:
 
-5,4,3,2,2,1
+5,4,3,2,1,-1,-2,-3,-4
+
+The following levels are only to stdout
+
+1
+
+The following levels do nothing (quiet)
+
+0
 
 Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
 
@@ -62,7 +70,7 @@ class SingularityMessage:
 
     def __init__(self,MESSAGELEVEL=None):
         self.level = get_logging_level()
-
+        self.history = []
         
     def emitError(self,level):
         '''determine if a level should print to
@@ -109,9 +117,6 @@ class SingularityMessage:
         else:
             prefix = ""
 
-        if not message.endswith('\n'):
-            message = "%s\n" %message
-
         # If the level is quiet, only print to error
         if self.level == QUIET:
             pass
@@ -119,10 +124,22 @@ class SingularityMessage:
         # Otherwise if in range print to stdout and stderr
         elif self.isEnabledFor(level):
             if self.emitError(level):
-                sys.stderr.write(message)
+                sys.stderr.writelines(message)
             else:
-                sys.stdout.write(message)
+                sys.stdout.writelines(message)
 
+        # Add all log messages to history
+        self.history.append(message)
+
+
+    def get_logs(join_newline=True):
+        ''''get_logs will return the complete history, joined by newline
+        (default) or as is.
+        '''
+        if join_newline:
+            return '\n'.join(self.history)
+        return self.history
+        
 
     def abort(self,message):
         self.emit(ABRT,message,'ABRT')        
@@ -140,10 +157,10 @@ class SingularityMessage:
         self.emit(INFO,message)        
 
     def verbose(self,message):
-        self.emit(VERBOSE,message,'VERBOSE')        
+        self.emit(VERBOSE,message,"VERBOSE")        
 
     def verbose1(self,message):
-        return self.verbose(message)
+        self.emit(VERBOSE,message,"VERBOSE1")        
 
     def verbose2(self,message):
         self.emit(VERBOSE2,message,'VERBOSE2')        

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -30,6 +30,8 @@ class SingularityMessage:
         self.level = get_logging_level()
         logging.basicConfig(level=self.level)
         self.logger = logging.getLogger('python')
+        formatter = logging.Formatter('%(message)s')
+        self.logger.setFormatter(formatter)
 
 
     def is_quiet(self):

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -71,7 +71,9 @@ class SingularityMessage:
     def __init__(self,MESSAGELEVEL=None):
         self.level = get_logging_level()
         self.history = []
-        
+        self.errorStream = sys.stderr
+        self.outputStream = sys.stdout        
+
     def emitError(self,level):
         '''determine if a level should print to
         stderr, includes all levels but INFO and QUIET'''
@@ -117,6 +119,9 @@ class SingularityMessage:
         else:
             prefix = ""
 
+        if not message.endswith('\n'):
+            message = "%s\n" %message
+
         # If the level is quiet, only print to error
         if self.level == QUIET:
             pass
@@ -124,9 +129,9 @@ class SingularityMessage:
         # Otherwise if in range print to stdout and stderr
         elif self.isEnabledFor(level):
             if self.emitError(level):
-                sys.stderr.writelines(message)
+                self.errorStream.write(message)
             else:
-                sys.stdout.writelines(message)
+                self.outputStream.write(message)
 
         # Add all log messages to history
         self.history.append(message)

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -109,6 +109,9 @@ class SingularityMessage:
         else:
             prefix = ""
 
+        if not message.endswith('\n'):
+            message = "%s\n" %message
+
         # If the level is quiet, only print to error
         if self.level == QUIET:
             pass

--- a/libexec/python/pull.py
+++ b/libexec/python/pull.py
@@ -50,7 +50,7 @@ def main():
     '''main is a wrapper for the client to hand the parser to the executable functions
     This makes it possible to set up a parser in test cases
     '''
-    bot.logger.debug("\n*** STARTING SINGULARITY PYTHON PULL ****")
+    bot.debug("\n*** STARTING SINGULARITY PYTHON PULL ****")
     from defaults import LAYERFILE, DISABLE_CACHE, getenv
 
     # What image is the user asking for?
@@ -68,7 +68,7 @@ def main():
                        layerfile=LAYERFILE)
 
     else:
-        bot.logger.error("uri %s is not currently supported for pull. Exiting.",image_uri)
+        bot.error("uri %s is not currently supported for pull. Exiting." %image_uri)
         sys.exit(1)
 
 

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -47,11 +47,11 @@ def get_image_uri(image,quiet=False):
 
     if len(match) == 0:
         if not quiet:
-            bot.logger.warning("Could not detect any uri in %s",image)
+            bot.warning("Could not detect any uri in %s" %image)
     else:
         image_uri = match[0].lower()
         if not quiet:
-            bot.logger.debug("Found uri %s",image_uri)
+            bot.debug("Found uri %s" %image_uri)
     return image_uri
 
 
@@ -133,11 +133,11 @@ def parse_image_uri(image,uri=None,quiet=False):
         repo_name = image[0]
 
     if not quiet:
-        bot.logger.debug("Registry: %s", registry)
-        bot.logger.debug("Namespace: %s", namespace)
-        bot.logger.debug("Repo Name: %s", repo_name)
-        bot.logger.debug("Repo Tag: %s", repo_tag)
-        bot.logger.debug("Version: %s", version)
+        bot.debug("Registry: %s" %registry)
+        bot.debug("Namespace: %s" %namespace)
+        bot.debug("Repo Name: %s" %repo_name)
+        bot.debug("Repo Tag: %s" %repo_tag)
+        bot.debug("Version: %s" %version)
 
     parsed = {'registry':registry,
               'namespace':namespace, 
@@ -147,7 +147,7 @@ def parse_image_uri(image,uri=None,quiet=False):
     # No field should be empty
     for fieldname,value in parsed.items():
         if len(value) == 0:
-            bot.logger.error("%s found empty, check uri! Exiting.", value)
+            bot.error("%s found empty, check uri! Exiting." %value)
             sys.exit(1)
 
     # Version is not required

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -133,11 +133,11 @@ def parse_image_uri(image,uri=None,quiet=False):
         repo_name = image[0]
 
     if not quiet:
-        bot.debug("Registry: %s" %registry)
-        bot.debug("Namespace: %s" %namespace)
-        bot.debug("Repo Name: %s" %repo_name)
-        bot.debug("Repo Tag: %s" %repo_tag)
-        bot.debug("Version: %s" %version)
+        bot.verbose("Registry: %s" %registry)
+        bot.verbose("Namespace: %s" %namespace)
+        bot.verbose("Repo Name: %s" %repo_name)
+        bot.verbose("Repo Tag: %s" %repo_tag)
+        bot.verbose("Version: %s" %version)
 
     parsed = {'registry':registry,
               'namespace':namespace, 

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -213,5 +213,5 @@ def extract_metadata(manifest,labelfile=None,prefix=None):
                         jsonfile=labelfile,
                         force=True)
 
-        bot.debug("Saving Singularity Hub metadata to %s" %labelfile)    
+        bot.verbose("Saving Singularity Hub metadata to %s" %labelfile)    
     return metadata

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -183,7 +183,7 @@ def get_image_name(manifest,extension='img.gz',use_hash=False):
         if len(image_name) > 0:
             image_name = image_name[0]
         else:
-            bot.logger.error("Singularity Hub Image not found with expected extension %s, exiting.",extension)
+            bot.error("Singularity Hub Image not found with expected extension %s, exiting." %extension)
             sys.exit(1)
           
     if not bot.is_quiet():
@@ -213,5 +213,5 @@ def extract_metadata(manifest,labelfile=None,prefix=None):
                         jsonfile=labelfile,
                         force=True)
 
-        bot.logger.debug("Saving Singularity Hub metadata to %s",labelfile)    
+        bot.debug("Saving Singularity Hub metadata to %s" %labelfile)    
     return metadata

--- a/libexec/python/shub/main.py
+++ b/libexec/python/shub/main.py
@@ -52,8 +52,8 @@ def SIZE(image,contentfile=None):
     '''size is intended to be run before an import, to return to the contentfile a list of sizes
     (one per layer) corresponding with the layers that will be downloaded for image
     '''
-    bot.logger.debug("Starting Singularity Hub SIZE, will get size from manifest")
-    bot.logger.debug("Singularity Hub image: %s", image)
+    bot.debug("Starting Singularity Hub SIZE, will get size from manifest")
+    bot.debug("Singularity Hub image: %s" %image)
     client = SingularityApiConnection(image=image)
     manifest = client.get_manifest()
     size = json.loads(manifest['metrics'].replace("'",'"'))['size']
@@ -96,7 +96,7 @@ def PULL(image,download_folder=None,layerfile=None):
                 'image': image }
 
     if layerfile != None:
-        bot.logger.debug("Writing Singularity Hub image path to %s", layerfile)
+        bot.debug("Writing Singularity Hub image path to %s" %layerfile)
         write_file(layerfile,image_file,mode="w")
 
     return manifest

--- a/libexec/python/size.py
+++ b/libexec/python/size.py
@@ -60,7 +60,7 @@ def main():
 
     if image_uri == "shub://":
 
-        bot.logger.debug("\n*** STARTING SINGULARITY HUB SIZE PYTHON  ****")    
+        bot.debug("\n*** STARTING SINGULARITY HUB SIZE PYTHON  ****")    
         from shub.main import SIZE
         SIZE(image=container,
              contentfile=LAYERFILE)
@@ -70,7 +70,7 @@ def main():
         from sutils import basic_auth_header
         from docker.main import SIZE
 
-        bot.logger.debug("Docker sizes will be written to: %s", LAYERFILE)
+        bot.debug("Docker sizes will be written to: %s" %LAYERFILE)
         username = getenv("SINGULARITY_DOCKER_USERNAME") 
         password = getenv("SINGULARITY_DOCKER_PASSWORD",silent=True)
 
@@ -83,7 +83,7 @@ def main():
              contentfile=LAYERFILE)
 
     else:
-        bot.logger.error("uri %s is not a currently supported uri for size. Exiting.",image_uri)
+        bot.error("uri %s is not a currently supported uri for size. Exiting." %image_uri)
         sys.exit(1)
 
 

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -99,10 +99,10 @@ def run_command(cmd):
     :param cmd: the command to send, should be a list for subprocess
     '''
     try:
-        bot.logger.debug("Running command %s with subprocess", " ".join(cmd))
+        bot.debug("Running command %s with subprocess", " ".join(cmd))
         process = subprocess.Popen(cmd,stdout=subprocess.PIPE)
     except OSError as error:
-        bot.logger.error("Error with subprocess: %s, returning None",error)
+        bot.error("Error with subprocess: %s, returning None",error)
         return None
 
     output = process.communicate()[0]
@@ -196,7 +196,7 @@ def create_tar(files,output_folder=None):
 
         # Warn the user if it already exists
         if os.path.exists(finished_tar):
-            bot.logger.debug("metadata file %s already exists, will over-write." %(finished_tar))
+            bot.debug("metadata file %s already exists, will over-write." %(finished_tar))
 
         # Add all content objects to file
         tar = tarfile.open(finished_tar, "w:gz")
@@ -205,7 +205,7 @@ def create_tar(files,output_folder=None):
         tar.close()
 
     else:
-        bot.logger.debug("No contents, environment or labels, for tarfile, will not generate.")
+        bot.debug("No contents, environment or labels, for tarfile, will not generate.")
 
     return finished_tar
 
@@ -253,7 +253,7 @@ def get_cache(subfolder=None,quiet=False):
     create_folders(cache_base)
 
     if not quiet:
-        bot.logger.info("Cache folder set to %s", cache_base)
+        bot.info("Cache folder set to %s", cache_base)
     return cache_base
 
 
@@ -268,7 +268,7 @@ def create_folders(path):
         if e.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else:
-            bot.logger.error("Error creating path %s, exiting.",path)
+            bot.error("Error creating path %s, exiting." %path)
             sys.exit(1)
 
 
@@ -316,7 +316,7 @@ def check_tar_permissions(tar_file,permission=None):
     for member in tar:  
         if member.isdir() or member.isfile() and not member.issym():
             if not has_permission(member,permission):
-                bot.logger.debug("Fixing permission for %s" %(member.name))
+                bot.debug("Fixing permission for %s" %(member.name))
                 member.mode = permission | member.mode
             extracted = tar.extractfile(member)        
             fixed_tar.addfile(member, extracted)
@@ -340,7 +340,7 @@ def write_file(filename,content,mode="w"):
     '''write_file will open a file, "filename" and write content, "content"
     and properly close the file
     '''
-    bot.logger.debug("Writing file %s with mode %s.",filename,mode)
+    bot.debug("Writing file %s with mode %s." %(filename,mode))
     with open(filename,mode) as filey:
         filey.writelines(content)
     return filename
@@ -352,7 +352,7 @@ def write_json(json_obj,filename,mode="w",print_pretty=True):
     :param filename: the output file to write to
     :param pretty_print: if True, will use nicer formatting   
     '''
-    bot.logger.debug("Writing json file %s with mode %s.",filename,mode)
+    bot.debug("Writing json file %s with mode %s." %(filename,mode))
     with open(filename,mode) as filey:
         if print_pretty == True:
             filey.writelines(json.dumps(json_obj, indent=4, separators=(',', ': ')))
@@ -374,7 +374,7 @@ def read_file(filename,mode="r"):
     '''write_file will open a file, "filename" and write content, "content"
     and properly close the file
     '''
-    bot.logger.debug("Reading file %s with mode %s.",filename,mode)
+    bot.debug("Reading file %s with mode %s." %(filename,mode))
     with open(filename,mode) as filey:
         content = filey.readlines()
     return content
@@ -399,11 +399,11 @@ def get_fullpath(file_path,required=True):
 
     # If file is required, we exit
     if required == True:
-        bot.logger.error("Cannot find file %s, exiting.",file_path)
+        bot.error("Cannot find file %s, exiting.",file_path)
         sys.exit(1)
 
     # If file isn't required and doesn't exist, return None
-    bot.logger.warning("Cannot find file %s",file_path)
+    bot.warning("Cannot find file %s" %file_path)
     return None
 
 
@@ -444,7 +444,7 @@ def write_singularity_infos(base_dir,prefix,start_number,content,extension=None)
 
     # if the base directory doesn't exist, exit with error.
     if not os.path.exists(base_dir):
-        bot.logger.warning("Cannot find required metadata directory %s. Exiting!",base_dir)
+        bot.warning("Cannot find required metadata directory %s. Exiting!" %base_dir)
         sys.exit(1)
 
     # Get the next available number

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -399,7 +399,7 @@ def get_fullpath(file_path,required=True):
 
     # If file is required, we exit
     if required == True:
-        bot.error("Cannot find file %s, exiting.",file_path)
+        bot.error("Cannot find file %s, exiting." %file_path)
         sys.exit(1)
 
     # If file isn't required and doesn't exist, return None

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -99,7 +99,7 @@ def run_command(cmd):
     :param cmd: the command to send, should be a list for subprocess
     '''
     try:
-        bot.debug("Running command %s with subprocess" %" ".join(cmd))
+        bot.verbose2("Running command %s with subprocess" %" ".join(cmd))
         process = subprocess.Popen(cmd,stdout=subprocess.PIPE)
     except OSError as error:
         bot.error("Error with subprocess: %s, returning None" %error)
@@ -316,7 +316,7 @@ def check_tar_permissions(tar_file,permission=None):
     for member in tar:  
         if member.isdir() or member.isfile() and not member.issym():
             if not has_permission(member,permission):
-                bot.debug("Fixing permission for %s" %(member.name))
+                bot.verbose3("Fixing permission for %s" %(member.name))
                 member.mode = permission | member.mode
             extracted = tar.extractfile(member)        
             fixed_tar.addfile(member, extracted)
@@ -340,7 +340,7 @@ def write_file(filename,content,mode="w"):
     '''write_file will open a file, "filename" and write content, "content"
     and properly close the file
     '''
-    bot.debug("Writing file %s with mode %s." %(filename,mode))
+    bot.verbose2("Writing file %s with mode %s." %(filename,mode))
     with open(filename,mode) as filey:
         filey.writelines(content)
     return filename
@@ -352,7 +352,7 @@ def write_json(json_obj,filename,mode="w",print_pretty=True):
     :param filename: the output file to write to
     :param pretty_print: if True, will use nicer formatting   
     '''
-    bot.debug("Writing json file %s with mode %s." %(filename,mode))
+    bot.verbose2("Writing json file %s with mode %s." %(filename,mode))
     with open(filename,mode) as filey:
         if print_pretty == True:
             filey.writelines(json.dumps(json_obj, indent=4, separators=(',', ': ')))
@@ -374,7 +374,7 @@ def read_file(filename,mode="r"):
     '''write_file will open a file, "filename" and write content, "content"
     and properly close the file
     '''
-    bot.debug("Reading file %s with mode %s." %(filename,mode))
+    bot.verbose3("Reading file %s with mode %s." %(filename,mode))
     with open(filename,mode) as filey:
         content = filey.readlines()
     return content

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -99,10 +99,10 @@ def run_command(cmd):
     :param cmd: the command to send, should be a list for subprocess
     '''
     try:
-        bot.debug("Running command %s with subprocess", " ".join(cmd))
+        bot.debug("Running command %s with subprocess" %" ".join(cmd))
         process = subprocess.Popen(cmd,stdout=subprocess.PIPE)
     except OSError as error:
-        bot.error("Error with subprocess: %s, returning None",error)
+        bot.error("Error with subprocess: %s, returning None" %error)
         return None
 
     output = process.communicate()[0]
@@ -253,7 +253,7 @@ def get_cache(subfolder=None,quiet=False):
     create_folders(cache_base)
 
     if not quiet:
-        bot.info("Cache folder set to %s", cache_base)
+        bot.info("Cache folder set to %s" %cache_base)
     return cache_base
 
 

--- a/libexec/python/templates.py
+++ b/libexec/python/templates.py
@@ -42,8 +42,8 @@ def get_template(template_name):
                             "mode": 493}
 
     if template_name in templates:
-        bot.logger.debug("Found template for %s", template_name)
+        bot.debug("Found template for %s" %template_name)
         return templates[template_name]
     else:
-        bot.logger.warning("Cannot find template %s",template_name)
+        bot.warning("Cannot find template %s" %template_name)
     return None


### PR DESCRIPTION
This is a simplification of the logger, to not use python's and to match the Singularity C code, allowing for a bit more flexibility in functionality.  It works as follows:

Here is the standard, regular verbosity:

```bash
vanessa@som-ctp:/tmp$ singularity import ubuntu.img  docker://ubuntu:latest
Docker image path: index.docker.io/library/ubuntu:latest
Cache folder set to /home/vanessa/.singularity/docker
Importing: base Singularity environment
Importing: /home/vanessa/.singularity/docker/sha256:d54efb8db41d4ac23d29469940ec92da94c9a6c2d9e26ec060bebad1d1b0e48d.tar.gz
Importing: /home/vanessa/.singularity/docker/sha256:f8b845f45a87dc7c095b15f3d9661e640ebc86f42cd8e8ab36674846472027f7.tar.gz
Importing: /home/vanessa/.singularity/docker/sha256:e8db7bf7c39fab6fec91b1b61e3914f21e60233c9823dd57c60bc360191aaf0d.tar.gz
Importing: /home/vanessa/.singularity/docker/sha256:9654c40e9079e3d5b271ec71f6d83f8ce80cfa6f09d9737fc6bfd4d2456fed3f.tar.gz
Importing: /home/vanessa/.singularity/docker/sha256:6d9ef359eaaa311860550b478790123c4b22a2eaede8f8f46691b0b4433c08cf.tar.gz
Importing: /home/vanessa/.singularity/metadata/sha256:fe44851d529f465f9aa107b32351c8a0a722fc0619a2a7c22b058084fac068a4.tar.gz
```

Notice the difference now is that INFO statements (previously printed like INFO:python Hello! are now just printed without the prefix. Here is quiet mode:

```bash
vanessa@som-ctp:/tmp$ singularity -q import ubuntu.img  docker://ubuntu:latest

```

and here is debug, notice that I've changed a lot of the levels to be more specific (verbose vs. debug, we weren't using any verbose levels before). The one issue I see is that some of my prints follow some of yours and there isn't a newline - eg:

```bash
Exec'ing: /usr/local/libexec/singularity/cli/import.exec ubuntu.imgVERBOSE2 SINGULARITY_COMMAND_ASIS found as False
```

I added my newline after - is there a good way to make this consistent?

```bash
vanessa@som-ctp:/tmp$ singularity --debug import ubuntu.img  docker://ubuntu:latest
enabling debugging
ending argument loop
Exec'ing: /usr/local/libexec/singularity/cli/import.exec ubuntu.imgVERBOSE2 SINGULARITY_COMMAND_ASIS found as False
VERBOSE2 SINGULARITY_ROOTFS not defined (None)
VERBOSE2 SINGULARITY_METADATA_FOLDER found as None/.singularity.d
VERBOSE2 SINGULARITY_DISABLE_CACHE found as False
VERBOSE2 SINGULARITY_CACHEDIR found as /home/vanessa/.singularity
VERBOSE2 SINGULARITY_ENVBASE found as None/.singularity.d/env
VERBOSE2 SINGULARITY_LABELFILE found as None/.singularity.d/labels.json
VERBOSE2 SINGULARITY_INCLUDECMD found as False
VERBOSE2 SINGULARITY_PULLFOLDER found as /tmp
VERBOSE2 SINGULARITY_CONTENTS found as /tmp/.singularity-layers.FBK2rXJD
VERBOSE2 SINGULARITY_CONTAINER found as docker://ubuntu:latest
DEBUG Found uri docker://
DEBUG 
*** STARTING DOCKER IMPORT PYTHON  ****
DEBUG Docker layers and (env,labels,runscript) will be written to: /tmp/.singularity-layers.FBK2rXJD
VERBOSE2 SINGULARITY_DOCKER_USERNAME not defined (None)
VERBOSE2 SINGULARITY_DOCKER_PASSWORD found
DEBUG Starting Docker IMPORT, includes environment, runscript, and metadata.
VERBOSE Docker image: ubuntu:latest
VERBOSE2 Specified Docker ENTRYPOINT as %runscript.
DEBUG Headers found: Accept,Content-Type
VERBOSE Registry: index.docker.io
VERBOSE Namespace: library
VERBOSE Repo Name: ubuntu
VERBOSE Repo Tag: latest
VERBOSE Version: None
VERBOSE Obtaining tags: https://index.docker.io/v2/library/ubuntu/tags/list
DEBUG GET https://index.docker.io/v2/library/ubuntu/tags/list
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/ubuntu:pull
DEBUG Headers found: Accept,Authorization,Content-Type
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/ubuntu:pull
DEBUG Headers found: Accept,Authorization,Content-Type
Docker image path: index.docker.io/library/ubuntu:latest
VERBOSE Obtaining manifest: https://index.docker.io/v2/library/ubuntu/manifests/latest
DEBUG GET https://index.docker.io/v2/library/ubuntu/manifests/latest
DEBUG Image manifest version 2.2 found.
DEBUG Adding digest sha256:d54efb8db41d4ac23d29469940ec92da94c9a6c2d9e26ec060bebad1d1b0e48d
DEBUG Adding digest sha256:f8b845f45a87dc7c095b15f3d9661e640ebc86f42cd8e8ab36674846472027f7
DEBUG Adding digest sha256:e8db7bf7c39fab6fec91b1b61e3914f21e60233c9823dd57c60bc360191aaf0d
DEBUG Adding digest sha256:9654c40e9079e3d5b271ec71f6d83f8ce80cfa6f09d9737fc6bfd4d2456fed3f
DEBUG Adding digest sha256:6d9ef359eaaa311860550b478790123c4b22a2eaede8f8f46691b0b4433c08cf
VERBOSE Obtaining manifest: https://index.docker.io/v2/library/ubuntu/manifests/latest
DEBUG GET https://index.docker.io/v2/library/ubuntu/manifests/latest
Cache folder set to /home/vanessa/.singularity/docker
VERBOSE3 Found Docker command (Entrypoint) None
VERBOSE3 Found Docker command (Cmd) /bin/bash
VERBOSE3 Adding Docker CMD as Singularity runscript...
DEBUG /bin/bash
VERBOSE3 Found Docker command (Env) PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
VERBOSE3 Found Docker container environment!
VERBOSE3 Adding Docker environment to metadata tar
DEBUG Found template for tarinfo
VERBOSE3 Found Docker command (Labels) {}
VERBOSE3 Adding Docker labels to metadata tar
DEBUG Found template for tarinfo
VERBOSE3 Adding Docker runscript to metadata tar
DEBUG Found template for tarinfo
DEBUG metadata file /home/vanessa/.singularity/metadata/sha256:fe44851d529f465f9aa107b32351c8a0a722fc0619a2a7c22b058084fac068a4.tar.gz already exists, will over-write.
VERBOSE2 Tar file with Docker env and labels: /home/vanessa/.singularity/metadata/sha256:fe44851d529f465f9aa107b32351c8a0a722fc0619a2a7c22b058084fac068a4.tar.gz
VERBOSE3 Writing Docker layers files to /tmp/.singularity-layers.FBK2rXJD
VERBOSE2 Writing file /tmp/.singularity-layers.FBK2rXJD with mode w.
VERBOSE2 Writing file /tmp/.singularity-layers.FBK2rXJD with mode a.
DEBUG *** FINISHING DOCKER IMPORT PYTHON PORTION ****
Importing: base Singularity environment
.
.
.
```
For the logger newline, it seems to work ok when I test locally:

```bash
In [1]: from message import bot

In [2]: bot.debug('hello!')
DEBUG hello!
```

@singularityware-admin
