### PR TITLE
Make the currently hard-coded SINGULARITYENV_PATH usable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,4 @@
     - Ralph Castain <rhc@open-mpi.org>
     - Yaroslav Halchenko <debian@onerussian.com>
     - Eduardo Arango <carlos.arango.gutierrez@correounivalle.edu.co>
+    - Oleksandr Moskalenko <om@rc.ufl.edu>

--- a/etc/init
+++ b/etc/init
@@ -11,7 +11,11 @@ unset ml
 unset BASH_ENV
 
 # Provide a sane path within the container
-SINGULARITYENV_PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+if [ -z ${SINGULARITYENV_PATH+x} ]; then
+    SINGULARITYENV_PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+else
+    SINGULARITYENV_PATH="$SINGULARITYENV_PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+fi
 
 # Don't save the shell's HISTFILE
 SINGULARITYENV_HISTFILE=""


### PR DESCRIPTION
**Description of the Pull Request (PR):**

etc/init is hard-coding SINGULARITYENV_PATH preventing its use at runtime. The included pull request tests for the presence of $SINGULARITYENV_PATH in the environment first and only sets the default $PATH if the above variable is not set in the environment.


**This fixes or addresses the following GitHub issues:**

- Ref: #754


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
