### PR TITLE
Allow @ sign to be included in path names

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -106,7 +106,7 @@ int envar_defined(char *name) {
 
 char *envar_path(char *name) {
     singularity_message(DEBUG, "Checking environment variable is valid path: '%s'\n", name);
-    return(envar_get(name, "/._+-=,:", PATH_MAX));
+    return(envar_get(name, "/._+-=,:@", PATH_MAX));
 }
 
 int envar_set(char *key, char *value, int overwrite) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Allow `@` to be included in path names via calls to `envar_path()`. As long as @gmkurtzer doesn't see any reason to exclude the `@` symbol from path names this is safe to merge.


**This fixes or addresses the following GitHub issues:**

- Ref: #705 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin 