### PR TITLE
Add/multiprocessing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_core
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker_import
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker_api
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_docker_tasks
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub_import
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub_pull
   - cd $TRAVIS_BUILD_DIR/libexec/python && python2 -m unittest tests.test_shub
@@ -71,6 +72,7 @@ script:
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_core
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker_import
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker_api
+  - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_docker_tasks
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub_import
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub_pull
   - cd $TRAVIS_BUILD_DIR/libexec/python && python3 -m unittest tests.test_shub

--- a/libexec/python/README.md
+++ b/libexec/python/README.md
@@ -146,6 +146,9 @@ Done. Container is at: ./vsoch-singularity-images-mongo.img
 ```
 
 ### General
+**SINGULARITY_PYTHREADS**
+The Python modules use threads (workers) to download layer files for Docker, and change permissions. By default, we will use 9 workers, unless the environment variable `SINGULARITY_PYTHREADS` is defined.
+
 
 **SINGULARITY_COMMAND_ASIS**
 By default, we want to make sure the container running process gets passed forward as the current process, so we want to prefix whatever the Docker command or entrypoint is with `exec`. We also want to make sure that following arguments get passed, so we append `"$@"`. Thus, some entrypoint or cmd might look like this:

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -7,6 +7,7 @@ Copyright (c) 2017, Vanessa Sochat. All rights reserved.
 '''
 
 from message import bot
+from defaults import SINGULARITY_WORKERS
 import multiprocessing
 import itertools
 import tempfile
@@ -33,8 +34,7 @@ class MultiProcess(object):
     def __init__(self, workers=None):
 
         if workers is None:
-            # In testing we found odd # to work better
-            workers = multiprocessing.cpu_count()*2-1
+            workers = SINGULARITY_WORKERS
         self.workers = workers
         bot.debug("Using %s workers for multiprocess." %(self.workers))
 

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -60,7 +60,7 @@ class MultiProcess(object):
             prefix = "[%s/%s]" %(progress,total)
             bot.show_progress(0,total,length=35,prefix=prefix)
             pool = multiprocessing.Pool(processes=self.workers,initializer=mute)
-            for result in pool.imap_unordered(multi_wrapper,multi_package(func,tasks)):
+            for result in pool.imap(multi_wrapper,multi_package(func,tasks)):
                 self.start()
                 results.append(result)
                 suffix = os.path.basename(result).strip('sha256:')[0:6]

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -138,6 +138,8 @@ SHUB_CONTAINERNAME = getenv("SHUB_CONTAINERNAME")
 _layerfile = "%s/.layers" %(METADATA_BASE)
 LAYERFILE = getenv("SINGULARITY_CONTENTS", default=_layerfile)
 
+SINGULARITY_WORKERS = int(getenv("SINGULARITY_PYTHREADS",default=9))
+
 #URI_IMAGE = "img://"
 #URI_TAR = "tar://"
 #URI_TARGC = "targz://"

--- a/libexec/python/docker/Makefile.am
+++ b/libexec/python/docker/Makefile.am
@@ -1,6 +1,6 @@
 scriptlibexecdir = $(libexecdir)/singularity/python/docker
 
-dist_scriptlibexec_DATA = api.py main.py __init__.py
+dist_scriptlibexec_DATA = api.py main.py tasks.py __init__.py
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -273,13 +273,13 @@ class DockerApiConnection(ApiConnection):
         bot.debug('Download of raw file (pre permissions fix) is %s' %tar_download)
 
         # Step 2: Fix Permissions?
+        if change_perms:
+            tar_download = change_tar_permissions(tar_download)
+
+        if return_tmp is True:
+            return tar_download
+
         try:
-            if change_perms:
-                tar_download = change_tar_permissions(tar_download)
-
-            if return_tmp is True:
-                return tar_download
-
             os.rename(tar_download,download_folder)
         except:
             bot.error("Cannot untar layer %s, was there a problem with download?" %tar_download)

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -27,12 +27,16 @@ from defaults import INCLUDE_CMD
 from base import MultiProcess
 
 from sutils import (
+    change_tar_permissions,
     get_cache, 
     write_file
 )
 
 from .api import (
     DockerApiConnection,
+)
+
+from .tasks import (
     download_layer,
     extract_runscript,
     extract_metadata_tar
@@ -95,7 +99,7 @@ def IMPORT(image,auth=None,layerfile=None):
        
     # Get the cache (or temporary one) for docker
     cache_base = get_cache(subfolder="docker")
-    download_client = MultiProcess(workers=3)
+    download_client = MultiProcess()
 
     # Generate a queue of tasks to run with MultiProcess
     layers = []
@@ -111,6 +115,7 @@ def IMPORT(image,auth=None,layerfile=None):
 
     if len(tasks) > 0:
         layers = layers + download_client.run(func=download_layer,
+                                              func2=change_tar_permissions,
                                               tasks=tasks)
 
     # Get Docker runscript

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -24,6 +24,8 @@ perform publicly and display publicly, and to permit other to do so.
 import os
 from defaults import INCLUDE_CMD
 
+from base import MultiProcess
+
 from sutils import (
     get_cache, 
     write_file
@@ -31,6 +33,7 @@ from sutils import (
 
 from .api import (
     DockerApiConnection,
+    download_layer,
     extract_runscript,
     extract_metadata_tar
 )
@@ -92,19 +95,23 @@ def IMPORT(image,auth=None,layerfile=None):
        
     # Get the cache (or temporary one) for docker
     cache_base = get_cache(subfolder="docker")
+    download_client = MultiProcess(workers=3)
 
+    # Generate a queue of tasks to run with MultiProcess
     layers = []
+    tasks = []
     for ii in range(len(images)):
         image_id = images[ii]
         targz = "%s/%s.tar.gz" %(cache_base,image_id)
         prefix = "[%s/%s] Download" %((ii+1),len(images))
         if not os.path.exists(targz):
-            targz = client.get_layer(image_id=image_id,
-                                     download_folder=cache_base,
-                                     prefix=prefix)
-            client.update_token()
-        layers.append(targz)
+            tasks.append((client,image_id,cache_base,prefix))
+        else:
+            layers.append(targz)
 
+    if len(tasks) > 0:
+        layers = layers + download_client.run(func=download_layer,
+                                              tasks=tasks)
 
     # Get Docker runscript
     runscript = extract_runscript(manifest=manifestv1,

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -109,11 +109,10 @@ def IMPORT(image,auth=None,layerfile=None):
         targz = "%s/%s.tar.gz" %(cache_base,image_id)
         if not os.path.exists(targz):
             tasks.append((client,image_id,cache_base))
-        else:
-            layers.append(targz)
+        layers.append(targz)
 
     if len(tasks) > 0:
-        layers = layers + download_client.run(func=download_layer,
+        download_layers = download_client.run(func=download_layer,
                                               func2=change_permissions,
                                               tasks=tasks)
 

--- a/libexec/python/docker/main.py
+++ b/libexec/python/docker/main.py
@@ -27,7 +27,6 @@ from defaults import INCLUDE_CMD
 from base import MultiProcess
 
 from sutils import (
-    change_tar_permissions,
     get_cache, 
     write_file
 )
@@ -37,6 +36,7 @@ from .api import (
 )
 
 from .tasks import (
+    change_permissions,
     download_layer,
     extract_runscript,
     extract_metadata_tar
@@ -107,15 +107,14 @@ def IMPORT(image,auth=None,layerfile=None):
     for ii in range(len(images)):
         image_id = images[ii]
         targz = "%s/%s.tar.gz" %(cache_base,image_id)
-        prefix = "[%s/%s] Download" %((ii+1),len(images))
         if not os.path.exists(targz):
-            tasks.append((client,image_id,cache_base,prefix))
+            tasks.append((client,image_id,cache_base))
         else:
             layers.append(targz)
 
     if len(tasks) > 0:
         layers = layers + download_client.run(func=download_layer,
-                                              func2=change_tar_permissions,
+                                              func2=change_permissions,
                                               tasks=tasks)
 
     # Get Docker runscript

--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -1,0 +1,233 @@
+'''
+
+tasks.py: Tasks for the Docker API
+
+Copyright (c) 2017, Vanessa Sochat. All rights reserved. 
+
+
+'''
+
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
+sys.path.append('..')
+
+from sutils import (
+    add_http,
+    get_cache,
+    create_tar,
+    write_singularity_infos
+)
+
+from defaults import (
+    DOCKER_NUMBER,
+    DOCKER_PREFIX,
+    ENV_BASE,
+    LABELFILE,
+    METADATA_FOLDER_NAME,
+    RUNSCRIPT_COMMAND_ASIS
+)
+
+from helpers.json.main import ADD
+from message import bot
+from templates import get_template
+
+import json
+import re
+
+    
+
+def download_layer(client,image_id,cache_base,prefix):
+    '''download_layer is a function (external to the client) to download a layer
+    and update the client's token after. This is intended to be used by the multiprocessing
+    function.'''
+    targz = client.get_layer(image_id=image_id,
+                             download_folder=cache_base,
+                             prefix=prefix)
+    client.update_token()
+    return targz
+
+
+def extract_runscript(manifest,includecmd=False):
+    '''create_runscript will write a bash script with default "ENTRYPOINT" 
+    into the base_dir. If includecmd is True, CMD is used instead. For both.
+    if the result is found empty, the other is tried, and then a default used.
+    :param manifest: the manifest to use to get the runscript
+    :param includecmd: overwrite default command (ENTRYPOINT) default is False
+    '''
+    cmd = None
+
+    # Does the user want to use the CMD instead of ENTRYPOINT?
+    commands = ["Entrypoint","Cmd"]
+    if includecmd == True:
+        commands.reverse()
+    configs = get_configs(manifest,commands,delim=" ")
+    
+    # Look for non "None" command
+    for command in commands:
+        if configs[command] is not None:
+            cmd = configs[command]
+            break
+
+    if cmd is not None:
+        bot.verbose3("Adding Docker %s as Singularity runscript..." %(command.upper()))
+        bot.debug(cmd)
+
+        # If the command is a list, join. (eg ['/usr/bin/python','hello.py']
+        if isinstance(cmd,list):
+            cmd = " ".join(cmd)
+
+        if not RUNSCRIPT_COMMAND_ASIS:
+            cmd = 'exec %s "$@"' %(cmd)
+        cmd = "#!/bin/sh\n\n%s" %(cmd)
+        return cmd
+
+    bot.debug("No Docker CMD or ENTRYPOINT found, skipping runscript generation.")
+    return cmd
+
+
+
+def extract_metadata_tar(manifest,image_name,include_env=True,
+                        include_labels=True,runscript=None):
+    '''extract_metadata_tar will write a tarfile with the environment,
+    labels, and runscript. include_env and include_labels should be booleans,
+    and runscript should be None or a string to write to the runscript. 
+    '''
+    tar_file = None
+    files = []
+    if include_env or include_labels:
+
+        # Extract and add environment
+        if include_env:               
+            environ = extract_env(manifest)
+            if environ not in [None,""]:
+                bot.verbose3('Adding Docker environment to metadata tar')
+                template = get_template('tarinfo')
+                template['name'] = './%s/env/%s-%s.sh' %(METADATA_FOLDER_NAME,
+                                                         DOCKER_NUMBER,
+                                                         DOCKER_PREFIX)
+                template['content'] = environ
+                files.append(template)
+
+        # Extract and add labels
+        if include_labels:
+            labels = extract_labels(manifest)
+            if labels is not None:
+                if isinstance(labels,dict):
+                    labels = json.dumps(labels)
+                bot.verbose3('Adding Docker labels to metadata tar')
+                template = get_template('tarinfo')
+                template['name'] = "./%s/labels.json" %METADATA_FOLDER_NAME
+                template['content'] = labels
+                files.append(template)
+
+        if runscript is not None:
+            bot.verbose3('Adding Docker runscript to metadata tar')
+            template = get_template('tarinfo')
+            template['name'] = "./%s/runscript" %METADATA_FOLDER_NAME
+            template['content'] = runscript
+            files.append(template)
+
+
+    if len(files) > 0:
+        output_folder = get_cache(subfolder="metadata", quiet=True)
+        tar_file = create_tar(files,output_folder)      
+    else:
+        bot.warning("No environment, labels files, or runscript will be included.")
+    return tar_file
+
+
+def extract_env(manifest):
+    '''extract the environment from the manifest, or return None. Used by
+    functions env_extract_image, and env_extract_tar
+    '''
+    environ = get_config(manifest,'Env')
+    if environ is not None:
+        if isinstance(environ,list):
+            environ = "\n".join(environ)
+        environ = ["export %s" %x for x in environ.split('\n')]
+        environ = "\n".join(environ)
+        bot.verbose3("Found Docker container environment!")    
+    return environ
+
+
+def env_extract_image(manifest):
+    '''env_extract_image will write a file of key value pairs of the environment
+    to export. The manner to export must be determined by the calling process
+    depending on the OS type.
+    :param manifest: the manifest to use
+    '''
+    environ = extract_env(manifest)
+    if environ is not None:
+        environ_file = write_singularity_infos(base_dir=ENV_BASE,
+                                               prefix=DOCKER_PREFIX,
+                                               start_number=DOCKER_NUMBER,
+                                               content=environ,
+                                               extension='sh')
+    return environ
+
+
+
+def extract_labels(manifest,labelfile=None,prefix=None):
+    '''extract_labels will write a file of key value pairs including
+    maintainer, and labels.
+    :param manifest: the manifest to use
+    :param labelfile: if defined, write to labelfile (json)
+    :param prefix: an optional prefix to add to the names
+    '''
+    if prefix is None:
+        prefix = ""
+
+    labels = get_config(manifest,'Labels')
+    if labels is not None and len(labels) is not 0:
+        bot.verbose3("Found Docker container labels!")    
+        if labelfile is not None:
+            for key,value in labels.items():
+                key = "%s%s" %(prefix,key)
+                value = ADD(key,value,labelfile,force=True)
+    return labels
+
+
+
+def get_config(manifest,spec="Entrypoint",delim=None):
+    '''get_config returns a particular spec (default is Entrypoint) 
+    from a VERSION 1 manifest obtained with get_manifest.
+    :param manifest: the manifest obtained from get_manifest
+    :param spec: the key of the spec to return, default is "Entrypoint"
+    :param delim: Given a list, the delim to use to join the entries. Default is newline
+    '''
+    cmd = None
+    if "history" in manifest:
+        history = manifest['history']
+        for entry in manifest['history']:
+            if 'v1Compatibility' in entry:
+                entry = json.loads(entry['v1Compatibility'])
+                if "config" in entry:
+                    if spec in entry["config"]:
+                        if entry["config"][spec] is not None:
+                            cmd = entry["config"][spec]
+                            break
+
+    # Standard is to include commands like ['/bin/sh']
+    if isinstance(cmd,list):
+        if delim is None:
+            delim = "\n"
+        cmd = delim.join(cmd)
+    bot.verbose3("Found Docker command (%s) %s" %(spec,cmd))
+
+    return cmd
+
+
+def get_configs(manifest,keys,delim=None):
+    '''get_configs is a wrapper for get_config to return a dictionary
+    with multiple config items.
+    :param manifest: the complete manifest
+    :param keys: the key to find
+    :param delim: given a list, combine based on this delim
+    '''
+    configs = dict()
+    if not isinstance(keys,list):
+        keys = [keys]
+    for key in keys:
+        configs[key] = get_config(manifest,key,delim=delim)
+    return configs

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -189,7 +189,7 @@ class SingularityMessage:
             symbol = '='
 
         if progress < length:
-            bar = symbol * progress + '>' + '-' * (length - progress - 1)
+            bar = symbol * progress + '|' + '-' * (length - progress - 1)
         else:
             bar = symbol * progress + '-' * (length - progress)
 

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -128,8 +128,7 @@ class SingularityApiConnection(ApiConnection):
 
         # Download image file atomically, streaming
         image_file = self.download_atomically(url=url,
-                                              file_name=image_file,
-                                              suffix="downloading image")
+                                              file_name=image_file)
 
         if extract == True:
             if not bot.is_quiet():

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -128,7 +128,8 @@ class SingularityApiConnection(ApiConnection):
 
         # Download image file atomically, streaming
         image_file = self.download_atomically(url=url,
-                                              file_name=image_file)
+                                              file_name=image_file,
+                                              show_progress=True)
 
         if extract == True:
             if not bot.is_quiet():

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -294,8 +294,7 @@ def has_permission(file_path,permission=None):
     return False
 
 
-def change_tar_permissions(tar_file,file_permission=None,folder_permission=None,
-                           suffix=None,prefix=None):
+def change_tar_permissions(tar_file,file_permission=None,folder_permission=None):
     '''change_tar_permissions changes a permission if 
     any member in a tarfile file does not have it
     :param file_path the path to the file
@@ -318,15 +317,10 @@ def change_tar_permissions(tar_file,file_permission=None,folder_permission=None,
         folder_permission = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  
 
 
-
     # Add owner write permission to all, not symlinks
     bot.verbose("Fixing permission for %s" %(tar_file))
     
     members = tar.getmembers()
-
-    ii=0
-    count = len(members)
-    bot.show_progress(ii,count,length=35,prefix=prefix,suffix=suffix)
     
     for member in members:  
 
@@ -343,10 +337,6 @@ def change_tar_permissions(tar_file,file_permission=None,folder_permission=None,
             fixed_tar.addfile(member, extracted)
         else:    
             fixed_tar.addfile(member)
-
-        ii += 1
-        bot.show_progress(ii,count,length=35,prefix=prefix,suffix=suffix)
-
 
     fixed_tar.close()
     tar.close()

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -52,51 +52,6 @@ class TestApi(TestCase):
         print("---END------------------------------------------")
 
 
-    def test_create_runscript(self):
-        '''test_create_runscript should ensure that a runscript is generated
-        with some command
-        '''
-        from docker.api import DockerApiConnection
-
-        print('Testing creation of runscript')
-        from docker.api import extract_runscript
-
-        manifest = self.client.get_manifest(old_version=True)
-
-        print("Case 1: Asking for CMD when none defined")        
-        default_cmd = 'exec /bin/bash "$@"'
-        runscript = extract_runscript(manifest=manifest,
-                                     includecmd=True)
-        # Commands are always in format exec [] "$@"
-        # 'exec echo \'Hello World\' "$@"'
-        self.assertTrue(default_cmd in runscript)
-
-        print("Case 2: Asking for ENTRYPOINT when none defined")        
-        runscript = extract_runscript(manifest=manifest)
-        self.assertTrue(default_cmd in runscript)
-
-        client = DockerApiConnection(image="docker://bids/mriqc:0.0.2")        
-        manifest = client.get_manifest(old_version=True)
-
-        print("Case 3: Asking for ENTRYPOINT when defined")        
-        runscript = extract_runscript(manifest=manifest)
-        self.assertTrue('exec /run_mriqc "$@"' in runscript)        
-
-        print("Case 4: Asking for CMD when defined")              
-        runscript = extract_runscript(manifest=manifest,
-                                      includecmd=True)
-        self.assertTrue('exec --help "$@"' in runscript)        
-
-        print("Case 5: Asking for ENTRYPOINT when None, should return CMD")    
-        from docker.api import get_configs
-        client = DockerApiConnection(image="tensorflow/tensorflow:1.0.0")        
-        manifest = client.get_manifest(old_version=True)
-
-        configs = get_configs(manifest,['Cmd','Entrypoint'])
-        self.assertEqual(configs['Entrypoint'],None)
-        runscript = extract_runscript(manifest=manifest)
-        self.assertTrue(configs['Cmd'] in runscript)
-
 
     def test_get_token(self):
         '''test_get_token will obtain a token from the Docker registry for a namepspace
@@ -170,27 +125,6 @@ class TestApi(TestCase):
         self.assertTrue(len(tags)>1)
         [self.assertTrue(x in tags) for x in ['latest','latest-gpu']]
   
-
-    def test_get_config(self):
-        '''test_get_config will obtain parameters from the DOcker configuration json
-        '''
-        from docker.api import DockerApiConnection
-
-        from docker.api import get_config
-
-        # Default should return entrypoint
-        print("Case 1: Ask for default command (Entrypoint)")
-        manifest = self.client.get_manifest(old_version=True)
-        entrypoint = get_config(manifest=manifest)
-
-        # Ubuntu latest should have None
-        self.assertEqual(entrypoint,None)
-        
-        print("Case 2: Ask for custom command (Cmd)")
-        entrypoint = get_config(manifest=manifest,
-                                spec="Cmd")
-        self.assertEqual(entrypoint,'/bin/bash')
-
 
 
     def test_get_layer(self):

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -139,13 +139,6 @@ class TestApi(TestCase):
                                            download_folder = self.tmpdir)
         self.assertTrue(os.path.exists(layer_file))
 
-        print("Case 2: Download a non existing layer, should fail")
-        fake_layer = "sha256:111111111112222222222223333333333"
-        with self.assertRaises(SystemExit) as cm:
-            layer_file = self.client.get_layer(image_id=fake_layer, 
-                                               download_folder=self.tmpdir)
-        self.assertEqual(cm.exception.code, 1)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_docker_tasks.py
+++ b/libexec/python/tests/test_docker_tasks.py
@@ -1,0 +1,128 @@
+'''
+
+test_docker_tasks.py: Docker tasks testing for Singularity in Python
+
+Copyright (c) 2017, Vanessa Sochat. All rights reserved. 
+
+'''
+
+import os
+import re
+import sys
+sys.path.append('..') # directory with docker
+
+from unittest import TestCase
+import shutil
+import tempfile
+
+VERSION = sys.version_info[0]
+
+print("*** PYTHON VERSION %s TASKS TESTING START ***" %(VERSION))
+
+class TestApi(TestCase):
+
+    def setUp(self):
+        self.image = 'docker://ubuntu:latest'
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ['SINGULARITY_ROOTFS'] = self.tmpdir
+        os.mkdir('%s/.singularity.d' %(self.tmpdir))
+        from docker.api import DockerApiConnection
+        self.client = DockerApiConnection(image=self.image)
+
+        print("\n---START----------------------------------------")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+        print("---END------------------------------------------")
+
+
+    def test_create_runscript(self):
+        '''test_create_runscript should ensure that a runscript is generated
+        with some command
+        '''
+        from docker.api import DockerApiConnection
+
+        print('Testing creation of runscript')
+        from docker.api import extract_runscript
+
+        manifest = self.client.get_manifest(old_version=True)
+
+        print("Case 1: Asking for CMD when none defined")        
+        default_cmd = 'exec /bin/bash "$@"'
+        runscript = extract_runscript(manifest=manifest,
+                                     includecmd=True)
+        # Commands are always in format exec [] "$@"
+        # 'exec echo \'Hello World\' "$@"'
+        self.assertTrue(default_cmd in runscript)
+
+        print("Case 2: Asking for ENTRYPOINT when none defined")        
+        runscript = extract_runscript(manifest=manifest)
+        self.assertTrue(default_cmd in runscript)
+
+        client = DockerApiConnection(image="docker://bids/mriqc:0.0.2")        
+        manifest = client.get_manifest(old_version=True)
+
+        print("Case 3: Asking for ENTRYPOINT when defined")        
+        runscript = extract_runscript(manifest=manifest)
+        self.assertTrue('exec /run_mriqc "$@"' in runscript)        
+
+        print("Case 4: Asking for CMD when defined")              
+        runscript = extract_runscript(manifest=manifest,
+                                      includecmd=True)
+        self.assertTrue('exec --help "$@"' in runscript)        
+
+        print("Case 5: Asking for ENTRYPOINT when None, should return CMD")    
+        from docker.api import get_configs
+        client = DockerApiConnection(image="tensorflow/tensorflow:1.0.0")        
+        manifest = client.get_manifest(old_version=True)
+
+        configs = get_configs(manifest,['Cmd','Entrypoint'])
+        self.assertEqual(configs['Entrypoint'],None)
+        runscript = extract_runscript(manifest=manifest)
+        self.assertTrue(configs['Cmd'] in runscript)
+  
+
+    def test_get_config(self):
+        '''test_get_config will obtain parameters from the DOcker configuration json
+        '''
+        from docker.api import DockerApiConnection
+
+        from docker.api import get_config
+
+        # Default should return entrypoint
+        print("Case 1: Ask for default command (Entrypoint)")
+        manifest = self.client.get_manifest(old_version=True)
+        entrypoint = get_config(manifest=manifest)
+
+        # Ubuntu latest should have None
+        self.assertEqual(entrypoint,None)
+        
+        print("Case 2: Ask for custom command (Cmd)")
+        entrypoint = get_config(manifest=manifest,
+                                spec="Cmd")
+        self.assertEqual(entrypoint,'/bin/bash')
+
+
+    def test_get_layer(self):
+        '''test_get_layer will download docker layers
+        '''
+        from docker.api import DockerApiConnection
+
+        images = self.client.get_images()
+        
+        print("Case 1: Download an existing layer, should succeed")
+        layer_file = self.client.get_layer(image_id=images[0], 
+                                           download_folder = self.tmpdir)
+        self.assertTrue(os.path.exists(layer_file))
+
+        print("Case 2: Download a non existing layer, should fail")
+        fake_layer = "sha256:111111111112222222222223333333333"
+        with self.assertRaises(SystemExit) as cm:
+            layer_file = self.client.get_layer(image_id=fake_layer, 
+                                               download_folder=self.tmpdir)
+        self.assertEqual(cm.exception.code, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/libexec/python/tests/test_docker_tasks.py
+++ b/libexec/python/tests/test_docker_tasks.py
@@ -44,7 +44,7 @@ class TestApi(TestCase):
         from docker.api import DockerApiConnection
 
         print('Testing creation of runscript')
-        from docker.api import extract_runscript
+        from docker.tasks import extract_runscript
 
         manifest = self.client.get_manifest(old_version=True)
 
@@ -73,7 +73,7 @@ class TestApi(TestCase):
         self.assertTrue('exec --help "$@"' in runscript)        
 
         print("Case 5: Asking for ENTRYPOINT when None, should return CMD")    
-        from docker.api import get_configs
+        from docker.tasks import get_configs
         client = DockerApiConnection(image="tensorflow/tensorflow:1.0.0")        
         manifest = client.get_manifest(old_version=True)
 
@@ -88,7 +88,7 @@ class TestApi(TestCase):
         '''
         from docker.api import DockerApiConnection
 
-        from docker.api import get_config
+        from docker.tasks import get_config
 
         # Default should return entrypoint
         print("Case 1: Ask for default command (Entrypoint)")

--- a/libexec/python/tests/test_docker_tasks.py
+++ b/libexec/python/tests/test_docker_tasks.py
@@ -104,25 +104,6 @@ class TestApi(TestCase):
         self.assertEqual(entrypoint,'/bin/bash')
 
 
-    def test_get_layer(self):
-        '''test_get_layer will download docker layers
-        '''
-        from docker.api import DockerApiConnection
-
-        images = self.client.get_images()
-        
-        print("Case 1: Download an existing layer, should succeed")
-        layer_file = self.client.get_layer(image_id=images[0], 
-                                           download_folder = self.tmpdir)
-        self.assertTrue(os.path.exists(layer_file))
-
-        print("Case 2: Download a non existing layer, should fail")
-        fake_layer = "sha256:111111111112222222222223333333333"
-        with self.assertRaises(SystemExit) as cm:
-            layer_file = self.client.get_layer(image_id=fake_layer, 
-                                               download_folder=self.tmpdir)
-        self.assertEqual(cm.exception.code, 1)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is the first PR to add multiprocessing to downloads, which, with some trivial testing, seems like it might speed things up by a small amount (see here http://www.vanessasaur.us/rawr/2017/multiprocess/). A few things I'd like to talk about:

## Progress Bar
the stream downloader now has the progress bar removed, in favor of including it with the multiprocessing calls (to ensure that you don't see crazy output). This also means that the updates are less frequent, and a lot more jumpy (eg, one bar is shown for all layers, and it proceeds when a layer is done. I used Pool.imap instead of Pool.imap_unordered or Pool.apply_async to ensure that the ordering is preserved.  This also means that the progress bar is gone for shub, and this should be changed. I'd like to have a discussion about a new progress bar strategy - is there a more ideal visual that can be shown that doesn't have the arrow `>` making the user expecting more moving progress? If so, should we do the same for the shub image, or implement the old version for that (having the call to bot.show_progress be in separate functions, which is different than how it was before, both were in the stream function.

## Testing
I'd like to have some test this out on different OS and CPUs to see if it does make a difference. And also get feedback on tweaking the MultiProcess module that I added in case we can make it faster.

I noticed strange behavior with pool, that it would print an empty newline after each process. As a fix I wrote a `mute` function that sends stderr output to null, and that resolved it. I don't think I need to close this, but wanted to check.

Going to sleep!


@singularityware-admin
