### PR TITLE
Use clone as fallback when unshare fails with CLONE_NEWPID

### DIFF
--- a/src/lib/runtime/ns/pid/pid.c
+++ b/src/lib/runtime/ns/pid/pid.c
@@ -63,6 +63,7 @@ int _singularity_runtime_ns_pid(void) {
     singularity_message(DEBUG, "Using PID namespace: CLONE_NEWPID\n");
     singularity_priv_escalate();
     singularity_message(DEBUG, "Virtualizing PID namespace\n");
+
     if ( unshare(CLONE_NEWPID) < 0 ) {
         if ( errno == EINVAL ) {
             singularity_registry_set("NS_CLONE", "1");

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -342,7 +342,11 @@ pid_t singularity_fork_ns(int flags) {
 
     // Fork child
     singularity_message(VERBOSE2, "Forking child process\n");
+
+    /* clone(CLONE_NEWPID) requires privilege, so escalate while cloning */
+    singularity_priv_escalate();
     child_pid = fork_ns(flags);
+    singularity_priv_drop();
 
     if ( child_pid == 0 ) {
         singularity_message(VERBOSE2, "Hello from child process\n");
@@ -477,7 +481,7 @@ pid_t singularity_fork_ns(int flags) {
         return(child_pid);
 
     } else {
-        singularity_message(ERROR, "Failed to fork child process\n");
+        singularity_message(ERROR, "Failed to fork child process: %s\n", strerror(errno));
         ABORT(255);
     }
 }

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -25,6 +25,8 @@
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
+#include <setjmp.h>
+#include <sched.h>
 #include <poll.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -43,6 +45,10 @@ int watchdog_rpipe = -1;
 int watchdog_wpipe = -1;
 pid_t child_pid;
 
+typedef struct fork_state_s
+{
+    sigjmp_buf env;
+} fork_state_t;
 
 // NOTE: singularity_message is NOT signal handler safe.
 // Hence, we MUST NOT do any sort of generic logging from these
@@ -135,6 +141,36 @@ static void signal_go_ahead(char code) {
     close(coordination_pipe[1]);
 }
 
+/* */
+static int clone_fn(void *data_ptr) {
+    fork_state_t *state = (fork_state_t *)data_ptr;
+    siglongjmp(state->env, 1);
+}
+
+/* */
+static int fork_ns(int flags) {
+    fork_state_t state;
+    if (sigsetjmp(state.env, 1))
+    {
+        return 0;
+    }
+
+    int stack_size = 32*1024;
+    void *child_stack_ptr = malloc(stack_size);
+    if (child_stack_ptr == 0)
+    {
+        errno = ENOMEM;
+        return -1;
+    }
+    child_stack_ptr += stack_size;
+
+    int retval = clone(clone_fn,
+          child_stack_ptr,
+          (SIGCHLD|flags),
+          &state
+         );
+    return retval;
+}
 
 pid_t singularity_fork(void) {
     int pipes[2];
@@ -291,6 +327,161 @@ pid_t singularity_fork(void) {
     }
 }
 
+pid_t singularity_fork_ns(int flags) {
+    int pipes[2];
+
+    // From: signal_pre_fork()
+    if ( pipe2(pipes, O_CLOEXEC) < 0 ) {
+        singularity_message(ERROR, "Failed to create watchdog communication pipes: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    watchdog_rpipe = pipes[0];
+    watchdog_wpipe = pipes[1];
+
+    prepare_fork();
+
+    // Fork child
+    singularity_message(VERBOSE2, "Forking child process\n");
+    child_pid = fork_ns(flags);
+
+    if ( child_pid == 0 ) {
+        singularity_message(VERBOSE2, "Hello from child process\n");
+
+        if (watchdog_wpipe != -1) {
+            singularity_message(DEBUG, "Closing watchdog write pipe\n");
+            close(watchdog_wpipe);
+        }
+        watchdog_wpipe = -1;
+
+        wait_for_go_ahead();
+
+        singularity_message(DEBUG, "Child process is returning control to process thread\n");
+        return(0);
+
+    } else if ( child_pid > 0 ) {
+        singularity_message(VERBOSE2, "Hello from parent process\n");
+
+        // From: setup_signal_handler()
+        sigset_t blocked_mask, old_mask, empty_mask;
+        sigfillset(&blocked_mask);
+        sigemptyset(&empty_mask);
+        sigprocmask(SIG_SETMASK, &blocked_mask, &old_mask);
+
+        struct sigaction action;
+        action.sa_sigaction = &handle_signal;
+        action.sa_flags = SA_SIGINFO|SA_RESTART;
+        // All our handlers are signal safe.
+        action.sa_mask = empty_mask;
+
+        struct pollfd fds[3];
+        int retval;
+        int child_ok = 1;
+
+
+        singularity_message(DEBUG, "Assigning sigaction()s\n");
+        if ( -1 == sigaction(SIGINT, &action, NULL) ) {
+            singularity_message(ERROR, "Failed to install SIGINT signal handler: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        if ( -1 == sigaction(SIGQUIT, &action, NULL) ) {
+            singularity_message(ERROR, "Failed to install SIGQUIT signal handler: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        if ( -1 == sigaction(SIGTERM, &action, NULL) ) {
+            singularity_message(ERROR, "Failed to install SIGTERM signal handler: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        if ( -1 == sigaction(SIGHUP, &action, NULL) ) {
+            singularity_message(ERROR, "Failed to install SIGHUP signal handler: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        if ( -1 == sigaction(SIGUSR1, &action, NULL) ) {
+            singularity_message(ERROR, "Failed to install SIGUSR1 signal handler: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        if ( -1 == sigaction(SIGUSR2, &action, NULL) ) {
+            singularity_message(ERROR, "Failed to install SIGUSR2 signal handler: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        action.sa_sigaction = &handle_sigchld;
+        if ( -1 == sigaction(SIGCHLD, &action, NULL) ) {
+            singularity_message(ERROR, "Failed to install SIGCHLD signal handler: %s\n", strerror(errno));
+            ABORT(255);
+        }
+
+        singularity_message(DEBUG, "Creating generic signal pipes\n");
+        if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
+            singularity_message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        generic_signal_rpipe = pipes[0];
+        generic_signal_wpipe = pipes[1];
+
+        singularity_message(DEBUG, "Creating sigchld signal pipes\n");
+        if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
+            singularity_message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
+            ABORT(255);
+        }
+        sigchld_signal_rpipe = pipes[0];
+        sigchld_signal_wpipe = pipes[1];
+
+        sigprocmask(SIG_SETMASK, &old_mask, NULL);
+
+        fds[0].fd = sigchld_signal_rpipe;
+        fds[0].events = POLLIN;
+        fds[0].revents = 0;
+        fds[1].fd = generic_signal_rpipe;
+        fds[1].events = POLLIN;
+        fds[1].revents = 0;
+        fds[2].fd = watchdog_rpipe;
+        fds[2].events = POLLIN;
+        fds[2].revents = 0;
+
+        if ( singularity_priv_is_suid() == 0 ) {
+            singularity_message(DEBUG, "Dropping permissions\n");
+            singularity_priv_drop();
+        }
+        
+        signal_go_ahead(0);
+
+        do {
+            singularity_message(DEBUG, "Waiting on signal from watchdog\n");
+            while ( -1 == (retval = poll(fds, watchdog_rpipe == -1 ? 2 : 3, -1)) && errno == EINTR ) {}
+            if ( -1 == retval ) {
+                singularity_message(ERROR, "Failed to wait for file descriptors: %s\n", strerror(errno));
+                ABORT(255);
+            }
+            if (fds[0].revents) {
+                child_ok = 0;
+            }
+            if (fds[1].revents) {
+                char signum = SIGKILL;
+                while (-1 == (retval = read(generic_signal_rpipe, &signum, 1)) && errno == EINTR) {} // Flawfinder: ignore
+                if (-1 == retval) {
+                    singularity_message(ERROR, "Failed to read from signal handler pipe: %s\n", strerror(errno));
+                    ABORT(255);
+                }
+                kill(child_pid, signum);
+            }
+            if (watchdog_rpipe != -1 && fds[2].revents) {
+                // Parent died.  Immediately kill child.  NOTE that this only
+                // works if the child has also dropped privileges.
+                kill(child_pid, SIGKILL);
+                close(watchdog_rpipe);
+                watchdog_rpipe = -1;
+            }
+        } while ( child_ok );
+
+        singularity_message(DEBUG, "Parent process is exiting\n");
+
+        return(child_pid);
+
+    } else {
+        singularity_message(ERROR, "Failed to fork child process\n");
+        ABORT(255);
+    }
+}
+
 
 void singularity_fork_run(void) {
     int tmpstatus;
@@ -298,6 +489,22 @@ void singularity_fork_run(void) {
     pid_t child;
 
     if ( ( child = singularity_fork() ) > 0 ) {
+        singularity_message(DEBUG, "Waiting on child process\n");
+                                
+        waitpid(child, &tmpstatus, 0);
+        retval = WEXITSTATUS(tmpstatus);
+        exit(retval);
+    }
+
+    return;
+}
+
+void singularity_fork_run_ns(int flags) {
+    int tmpstatus;
+    int retval = 0;
+    pid_t child;
+
+    if ( ( child = singularity_fork_ns(flags) ) > 0 ) {
         singularity_message(DEBUG, "Waiting on child process\n");
                                 
         waitpid(child, &tmpstatus, 0);

--- a/src/util/fork.h
+++ b/src/util/fork.h
@@ -27,6 +27,7 @@
     // pipes and signal handlers so that signals are correctly passed around
     // between children and parents.
     pid_t singularity_fork(void);
+    pid_t singularity_fork_ns(int flags);
 
 
     // SINGLARITY_FORK_RUN()
@@ -37,6 +38,7 @@
     // Similar to singularity_fork() above, this will maintain the proper
     // communication channels for signal handling.
     void singularity_fork_run(void);
+    void singularity_fork_run_ns(int flags);
 
 
     // SINGULARITY_FORK_EXEC


### PR DESCRIPTION
**Description of the Pull Request (PR):**

On some kernel versions, the CLONE_NEWPID flag is available only for `clone` rather than for both `clone` and `unshare`. On these systems, a call to `unshare(CLONE_NEWPID)` causes a runtime failure. This is especially problematic for systems that do not support `PR_SET_NO_NEW_PRIVS`, since those systems must run containers inside of a PID NS (security concerns), and will otherwise fail completely. This PR catches this failure at runtime and falls back to using the `clone` system call when necessary. 


**This fixes or addresses the following GitHub issues:**

- Ref: #777 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
