### PR TITLE
Import Complete set of NVidia libraries with --nv

### DIFF
--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -116,7 +116,8 @@ while true; do
         ;;
         -n|--nv)
             shift
-            for i in `ldconfig -p | grep -E "/libnv|/libcuda|/libEGL|/libGL|/libnvcu|/libvdpau|/libOpenCL|/libOpenGL"`; do
+             for i in `ldconfig -p | grep -E "/libnv|/libcuda|/libEGL|/libGL|/libvdpau|/libOpenCL|/libOpenGL|\
+                /libcusparse|/libcusolver|/libcurand|/libcuinj|/libcufft|/libcudnn|/libcublas|/libnpp"`; do
                 if [ -f "$i" ]; then
                     message 2 "Found NV library: $i\n"
                     if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then


### PR DESCRIPTION
Currently, several NVidia CUDA libraries are omitted with --nv flag. This imports all libraries from cuda-8.0 and, among other things, allows running tensorflow_gpu without the need for installing cuda inside the container. Also removing redundant entry "libnvcu" , already caught by "libnv".


Attn: @singularityware-admin
