### PR TITLE
Give user customization of singularity hub image name

### DIFF
--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -44,6 +44,12 @@ while true; do
             fi
             exit
         ;;
+        -n|--name|name)
+            shift
+            SHUB_CONTAINERNAME="${1:-}"
+            export SHUB_CONTAINERNAME
+            shift
+        ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"
             exit 1

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -52,7 +52,7 @@ while true; do
         ;;
         -C|--commit|commit)
             shift
-            if [ -z "${SHUB_CONTAINERNAME}" ]; then
+            if [ -z "$SHUB_CONTAINERNAME" ]; then
                 SHUB_NAMEBYCOMMIT="yes"
                 unset SHUB_NAMEBYHASH
                 export SHUB_NAMEBYCOMMIT
@@ -61,8 +61,8 @@ while true; do
         ;;
         -H|--hash|hash)
             shift
-            if [ -z "${SHUB_CONTAINERNAME}" ]; then
-                if [ -z "${SHUB_NAMEBYCOMMIT}" ]; then
+            if [ -z "$SHUB_CONTAINERNAME" ]; then
+                if [ -z "$SHUB_NAMEBYCOMMIT" ]; then
                     SHUB_NAMEBYHASH="yes"
                     export SHUB_NAMEBYHASH
                 fi

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -57,7 +57,6 @@ while true; do
                 unset SHUB_NAMEBYHASH
                 export SHUB_NAMEBYCOMMIT
             fi 
-            shift
         ;;
         -H|--hash|hash)
             shift
@@ -67,7 +66,6 @@ while true; do
                     export SHUB_NAMEBYHASH
                 fi
             fi 
-            shift
         ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -52,7 +52,7 @@ while true; do
         ;;
         -C|--commit|commit)
             shift
-            if [ -z "$SHUB_CONTAINERNAME" ]; then
+            if [ -z "${SHUB_CONTAINERNAME+x}" ]; then
                 SHUB_NAMEBYCOMMIT="yes"
                 unset SHUB_NAMEBYHASH
                 export SHUB_NAMEBYCOMMIT
@@ -61,8 +61,8 @@ while true; do
         ;;
         -H|--hash|hash)
             shift
-            if [ -z "$SHUB_CONTAINERNAME" ]; then
-                if [ -z "$SHUB_NAMEBYCOMMIT" ]; then
+            if [ -z "${SHUB_CONTAINERNAME+x}" ]; then
+                if [ -z "${SHUB_NAMEBYCOMMIT+x}" ]; then
                     SHUB_NAMEBYHASH="yes"
                     export SHUB_NAMEBYHASH
                 fi

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -104,16 +104,17 @@ export SINGULARITY_CONTAINER SINGULARITY_PULLFOLDER SINGULARITY_CONTENTS
 
 # Determine if the user wants a custom name, and export
 
-if [ -z "$SHUB_NAMEBYHASH" ]; then 
+
+if [ -n "$SHUB_NAMEBYHASH" ]; then 
     export $SHUB_NAMEBYHASH="yes"
 fi
 
-if [ -z "$SHUB_NAMEBYCOMMIT" ]; then 
+if [ -n "$SHUB_NAMEBYCOMMIT" ]; then 
     export $SHUB_NAMEBYCOMMIT="yes"
     unset SHUB_NAMEBYHASH
 fi
 
-if [ -z "$SHUB_CONTAINERNAME" ]; then 
+if [ -n "$SHUB_CONTAINERNAME" ]; then 
     export $SHUB_CONTAINERNAME
     unset SHUB_NAMEBYCOMMIT SHUB_NAMEBYHASH
 fi

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -52,7 +52,7 @@ while true; do
         ;;
         -C|--commit|commit)
             shift
-            if [ -n "${!SHUB_CONTAINERNAME}" ]; then
+            if [ -z "${!SHUB_CONTAINERNAME}" ]; then
                 SHUB_NAMEBYCOMMIT="yes"
                 unset SHUB_NAMEBYHASH
                 export SHUB_NAMEBYCOMMIT
