### PR TITLE
Adding check for empty Docker layers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 
 addons:
-  sonarqube: true
   apt:
     packages:
       - flawfinder


### PR DESCRIPTION
Fixes #633 

We recently observed that, for some images with `ENV` or `LABELS` they can produce empty layers. 

https://github.com/singularityware/singularity/issues/633

This isn't a problem for Docker, but in our case, we did not expect this and attempt to change permissions using a function to show progress that divides the progress by the total objects to change. In the case of an empty layer, the total objects is 0, and you can imagine where that goes (division by zero, anyone?). As a reasonable fix to this, I have added a check for the number of objects, and given that it's 0, the user is warned:

```
singularity run docker://poldracklab/mriqc:0.9.3
Docker image path: index.docker.io/poldracklab/mriqc:0.9.3
Cache folder set to /home/vanessa/.singularity/docker
[1/24] Download |===================================| 100.0% layer 3ed9
WARNING /home/vanessa/.singularity/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz.IZWQ8d is empty.
[2/24] Download |===================================| 100.0% layer 4936
[2/24] Prepare  |===================================| 100.0% layer 4936
[3/24] Download |===================================| 100.0% layer d712
[3/24] Prepare  |===================================| 100.0% layer d712
[4/24] Download |===================================| 100.0% layer 7366
[4/24] Prepare  |===================================| 100.0% layer 7366
[5/24] Download |===================================| 100.0% layer de5b
[5/24] Prepare  |===================================| 100.0% layer de5b
[6/24] Download |===================================| 100.0% layer 4a55
[6/24] Prepare  |===================================| 100.0% layer 4a55
[7/24] Download |===================================| 100.0% layer 91f5
[7/24] Prepare  |===================================| 100.0% layer 91f5
[8/24] Download |===================================| 100.0% layer f506
[8/24] Prepare  |===================================| 100.0% layer f506
[9/24] Download |===================================| 100.0% layer 12f2
[9/24] Prepare  |===================================| 100.0% layer 12f2
[10/24] Download |===================================| 100.0% layer 9ddc
```

I think this is a reasonable solution, because there could be many stupid cases when a layer is empty, and this should not break the standard import/run, but the user should be alerted in case this is undesired functionality. 

This image is a beast so it's still running the above (we need to make sure there is no issue from within Singularity to still extract the empty layer, but after that we should be good to go. @chrisfilo 


@singularityware-admin
