### PR TITLE
Fork.c overhaul to use clone() instead of fork()

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     }
 
     singularity_priv_escalate();
-    retval = singularity_fork_exec(cp_cmd);
+    retval = singularity_fork_exec(0, cp_cmd);
     singularity_priv_drop();
 
     if ( retval != 0 ) {

--- a/src/create.c
+++ b/src/create.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
 
     singularity_priv_escalate();
     singularity_message(INFO, "Creating file system within image\n");
-    singularity_fork_exec(mkfs_cmd);
+    singularity_fork_exec(0, mkfs_cmd);
     singularity_priv_drop();
 
     singularity_message(INFO, "Image is done: %s\n", image.path);

--- a/src/expand.c
+++ b/src/expand.c
@@ -98,14 +98,14 @@ int main(int argc, char **argv) {
 
     singularity_priv_escalate();
     singularity_message(INFO, "Checking file system\n");
-    if ( singularity_fork_exec(e2fsck_cmd) != 0 ) {
+    if ( singularity_fork_exec(0, e2fsck_cmd) != 0 ) {
         singularity_message(ERROR, "Failed running %s\n", e2fsck_cmd[0]);
         ABORT(255);
     }
     singularity_priv_drop();
     singularity_priv_escalate();
     singularity_message(INFO, "Resizing file system\n");
-    if ( singularity_fork_exec(resize2fs_cmd) != 0 ) {
+    if ( singularity_fork_exec(0, resize2fs_cmd) != 0 ) {
         singularity_message(ERROR, "Failed running '%s' '%s'\n", resize2fs_cmd[0], resize2fs_cmd[1]);
         ABORT(255);
     }

--- a/src/export.c
+++ b/src/export.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     }
 
     singularity_priv_escalate();
-    retval = singularity_fork_exec(tar_cmd);
+    retval = singularity_fork_exec(0, tar_cmd);
     singularity_priv_drop();
 
     if ( retval != 0 ) {

--- a/src/import.c
+++ b/src/import.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
 
     singularity_priv_escalate();
     singularity_message(VERBOSE, "Opening STDIN for tar stream\n");
-    retval = singularity_fork_exec(tar_cmd);
+    retval = singularity_fork_exec(0, tar_cmd);
     singularity_priv_drop();
 
     if ( retval != 0 ) {

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -370,7 +370,6 @@ void singularity_fork_run(unsigned int flags) {
 }
 
 int singularity_fork_exec(unsigned int flags, char **argv) {
-    int tmpstatus;
     int retval;
     int i = 0;
     pid_t child;

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -300,13 +300,24 @@ void install_sigchld_signal_handle() {
 }
 
 pid_t singularity_fork(unsigned int flags) {
+    int priv_fork = 0;
     prepare_fork();
+
+    if ( geteuid() == 0 ) {
+        priv_fork = 1;
+    }
 
     singularity_message(VERBOSE2, "Forking child process\n");
     
-    singularity_priv_escalate();
+    if ( priv_fork == 0 ) {
+        singularity_priv_escalate();
+    }
+    
     child_pid = fork_ns(flags);
-    singularity_priv_drop();
+
+    if ( priv_fork == 0 ) {
+        singularity_priv_drop();
+    }
     
     if ( child_pid == 0 ) {
         singularity_message(VERBOSE2, "Hello from child process\n");

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -199,15 +199,8 @@ static int fork_ns(unsigned int flags) {
     if ( sigsetjmp(state.env, 1) ) {
         return 0;
     }
-
-    struct rlimit stack_limit;
-
-    if ( -1 == getrlimit(RLIMIT_STACK, &stack_limit) ) {
-        singularity_message(ERROR, "Unable to get current stack limit: %s\n", strerror(errno));
-        ABORT(255);
-    }
     
-    int stack_size = stack_limit.rlim_cur;
+    int stack_size = 1024*1024;
     void *child_stack_ptr = malloc(stack_size);
     if ( child_stack_ptr == 0 ) {
         errno = ENOMEM;

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -24,9 +24,12 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <string.h>
+#include <setjmp.h>
+#include <sched.h>
 #include <unistd.h>
 #include <poll.h>
 #include <sys/types.h>
+#include <sys/resource.h>
 #include <sys/wait.h>
 #include <stdio.h>
 
@@ -42,6 +45,13 @@ int sigchld_signal_wpipe = -1;
 int watchdog_rpipe = -1;
 int watchdog_wpipe = -1;
 pid_t child_pid;
+
+struct pollfd fds[2];
+
+typedef struct fork_state_s
+{
+    sigjmp_buf env;
+} fork_state_t;
 
 
 // NOTE: singularity_message is NOT signal handler safe.
@@ -135,186 +145,237 @@ static void signal_go_ahead(char code) {
     close(coordination_pipe[1]);
 }
 
+static int wait_child() {
+    int child_ok = 1;
+    int retval, tmpstatus;
 
-pid_t singularity_fork(void) {
-    int pipes[2];
+    singularity_message(DEBUG, "Parent process is waiting on child process\n");
+    
+    do {            
+        /* Poll the signal handle read pipes to wait for any written signals */
+        while ( -1 == (retval = poll(fds, 2, -1)) && errno == EINTR ) {}
+        if ( -1 == retval ) {
+            singularity_message(ERROR, "Failed to wait for file descriptors: %s\n", strerror(errno));
+            ABORT(255);
+        }
+            
+        /* When SIGCHILD is received, set child_ok = 0 to break out of loop */
+        if (fds[0].revents) {
+            singularity_message(DEBUG, "SIGCHLD raised, parent is exiting\n");
+            child_ok = 0;
+        }
 
-    // From: signal_pre_fork()
-    if ( pipe2(pipes, O_CLOEXEC) < 0 ) {
-        singularity_message(ERROR, "Failed to create watchdog communication pipes: %s\n", strerror(errno));
+        /* If we catch any other signal, */
+        if (fds[1].revents) {
+            char signum = SIGKILL;
+            while (-1 == (retval = read(generic_signal_rpipe, &signum, 1)) && errno == EINTR) {} // Flawfinder: ignore
+            if (-1 == retval) {
+                singularity_message(ERROR, "Failed to read from signal handler pipe: %s\n", strerror(errno));
+                ABORT(255);
+            }
+            singularity_message(VERBOSE2, "Sending signal to child: %d\n", signum);
+            kill(child_pid, signum);
+        }
+    } while( child_ok );
+
+    /* Catch the exit status of the child process */
+    retval = 0;
+    waitpid(child_pid, &tmpstatus, 0);
+    retval = WEXITSTATUS(tmpstatus);
+    
+    return(retval);
+}
+
+/* */
+static int clone_fn(void *data_ptr) {
+    fork_state_t *state = (fork_state_t *)data_ptr;
+    siglongjmp(state->env, 1);
+}
+
+/* */
+static int fork_ns(unsigned int flags) {
+    fork_state_t state;
+    
+    if ( sigsetjmp(state.env, 1) ) {
+        return 0;
+    }
+
+    struct rlimit stack_limit;
+
+    if ( -1 == getrlimit(RLIMIT_STACK, &stack_limit) ) {
+        singularity_message(ERROR, "Unable to get current stack limit: %s\n", strerror(errno));
         ABORT(255);
     }
-    watchdog_rpipe = pipes[0];
-    watchdog_wpipe = pipes[1];
+    
+    int stack_size = stack_limit.rlim_cur;
+    void *child_stack_ptr = malloc(stack_size);
+    if ( child_stack_ptr == 0 ) {
+        errno = ENOMEM;
+        return -1;
+    }
+    child_stack_ptr += stack_size;
 
+    int retval = clone(clone_fn,
+          child_stack_ptr,
+          (SIGCHLD|flags),
+          &state
+         );
+    return retval;
+}
+
+void install_generic_signal_handle() {
+    int pipes[2];
+    struct sigaction action;
+    sigset_t empty_mask;
+    
+    sigemptyset(&empty_mask);
+    
+    /* Fill action with handle_signal function */
+    action.sa_sigaction = &handle_signal;
+    action.sa_flags = SA_SIGINFO|SA_RESTART;
+    action.sa_mask = empty_mask;
+
+    singularity_message(DEBUG, "Assigning generic sigaction()s\n");
+    if ( -1 == sigaction(SIGINT, &action, NULL) ) {
+        singularity_message(ERROR, "Failed to install SIGINT signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGQUIT, &action, NULL) ) {
+        singularity_message(ERROR, "Failed to install SIGQUIT signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGTERM, &action, NULL) ) {
+        singularity_message(ERROR, "Failed to install SIGTERM signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGHUP, &action, NULL) ) {
+        singularity_message(ERROR, "Failed to install SIGHUP signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGUSR1, &action, NULL) ) {
+        singularity_message(ERROR, "Failed to install SIGUSR1 signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    if ( -1 == sigaction(SIGUSR2, &action, NULL) ) {
+        singularity_message(ERROR, "Failed to install SIGUSR2 signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+
+    /* Open pipes for handle_signal() to write to */
+    singularity_message(DEBUG, "Creating generic signal pipes\n");
+    if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
+        singularity_message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    generic_signal_rpipe = pipes[0];
+    generic_signal_wpipe = pipes[1];
+}
+
+void install_sigchld_signal_handle() {
+    int pipes[2];
+    struct sigaction action;
+    sigset_t empty_mask;
+    
+    sigemptyset(&empty_mask);
+
+    /* Fill action with handle_sigchld function */
+    action.sa_sigaction = &handle_sigchld;
+    action.sa_flags = SA_SIGINFO|SA_RESTART;
+    action.sa_mask = empty_mask;
+    
+    singularity_message(DEBUG, "Assigning SIGCHLD sigaction()\n");
+    if ( -1 == sigaction(SIGCHLD, &action, NULL) ) {
+        singularity_message(ERROR, "Failed to install SIGCHLD signal handler: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    
+    /* Open pipes for handle_sigchld() to write to */
+    singularity_message(DEBUG, "Creating sigchld signal pipes\n");
+    if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
+        singularity_message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
+        ABORT(255);
+    }
+    sigchld_signal_rpipe = pipes[0];
+    sigchld_signal_wpipe = pipes[1];
+}
+
+pid_t singularity_fork(unsigned int flags) {
     prepare_fork();
 
-    // Fork child
     singularity_message(VERBOSE2, "Forking child process\n");
-    child_pid = fork();
-
+    
+    singularity_priv_escalate();
+    child_pid = fork_ns(flags);
+    singularity_priv_drop();
+    
     if ( child_pid == 0 ) {
         singularity_message(VERBOSE2, "Hello from child process\n");
 
-        if (watchdog_wpipe != -1) {
-            singularity_message(DEBUG, "Closing watchdog write pipe\n");
-            close(watchdog_wpipe);
-        }
-        watchdog_wpipe = -1;
-
         wait_for_go_ahead();
-
-        singularity_message(DEBUG, "Child process is returning control to process thread\n");
-        return(0);
-
+        singularity_message(DEBUG, "Received go-ahead from parent, continuing\n");
+        
+        return(child_pid);
     } else if ( child_pid > 0 ) {
         singularity_message(VERBOSE2, "Hello from parent process\n");
-
-        // From: setup_signal_handler()
-        sigset_t blocked_mask, old_mask, empty_mask;
+        
+        /* Set signal mask to block all signals while we set up sig actions */
+        sigset_t blocked_mask, old_mask;
         sigfillset(&blocked_mask);
-        sigemptyset(&empty_mask);
         sigprocmask(SIG_SETMASK, &blocked_mask, &old_mask);
 
-        struct sigaction action;
-        action.sa_sigaction = &handle_signal;
-        action.sa_flags = SA_SIGINFO|SA_RESTART;
-        // All our handlers are signal safe.
-        action.sa_mask = empty_mask;
+        /* Now that we can't receive any signals, install signal handlers for all signals we want to catch */
+        install_generic_signal_handle();
+        install_sigchld_signal_handle();
 
-        struct pollfd fds[3];
-        int retval;
-        int child_ok = 1;
-
-
-        singularity_message(DEBUG, "Assigning sigaction()s\n");
-        if ( -1 == sigaction(SIGINT, &action, NULL) ) {
-            singularity_message(ERROR, "Failed to install SIGINT signal handler: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        if ( -1 == sigaction(SIGQUIT, &action, NULL) ) {
-            singularity_message(ERROR, "Failed to install SIGQUIT signal handler: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        if ( -1 == sigaction(SIGTERM, &action, NULL) ) {
-            singularity_message(ERROR, "Failed to install SIGTERM signal handler: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        if ( -1 == sigaction(SIGHUP, &action, NULL) ) {
-            singularity_message(ERROR, "Failed to install SIGHUP signal handler: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        if ( -1 == sigaction(SIGUSR1, &action, NULL) ) {
-            singularity_message(ERROR, "Failed to install SIGUSR1 signal handler: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        if ( -1 == sigaction(SIGUSR2, &action, NULL) ) {
-            singularity_message(ERROR, "Failed to install SIGUSR2 signal handler: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        action.sa_sigaction = &handle_sigchld;
-        if ( -1 == sigaction(SIGCHLD, &action, NULL) ) {
-            singularity_message(ERROR, "Failed to install SIGCHLD signal handler: %s\n", strerror(errno));
-            ABORT(255);
-        }
-
-        singularity_message(DEBUG, "Creating generic signal pipes\n");
-        if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
-            singularity_message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        generic_signal_rpipe = pipes[0];
-        generic_signal_wpipe = pipes[1];
-
-        singularity_message(DEBUG, "Creating sigchld signal pipes\n");
-        if ( -1 == pipe2(pipes, O_CLOEXEC) ) {
-            singularity_message(ERROR, "Failed to create communication pipes: %s\n", strerror(errno));
-            ABORT(255);
-        }
-        sigchld_signal_rpipe = pipes[0];
-        sigchld_signal_wpipe = pipes[1];
-
+        /* Set signal mask back to the original mask, unblocking the blocked signals */
         sigprocmask(SIG_SETMASK, &old_mask, NULL);
 
+        /* Set fds[n].fd to the read pipes created earlier */
         fds[0].fd = sigchld_signal_rpipe;
         fds[0].events = POLLIN;
         fds[0].revents = 0;
         fds[1].fd = generic_signal_rpipe;
         fds[1].events = POLLIN;
         fds[1].revents = 0;
-        fds[2].fd = watchdog_rpipe;
-        fds[2].events = POLLIN;
-        fds[2].revents = 0;
 
+        /* Drop privs if we're SUID */
         if ( singularity_priv_is_suid() == 0 ) {
             singularity_message(DEBUG, "Dropping permissions\n");
             singularity_priv_drop();
         }
-        
+
+        /* Allow child process to continue */
+        singularity_message(DEBUG, "Signalling go-ahead to child\n");
         signal_go_ahead(0);
-
-        do {
-            singularity_message(DEBUG, "Waiting on signal from watchdog\n");
-            while ( -1 == (retval = poll(fds, watchdog_rpipe == -1 ? 2 : 3, -1)) && errno == EINTR ) {}
-            if ( -1 == retval ) {
-                singularity_message(ERROR, "Failed to wait for file descriptors: %s\n", strerror(errno));
-                ABORT(255);
-            }
-            if (fds[0].revents) {
-                child_ok = 0;
-            }
-            if (fds[1].revents) {
-                char signum = SIGKILL;
-                while (-1 == (retval = read(generic_signal_rpipe, &signum, 1)) && errno == EINTR) {} // Flawfinder: ignore
-                if (-1 == retval) {
-                    singularity_message(ERROR, "Failed to read from signal handler pipe: %s\n", strerror(errno));
-                    ABORT(255);
-                }
-                kill(child_pid, signum);
-            }
-            if (watchdog_rpipe != -1 && fds[2].revents) {
-                // Parent died.  Immediately kill child.  NOTE that this only
-                // works if the child has also dropped privileges.
-                kill(child_pid, SIGKILL);
-                close(watchdog_rpipe);
-                watchdog_rpipe = -1;
-            }
-        } while ( child_ok );
-
-        singularity_message(DEBUG, "Parent process is exiting\n");
-
+        
         return(child_pid);
-
     } else {
-        singularity_message(ERROR, "Failed to fork child process\n");
+        singularity_message(ERROR, "Failed to fork child process: %s\n", strerror(errno));
         ABORT(255);
-    }
+    }    
 }
 
-
-void singularity_fork_run(void) {
-    int tmpstatus;
-    int retval = 0;
+void singularity_fork_run(unsigned int flags) {
     pid_t child;
+    int retval;
 
-    if ( ( child = singularity_fork() ) > 0 ) {
-        singularity_message(DEBUG, "Waiting on child process\n");
-                                
-        waitpid(child, &tmpstatus, 0);
-        retval = WEXITSTATUS(tmpstatus);
+    child = singularity_fork(flags);
+
+    if ( child == 0 ) {
+        return;
+    } else if ( child > 0 ) {
+        retval = wait_child();
         exit(retval);
     }
-
-    return;
 }
 
-int singularity_fork_exec(char **argv) {
+int singularity_fork_exec(unsigned int flags, char **argv) {
     int tmpstatus;
-    int retval = 0;
+    int retval;
     int i = 0;
     pid_t child;
 
-    child = singularity_fork();
+    child = singularity_fork(0);
 
     if ( child == 0 ) {
         while(1) {
@@ -335,15 +396,10 @@ int singularity_fork_exec(char **argv) {
         }
 
     } else if ( child > 0 ) {
-        singularity_message(DEBUG, "Waiting on child process\n");
-                                
-        waitpid(child, &tmpstatus, 0);
-        retval = WEXITSTATUS(tmpstatus);
+        retval = wait_child();
     }
 
     singularity_message(DEBUG, "Returning from singularity_fork_exec with: %d\n", retval);
     return(retval);
 }
-
-
 

--- a/src/util/fork.h
+++ b/src/util/fork.h
@@ -26,7 +26,7 @@
     // Wrap the fork() system call and create the necessary communication
     // pipes and signal handlers so that signals are correctly passed around
     // between children and parents.
-    pid_t singularity_fork(void);
+    pid_t singularity_fork(unsigned int flags);
 
 
     // SINGLARITY_FORK_RUN()
@@ -36,13 +36,13 @@
     // then the parent will also exit with the same exit code as the parent.
     // Similar to singularity_fork() above, this will maintain the proper
     // communication channels for signal handling.
-    void singularity_fork_run(void);
+    void singularity_fork_run(unsigned int flags);
 
 
     // SINGULARITY_FORK_EXEC
     // Fork and exec a child system command, wait for it to return, and then
     // return with the appropriate exit value.
-    int singularity_fork_exec(char **argv);
+    int singularity_fork_exec(unsigned int flags, char **argv);
 
 
 #endif /* __SINGULARITY_FORK_H_ */


### PR DESCRIPTION
**Description of the Pull Request (PR):**
As discussed in #777, on some systems a call to `unshare()` will fail in some systems that support `CLONE_NEWPID` only for `clone()`. The original fix ( #793 ) was to simply check if calling `unshare()` failed and attempt to use `clone()` as a fallback. This works as a temporary fix, but there is no reason not to always use `clone()`.

This PR does the following:

1. Implement `fork_ns()` which mimics `fork()` interface but uses `clone()`. Thanks @bbockelm 

2. Add two new functions to install the signal handlers. These are in functions so that in the future we can move to a more "object oriented" forking methodology as discussed w/ Greg.

3. Add new function `wait_child()` which listens on the pipes that were created for the signal handlers to write to, and propagates signals as expected. This function use to be inside of `singularity_fork()`

4. `singularity_fork()` now has the same behavior as `fork()`. Both the parent and child will return before blocking. It is now the parent's responsibility to call `wait_child()` after it calls `singularity_fork()` if it wishes to block for the signals. Further, if `singularity_fork()` is called with escalated privileges, we will not raise and drop privileges before and after the call to `fork_ns()` so that we preserve the ability to call binaries as root (_e.g. create.c_)

5. Update all calls to `singularity_fork*` to match the new interface [takes one additional argument, _unsigned int flags_, which are passed as flags to `clone()`]

6. src/lib/runtime/ns/pid/pid.c is much more streamlined.


**This fixes or addresses the following GitHub issues:**

- Ref: #777 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: 
@singularityware/singularity-admin 
@AdamSimpson Please ensure that this PR fixes your issue still
@bbockelm Would like your thoughts on the refactoring of fork.c, maybe better stack size code?