### PR TITLE
Honor $TMPDIR instead of hardcoding /tmp

### DIFF
--- a/libexec/bootstrap-scripts/deffile-driver-docker.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-docker.sh
@@ -52,7 +52,7 @@ fi
 SINGULARITY_CONTAINER="docker://$FROM"
 SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity.d/labels.json"
 
-SINGULARITY_CONTENTS=`mktemp /tmp/.singularity-layers.XXXXXXXX`
+SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
 export SINGULARITY_CONTAINER SINGULARITY_CONTENTS SINGULARITY_LABELFILE
 
 eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"

--- a/libexec/bootstrap-scripts/deffile-driver-docker.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-docker.sh
@@ -52,7 +52,10 @@ fi
 SINGULARITY_CONTAINER="docker://$FROM"
 SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity.d/labels.json"
 
-SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
+if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`; then
+    message ERROR "Failed to create temporary directory\n"
+    ABORT 255
+fi
 export SINGULARITY_CONTAINER SINGULARITY_CONTENTS SINGULARITY_LABELFILE
 
 eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"

--- a/libexec/bootstrap-scripts/main-dockerhub.sh
+++ b/libexec/bootstrap-scripts/main-dockerhub.sh
@@ -42,7 +42,10 @@ fi
 
 
 SINGULARITY_CONTAINER="$SINGULARITY_BUILDDEF"
-SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
+if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`; then
+    message ERROR "Failed to create temporary directory\n"
+    ABORT 255
+fi
 export SINGULARITY_CONTAINER SINGULARITY_CONTENTS
 
 eval_abort "$SINGULARITY_libexecdir/singularity/bootstrap-scripts/pre.sh"

--- a/libexec/bootstrap-scripts/main-dockerhub.sh
+++ b/libexec/bootstrap-scripts/main-dockerhub.sh
@@ -42,7 +42,7 @@ fi
 
 
 SINGULARITY_CONTAINER="$SINGULARITY_BUILDDEF"
-SINGULARITY_CONTENTS=`mktemp /tmp/.singularity-layers.XXXXXXXX`
+SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
 export SINGULARITY_CONTAINER SINGULARITY_CONTENTS
 
 eval_abort "$SINGULARITY_libexecdir/singularity/bootstrap-scripts/pre.sh"

--- a/libexec/cli/import.exec
+++ b/libexec/cli/import.exec
@@ -85,7 +85,7 @@ if [ -n "${1:-}" ]; then
     case $1 in
         docker://*)
             SINGULARITY_CONTAINER="$1"
-            SINGULARITY_CONTENTS=`mktemp /tmp/.singularity-layers.XXXXXXXX`
+            SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
             export SINGULARITY_CONTAINER SINGULARITY_CONTENTS
             eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"
             message 1 "Importing: base Singularity environment\n"

--- a/libexec/cli/import.exec
+++ b/libexec/cli/import.exec
@@ -85,7 +85,10 @@ if [ -n "${1:-}" ]; then
     case $1 in
         docker://*)
             SINGULARITY_CONTAINER="$1"
-            SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
+            if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`; then
+                message ERROR "Failed to create temporary directory\n"
+                ABORT 255
+            fi
             export SINGULARITY_CONTAINER SINGULARITY_CONTENTS
             eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"
             message 1 "Importing: base Singularity environment\n"

--- a/libexec/cli/inspect.exec
+++ b/libexec/cli/inspect.exec
@@ -99,7 +99,10 @@ fi
 
 RETVAL=0
 SINGULARITY_IMAGE="${1:-}"
-SINGULARITY_MOUNTPOINT=`mktemp -d ${TMPDIR:-/tmp}/.singularity-inspect.XXXXXXXX`
+if ! SINGULARITY_MOUNTPOINT=`mktemp -d ${TMPDIR:-/tmp}/.singularity-inspect.XXXXXXXX`; then
+    message ERROR "Failed to create temporary directory\n"
+    ABORT 255
+fi
 export SINGULARITY_IMAGE SINGULARITY_MOUNTPOINT
 shift
 

--- a/libexec/cli/inspect.exec
+++ b/libexec/cli/inspect.exec
@@ -99,7 +99,7 @@ fi
 
 RETVAL=0
 SINGULARITY_IMAGE="${1:-}"
-SINGULARITY_MOUNTPOINT=`mktemp -d /tmp/.singularity-inspect.XXXXXXXX`
+SINGULARITY_MOUNTPOINT=`mktemp -d ${TMPDIR:-/tmp}/.singularity-inspect.XXXXXXXX`
 export SINGULARITY_IMAGE SINGULARITY_MOUNTPOINT
 shift
 

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -99,7 +99,10 @@ fi
 
 RETVAL=0
 SINGULARITY_CONTAINER="${1:-}"
-SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`
+if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`; then
+    message ERROR "Failed to create temporary directory\n"
+    ABORT 255
+fi
 if [ -n "${SINGULARITY_CACHEDIR:-}" ]; then
     SINGULARITY_PULLFOLDER="$SINGULARITY_CACHEDIR"
 else

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -99,7 +99,7 @@ fi
 
 RETVAL=0
 SINGULARITY_CONTAINER="${1:-}"
-SINGULARITY_CONTENTS=`mktemp /tmp/.singularity-layerfile.XXXXXX`
+SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`
 if [ -n "${SINGULARITY_CACHEDIR:-}" ]; then
     SINGULARITY_PULLFOLDER="$SINGULARITY_CACHEDIR"
 else