@@ -61,8 +61,8 @@ while true; do
         ;;
         -H|--hash|hash)
             shift
-            if [ -n "${!SHUB_CONTAINERNAME}" ]; then
-                if [ -n "${!SHUB_NAMEBYCOMMIT}" ]; then
+            if [ -z "${!SHUB_CONTAINERNAME}" ]; then
+                if [ -z "${!SHUB_NAMEBYCOMMIT}" ]; then
                     SHUB_NAMEBYHASH="yes"
                     export SHUB_NAMEBYHASH
                 fi
@@ -100,24 +100,6 @@ fi
 shift
 
 export SINGULARITY_CONTAINER SINGULARITY_PULLFOLDER SINGULARITY_CONTENTS
-
-
-# Determine if the user wants a custom name, and export
-
-
-if [[ -v "$SHUB_NAMEBYHASH" ]]; then 
-    export $SHUB_NAMEBYHASH="yes"
-fi
-
-if [[ -v "$SHUB_NAMEBYCOMMIT" ]]; then 
-    export $SHUB_NAMEBYCOMMIT="yes"
-    unset SHUB_NAMEBYHASH
-fi
-
-if [[ -v "$SHUB_CONTAINERNAME" ]]; then 
-    export $SHUB_CONTAINERNAME
-    unset SHUB_NAMEBYCOMMIT SHUB_NAMEBYHASH
-fi
 
 case "$SINGULARITY_CONTAINER" in
     *://*)

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -105,16 +105,16 @@ export SINGULARITY_CONTAINER SINGULARITY_PULLFOLDER SINGULARITY_CONTENTS
 # Determine if the user wants a custom name, and export
 
 
-if [ -n "$SHUB_NAMEBYHASH" ]; then 
+if [[ -v "$SHUB_NAMEBYHASH" ]]; then 
     export $SHUB_NAMEBYHASH="yes"
 fi
 
-if [ -n "$SHUB_NAMEBYCOMMIT" ]; then 
+if [[ -v "$SHUB_NAMEBYCOMMIT" ]]; then 
     export $SHUB_NAMEBYCOMMIT="yes"
     unset SHUB_NAMEBYHASH
 fi
 
-if [ -n "$SHUB_CONTAINERNAME" ]; then 
+if [[ -v "$SHUB_CONTAINERNAME" ]]; then 
     export $SHUB_CONTAINERNAME
     unset SHUB_NAMEBYCOMMIT SHUB_NAMEBYHASH
 fi

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -52,7 +52,7 @@ while true; do
         ;;
         -C|--commit|commit)
             shift
-            if [ -z "${!SHUB_CONTAINERNAME}" ]; then
+            if [ -z "${SHUB_CONTAINERNAME}" ]; then
                 SHUB_NAMEBYCOMMIT="yes"
                 unset SHUB_NAMEBYHASH
                 export SHUB_NAMEBYCOMMIT
@@ -61,8 +61,8 @@ while true; do
         ;;
         -H|--hash|hash)
             shift
-            if [ -z "${!SHUB_CONTAINERNAME}" ]; then
-                if [ -z "${!SHUB_NAMEBYCOMMIT}" ]; then
+            if [ -z "${SHUB_CONTAINERNAME}" ]; then
+                if [ -z "${SHUB_NAMEBYCOMMIT}" ]; then
                     SHUB_NAMEBYHASH="yes"
                     export SHUB_NAMEBYHASH
                 fi

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -76,6 +76,23 @@ shift
 
 export SINGULARITY_CONTAINER SINGULARITY_PULLFOLDER SINGULARITY_CONTENTS
 
