### PR TITLE
Adding ability to read docker credentials from .docker/config.json

### DIFF
--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -96,14 +96,14 @@ if COLORIZE is not None:
 # Cache
 #######################################################################
 
+USERHOME = pwd.getpwuid(os.getuid())[5]
 DISABLE_CACHE = convert2boolean(getenv("SINGULARITY_DISABLE_CACHE",
                                 default=False))
 
 if DISABLE_CACHE == True:
     SINGULARITY_CACHE = tempfile.mkdtemp()
 else:
-    userhome = pwd.getpwuid(os.getuid())[5]
-    _cache = os.path.join(userhome,".singularity") 
+    _cache = os.path.join(USERHOME,".singularity") 
     SINGULARITY_CACHE = getenv("SINGULARITY_CACHEDIR", default=_cache)
 
 if not os.path.exists(SINGULARITY_CACHE):

--- a/libexec/python/import.py
+++ b/libexec/python/import.py
@@ -74,7 +74,7 @@ def main():
 
         auth = None
         if username is not None and password is not None:
-            auth = basic_auth_header(username, password)            
+            auth = basic_auth_header(username, password)
 
         from docker.main import IMPORT
 

--- a/libexec/python/import.py
+++ b/libexec/python/import.py
@@ -74,7 +74,7 @@ def main():
 
         auth = None
         if username is not None and password is not None:
-            auth = basic_auth_header(username, password)
+            auth = basic_auth_header(username, password)            
 
         from docker.main import IMPORT
 

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -53,6 +53,29 @@ class TestApi(TestCase):
 
 
 
+    def test_get_registry(self):
+        '''test_get_registry will verify that the function returns the api base
+        with https (default) and verison (default)
+        '''
+        from docker.api import DockerApiConnection
+
+        print("Case 1: Ask for default registry")
+        registry = self.get_registry()
+        self.assertEqual(registry,"https://index.docker.io/v2/")
+
+        print("Case 2: Remove https")
+        registry = self.get_registry(add_https=False)
+        self.assertEqual(registry,"index.docker.io/v2/")
+
+        print("Case 3: Remove version")
+        registry = self.get_registry(add_version=False)
+        self.assertEqual(registry,"https://index.docker.io")
+
+        print("Case 4: Remove everything")
+        registry = self.get_registry(add_version=False,add_https=False)
+        self.assertEqual(registry,"index.docker.io")
+
+
     def test_get_token(self):
         '''test_get_token will obtain a token from the Docker registry for a namepspace
         and repo. 

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -60,19 +60,19 @@ class TestApi(TestCase):
         from docker.api import DockerApiConnection
 
         print("Case 1: Ask for default registry")
-        registry = self.get_registry()
-        self.assertEqual(registry,"https://index.docker.io/v2/")
+        registry = self.client.get_registry()
+        self.assertEqual(registry,"https://index.docker.io/v2")
 
         print("Case 2: Remove https")
-        registry = self.get_registry(add_https=False)
-        self.assertEqual(registry,"index.docker.io/v2/")
+        registry = self.client.get_registry(add_https=False)
+        self.assertEqual(registry,"index.docker.io/v2")
 
         print("Case 3: Remove version")
-        registry = self.get_registry(add_version=False)
+        registry = self.client.get_registry(add_version=False)
         self.assertEqual(registry,"https://index.docker.io")
 
         print("Case 4: Remove everything")
-        registry = self.get_registry(add_version=False,add_https=False)
+        registry = self.client.get_registry(add_version=False,add_https=False)
         self.assertEqual(registry,"index.docker.io")
 
 


### PR DESCRIPTION
Fixes #693 

Changes proposed in this pull request

- This PR adds a function to the docker api client that can read in the config token from the user's config.json, which is located in `/.docker/config.json`, and generated when a user does docker login. I was first against adding this additional use case, but I think it's reasonable to minimally look for this as an option given that the authentication has failed, and the user has not provided a credential - for the subset of users that also use Docker, it will mean not having to export environment variables.
 - I also wrote a function to get the registry an actual function (since we use it many times), and with this more properly defined the `USERHOME` variable in defaults.py
 - Adding a test for this.

The config.json seems to store a base64 credential that is indexed by the registry version, and as far as I know, it works to use a version 1 credential for version 2 registry (this is how I tested). We should keep our eye on this in case there are situations when one credential doesn't work for the other. However, given that the user has gotten to the point, they would have just hit a sys.exit(1) anyway, so it doesn't hurt to try!

@singularityware-admin
