### PR TITLE
`-f/--file` option restored to export command in export.exec and export.help

### DIFF
--- a/libexec/cli/export.exec
+++ b/libexec/cli/export.exec
@@ -33,6 +33,8 @@ else
     exit 1
 fi
 
+SINGULARITY_EXPORT_FILE=""
+
 while true; do
     case ${1:-} in
         -h|--help|help)
@@ -73,11 +75,11 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
-if [ -n $SINGULARITY_EXPORT_FILE ]; then
+if [ -n "$SINGULARITY_EXPORT_FILE" ]; then
 	if [ -z "${SINGULARITY_NOSUID:-}" -a -u "$SINGULARITY_libexecdir/singularity/bin/export-suid" ]; then
-	    exec "$SINGULARITY_libexecdir/singularity/bin/export-suid" > "$SINGULARITY_EXPORT_FILE"
+		exec "$SINGULARITY_libexecdir/singularity/bin/export-suid" > "$SINGULARITY_EXPORT_FILE"
 	elif [ -x "$SINGULARITY_libexecdir/singularity/bin/export" ]; then
-	    exec "$SINGULARITY_libexecdir/singularity/bin/export" > "$SINGULARITY_EXPORT_FILE" 
+		exec "$SINGULARITY_libexecdir/singularity/bin/export" > "$SINGULARITY_EXPORT_FILE" 
 	else
 	    message ERROR "Could not locate the Singularity binary: $SINGULARITY_libexecdir/singularity/bin/export\n"
 	    exit 1

--- a/libexec/cli/export.exec
+++ b/libexec/cli/export.exec
@@ -33,8 +33,6 @@ else
     exit 1
 fi
 
-SINGULARITY_EXPORT_FILE=""
-
 while true; do
     case ${1:-} in
         -h|--help|help)
@@ -75,7 +73,7 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
-if [ -n "$SINGULARITY_EXPORT_FILE" ]; then
+if [ -n "${SINGULARITY_EXPORT_FILE:-}" ]; then
 	if [ -z "${SINGULARITY_NOSUID:-}" -a -u "$SINGULARITY_libexecdir/singularity/bin/export-suid" ]; then
 		exec "$SINGULARITY_libexecdir/singularity/bin/export-suid" > "$SINGULARITY_EXPORT_FILE"
 	elif [ -x "$SINGULARITY_libexecdir/singularity/bin/export" ]; then

--- a/libexec/cli/export.exec
+++ b/libexec/cli/export.exec
@@ -19,7 +19,6 @@
 # 
 # 
 
-
 ## Basic sanity
 if [ -z "$SINGULARITY_libexecdir" ]; then
     echo "Could not identify the Singularity libexecdir."
@@ -45,6 +44,11 @@ while true; do
             fi
             exit
         ;;
+        -f|--file)
+             shift
+             SINGULARITY_EXPORT_FILE="${1:-}"
+             shift
+         ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"
             exit 1
@@ -69,6 +73,16 @@ SINGULARITY_IMAGE="${1:-}"
 export SINGULARITY_IMAGE
 shift
 
+if [ -n $SINGULARITY_EXPORT_FILE ]; then
+	if [ -z "${SINGULARITY_NOSUID:-}" -a -u "$SINGULARITY_libexecdir/singularity/bin/export-suid" ]; then
+	    exec "$SINGULARITY_libexecdir/singularity/bin/export-suid" > "$SINGULARITY_EXPORT_FILE"
+	elif [ -x "$SINGULARITY_libexecdir/singularity/bin/export" ]; then
+	    exec "$SINGULARITY_libexecdir/singularity/bin/export" > "$SINGULARITY_EXPORT_FILE" 
+	else
+	    message ERROR "Could not locate the Singularity binary: $SINGULARITY_libexecdir/singularity/bin/export\n"
+	    exit 1
+	fi
+fi
 
 if [ -z "${SINGULARITY_NOSUID:-}" -a -u "$SINGULARITY_libexecdir/singularity/bin/export-suid" ]; then
     exec "$SINGULARITY_libexecdir/singularity/bin/export-suid"
@@ -79,7 +93,5 @@ else
     exit 1
 fi
 
