### PR TITLE
Fix for glibc-2.25 changes

### DIFF
--- a/src/lib/loop-control.c
+++ b/src/lib/loop-control.c
@@ -26,6 +26,7 @@
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <errno.h> 
 #include <string.h>
 #include <fcntl.h>

--- a/src/lib/mount/dev/dev.c
+++ b/src/lib/mount/dev/dev.c
@@ -25,6 +25,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
In glibc 2.25 sys/types.h doesn't automatically include sys/sysmacros.h
anymore [1]. This leads to errors [2] like

libtool: link: x86_64-pc-linux-gnu-gcc -Wall -fpie -fPIC -O2 -pipe
-march=native -Wall -Wl,-O1 -Wl,--as-needed -o sexec-suid sexec_suid-sexec.o
util/sexec_suid-util.o util/sexec_suid-file.o  lib/.libs/libsingularity.a
lib/.libs/libsingularity.a(libsingularity_la-loop-control.o): In function
`singularity_loop_bind':
loop-control.c:(.text+0x422): undefined reference to `makedev'
lib/.libs/libsingularity.a(dev.o): In function `singularity_mount_dev':

1)
https://sourceware.org/ml/libc-alpha/2015-11/msg00253.html
2)
https://bugs.gentoo.org/show_bug.cgi?id=617082

Signed-off-by: Justin Lecher <jlec@gentoo.org>