### PR TITLE
fixing printing of metadata to labels.json to be pretty

### DIFF
--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -134,7 +134,7 @@ def extract_metadata_tar(manifest,image_name,include_env=True,
             labels = extract_labels(manifest)
             if labels is not None:
                 if isinstance(labels,dict):
-                    labels = json.dumps(labels)
+                    labels = json.dumps(labels, indent=4, separators=(',', ': '))
                 bot.verbose3('Adding Docker labels to metadata tar')
                 template = get_template('tarinfo')
                 template['name'] = "./%s/labels.json" %METADATA_FOLDER_NAME


### PR DESCRIPTION
This is a quick fix so the metadata returned in the .tar.gz is pretty! It goes from this:

```javascript
{"org.label-schema.version":"0.9.3","org.label-schema.schema-version":"1.0","org.label-schema.vcs-ref":"de60ff0","org.label-schema.url":"http://mriqc.readthedocs.io","org.label-schema.vcs-url":"https://github.com/poldracklab/mriqc","org.label-schema.build-date":"2017-04-23T18:10:33Z","org.label-schema.name":"MRIQC","org.label-schema.description":"MRIQC-NR-IQMs(no-referenceImageQualityMetrics)forMRI"}
```

to this:

```javascript
vanessa@vanessa-ThinkPad-T460s:~/Desktop$ singularity exec docker.img cat /.singularity.d/labels.json
{
    "org.label-schema.version": "0.9.3",
    "org.label-schema.schema-version": "1.0",
    "org.label-schema.vcs-ref": "de60ff0",
    "org.label-schema.url": "http://mriqc.readthedocs.io",
    "org.label-schema.vcs-url": "https://github.com/poldracklab/mriqc",
    "org.label-schema.build-date": "2017-04-23T18:10:33Z",
    "org.label-schema.name": "MRIQC",
    "org.label-schema.description": "MRIQC  - NR-IQMs (no-reference Image Quality Metrics) for MRI"
}
```
The reason was because we don't use the write_json function from sutils (because we are just generating the json string to be used in another function). This was an oversight on my part.

and thus we can support an "inspect" command that isn't fugly :)

@singularityware-admin