--- a/libexec/image-handler.sh
+++ b/libexec/image-handler.sh
@@ -72,7 +72,10 @@ case "$SINGULARITY_IMAGE" in
         SINGULARITY_CONTAINER="$SINGULARITY_IMAGE"
         SINGULARITY_IMAGE="$SINGULARITY_ROOTFS"
         SINGULARITY_CLEANUPDIR="$SINGULARITY_TMPDIR"
-        SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
+        if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`; then
+            message ERROR "Failed to create temporary directory\n"
+            ABORT 255
+        fi
 
         export SINGULARITY_ROOTFS SINGULARITY_IMAGE SINGULARITY_CONTAINER SINGULARITY_CONTENTS SINGULARITY_CLEANUPDIR
 
@@ -101,7 +104,10 @@ case "$SINGULARITY_IMAGE" in
 
     ;;
     shub://*)
-        SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`
+        if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`; then
+            message ERROR "Failed to create temporary directory\n"
+            ABORT 255
+        fi
 
         if [ -n "${SINGULARITY_CACHEDIR:-}" ]; then
             SINGULARITY_PULLFOLDER="$SINGULARITY_CACHEDIR"

--- a/libexec/image-handler.sh
+++ b/libexec/image-handler.sh
@@ -55,7 +55,7 @@ case "$SINGULARITY_IMAGE" in
         NAME=`echo "$SINGULARITY_IMAGE" | sed -e 's@^docker://@@'`
 
         if [ -z "${SINGULARITY_LOCALCACHEDIR:-}" ]; then
-            SINGULARITY_LOCALCACHEDIR="/tmp"
+            SINGULARITY_LOCALCACHEDIR="${TMPDIR:-/tmp}"
         fi
 
         if ! SINGULARITY_TMPDIR=`mktemp -d $SINGULARITY_LOCALCACHEDIR/.singularity-runtime.XXXXXXXX`; then
@@ -72,7 +72,7 @@ case "$SINGULARITY_IMAGE" in
         SINGULARITY_CONTAINER="$SINGULARITY_IMAGE"
         SINGULARITY_IMAGE="$SINGULARITY_ROOTFS"
         SINGULARITY_CLEANUPDIR="$SINGULARITY_TMPDIR"
-        SINGULARITY_CONTENTS=`mktemp /tmp/.singularity-layers.XXXXXXXX`
+        SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layers.XXXXXXXX`
 
         export SINGULARITY_ROOTFS SINGULARITY_IMAGE SINGULARITY_CONTAINER SINGULARITY_CONTENTS SINGULARITY_CLEANUPDIR
 
@@ -101,7 +101,7 @@ case "$SINGULARITY_IMAGE" in
 
     ;;
     shub://*)
