### PR TITLE
Quote string components before doing bash eval

### DIFF
--- a/libexec/bootstrap-scripts/post.sh
+++ b/libexec/bootstrap-scripts/post.sh
@@ -27,7 +27,7 @@ fi
 
 ## Load functions
 if [ -f "$SINGULARITY_libexecdir/singularity/functions" ]; then
-    . "$SINGULARITY_libexecdir/singularity/functions"
+    . $SINGULARITY_libexecdir/singularity/functions
 else
     echo "Error loading functions: $SINGULARITY_libexecdir/singularity/functions"
     exit 1
@@ -50,16 +50,19 @@ EOF
 
 
 # Populate the labels.
-SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity.d/labels.json"
+# NOTE: We have to be careful to quote stuff that we know isn't quoted.
+SINGULARITY_LABELFILE=$(printf "%q" "$SINGULARITY_ROOTFS/.singularity.d/labels.json")
+SINGULARITY_ADD_SCRIPT=$(printf "%q" "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py")
 
-eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" -f --key "SINGULARITY_DEFFILE" --value "$SINGULARITY_BUILDDEF" --file $SINGULARITY_LABELFILE
 
-eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" -f --key "SINGULARITY_BOOTSTRAP_VERSION" --value "$SINGULARITY_version" --file $SINGULARITY_LABELFILE
+eval $SINGULARITY_ADD_SCRIPT -f --key SINGULARITY_DEFFILE --value $(printf "%q" "$SINGULARITY_BUILDDEF") --file $SINGULARITY_LABELFILE
+
+eval $SINGULARITY_ADD_SCRIPT -f --key SINGULARITY_BOOTSTRAP_VERSION --value $(printf "%q" "$SINGULARITY_version") --file $SINGULARITY_LABELFILE
 
 env | egrep "^SINGULARITY_DEFFILE_" | while read i; do
     KEY=`echo $i | cut -f1 -d =`
     VAL=`echo $i | cut -f2- -d =`
-    eval "$SINGULARITY_libexecdir/singularity/python/helpers/json/add.py" -f --key "$KEY" --value "$VAL" --file $SINGULARITY_LABELFILE
+    eval $SINGULARITY_ADD_SCRIPT -f --key $(printf "%q" "$KEY") --value $(printf "%q" "$VAL") --file $SINGULARITY_LABELFILE
 
 done
 


### PR DESCRIPTION
When doing a bash `eval`, we need to escape any variables that come from
the "outside".

Thanks to http://stackoverflow.com/questions/2854655 for the solution!

Fixes #607 (though it'll need to be closed manually, because this isn't pushing to the default branch.)

Changes proposed in this pull request

 - Shell-quote SINGULARITY_LABELFILE, the path to `add.py` (SINGULARITY_ADD_SCRIPT), and all other values that could come in from the outside.