### PR TITLE
PULL_REQUEST_TEMPLATE.md links fixed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,9 @@ fixing or enhancing.
 
 **Checkoff for all PRs:**
 
-- [ ] I have read the [Guidelines for Contributing](CONTRIBUTING.md), and this PR conforms to the stated requirements.
+- [ ] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
 - [ ] I have tested this PR locally with a `make test`
-- [ ] I have added myself as a contributor to the [Author's file](AUTHORS.md)
+- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
 - [ ] This PR is ready for review and/or merge
 
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@
     - Nathan Lin <nathan.lin@yale.edu>
     - Ralph Castain <rhc@open-mpi.org>
     - Yaroslav Halchenko <debian@onerussian.com>
+    - Eduardo Arango <carlos.arango.gutierrez@correounivalle.edu.co>


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Links on PULL_REQUEST_TEMPLATE.md are broken (Error 404)


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] I have added myself as a contributor to the [Author's file](AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
