### PR TITLE
Adding permission o+w to all in memory tars, and verbose progress bar

### DIFF
--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -93,7 +93,7 @@ class ApiConnection(object):
         if 'Content-Length' in response.headers and response.code not in [400,401]:
             progress = 0
             content_size = int(response.headers['Content-Length'])
-            bot.show_progress(progress,content_size,length=50)
+            bot.show_progress(progress,content_size,length=50,suffix=bot.coffee)
 
         chunk_size = 1 << 20
         with open(file_name, 'wb') as filey:
@@ -102,14 +102,15 @@ class ApiConnection(object):
                 if not chunk: 
                     break
                 try:
+
                     filey.write(chunk)
                     if content_size is not None:
                         progress+=chunk_size
                         bot.show_progress(iteration=progress,
                                           total=content_size,
                                           length=50,
-                                          min_level=0,
-                                          carriage_return=False)
+                                          carriage_return=False,
+                                          suffix=bot.coffee)
                 except Exception as error:
                     bot.error("Error writing to %s: %s exiting" %(file_name,error))
                     sys.exit(1)

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -93,7 +93,7 @@ class ApiConnection(object):
         if 'Content-Length' in response.headers and response.code not in [400,401]:
             progress = 0
             content_size = int(response.headers['Content-Length'])
-            bot.show_progress(progress,content_size,length=50,suffix=bot.coffee)
+            bot.show_progress(progress,content_size,length=40,suffix="downloading layer")
 
         chunk_size = 1 << 20
         with open(file_name, 'wb') as filey:
@@ -108,9 +108,9 @@ class ApiConnection(object):
                         progress+=chunk_size
                         bot.show_progress(iteration=progress,
                                           total=content_size,
-                                          length=50,
+                                          length=40,
                                           carriage_return=False,
-                                          suffix=bot.coffee)
+                                          suffix="downloading layer")
                 except Exception as error:
                     bot.error("Error writing to %s: %s exiting" %(file_name,error))
                     sys.exit(1)
@@ -210,12 +210,12 @@ class ApiConnection(object):
             response = self.stream(url,file_name=tmp_file,headers=headers)
             os.rename(tmp_file, file_name)
         except:
-             download_folder = os.path.dirname(os.path.abspath(file_name))
-             bot.error("Error downloading %s. Do you have permission to write to %s?" %(url, download_folder))
-             try:
-                 os.remove(tmp_file)
-             except:
-                 pass
-             sys.exit(1)
+            download_folder = os.path.dirname(os.path.abspath(file_name))
+            bot.error("Error downloading %s. Do you have permission to write to %s?" %(url, download_folder))
+            try:
+                os.remove(tmp_file)
+            except:
+                pass
+            sys.exit(1)
 
         return file_name

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -66,13 +66,16 @@ class ApiConnection(object):
 
 
 
-    def stream(self,url,file_name,data=None,headers=None,default_headers=True):
+    def stream(self,url,file_name,data=None,headers=None,default_headers=True,suffix=None):
         '''stream is a get that will stream to file_name
         :param data: a dictionary of key:value items to add to the data args variable
         :param url: the url to get
         :returns response: the requests response object, or stream        
         '''
         bot.debug("GET (stream) %s" %url)
+
+        if suffix is None:
+            suffix = "downloading layer"
 
         # If we use default headers, start with client's
         request_headers = dict()
@@ -93,7 +96,7 @@ class ApiConnection(object):
         if 'Content-Length' in response.headers and response.code not in [400,401]:
             progress = 0
             content_size = int(response.headers['Content-Length'])
-            bot.show_progress(progress,content_size,length=40,suffix="downloading layer")
+            bot.show_progress(progress,content_size,length=40,suffix=suffix)
 
         chunk_size = 1 << 20
         with open(file_name, 'wb') as filey:
@@ -110,7 +113,7 @@ class ApiConnection(object):
                                           total=content_size,
                                           length=40,
                                           carriage_return=False,
-                                          suffix="downloading layer")
+                                          suffix=suffix)
                 except Exception as error:
                     bot.error("Error writing to %s: %s exiting" %(file_name,error))
                     sys.exit(1)
@@ -197,7 +200,7 @@ class ApiConnection(object):
         return request
 
 
-    def download_atomically(self,url,file_name,headers=None):
+    def download_atomically(self,url,file_name,headers=None,suffix=None):
         '''download stream atomically will stream to a temporary file, and
         rename only upon successful completion. This is to ensure that
         errored downloads are not found as complete in the cache
@@ -207,7 +210,7 @@ class ApiConnection(object):
         '''
         try:
             tmp_file = "%s.%s" %(file_name,next(tempfile._get_candidate_names()))