+
+# Determine if the user wants a custom name, and export
+
+if [ -z "$SHUB_NAMEBYHASH" ]; then 
+    export $SHUB_NAMEBYHASH="yes"
+fi
+
+if [ -z "$SHUB_NAMEBYCOMMIT" ]; then 
+    export $SHUB_NAMEBYCOMMIT="yes"
+    unset SHUB_NAMEBYHASH
+fi
+
+if [ -z "$SHUB_CONTAINERNAME" ]; then 
+    export $SHUB_CONTAINERNAME
+    unset SHUB_NAMEBYCOMMIT SHUB_NAMEBYHASH
+fi
+
 case "$SINGULARITY_CONTAINER" in
     *://*)
         eval $SINGULARITY_libexecdir/singularity/python/pull.py

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -50,6 +50,25 @@ while true; do
             export SHUB_CONTAINERNAME
             shift
         ;;
+        -C|--commit|commit)
+            shift
+            if [ -n "${!SHUB_CONTAINERNAME}" ]; then
+                SHUB_NAMEBYCOMMIT="yes"
+                unset SHUB_NAMEBYHASH
+                export SHUB_NAMEBYCOMMIT
+            fi 
+            shift
+        ;;
+        -H|--hash|hash)
+            shift
+            if [ -n "${!SHUB_CONTAINERNAME}" ]; then
+                if [ -n "${!SHUB_NAMEBYCOMMIT}" ]; then
+                    SHUB_NAMEBYHASH="yes"
+                    export SHUB_NAMEBYHASH
+                fi
+            fi 
+            shift
+        ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"
             exit 1

--- a/libexec/cli/pull.help
+++ b/libexec/cli/pull.help
@@ -15,18 +15,6 @@ PULL OPTIONS:
     -H/--hash   Name container based on file hash (second priority)
     
 
-CONTAINER NAME:
-
-    You can also customize the container name by setting an environment variables
-    export SHUB_CONTAINERNAME="meatballs.img"
-
-    Specify to name based on the Github commit associated with the container
-    export SHUB_NAMEBYCOMMIT="yes"
-
-    Specify to name based on the file hash of the container
-    export SHUB_NAMEBYHASH="yes"
-
-
 EXAMPLES:
 
     $ singularity pull shub://vsoch/singularity-images

--- a/libexec/cli/pull.help
+++ b/libexec/cli/pull.help
@@ -4,12 +4,22 @@ pull takes a Singularity Hub (shub) URI and will pull a container
 to PWD. If you want the image to go to SINGULARITY_CACHEDIR, you
 should use one of run, exec, or shell.
 
-note: This command must be executed as root if you intend to operate on
-      a Singularity image.
-
 SUPPORTED URIs:
 
     shub: Pull an image using python from Singularity Hub to $PWD
+
+
+CONTAINER NAME:
+
+    You can customize the container name by setting an environment variables
+    export SHUB_CONTAINERNAME="meatballs.img"
+
+    Specify to name based on the Github commit associated with the container
+    export SHUB_NAMEBYCOMMIT="yes"
+
+    Specify to name based on the file hash of the container
+    export SHUB_NAMEBYHASH="yes"
+
 
 EXAMPLES:
 

--- a/libexec/cli/pull.help
+++ b/libexec/cli/pull.help
@@ -10,12 +10,12 @@ SUPPORTED URIs:
 
 
 PULL OPTIONS:
-    -n/--name   Specify a custom container name
+    -n/--name   Specify a custom container name (first priority)
+    -C/--commit Name container based on Github commit (second priority)
+    -H/--hash   Name container based on file hash (second priority)
     
 
 CONTAINER NAME:
-
-    singularity pull --name "meatballs.img" shub://vsoch/singularity-images
 
     You can also customize the container name by setting an environment variables
     export SHUB_CONTAINERNAME="meatballs.img"
@@ -32,6 +32,10 @@ EXAMPLES:
     $ singularity pull shub://vsoch/singularity-images
       Found image vsoch/singularity-images:mongo
       Downloading image... vsoch-singularity-images-mongo.img
+
+    $ singularity pull --name "meatballs.img" shub://vsoch/singularity-images
+    $ singularity pull --commit shub://vsoch/singularity-images
+    $ singularity pull --hash shub://vsoch/singularity-images
     
 For additional help, please visit our public documentation pages which are
 found at:

--- a/libexec/cli/pull.help
+++ b/libexec/cli/pull.help
@@ -9,9 +9,15 @@ SUPPORTED URIs:
     shub: Pull an image using python from Singularity Hub to $PWD
 
 
+PULL OPTIONS:
+    -n/--name   Specify a custom container name
+    
+
 CONTAINER NAME:
 
-    You can customize the container name by setting an environment variables
+    singularity pull --name "meatballs.img" shub://vsoch/singularity-images
+
+    You can also customize the container name by setting an environment variables
     export SHUB_CONTAINERNAME="meatballs.img"
 
     Specify to name based on the Github commit associated with the container

--- a/libexec/python/README.md
+++ b/libexec/python/README.md
@@ -111,33 +111,38 @@ The default base for the Singularity Hub API, which is `https://singularity-hub.
 The user is empowered to define a custom name for the singularity image downloaded. The first preference goes to specifying an `SHUB_CONTAINERNAME`. For example:
 
 ```bash
-SHUB_CONTAINERNAME='meatballs.img'
-singularity pull vsoch/singularity-images
+export SHUB_CONTAINERNAME="meatballs.img"
+singularity pull shub://vsoch/singularity-images
+...
+Done. Container is at: ./meatballs.img
 ```
 
 **SHUB_NAMEBYCOMMIT**
 Second preference goes to naming the container by commit. If this variable is found in the environment, regardless of the value, it will be done!
 
 ```bash
-SHUB_CONTAINERNAME=
+unset SHUB_CONTAINERNAME
 SHUB_NAMEBYCOMMIT=yesplease
-singularity pull vsoch/singularity-images
+singularity pull shub://vsoch/singularity-images
+Done. Container is at: ./7a75cd7a32192e5d50f267982e0c30aff794076b.img
 ```
 
 **SHUB_NAMEBYHASH**
 Finally, we can name the container based on the file hash.
 
 ```bash
-SHUB_CONTAINERNAME=
-SHUB_NAMEBYCOMMIT=yesplease
-singularity pull vsoch/singularity-images
+unset SHUB_NAMEBYCOMMIT
+SHUB_NAMEBYHASH=yesplease
+singularity pull shub://vsoch/singularity-images
+Done. Container is at: ./a989bc72cb154d007aa47a5034978328.img
 ```
 
 If none of the above are selected, the default is to use the username and reponame
 
 ```bash
-SHUB_NAMEBYCOMMIT=
-singularity pull vsoch/singularity-images
+unset SHUB_NAMEBYHASH
+singularity pull shub://vsoch/singularity-images
+Done. Container is at: ./vsoch-singularity-images-mongo.img
 ```
 
 ### General

--- a/libexec/python/README.md
+++ b/libexec/python/README.md
@@ -107,7 +107,38 @@ Singularity images are imported in entirety (meaning no environmental data to pa
 **SHUB_API_BASE**
 The default base for the Singularity Hub API, which is `https://singularity-hub.org/api`
 
+**SHUB_CONTAINERNAME**
+The user is empowered to define a custom name for the singularity image downloaded. The first preference goes to specifying an `SHUB_CONTAINERNAME`. For example:
 
+```bash
+SHUB_CONTAINERNAME='meatballs.img'
+singularity pull vsoch/singularity-images
+```
+
+**SHUB_NAMEBYCOMMIT**
+Second preference goes to naming the container by commit. If this variable is found in the environment, regardless of the value, it will be done!
+
+```bash
+SHUB_CONTAINERNAME=
+SHUB_NAMEBYCOMMIT=yesplease
+singularity pull vsoch/singularity-images
+```
+
+**SHUB_NAMEBYHASH**
+Finally, we can name the container based on the file hash.
+
+```bash
+SHUB_CONTAINERNAME=
+SHUB_NAMEBYCOMMIT=yesplease
+singularity pull vsoch/singularity-images
+```
+
+If none of the above are selected, the default is to use the username and reponame
+
+```bash
+SHUB_NAMEBYCOMMIT=
+singularity pull vsoch/singularity-images
+```
 
 ### General
 

