### PR TITLE
Fix --nv option

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -6,7 +6,7 @@ all: singularity.conf
 singularity.conf: singularity.conf.in ../src/util/config_defaults.h
 	./configure_transform.py --defaults ../src/util/config_defaults.h --infile singularity.conf.in --outfile singularity.conf
 
-dist_conf_DATA = default-nsswitch.conf singularity.conf init
+dist_conf_DATA = default-nsswitch.conf singularity.conf init nvliblist.conf
 dist_completion_DATA =  bash_completion.d/singularity
 
 CLEANFILES = singularity.conf

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -1,0 +1,42 @@
+# NVLIBLIST.CONF
+# This configuration file determines which NVIDIA libraries to search for on 
+# the host system when the --nv option is invoked.  You can edit it if you have
+# different libraries on your host system.
+
+libcuda.so
+libEGL_installertest.so
+libEGL_nvidia.so
+libEGL.so
+libGLdispatch.so
+libGLESv1_CM_nvidia.so
+libGLESv1_CM.so
+libGLESv2_nvidia.so
+libGLESv2.so
+libGL.so
+libGLX_installertest.so
+libGLX_nvidia.so
+libglx.so
+libGLX.so
+libnvcuvid.so
+libnvidia-cfg.so
+libnvidia-compiler.so
+libnvidia-eglcore.so
+libnvidia-egl-wayland.so
+libnvidia-encode.so
+libnvidia-fatbinaryloader.so
+libnvidia-fbc.so
+libnvidia-glcore.so
+libnvidia-glsi.so
+libnvidia-gtk2.so
+libnvidia-gtk3.so
+libnvidia-ifr.so
+libnvidia-ml.so
+libnvidia-opencl.so
+libnvidia-ptxjitcompiler.so
+libnvidia-tls.so
+libnvidia-wfb.so
+libOpenCL.so
+libOpenGL.so
+libvdpau_nvidia.so
+nvidia_drv.so
+tls_test_.so

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -116,23 +116,24 @@ while true; do
         ;;
         -n|--nv)
             shift
-            for i in `ldconfig -p | grep -E "/libnv|/libcuda|/libEGL|/libGL|/libvdpau|/libOpenGL" \
-                    | grep -v -E "/libcudart|/libnvrtc|/libnvToolsExt"`; do
-                if [ -f "$i" ]; then
-                    message 2 "Found NV library: $i\n"
-                    if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
-                        SINGULARITY_CONTAINLIBS="$i"
-                    else
-                        SINGULARITY_CONTAINLIBS="$SINGULARITY_CONTAINLIBS,$i"
+            for lib in $(cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -v "^#"); do
+                for i in $(ldconfig -p | grep "${lib}"); do
+                    if [ -f "$i" ]; then
+                        message 2 "Found NV library: $i\n"
+                        if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
+                            SINGULARITY_CONTAINLIBS="$i"
+                        else
+                            SINGULARITY_CONTAINLIBS="$SINGULARITY_CONTAINLIBS,$i"
+                        fi
                     fi
-                fi
+                done
             done
             if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
                 message WARN "Could not find any Nvidia libraries on this host!\n";
             else
                 export SINGULARITY_CONTAINLIBS
             fi
-            if NVIDIA_SMI=`which nvidia-smi`; then
+            if NVIDIA_SMI=$(which nvidia-smi); then
                 if [ -n "${SINGULARITY_BINDPATH:-}" ]; then
                     SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH},${NVIDIA_SMI}"
                 else

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -117,7 +117,7 @@ while true; do
         -n|--nv)
             shift
             SINGULARITY_NVLIBLIST=$(mktemp singularity-nvliblist.XXXXXXXX)
-            cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -v "^#" > $SINGULARITY_NVLIBLIST
+            cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" > $SINGULARITY_NVLIBLIST
             for i in $(ldconfig -p | grep -f "${SINGULARITY_NVLIBLIST}"); do
                 if [ -f "$i" ]; then
                     message 2 "Found NV library: $i\n"

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -116,18 +116,19 @@ while true; do
         ;;
         -n|--nv)
             shift
-            for lib in $(cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -v "^#"); do
-                for i in $(ldconfig -p | grep "${lib}"); do
-                    if [ -f "$i" ]; then
-                        message 2 "Found NV library: $i\n"
-                        if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
-                            SINGULARITY_CONTAINLIBS="$i"
-                        else
-                            SINGULARITY_CONTAINLIBS="$SINGULARITY_CONTAINLIBS,$i"
-                        fi
+            SINGULARITY_NVLIBLIST=$(mktemp singularity-nvliblist.XXXXXXXX)
+            cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -v "^#" > $SINGULARITY_NVLIBLIST
+            for i in $(ldconfig -p | grep -f "${SINGULARITY_NVLIBLIST}"); do
+                if [ -f "$i" ]; then
+                    message 2 "Found NV library: $i\n"
+                    if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
+                        SINGULARITY_CONTAINLIBS="$i"
+                     else
+                        SINGULARITY_CONTAINLIBS="$SINGULARITY_CONTAINLIBS,$i"
                     fi
-                done
+                fi
             done
+            rm $SINGULARITY_NVLIBLIST
             if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
                 message WARN "Could not find any Nvidia libraries on this host!\n";
             else

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -116,7 +116,8 @@ while true; do
         ;;
         -n|--nv)
             shift
-            for i in `ldconfig -p | grep -E "/libnv|/libcuda|/libEGL|/libGL|/libnvcu|/libvdpau|/libOpenCL|/libOpenGL"`; do
+            for i in `ldconfig -p | grep -E "/libnv|/libcuda|/libEGL|/libGL|/libvdpau|/libOpenGL" \
+                    | grep -v -E "/libcudart|/libnvrtc|/libnvToolsExt"`; do
                 if [ -f "$i" ]; then
                     message 2 "Found NV library: $i\n"
                     if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then


### PR DESCRIPTION
--nv option needs to be adjusted because it "imports" several CUDA libraries, which should be provided by the container.

This commit does two things:
1. Remove two unnecessary entries from the "grep" pattern:
   a) "libnvcu", because "libnv" already catches that
   b} "libOpenCL". Strangely, both kernel driver and cuda  provide libOpenCL.so (installed in two different locations), which differ according to diff. However, the cuda one has a higher priority according to ldconfig, and so OpenCL already in the container should be used. Because of this the grep pattern should not include libOpenCL.
2. Because grep catches several cuda-related libraries, specifically libcudart.so*, libnvrtc.so, and libnvToolsExt.so* I am adding grep -v statement after the pipe to avoid this.

One way this issue manifested itself, was that libraries in /.singularity.d/libs were replicated with libraries inside the container. With this fix, it does not happen anymore.

Finally, this is related to Pull Request #774 which I am going to delete.

Attn: @singularityware-admin