-            response = self.stream(url,file_name=tmp_file,headers=headers)
+            response = self.stream(url,file_name=tmp_file,headers=headers,suffix=suffix)
             os.rename(tmp_file, file_name)
         except:
             download_folder = os.path.dirname(os.path.abspath(file_name))

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -31,9 +31,8 @@ from base import ApiConnection
 from sutils import (
     add_http,
     get_cache,
-    check_tar_permissions,
+    change_tar_permissions,
     create_tar,
-    write_file, 
     write_singularity_infos
 )
 
@@ -44,7 +43,6 @@ from defaults import (
     DOCKER_PREFIX,
     ENV_BASE,
     LABELFILE,
-    METADATA_BASE,
     METADATA_FOLDER_NAME,
     RUNSCRIPT_COMMAND_ASIS
 )
@@ -271,7 +269,7 @@ class DockerApiConnection(ApiConnection):
 
         # Fix permissions step 2
         try:
-            finished_tar = check_tar_permissions(tar_download)
+            finished_tar = change_tar_permissions(tar_download)
             os.rename(finished_tar,download_folder)
         except:
             bot.error("Cannot untar layer %s, was there a problem with download?" %tar_download)

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -255,11 +255,13 @@ class DockerApiConnection(ApiConnection):
         base = "%s/%s/%s/%s/blobs/%s" %(registry,self.api_version,self.namespace,self.repo_name,image_id)
         bot.verbose("Downloading layers from %s" %base)
     
-        if download_folder is not None:
-            download_folder = "%s/%s.tar.gz" %(download_folder,image_id)
+        if download_folder is None:        
+            download_folder = tempfile.mkdtemp()
 
