### PR TITLE
adding docs for -T/--notest command in bootstrap

### DIFF
--- a/libexec/cli/bootstrap.help
+++ b/libexec/cli/bootstrap.help
@@ -59,6 +59,7 @@ note: This command must be executed as root.
 
 
 CREATE OPTIONS:
+    -T|--notest     Bootstrap without running tests in %test section
     -f/--force      Force a rebootstrap of an OS (note: this does not delete
                     what is currently in the image, just causes the core to
                     be reinstalled)


### PR DESCRIPTION
Fixes #@gmk :)

Changes proposed in this pull request

 - adding a line to the bootstrap help doc to explain the notest option.
 -

@singularityware-admin