-        SINGULARITY_CONTENTS=`mktemp /tmp/.singularity-layerfile.XXXXXX`
+        SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`
 
         if [ -n "${SINGULARITY_CACHEDIR:-}" ]; then
             SINGULARITY_PULLFOLDER="$SINGULARITY_CACHEDIR"
@@ -135,7 +135,7 @@ case "$SINGULARITY_IMAGE" in
     *.cpioz|*.vnfs)
         NAME=`basename "$SINGULARITY_IMAGE"`
         if [ -z "${SINGULARITY_CACHEDIR:-}" ]; then
-            SINGULARITY_CACHEDIR="/tmp"
+            SINGULARITY_CACHEDIR="${TMPDIR:-/tmp}"
         fi
         if [ ! -d "$SINGULARITY_CACHEDIR" ]; then
             message ERROR "Cache directory does not exist: $SINGULARITY_CACHEDIR\n"
@@ -166,7 +166,7 @@ case "$SINGULARITY_IMAGE" in
     *.cpio)
         NAME=`basename "$SINGULARITY_IMAGE"`
         if [ -z "${SINGULARITY_CACHEDIR:-}" ]; then
-            SINGULARITY_CACHEDIR="/tmp"
+            SINGULARITY_CACHEDIR="${TMPDIR:-/tmp}"
         fi
         if [ ! -d "$SINGULARITY_CACHEDIR" ]; then
             message ERROR "Cache directory does not exist: $SINGULARITY_CACHEDIR\n"
@@ -197,7 +197,7 @@ case "$SINGULARITY_IMAGE" in
     *.tar)
         NAME=`basename "$SINGULARITY_IMAGE"`
         if [ -z "${SINGULARITY_CACHEDIR:-}" ]; then
-            SINGULARITY_CACHEDIR="/tmp"
+            SINGULARITY_CACHEDIR="${TMPDIR:-/tmp}"
         fi
         if [ ! -d "$SINGULARITY_CACHEDIR" ]; then
             message ERROR "Cache directory does not exist: $SINGULARITY_CACHEDIR\n"
@@ -228,7 +228,7 @@ case "$SINGULARITY_IMAGE" in
     *.tgz|*.tar.gz)
         NAME=`basename "$SINGULARITY_IMAGE"`
         if [ -z "${SINGULARITY_CACHEDIR:-}" ]; then
-            SINGULARITY_CACHEDIR="/tmp"
+            SINGULARITY_CACHEDIR="${TMPDIR:-/tmp}"
         fi
         if [ ! -d "$SINGULARITY_CACHEDIR" ]; then
             message ERROR "Cache directory does not exist: $SINGULARITY_CACHEDIR\n"
@@ -260,7 +260,7 @@ case "$SINGULARITY_IMAGE" in
     *.tbz|*.tar.bz)
         NAME=`basename "$SINGULARITY_IMAGE"`
         if [ -z "${SINGULARITY_CACHEDIR:-}" ]; then
-            SINGULARITY_CACHEDIR="/tmp"
+            SINGULARITY_CACHEDIR="${TMPDIR:-/tmp}"
         fi
         if [ ! -d "$SINGULARITY_CACHEDIR" ]; then
             message ERROR "Cache directory does not exist: $SINGULARITY_CACHEDIR\n"

--- a/tests/functions
+++ b/tests/functions
@@ -39,7 +39,7 @@ test_init() {
         test_cleanup
     fi
 
-    SINGULARITY_TESTDIR=`mktemp -d /tmp/stest.XXXXXX`
+    SINGULARITY_TESTDIR=`mktemp -d ${TMPDIR:-/tmp}/stest.XXXXXX`
 
     echo
     echo "################################################################################"

--- a/tests/functions
+++ b/tests/functions
@@ -39,7 +39,10 @@ test_init() {
         test_cleanup
     fi
 
-    SINGULARITY_TESTDIR=`mktemp -d ${TMPDIR:-/tmp}/stest.XXXXXX`
+    if ! SINGULARITY_TESTDIR=`mktemp -d ${TMPDIR:-/tmp}/stest.XXXXXX`; then
+        message ERROR "Failed to create temporary directory\n"
+        ABORT 255
+    fi
 
     echo
     echo "################################################################################"


### PR DESCRIPTION
This allows a user to choose where (some) temporary directories such as
`.singularity-layers.XXXXXXXX` are placed by setting the `$TMPDIR` environment
variable. This may allow them, for example, to avoid running into limitations imposed on
`/tmp` that are not in place for `$TMPDIR`.

Notes:
* Possibly `mktemp --tmpdir template.XXX` is not portable enough. Then `mktemp ${TMPDIR:-/tmp}/template.XXX` could be used instead.
* It would be nice to set `$TMPDIR` once at the beginning if it is unset and then use only `$TMPDIR` subsequently instead of repeating `${TMPDIR:-/tmp}`. Autoconf uses `: ${TMPDIR=/tmp}` to achieve this.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin
