### PR TITLE
Fixing shub pull 404 message, cleanup on fail

### DIFF
--- a/libexec/python/pull.py
+++ b/libexec/python/pull.py
@@ -56,7 +56,7 @@ def main():
     pull_folder = getenv("SINGULARITY_PULLFOLDER", required=True)
     
     image_uri = get_image_uri(container)
-    container = remove_image_uri(container)
+    container = remove_image_uri(container,quiet=True)
     
     if image_uri == "shub://":
 

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -145,14 +145,14 @@ class SingularityApiConnection(ApiConnection):
             if not bot.is_quiet():
                 print("Decompressing %s" %image_file)
             output = run_command(['gzip','-d','-f',image_file])
-            final_image = image_file.replace('.gz','')
+            image_file = image_file.replace('.gz','')
 
             # Any error in extraction (return code not 0) will return None
             if output is None:
                 bot.error('Error extracting image, cleaning up.')
-                clean_up([image_file,final_image])
+                clean_up([image_file,"%s.gz" %image_file])
 
-        return final_image
+        return image_file
 
 
 

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -34,8 +34,10 @@ from shell import (
 
 from sutils import (
     add_http,
+    clean_up,
     is_number,
-    read_file
+    read_file,
+    run_command
 )
 
 from base import ApiConnection
@@ -142,9 +144,15 @@ class SingularityApiConnection(ApiConnection):
         if extract == True:
             if not bot.is_quiet():
                 print("Decompressing %s" %image_file)
-            os.system('gzip -d -f %s' %(image_file))
-            image_file = image_file.replace('.gz','')
-        return image_file
+            output = run_command(['gzip','-d','-f',image_file])
+            final_image = image_file.replace('.gz','')
+
+            # Any error in extraction (return code not 0) will return None
+            if output is None:
+                bot.error('Error extracting image, cleaning up.')
+                clean_up([image_file,final_image])
+
+        return final_image
 
 
 

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -98,12 +98,20 @@ class SingularityApiConnection(ApiConnection):
         # If we eventually have private images, need to authenticate here       
         # --------------------------------------------------------------- 
 
-        response = self.get(base)
+        # If the Hub returns 404, the image name is likely wrong
+        response = self.get(base,return_response=True)
+        if response.code == 404:
+            bot.error("Cannot find image %s. Is your capitalization correct?" %image)
+            sys.exit(1)
+
         try:
+            response = response.read().decode('utf-8')
             response = json.loads(response)
+
         except:
             print("Error getting image manifest using url %s" %(base))
             sys.exit(1)
+
         return response
 
 

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -121,7 +121,16 @@ def is_number(image):
         return False
 
 
+def clean_up(files):
+    '''clean up will delete a list of files, only if they exist
+    '''
+    if not isinstance(files,list):
+        files = [files]
 
+    for f in files:
+        if os.path.exists(f):
+            bot.verbose3("Cleaning up %s" %f)
+            os.remove(f)
 
 ############################################################################
 ## TAR/COMPRESSION #########################################################


### PR DESCRIPTION
This will close #751 

The issue was that an "error" (404) returned a properly formed json, and we needed to look at the status code before parsing that. It was a quick fix - I instead call the get function of the client to return the response, check the status code:

 - if 404, give user message and gracefully exit
 - if ok, continue to read the json as we did before. Instead of the error shown in the issue above, it now looks like this

```
singularity pull shub://repronim/niceman
ERROR Cannot find image repronim/niceman. Is your capitalization correct?
```

Attn: @singularityware-admin