--- a/libexec/python/README.md
+++ b/libexec/python/README.md
@@ -122,7 +122,7 @@ Second preference goes to naming the container by commit. If this variable is fo
 
 ```bash
 unset SHUB_CONTAINERNAME
-SHUB_NAMEBYCOMMIT=yesplease
+export SHUB_NAMEBYCOMMIT=yesplease
 singularity pull shub://vsoch/singularity-images
 Done. Container is at: ./7a75cd7a32192e5d50f267982e0c30aff794076b.img
 ```
@@ -132,7 +132,7 @@ Finally, we can name the container based on the file hash.
 
 ```bash
 unset SHUB_NAMEBYCOMMIT
-SHUB_NAMEBYHASH=yesplease
+export SHUB_NAMEBYHASH=yesplease
 singularity pull shub://vsoch/singularity-images
 Done. Container is at: ./a989bc72cb154d007aa47a5034978328.img
 ```

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -127,7 +127,9 @@ INCLUDE_CMD = convert2boolean(getenv("SINGULARITY_INCLUDECMD",
 
 SINGULARITY_PULLFOLDER = getenv("SINGULARITY_PULLFOLDER", default=os.getcwd())
 SHUB_API_BASE = "singularity-hub.org/api"
-
+SHUB_NAMEBYHASH = getenv("SHUB_NAMEBYHASH")
+SHUB_NAMEBYCOMMIT = getenv("SHUB_NAMEBYCOMMIT")
+SHUB_CONTAINERNAME = getenv("SHUB_CONTAINERNAME")
 
 #######################################################################
 # Python Internal API URI Handling

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -45,7 +45,7 @@ from base import ApiConnection
 from helpers.json.main import ADD
 
 from defaults import (
-    SHUB_API_BASE,
+    SHUB_API_BASE
 )
 
 from message import bot

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -174,10 +174,11 @@ def get_image_name(manifest,extension='img.gz'):
     :param use_hash: use the image hash instead of name
     '''
     from defaults import SHUB_CONTAINERNAME, SHUB_NAMEBYCOMMIT, SHUB_NAMEBYHASH
-
+   
     # First preference goes to a custom name
     if SHUB_CONTAINERNAME is not None:
-        SHUB_CONTAINERNAME = SHUB_CONTAINERNAME.replace(" ","").strip(".gz").strip('.img')
+        for replace in [" ",".gz",".img"]:
+            SHUB_CONTAINERNAME = SHUB_CONTAINERNAME.replace(replace,"")
         image_name = "%s.%s" %(SHUB_CONTAINERNAME,extension)
 
     # Second preference goes to commit
@@ -186,7 +187,7 @@ def get_image_name(manifest,extension='img.gz'):
 
     elif SHUB_NAMEBYHASH is not None:
         image_url = os.path.basename(unquote(manifest['image']))
-        image_name = re.findall(".+[.]%s" %(extension),image_url)
+        image_name = re.findall(".+[.]%s" %(extension),image_url)[0]
     
     # Default uses the image name-branch
     else:

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -45,7 +45,7 @@ from base import ApiConnection
 from helpers.json.main import ADD
 
 from defaults import (
-    SHUB_API_BASE
+    SHUB_API_BASE,
 )
 
 from message import bot
@@ -143,7 +143,7 @@ class SingularityApiConnection(ApiConnection):
         :param manifest: the manifest obtained with get_manifest
         :param download_folder: the folder to download to, if None, will be pwd
         :param extract: if True, will extract image to .img and return that.
-        '''    
+        '''
         image_file = get_image_name(manifest)
 
         if not bot.is_quiet():
@@ -168,27 +168,35 @@ class SingularityApiConnection(ApiConnection):
 
 
 # Various Helpers ---------------------------------------------------------------------------------
-def get_image_name(manifest,extension='img.gz',use_hash=False):
+def get_image_name(manifest,extension='img.gz'):
     '''get_image_name will return the image name for a manifest
     :param manifest: the image manifest with 'image' as key with download link
     :param use_hash: use the image hash instead of name
     '''
-    if not use_hash:
-        image_name = "%s-%s.%s" %(manifest['name'].replace('/','-'),
-                                  manifest['branch'].replace('/','-'),
-                                  extension)
-    else:
+    from defaults import SHUB_CONTAINERNAME, SHUB_NAMEBYCOMMIT, SHUB_NAMEBYHASH
+
+    # First preference goes to a custom name
+    if SHUB_CONTAINERNAME is not None:
+        SHUB_CONTAINERNAME = SHUB_CONTAINERNAME.replace(" ","").strip(".gz").strip('.img')
+        image_name = "%s.%s" %(SHUB_CONTAINERNAME,extension)
+
+    # Second preference goes to commit
+    elif SHUB_NAMEBYCOMMIT is not None:
+        image_name = "%s.%s" %(manifest['version'],extension)
+
+    elif SHUB_NAMEBYHASH is not None:
         image_url = os.path.basename(unquote(manifest['image']))
         image_name = re.findall(".+[.]%s" %(extension),image_url)
-        if len(image_name) > 0:
-            image_name = image_name[0]
-        else:
-            bot.error("Singularity Hub Image not found with expected extension %s, exiting." %extension)
-            sys.exit(1)
-          
+    
+    # Default uses the image name-branch
+    else:
+        image_name = "%s-%s.%s" %(manifest['name'].replace('/','-'),
+                                  manifest['branch'].replace('/','-'),
+                                  extension)          
     if not bot.is_quiet():
         print("Singularity Hub Image: %s" %image_name)
     return image_name
+
 
 
 def extract_metadata(manifest,labelfile=None,prefix=None):

--- a/libexec/python/tests/test_shub.py
+++ b/libexec/python/tests/test_shub.py
@@ -135,13 +135,6 @@ class TestApi(TestCase):
         self.assertEqual('vsoch-singularity-images-master.img.gz',
                          image_name)
 
-        print("Case 2: ask for hash, but with invalid extension")
-        with self.assertRaises(SystemExit) as cm:
-            image_name = get_image_name(manifest,
-                                        extension='.bz2',
-                                        use_hash=True)
-        self.assertEqual(cm.exception.code, 1)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #573 

This PR will allow the user to specify the singularity hub image name to be pulled by way of environment variables. Essentially, the following three variables are looked for, with preference for this order:

 -  `SHUB_CONTAINERNAME`: will allow the user to define a custom name
 - `SHUB_NAMEBYCOMMIT`: if found, will name the container based on it's github commit
 - `SHUB_NAMEBYHASH`: if found, will name the container based on the hash of the file

It works as follows:

```bash
export SHUB_CONTAINERNAME="meatballs.img"
singularity pull shub://vsoch/singularity-images
...
Done. Container is at: ./meatballs.img
```

Second preference goes to naming the container by commit. If this variable is found in the environment, regardless of the value, it will be done!

```bash
unset SHUB_CONTAINERNAME
export SHUB_NAMEBYCOMMIT=yesplease
singularity pull shub://vsoch/singularity-images
Done. Container is at: ./7a75cd7a32192e5d50f267982e0c30aff794076b.img
```

Finally, we can name the container based on the file hash.

```bash
unset SHUB_NAMEBYCOMMIT
export SHUB_NAMEBYHASH=yesplease
singularity pull shub://vsoch/singularity-images
Done. Container is at: ./a989bc72cb154d007aa47a5034978328.img
```

If none of the above are selected, the default is to use the username and reponame (what we have now)

```bash
unset SHUB_NAMEBYHASH
singularity pull shub://vsoch/singularity-images
Done. Container is at: ./vsoch-singularity-images-mongo.img
```



@singularityware-admin