-            # Update user what we are doing
-            bot.info("Downloading layer %s" %image_id)
+        download_folder = "%s/%s.tar.gz" %(download_folder,image_id)
+
+        # Update user what we are doing
+        bot.info("Downloading layer %s" %image_id)
 
         # Download the layer atomically, step 1
         file_name = "%s.%s" %(download_folder,next(tempfile._get_candidate_names()))

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -32,7 +32,7 @@ from sutils import (
 from .api import (
     DockerApiConnection,
     extract_runscript,
-    extract_metadata_tar,
+    extract_metadata_tar
 )
 
 from message import bot

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -21,31 +21,21 @@ perform publicly and display publicly, and to permit other to do so.
 
 '''
 
-import sys
 import os
 from defaults import INCLUDE_CMD
 
 from sutils import (
-    check_tar_permissions,
-    extract_tar,
     get_cache, 
     write_file
 )
 
 from .api import (
     DockerApiConnection,
-    extract_env,
-    extract_labels,
     extract_runscript,
     extract_metadata_tar,
 )
 
 from message import bot
-import json
-import shutil
-import re
-import os
-import tempfile
 
 
 def SIZE(image,auth=None,contentfile=None):

--- a/libexec/python/helpers/json/add.py
+++ b/libexec/python/helpers/json/add.py
@@ -35,12 +35,8 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)))
 
 import optparse
-import pickle
-from glob import glob
 from helpers.json.main import ADD
 from message import bot
-import os
-import sys
 
 def get_parser():
 

--- a/libexec/python/helpers/json/delete.py
+++ b/libexec/python/helpers/json/delete.py
@@ -34,12 +34,8 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)))
 
 import optparse
-import pickle
-from glob import glob
 from helpers.json.main import DELETE
 from message import bot
-import os
-import sys
 
 def get_parser():
 

--- a/libexec/python/helpers/json/dump.py
+++ b/libexec/python/helpers/json/dump.py
@@ -33,12 +33,8 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)))
 
 import optparse
-import pickle
-from glob import glob
 from helpers.json.main import DUMP
 from message import bot
-import os
-import sys
 
 def get_parser():
 

--- a/libexec/python/helpers/json/get.py
+++ b/libexec/python/helpers/json/get.py
@@ -34,12 +34,8 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)))
 
 import optparse
-import pickle
-from glob import glob
 from helpers.json.main import GET
 from message import bot
-import os
-import sys
 
 def get_parser():
 

--- a/libexec/python/helpers/json/main.py
+++ b/libexec/python/helpers/json/main.py
@@ -33,8 +33,6 @@ from sutils import (
 from message import bot
 import json
 import re
-import os
-import tempfile
 
 
 def DUMP(jsonfile):

--- a/libexec/python/import.py
+++ b/libexec/python/import.py
@@ -46,8 +46,6 @@ from shell import (
 
 from defaults import getenv
 from message import bot
-import os
-import sys
 
 
 def main():

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -76,6 +76,13 @@ class SingularityMessage:
         self.errorStream = sys.stderr
         self.outputStream = sys.stdout        
 
+        self.coffee = u"\u26FE"
+        self.star = u"\u2605"
+        self.whitestar = u"\u2606"
+        self.sun =  u"\u2600"
+        self.skull = u"\u2620"
+        self.warning = u"\u2622"
+
     def emitError(self,level):
         '''determine if a level should print to
         stderr, includes all levels but INFO and QUIET'''
@@ -152,7 +159,7 @@ class SingularityMessage:
         
 
 
-    def show_progress(self,iteration,total,length=100,min_level=1,carriage_return=True):
+    def show_progress(self,iteration,total,length=100,min_level=0,carriage_return=True,suffix=None):
         '''create a terminal progress bar, default bar shows for verbose+
         :param iteration: current iteration (Int)
         :param total: total iterations (Int)
@@ -161,17 +168,21 @@ class SingularityMessage:
         percent = 100 * (iteration / float(total))
         progress = int(length * iteration // total)
 
+        if suffix is None:
+            suffix = ''
+
         # Download sizes can be imperfect, setting carriage_return to False
         # and writing newline with caller cleans up the UI
         if percent >= 100:
-            progress = percent = 100
+            percent = 100
+            progress = length
 
         bar = '█' * progress + '-' * (length - progress)
 
         # Only show progress bar for level > min_level
         if self.level > min_level:
             percent = ("{0:.1f}").format(percent)
-            sys.stdout.write('\rProgress |%s| %s%s' % (bar, percent, '%')),
+            sys.stdout.write('\rProgress |%s| %s%s %s  ' % (bar, percent, '%', suffix)),
             if iteration == total and carriage_return: 
                 sys.stdout.write('\n')
             sys.stdout.flush()
@@ -182,9 +193,11 @@ class SingularityMessage:
         self.emit(ABRT,message,'ABRT')        
 
     def error(self,message):
+        message = "%s %s" %(message,self.skull)
         self.emit(ERROR,message,'ERROR')        
 
     def warning(self,message):
+        message = "%s %s" %(message,self.warning)
         self.emit(WARNING,message,'WARNING')        
 
     def log(self,message):

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -81,7 +81,7 @@ class SingularityMessage:
         self.whitestar = u"\u2606"
         self.sun =  u"\u2600"
         self.skull = u"\u2620"
-        self.warning = u"\u2622"
+        self.radioactive = u"\u2622"
 
     def emitError(self,level):
         '''determine if a level should print to
@@ -207,7 +207,7 @@ class SingularityMessage:
         self.emit(ERROR,message,'ERROR')        
 
     def warning(self,message):
-        message = "%s %s" %(message,self.warning)
+        message = "%s %s" %(message,self.radioactive)
         self.emit(WARNING,message,'WARNING')        
 
     def log(self,message):

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -163,7 +163,8 @@ class SingularityMessage:
         
 
 
-    def show_progress(self,iteration,total,length=100,min_level=0,carriage_return=True,suffix=None):
+    def show_progress(self,iteration,total,length=100,min_level=0,
+                      carriage_return=True,suffix=None,symbol=None):
         '''create a terminal progress bar, default bar shows for verbose+
         :param iteration: current iteration (Int)
         :param total: total iterations (Int)
@@ -181,7 +182,9 @@ class SingularityMessage:
             percent = 100
             progress = length
 
-        bar = '█' * progress + '-' * (length - progress)
+        if symbol is None:
+            symbol = '='
+        bar = symbol * progress + '>' + '-' * (length - progress - 1)
 
         # Only show progress bar for level > min_level
         if self.level > min_level:

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -141,12 +141,22 @@ class SingularityMessage:
         # Otherwise if in range print to stdout and stderr
         elif self.isEnabledFor(level):
             if self.emitError(level):
-                self.errorStream.write(message)
+                self.write(self.errorStream,message)
             else:
-                self.outputStream.write(message)
+                self.write(self.outputStream,message)
 
         # Add all log messages to history
         self.history.append(message)
+
+
+    def write(self,stream,message):
+        '''write will write a message to a stream, making sure
+        to fix the encoding if it errors
+        '''
+        try:
+            stream.write(message)
+        except:
+            stream.write(message.encode('utf-8'))
 
 
     def get_logs(self,join_newline=True):

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -77,8 +77,7 @@ class SingularityMessage:
         self.outputStream = sys.stdout
 
         # Encodings        
-        self.get_encoding()
-        self.utf8 = ['utf-8','utf8']
+        self.utf8 = ['utf-8','utf8','UTF-8','UTF8']
 
         self.coffee = '\u26FE'
         self.star = '\u2605'
@@ -86,14 +85,6 @@ class SingularityMessage:
         self.sun =  '\u2600'
         self.skull = '\u2620'
         self.radioactive = '\u2622'
-
-    def get_encoding(self):
-        '''get_encoding attempts to find the encoding of the
-        stdout. If None, assumes is not utf-8
-        '''
-        self.encoding = sys.stdout.encoding
-        if self.encoding is not None:
-            self.encoding = self.encoding.lower()
 
 
     def emitError(self,level):
@@ -163,12 +154,12 @@ class SingularityMessage:
 
 
     def write(self,stream,message):
-        '''write will write a message to a stream, making sure
-        to fix the encoding if it errors
+        '''write will write a message to a stream, 
+        first checking the encoding
         '''
-        try:
+        if stream.encoding in self.utf8:
             stream.write(message)
-        except:
+        else:
             stream.write(message.encode('utf-8'))
 
 
@@ -191,7 +182,7 @@ class SingularityMessage:
         percent = 100 * (iteration / float(total))
         progress = int(length * iteration // total)
 
-        if suffix is None or self.encoding not in self.utf8:
+        if suffix is None or sys.stdout.encoding not in self.utf8:
             suffix = ''
 
         # Download sizes can be imperfect, setting carriage_return to False
@@ -216,12 +207,12 @@ class SingularityMessage:
         self.emit(ABRT,message,'ABRT')        
 
     def error(self,message):
-        if self.encoding in self.utf8:
+        if sys.stderr.encoding in self.utf8:
             message = "%s %s" %(message,self.skull)
         self.emit(ERROR,message,'ERROR')        
 
     def warning(self,message):
-        if self.encoding in self.utf8:
+        if sys.stderr.encoding in self.utf8:
             message = "%s %s" %(message,self.radioactive)
         self.emit(WARNING,message,'WARNING')        
 

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -74,7 +74,11 @@ class SingularityMessage:
         self.level = get_logging_level()
         self.history = []
         self.errorStream = sys.stderr
-        self.outputStream = sys.stdout        
+        self.outputStream = sys.stdout
+
+        # Encodings        
+        self.encoding = sys.stdout.encoding.lower()
+        self.utf8 = ['utf-8','utf8']
 
         self.coffee = '\u26FE'
         self.star = '\u2605'
@@ -178,7 +182,7 @@ class SingularityMessage:
         percent = 100 * (iteration / float(total))
         progress = int(length * iteration // total)
 
-        if suffix is None:
+        if suffix is None or self.encoding in ['utf-8']:
             suffix = ''
 
         # Download sizes can be imperfect, setting carriage_return to False
@@ -203,11 +207,13 @@ class SingularityMessage:
         self.emit(ABRT,message,'ABRT')        
 
     def error(self,message):
-        message = "%s %s" %(message,self.skull)
+        if self.encoding in self.utf8:
+            message = "%s %s" %(message,self.skull)
         self.emit(ERROR,message,'ERROR')        
 
     def warning(self,message):
-        message = "%s %s" %(message,self.radioactive)
+        if self.encoding in self.utf8:
+            message = "%s %s" %(message,self.radioactive)
         self.emit(WARNING,message,'WARNING')        
 
     def log(self,message):

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -75,17 +75,7 @@ class SingularityMessage:
         self.history = []
         self.errorStream = sys.stderr
         self.outputStream = sys.stdout
-
-        # Encodings        
-        self.utf8 = ['utf-8','utf8','UTF-8','UTF8']
-
-        self.coffee = '\u26FE'
-        self.star = '\u2605'
-        self.whitestar = '\u2606'
-        self.sun =  '\u2600'
-        self.skull = '\u2620'
-        self.radioactive = '\u2622'
-
+        self.utf8 = ['UTF-8','utf-8','UTF8','utf8']
 
     def emitError(self,level):
         '''determine if a level should print to
@@ -182,7 +172,7 @@ class SingularityMessage:
         percent = 100 * (iteration / float(total))
         progress = int(length * iteration // total)
 
-        if suffix is None or sys.stdout.encoding not in self.utf8:
+        if suffix is None:
             suffix = ''
 
         # Download sizes can be imperfect, setting carriage_return to False
@@ -207,13 +197,9 @@ class SingularityMessage:
         self.emit(ABRT,message,'ABRT')        
 
     def error(self,message):
-        if sys.stderr.encoding in self.utf8:
-            message = "%s %s" %(message,self.skull)
         self.emit(ERROR,message,'ERROR')        
 
     def warning(self,message):
-        if sys.stderr.encoding in self.utf8:
-            message = "%s %s" %(message,self.radioactive)
         self.emit(WARNING,message,'WARNING')        
 
     def log(self,message):

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -77,7 +77,7 @@ class SingularityMessage:
         self.outputStream = sys.stdout
 
         # Encodings        
-        self.encoding = sys.stdout.encoding.lower()
+        self.get_encoding()
         self.utf8 = ['utf-8','utf8']
 
         self.coffee = '\u26FE'
@@ -86,6 +86,15 @@ class SingularityMessage:
         self.sun =  '\u2600'
         self.skull = '\u2620'
         self.radioactive = '\u2622'
+
+    def get_encoding(self):
+        '''get_encoding attempts to find the encoding of the
+        stdout. If None, assumes is not utf-8
+        '''
+        self.encoding = sys.stdout.encoding
+        if self.encoding is not None:
+            self.encoding = self.encoding.lower()
+
 
     def emitError(self,level):
         '''determine if a level should print to

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -76,12 +76,12 @@ class SingularityMessage:
         self.errorStream = sys.stderr
         self.outputStream = sys.stdout        
 
-        self.coffee = u"\u26FE"
-        self.star = u"\u2605"
-        self.whitestar = u"\u2606"
-        self.sun =  u"\u2600"
-        self.skull = u"\u2620"
-        self.radioactive = u"\u2622"
+        self.coffee = '\u26FE'
+        self.star = '\u2605'
+        self.whitestar = '\u2606'
+        self.sun =  '\u2600'
+        self.skull = '\u2620'
+        self.radioactive = '\u2622'
 
     def emitError(self,level):
         '''determine if a level should print to

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 '''
 
 message.py: simple logger for Singularity python helper

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -149,6 +149,33 @@ class SingularityMessage:
         return self.history
         
 
+
+    def show_progress(self,iteration,total,length=100,min_level=1,carriage_return=True):
+        '''create a terminal progress bar, default bar shows for verbose+
+        :param iteration: current iteration (Int)
+        :param total: total iterations (Int)
+        :param length: character length of bar (Int)
+        '''
+        percent = 100 * (iteration / float(total))
+        progress = int(length * iteration // total)
+
+        # Download sizes can be imperfect, setting carriage_return to False
+        # and writing newline with caller cleans up the UI
+        if percent >= 100:
+            progress = percent = 100
+
+        bar = '█' * progress + '-' * (length - progress)
+
+        # Only show progress bar for level > min_level
+        if self.level > min_level:
+            percent = ("{0:.1f}").format(percent)
+            sys.stdout.write('\rProgress |%s| %s%s' % (bar, percent, '%')),
+            if iteration == total and carriage_return: 
+                sys.stdout.write('\n')
+            sys.stdout.flush()
+
+
+
     def abort(self,message):
         self.emit(ABRT,message,'ABRT')        
 

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -182,7 +182,7 @@ class SingularityMessage:
         percent = 100 * (iteration / float(total))
         progress = int(length * iteration // total)
 
-        if suffix is None or self.encoding in ['utf-8']:
+        if suffix is None or self.encoding not in self.utf8:
             suffix = ''
 
         # Download sizes can be imperfect, setting carriage_return to False

--- a/libexec/python/pull.py
+++ b/libexec/python/pull.py
@@ -34,7 +34,6 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 import sys
-import os
 
 from shell import (
     get_image_uri,
@@ -42,7 +41,6 @@ from shell import (
 )
 
 from message import bot
-import os
 import sys
 
 

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -153,7 +153,8 @@ class SingularityApiConnection(ApiConnection):
 
         # Download image file atomically, streaming
         image_file = self.download_atomically(url=url,
-                                              file_name=image_file)
+                                              file_name=image_file,
+                                              suffix="downloading image")
 
         if extract == True:
             if not bot.is_quiet():

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -35,9 +35,7 @@ from shell import (
 from sutils import (
     add_http,
     is_number,
-    read_file,
-    write_file,
-    write_singularity_infos
+    read_file
 )
 
 from base import ApiConnection
@@ -50,7 +48,6 @@ from defaults import (
 
 from message import bot
 import json
-import os
 import re
 
 try:

--- a/libexec/python/shub/main.py
+++ b/libexec/python/shub/main.py
@@ -34,7 +34,6 @@ from .api import (
 )
 
 from sutils import (
-    add_http,
     get_cache,
     write_file
 )
@@ -45,7 +44,6 @@ from message import bot
 import json
 import re
 import os
-import tempfile
 
 
 def SIZE(image,contentfile=None):

--- a/libexec/python/size.py
+++ b/libexec/python/size.py
@@ -34,7 +34,6 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 import sys
-import os
 
 from shell import (
     get_image_uri,

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -125,19 +125,17 @@ def is_number(image):
 
 
 
-def show_progress(iteration,total,decimals=1,length=100,fill='█'):
+def show_progress(iteration,total,length=100,fill='█'):
     '''create a terminal progress bar
     :param iteration: current iteration (Int)
     :param total: total iterations (Int)
-    :param decimals: positive number of decimals in percent complete (Int)
     :para, length: character length of bar (Int)
     :param fill: bar fill character (Str)
     '''
-    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
-    filledLength = int(length * iteration // total)
-    bar = fill * filledLength + '-' * (length - filledLength)
-    print('\r%s |%s| %s%% %s' % (prefix, bar, percent, suffix), end = '\r')
-    # Print New Line on Complete
+    percent = ("{0:.1f}").format(100 * (iteration / float(total)))
+    progress = int(length * iteration // total)
+    bar = fill * progress + '-' * (length - progress)
+    print('\rProgress |%s| %s%%' % (bar, percent), end = '\r')
     if iteration == total: 
         print()
 
@@ -332,10 +330,11 @@ def check_tar_permissions(tar_file,permission=None):
     bot.verbose3("Fixing permission for %s" %(tar_file))
     
     ii=0
-    count = len(tar.members)
+    members = tar.getmembers()
+    count = len(members)
 
     show_progress(ii, count,length=50)
-    for member in tar:  
+    for member in members:  
         if member.isdir() or member.isfile() and not member.issym():
             member.mode = permission | member.mode
             extracted = tar.extractfile(member)        

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -126,18 +126,16 @@ def is_number(image):
 
 
 def show_progress(iteration,total,decimals=1,length=100,fill='█'):
-    '''
-    Call in a loop to create terminal progress bar
-    @params:
-        iteration   - Required  : current iteration (Int)
-        total       - Required  : total iterations (Int)
-        decimals    - Optional  : positive number of decimals in percent complete (Int)
-        length      - Optional  : character length of bar (Int)
-        fill        - Optional  : bar fill character (Str)
+    '''create a terminal progress bar
+    :param iteration: current iteration (Int)
+    :param total: total iterations (Int)
+    :param decimals: positive number of decimals in percent complete (Int)
+    :para, length: character length of bar (Int)
+    :param fill: bar fill character (Str)
     '''
     percent = ("{0:.%sf}" %str(decimals)).format(100 * (iteration / float(total)))
     progress = int(length * iteration // total)
-    bar = fill * progress + '-' * (length - filledLength)
+    bar = fill * progress + '-' * (length - progress)
     print('\rProgress |%s| %s%%' % (bar, percent), end = '\r')
     if iteration == total: 
         print()

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -21,7 +21,7 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 from defaults import (
-    SINGULARITY_CACHE,
+    SINGULARITY_CACHE
 )
 from message import bot
 import datetime

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -135,9 +135,9 @@ def show_progress(iteration,total,length=100,fill='█'):
     percent = ("{0:.1f}").format(100 * (iteration / float(total)))
     progress = int(length * iteration // total)
     bar = fill * progress + '-' * (length - progress)
-    print('\rProgress |%s| %s%%' % (bar, percent), end = '\r')
+    bot.verbose('\rProgress |%s| %s%%' % (bar, percent), end = '\r')
     if iteration == total: 
-        print()
+        bot.verbose()
 
 
 
@@ -310,8 +310,8 @@ def has_permission(file_path,permission=None):
     return False
 
 
-def check_tar_permissions(tar_file,permission=None):
-    '''check_tar_permissions changes a permission if 
+def change_tar_permissions(tar_file,permission=None):
+    '''change_tar_permissions changes a permission if 
     any member in a tarfile file does not have it
     :param file_path the path to the file
     :param permission: the stat permission to use
@@ -327,13 +327,14 @@ def check_tar_permissions(tar_file,permission=None):
         permission = stat.S_IWUSR
 
     # Add owner write permission to all, not symlinks
-    bot.verbose3("Fixing permission for %s" %(tar_file))
+    bot.verbose("Fixing permission for %s" %(tar_file))
     
-    ii=0
     members = tar.getmembers()
-    count = len(members)
 
-    show_progress(ii, count,length=50)
+    ii=0
+    count = len(members)
+    show_progress(ii,count,length=50)
+
     for member in members:  
         if member.isdir() or member.isfile() and not member.issym():
             member.mode = permission | member.mode
@@ -341,8 +342,10 @@ def check_tar_permissions(tar_file,permission=None):
             fixed_tar.addfile(member, extracted)
         else:    
             fixed_tar.addfile(member)
+
         ii += 1
-        show_progress(ii, count,length = 50)
+        show_progress(ii,count,length=50)
+
 
     fixed_tar.close()
     tar.close()

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -325,7 +325,7 @@ def change_tar_permissions(tar_file,file_permission=None,folder_permission=None)
 
     ii=0
     count = len(members)
-    bot.show_progress(ii,count,length=50)
+    bot.show_progress(ii,count,length=50,suffix=bot.coffee)
 
     for member in members:  
 
@@ -344,7 +344,7 @@ def change_tar_permissions(tar_file,file_permission=None,folder_permission=None)
             fixed_tar.addfile(member)
 
         ii += 1
-        bot.show_progress(ii,count,length=50)
+        bot.show_progress(ii,count,length=50,suffix=bot.coffee)
 
 
     fixed_tar.close()

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -132,7 +132,7 @@ def show_progress(iteration,total,length=100,fill='█'):
     percent = ("{0:.1f}").format(100 * (iteration / float(total)))
     progress = int(length * iteration // total)
     bar = fill * progress + '-' * (length - progress)
-    bot.verbose('\rProgress |%s| %s%%' % (bar, percent), end = '\r')
+    bot.verbose('\rProgress |%s| %s%%\r' % (bar, percent))
     if iteration == total: 
         bot.verbose()
 

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -22,7 +22,6 @@ perform publicly and display publicly, and to permit other to do so.
 
 from defaults import (
     SINGULARITY_CACHE,
-    DISABLE_CACHE
 )
 from message import bot
 import datetime
@@ -30,10 +29,8 @@ import errno
 import hashlib
 import json
 import os
-import shutil
 import subprocess
 import stat
-from stat import ST_MODE
 import sys
 import tempfile
 import tarfile

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -325,7 +325,7 @@ def change_tar_permissions(tar_file,file_permission=None,folder_permission=None)
 
     ii=0
     count = len(members)
-    bot.show_progress(ii,count,length=50,suffix=bot.coffee)
+    bot.show_progress(ii,count,length=40,suffix="changing permissions")
 
     for member in members:  
 
@@ -344,7 +344,7 @@ def change_tar_permissions(tar_file,file_permission=None,folder_permission=None)
             fixed_tar.addfile(member)
 
         ii += 1
-        bot.show_progress(ii,count,length=50,suffix=bot.coffee)
+        bot.show_progress(ii,count,length=40,suffix="changing permissions")
 
 
     fixed_tar.close()

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -133,10 +133,11 @@ def show_progress(iteration,total,decimals=1,length=100,fill='█'):
     :para, length: character length of bar (Int)
     :param fill: bar fill character (Str)
     '''
-    percent = ("{0:.%sf}" %str(decimals)).format(100 * (iteration / float(total)))
-    progress = int(length * iteration // total)
-    bar = fill * progress + '-' * (length - progress)
-    print('\rProgress |%s| %s%%' % (bar, percent), end = '\r')
+    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+    filledLength = int(length * iteration // total)
+    bar = fill * filledLength + '-' * (length - filledLength)
+    print('\r%s |%s| %s%% %s' % (prefix, bar, percent, suffix), end = '\r')
+    # Print New Line on Complete
     if iteration == total: 
         print()
 

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -132,9 +132,12 @@ def show_progress(iteration,total,length=100,fill='█'):
     percent = ("{0:.1f}").format(100 * (iteration / float(total)))
     progress = int(length * iteration // total)
     bar = fill * progress + '-' * (length - progress)
-    bot.verbose('\rProgress |%s| %s%%\r' % (bar, percent))
-    if iteration == total: 
-        bot.verbose()
+
+    # Only show progress bar for level verbose
+    if bot.level > 1:
+        print('\rProgress |%s| %s%%' % (bar, percent), end="\r")
+        if iteration == total: 
+            print()
 
 
 

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -124,7 +124,7 @@ def is_number(image):
 
 
 
-def show_progress(iteration,total,length=100,fill='█'):
+def show_progress(iteration,total,length=100):
     '''create a terminal progress bar
     :param iteration: current iteration (Int)
     :param total: total iterations (Int)
@@ -133,13 +133,14 @@ def show_progress(iteration,total,length=100,fill='█'):
     '''
     percent = ("{0:.1f}").format(100 * (iteration / float(total)))
     progress = int(length * iteration // total)
-    bar = fill * progress + '-' * (length - progress)
+    bar = '█' * progress + '-' * (length - progress)
 
     # Only show progress bar for level verbose
     if bot.level > 1:
-        print('\rProgress |%s| %s%%' % (bar, percent), end="\r")
+        sys.stdout.write('\rProgress |%s| %s%s' % (bar, percent, '%')),
         if iteration == total: 
-            print()
+            sys.stdout.write('\n')
+        sys.stdout.flush()
 
 
 

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -125,6 +125,23 @@ def is_number(image):
 
 
 
+def show_progress(iteration,total,decimals=1,length=100,fill='█'):
+    '''
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+    '''
+    percent = ("{0:.%sf}" %str(decimals)).format(100 * (iteration / float(total)))
+    progress = int(length * iteration // total)
+    bar = fill * progress + '-' * (length - filledLength)
+    print('\rProgress |%s| %s%%' % (bar, percent), end = '\r')
+    if iteration == total: 
+        print()
+
 
 
 ############################################################################
@@ -312,16 +329,22 @@ def check_tar_permissions(tar_file,permission=None):
     if permission == None:
         permission = stat.S_IWUSR
 
-    # Check permissions for folders, not symlinks
+    # Add owner write permission to all, not symlinks
+    bot.verbose3("Fixing permission for %s" %(tar_file))
+    
+    ii=0
+    count = len(tar.members)
+
+    show_progress(ii, count,length=50)
     for member in tar:  
         if member.isdir() or member.isfile() and not member.issym():
-            if not has_permission(member,permission):
-                bot.verbose3("Fixing permission for %s" %(member.name))
-                member.mode = permission | member.mode
+            member.mode = permission | member.mode
             extracted = tar.extractfile(member)        
             fixed_tar.addfile(member, extracted)
         else:    
             fixed_tar.addfile(member)
+        ii += 1
+        show_progress(ii, count,length = 50)
 
     fixed_tar.close()
     tar.close()

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 '''
 utils.py: python helper for singularity command line tool
 

--- a/libexec/python/templates.py
+++ b/libexec/python/templates.py
@@ -21,10 +21,6 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 from message import bot
-import tempfile
-import os
-import pwd
-import sys
 
 
 def get_template(template_name):

--- a/libexec/python/tests/test_docker_import.py
+++ b/libexec/python/tests/test_docker_import.py
@@ -70,7 +70,6 @@ class TestImport(TestCase):
         t = output.communicate()[0],output.returncode
         result = {'message':t[0],
                   'return_code':t[1]}
-        print(result['message'])
         self.assertEqual(result['return_code'],0)
         self.assertTrue(os.path.exists(self.contents_file))
 

--- a/libexec/python/tests/test_shub_import.py
+++ b/libexec/python/tests/test_shub_import.py
@@ -71,7 +71,6 @@ class TestImport(TestCase):
         t = output.communicate()[0],output.returncode
         result = {'message':t[0],
                   'return_code':t[1]}
-        print(result['message'])
         self.assertEqual(result['return_code'],0)
 
 

--- a/libexec/python/tests/test_shub_pull.py
+++ b/libexec/python/tests/test_shub_pull.py
@@ -71,7 +71,6 @@ class TestImport(TestCase):
         t = output.communicate()[0],output.returncode
         result = {'message':t[0],
                   'return_code':t[1]}
-        print(result['message'])
         self.assertEqual(result['return_code'],0)
 
 


### PR DESCRIPTION
This PR will modify the in memory tar extraction to add permission "write" to the owner (o+w) - the function is renamed to `change_tar_permissions` from `check_tar_permissions` because we are no longer checking anything. I also went through and removed unnecessary imports, and added a progress bar for the user given a verbose or higher level. A demo is here: 

https://asciinema.org/a/112081?speed=3

Note that adding the permission doesn't seem to make the images just work seamlessly, for example for the tensorflow image shown in the asciinema above, I cannot run it, because `/run/user` doesn't have execute, or something like that:

```bash
vanessa@som-ctp:/tmp$ singularity shell tensorflow.img 
Singularity: Invoking an interactive shell within container...

Singularity tensorflow.img:/tmp>
```
Should that work? Does the changing permission step need to check if the file has o+x permission, and not change those first?

@singularityware-admin
