### PR TITLE
Allow hyphen in TERM environment variable

### DIFF
--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -47,7 +47,7 @@
 int main(int argc, char **argv) {
     struct image_object image;
     char *lang = envar_get("LANG", "_-=+:,.%", 128);
-    char *term = envar_get("TERM", NULL, 128);
+    char *term = envar_get("TERM", "-", 128);
 
     singularity_config_init(joinpath(SYSCONFDIR, "/singularity/singularity.conf"));
     singularity_registry_init();


### PR DESCRIPTION
Running `ls /lib/terminfo/* | grep \-` on a stock Ubuntu 16.10 Desktop system
shows 22 terminal types that use the hyphen character.  When using the Terminal
in the Unity desktop, the terminal type is set to `xterm-256color`.

A manual scan of the list shows that the hyphen is the only non-alphanum
character in the list of terminal types.

Fixes #577.

Changes proposed in this pull request

 - Add hyphen to the list of allowed non-alphanum characters in the `TERM` environment variable.

@singularityware-admin
