### PR TITLE
Allow the '+' character in pathnames.

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -102,7 +102,7 @@ int envar_defined(char *name) {
 
 char *envar_path(char *name) {
     singularity_message(DEBUG, "Checking environment variable is valid path: '%s'\n", name);
-    return(envar(name, "/._-=,:", PATH_MAX));
+    return(envar(name, "/._-+=,:", PATH_MAX));
 }
 
 


### PR DESCRIPTION
We have several pathnames with '+' characters in our environment.
Singularity doesn't allow these paths to passed as bindmounts because
of the presence of this character.  Is there a particular reason why '+' 
characters aren't permitted?  In a cursory look at the code, I wasn't able 
to find any obvious security issues with permitting them.

@singularityware-admin