### PR TITLE
Allow mount point to have SETGID/SETUID bits set

### DIFF
--- a/src/lib/image/mount/mount.c
+++ b/src/lib/image/mount/mount.c
@@ -53,7 +53,7 @@ int _singularity_image_mount(struct image_object *image, char *mount_point) {
         ABORT(255);
     }
 
-    if ( chk_mode(mount_point, 0040755) != 0 ) {
+    if ( chk_mode(mount_point, 0040755, 0007000) != 0 ) {
         int ret;
         singularity_message(DEBUG, "fixing bad permissions on %s\n", mount_point);
 

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -99,7 +99,7 @@ int chk_perms(char *path, mode_t mode) {
     return(-1);
 }
 
-int chk_mode(char *path, mode_t mode) {
+int chk_mode(char *path, mode_t mode, mode_t mask) {
     struct stat filestat;
 
     singularity_message(DEBUG, "Checking exact mode (%o) on: %s\n", mode, path);
@@ -109,7 +109,7 @@ int chk_mode(char *path, mode_t mode) {
         return(-1);
     }
 
-    if ( filestat.st_mode == mode ) {
+    if ( ( filestat.st_mode | mask )  == ( mode | mask ) ) {
         singularity_message(DEBUG, "Found appropriate mode on file: %s\n", path);
         return(0);
     } else {

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -24,7 +24,7 @@
 char *file_id(char *path);
 char *file_devino(char *path);
 int chk_perms(char *path, mode_t mode);
-int chk_mode(char *path, mode_t mode);
+int chk_mode(char *path, mode_t mode, mode_t mask);
 int is_file(char *path);
 int is_fifo(char *path);
 int is_link(char *path);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Allow `mount_point` in `singularity_image_mount()` to mount in locations with 2755, 4755, and 6755 permissions, instead of just 0755 permissions. If there is a better way to do this than the dumb way I've implemented it here, I'm all ears. Perhaps a better solution would be to have `chk_mode()` instead have arguments `int chk_mode(char *path, mode_t *mode)` where mode is instead an array of modes, however I believe that this isn't really necessary.

**This fixes or addresses the following GitHub issues:**

- Ref: #707 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
