### PR TITLE
Allow @ sign to be included in path names

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,9 @@ fixing or enhancing.
 
 **Checkoff for all PRs:**
 
-- [ ] I have read the [Guidelines for Contributing](CONTRIBUTING.md), and this PR conforms to the stated requirements.
+- [ ] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
 - [ ] I have tested this PR locally with a `make test`
-- [ ] I have added myself as a contributor to the [Author's file](AUTHORS.md)
+- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
 - [ ] This PR is ready for review and/or merge
 
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@
     - Nathan Lin <nathan.lin@yale.edu>
     - Ralph Castain <rhc@open-mpi.org>
     - Yaroslav Halchenko <debian@onerussian.com>
+    - Eduardo Arango <carlos.arango.gutierrez@correounivalle.edu.co>

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([singularity],[2.2.99],[gmkurtzer@lbl.gov])
+AC_INIT([singularity],[2.3],[gmkurtzer@lbl.gov])
 
 if test -z "$prefix" -o "$prefix" = "NONE" ; then
   prefix=${ac_default_prefix}

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -106,7 +106,7 @@ int envar_defined(char *name) {
 
 char *envar_path(char *name) {
     singularity_message(DEBUG, "Checking environment variable is valid path: '%s'\n", name);
-    return(envar_get(name, "/._+-=,:", PATH_MAX));
+    return(envar_get(name, "/._+-=,:@", PATH_MAX));
 }
 
 int envar_set(char *key, char *value, int overwrite) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Allow `@` to be included in path names via calls to `envar_path()`. As long as @gmkurtzer doesn't see any reason to exclude the `@` symbol from path names this is safe to merge.


**This fixes or addresses the following GitHub issues:**

- Ref: #705 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
