### PR TITLE
Fix misleading typo regarding uid/gid remapping

### DIFF
--- a/src/util/privilege.c
+++ b/src/util/privilege.c
@@ -240,7 +240,7 @@ void singularity_priv_userns(void) {
             free(map_file);
         }
         {
-            singularity_message(DEBUG, "Setting GID map to: '0 %i 1'\n", gid);
+            singularity_message(DEBUG, "Setting GID map to: '%i %i 1'\n", gid, gid);
             char *map_file = (char *) malloc(PATH_MAX);
             snprintf(map_file, PATH_MAX-1, "/proc/%d/gid_map", getpid()); // Flawfinder: ignore
             FILE *map_fp = fopen(map_file, "w+"); // Flawfinder: ignore
@@ -258,7 +258,7 @@ void singularity_priv_userns(void) {
             free(map_file);
         }
         {   
-            singularity_message(DEBUG, "Setting UID map to: '0 %i 1'\n", uid);
+            singularity_message(DEBUG, "Setting UID map to: '%i %i 1'\n", uid, uid);
             char *map_file = (char *) malloc(PATH_MAX);
             snprintf(map_file, PATH_MAX-1, "/proc/%d/uid_map", getpid()); // Flawfinder: ignore
             FILE *map_fp = fopen(map_file, "w+"); // Flawfinder: ignore


### PR DESCRIPTION
The log didn't match the values written to the uid_map/gid_map files