### PR TITLE
Patch to fix slurm plugin build (development)

### DIFF
--- a/src/slurm/Makefile.am
+++ b/src/slurm/Makefile.am
@@ -4,7 +4,7 @@ plugindir = $(libdir)/slurm
 if WITH_SLURM
 plugin_LTLIBRARIES = singularity_spank.la
 singularity_spank_la_SOURCES = singularity.c
-singularity_spank_la_LIBADD = ../lib/libsingularity_internal.la
+singularity_spank_la_LIBADD = ../lib/runtime/libinternal.la
 singularity_spank_la_LDFLAGS = -module -no-undefined -avoid-version -export-symbols-regex '^slurm_spank_|^plugin_'
 endif
 

--- a/src/slurm/singularity.c
+++ b/src/slurm/singularity.c
@@ -22,6 +22,7 @@
 
 #define _GNU_SOURCE 1
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -29,9 +30,9 @@
 #include <string.h>
 
 #include "config.h"
-#include "lib/singularity.h"
 #include "util/util.h"
 #include "util/file.h"
+#include "util/registry.h"
 
 #include "slurm/spank.h"
 
@@ -169,7 +170,6 @@ static int setup_container(spank_t spank)
     }
 
 
-    char *image;
     if ( ( image = singularity_registry_get("IMAGE") ) == NULL ) {
         singularity_message(ERROR, "SINGULARITY_CONTAINER not defined!\n");
     }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This patch fixes the issues with building the Slurm plugin for Singularity 2.3.1


**This fixes or addresses the following GitHub issues:**

- Ref: #701  


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`
- [x ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [ ] This PR is ready for review and/or merge


Attn: @singularityware-admin