-
 message ERROR "We should never have gotten here... ARRRGGGG!!!!\n"
 exit 255
-

--- a/libexec/cli/export.exec
+++ b/libexec/cli/export.exec
@@ -82,15 +82,15 @@ if [ -n $SINGULARITY_EXPORT_FILE ]; then
 	    message ERROR "Could not locate the Singularity binary: $SINGULARITY_libexecdir/singularity/bin/export\n"
 	    exit 1
 	fi
-fi
-
-if [ -z "${SINGULARITY_NOSUID:-}" -a -u "$SINGULARITY_libexecdir/singularity/bin/export-suid" ]; then
-    exec "$SINGULARITY_libexecdir/singularity/bin/export-suid"
-elif [ -x "$SINGULARITY_libexecdir/singularity/bin/export" ]; then
-    exec "$SINGULARITY_libexecdir/singularity/bin/export"
 else
-    message ERROR "Could not locate the Singularity binary: $SINGULARITY_libexecdir/singularity/bin/export\n"
-    exit 1
+	if [ -z "${SINGULARITY_NOSUID:-}" -a -u "$SINGULARITY_libexecdir/singularity/bin/export-suid" ]; then
+    	    exec "$SINGULARITY_libexecdir/singularity/bin/export-suid"
+	elif [ -x "$SINGULARITY_libexecdir/singularity/bin/export" ]; then
+    	    exec "$SINGULARITY_libexecdir/singularity/bin/export"
+	else
+    	message ERROR "Could not locate the Singularity binary: $SINGULARITY_libexecdir/singularity/bin/export\n"
+    	exit 1
+	fi
 fi
 
 message ERROR "We should never have gotten here... ARRRGGGG!!!!\n"

--- a/libexec/cli/export.help
+++ b/libexec/cli/export.help
@@ -10,9 +10,11 @@ EXAMPLES:
     $ singularity export /tmp/Debian.img | gzip -9 > /tmp/Debian.tar.gz
     $ singularity export -f Debian.tar /tmp/Debian.img
 
+ 
+EXPORT OPTIONS:
+    -f/--file       Output to a file instead of a pipe
 
 For additional help, please visit our public documentation pages which are
 found at:
 
     http://singularity.lbl.gov/
-

--- a/tests/28-importexport.sh
+++ b/tests/28-importexport.sh
@@ -36,6 +36,18 @@ stest 0 singularity import "$CONTAINER" docker://busybox
 stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
+stest 0 sh -c "singularity export -f '$CONTAINERTAR' '$CONTAINER'"
+stest 0 singularity create -F -s 568 "$CONTAINER"
+stest 0 sh -c "singularity import '$CONTAINER' < '$CONTAINERTAR'"
+stest 0 singularity exec "$CONTAINER" true
+stest 1 singularity exec "$CONTAINER" false
+
+stest 0 sh -c "singularity export --false '$CONTAINERTAR' '$CONTAINER'"
+stest 0 singularity create -F -s 568 "$CONTAINER"
+stest 0 sh -c "singularity import '$CONTAINER' < '$CONTAINERTAR'"
+stest 0 singularity exec "$CONTAINER" true
+stest 1 singularity exec "$CONTAINER" false
+
 stest 0 sh -c "singularity export '$CONTAINER' > '$CONTAINERTAR'"
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 sh -c "singularity import '$CONTAINER' < '$CONTAINERTAR'"

--- a/tests/28-importexport.sh
+++ b/tests/28-importexport.sh
@@ -42,7 +42,7 @@ stest 0 sh -c "singularity import '$CONTAINER' < '$CONTAINERTAR'"
 stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
-stest 0 sh -c "singularity export --false '$CONTAINERTAR' '$CONTAINER'"
+stest 0 sh -c "singularity export --file '$CONTAINERTAR' '$CONTAINER'"
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 0 sh -c "singularity import '$CONTAINER' < '$CONTAINERTAR'"
 stest 0 singularity exec "$CONTAINER" true


### PR DESCRIPTION
Changes proposed in this pull request

 - `-f/--file` option restored to export command in export.exec and export.help

@singularityware-admin
