### PR TITLE
Adds an option to override tmp directory

### DIFF
--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -75,6 +75,8 @@ _singularity() {
                 _filedir
             elif [[ ${cur} == -H || ${cur} == --home ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
+            elif [[ ${cur} == -T || ${cur} == --temp ]]; then
+                COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -* ]] ; then

--- a/etc/singularity.conf.in
+++ b/etc/singularity.conf.in
@@ -113,8 +113,9 @@
 # DEFAULT: @MOUNT_TMP_DEFAULT@
 # Should we automatically bind mount /tmp and /var/tmp into the container? If
 # the --contain option is used, both tmp locations will be created in the
-# session directory or can be specified via the  SINGULARITY_WORKDIR
-# environment variable (or the --workingdir command line option).
+# session directory or can be specified via the SINGULARITY_TEMP or
+# SINGULARITY_WORKDIR environment variable (or the --workingdir command line
+# option).
 @MOUNT_TMP@ = @MOUNT_TMP_DEFAULT@
 
 

--- a/libexec/cli/exec.exec
+++ b/libexec/cli/exec.exec
@@ -68,7 +68,13 @@ while true; do
             SINGULARITY_HOME="$1"
             export SINGULARITY_HOME
             shift
-        ;;  
+        ;;
+        -T|--temp)
+            shift
+            SINGULARITY_TEMP="$1"
+            export SINGULARITY_TEMP
+            shift
+        ;;
         -c|--contain)
             shift
             SINGULARITY_CONTAIN=1

--- a/libexec/cli/exec.help
+++ b/libexec/cli/exec.help
@@ -14,6 +14,10 @@ EXEC OPTIONS:
                         src path or src:dest pair.  src is the source path
                         of the home directory outside the container and dest
                         overrides the home directory within the container
+    -T/--temp <spec>    A temp directory specification. spec can either be a
+                        src path or src:dest pair.  src is the source path
+                        of the temp directory outside the container and dest
+                        overrides the temp directory within the container
     -i/--ipc            Run container in a new IPC namespace
     -p/--pid            Run container in a new PID namespace
     --pwd               Initial working directory for payload process inside 

--- a/libexec/cli/run.exec
+++ b/libexec/cli/run.exec
@@ -68,7 +68,13 @@ while true; do
             SINGULARITY_HOME="$1"
             export SINGULARITY_HOME
             shift
-        ;; 
+        ;;
+        -T|--temp)
+            shift
+            SINGULARITY_TEMP="$1"
+            export SINGULARITY_TEMP
+            shift
+        ;;
         -W|--wdir|--workdir|--workingdir)
             shift
             SINGULARITY_WORKDIR="$1"

--- a/libexec/cli/run.help
+++ b/libexec/cli/run.help
@@ -19,6 +19,10 @@ RUN OPTIONS:
                         src path or src:dest pair.  src is the source path
                         of the home directory outside the container and dest
                         overrides the home directory within the container
+    -T/--temp <spec>    A temp directory specification. spec can either be a
+                        src path or src:dest pair.  src is the source path
+                        of the temp directory outside the container and dest
+                        overrides the temp directory within the container
     -i/--ipc            Run container in a new IPC namespace
     -p/--pid            Run container in a new PID namespace
     --pwd               Initial working directory for payload process inside

--- a/libexec/cli/shell.exec
+++ b/libexec/cli/shell.exec
@@ -80,6 +80,12 @@ while true; do
             export SINGULARITY_HOME
             shift
         ;;
+        -T|--temp)
+            shift
+            SINGULARITY_TEMP="$1"
+            export SINGULARITY_TEMP
+            shift
+        ;;
         -W|--wdir|--workdir|--workingdir)
             shift
             SINGULARITY_WORKDIR="$1"

--- a/libexec/cli/shell.help
+++ b/libexec/cli/shell.help
@@ -17,6 +17,10 @@ SHELL OPTIONS:
                         src path or src:dest pair.  src is the source path
                         of the home directory outside the container and dest
                         overrides the home directory within the container
+    -T/--temp <spec>    A temp directory specification. spec can either be a
+                        src path or src:dest pair.  src is the source path
+                        of the temp directory outside the container and dest
+                        overrides the temp directory within the container
     -i/--ipc            Run container in a new IPC namespace
     -p/--pid            Run container in a new PID namespace (creates child)
     --pwd               Initial working directory for payload process inside

--- a/src/lib/mount/tmp/tmp.c
+++ b/src/lib/mount/tmp/tmp.c
@@ -48,7 +48,24 @@ int singularity_mount_tmp(void) {
         return(0);
     }
 
-    if ( envar_defined("SINGULARITY_CONTAIN") == TRUE ) {
+    if ( ( tmp_source = envar_path("SINGULARITY_TEMP") ) != NULL ) {
+        char *colon;
+        if ( singularity_config_get_bool(USER_BIND_CONTROL) <= 0 ) {
+            singularity_message(ERROR, "User bind control is disabled by system administrator\n");
+            ABORT(5);
+        }
+
+        colon = strchr(tmp_source, ':');
+        if ( colon != NULL ) {
+            *colon = '\0';
+            tmp_source = strdup(tmp_source);
+            *colon = ':';
+        }
+
+        vartmp_source = strdup("/var/tmp");
+
+        singularity_message(VERBOSE2, "Set the tmp directory source (via envar) to: %s\n", tmp_source);
+    } else if ( envar_defined("SINGULARITY_CONTAIN") == TRUE ) {
         char *tmpdirpath;
         if ( ( tmpdirpath = envar_path("SINGULARITY_WORKDIR") ) != NULL ) {
             if ( singularity_config_get_bool(USER_BIND_CONTROL) <= 0 ) {


### PR DESCRIPTION
As proposed in #642 adds the -T (--temp) option. This allows to override the
/tmp directory similar to the -H (--home) option.