### PR TITLE
Add block to stest() function to warn instead of error.

### DIFF
--- a/tests/02-flawfinder.sh
+++ b/tests/02-flawfinder.sh
@@ -24,7 +24,7 @@
 
 test_init "Running Flawfinder"
 
-stest 0 which flawfinder
+stest 1 which flawfinder
 stest 0 sh -c "flawfinder -SQ --minlevel=3 ../src > '$SINGULARITY_TESTDIR/ff.out'"
 if ! grep -q 'No hits found.' "$SINGULARITY_TESTDIR/ff.out"; then
     cat "$SINGULARITY_TESTDIR/ff.out"

--- a/tests/functions
+++ b/tests/functions
@@ -87,6 +87,12 @@ stest() {
         echo "Full output in: $SINGULARITY_TESTDIR"
         exit_cleanup
         exit 1
+    elif [ "$ERROR" = "1" -a "$RETVAL" != "0" ]; then
+        message 2 "%13s WARNING\n" "(retval=$RETVAL)"
+        cat "$OUTPUT"
+        echo "Full output in: $SINGULARITY_TESTDIR"
+        exit_cleanup
+        exit 0
     else
         message 2 "%13s OK\n" "(retval=$RETVAL)"
     fi

--- a/tests/functions
+++ b/tests/functions
@@ -63,6 +63,11 @@ exit_cleanup() {
     return 0
 }
 
+#
+# ERROR Values
+#  0 - Standard. ERROR on failure
+#  1 - Warning. Failure is okay. Warn if this happens
+#
 stest() {
     ERROR="${1:-}"
     OUTPUT="$SINGULARITY_TESTDIR/output"
@@ -81,18 +86,18 @@ stest() {
         echo "Full output in: $SINGULARITY_TESTDIR"
         exit_cleanup
         exit 1
-    elif [ "$ERROR" != "0" -a "$RETVAL" = "0" ]; then
-        message 2 "%13s ERROR\n" "(retval=$RETVAL)"
-        cat "$OUTPUT"
-        echo "Full output in: $SINGULARITY_TESTDIR"
-        exit_cleanup
-        exit 1
     elif [ "$ERROR" = "1" -a "$RETVAL" != "0" ]; then
         message 2 "%13s WARNING\n" "(retval=$RETVAL)"
         cat "$OUTPUT"
         echo "Full output in: $SINGULARITY_TESTDIR"
         exit_cleanup
         exit 0
+    elif [ $ERROR -gt 1 -a "$RETVAL" = "0" ]; then
+        message 2 "%13s ERROR\n" "(retval=$RETVAL)"
+        cat "$OUTPUT"
+        echo "Full output in: $SINGULARITY_TESTDIR"
+        exit_cleanup
+        exit 1
     else
         message 2 "%13s OK\n" "(retval=$RETVAL)"
     fi


### PR DESCRIPTION
Change 02-flawfinder.sh to warn instead of error if the flawfinder
binary is not found.

**Description of the Pull Request (PR):**

Modify the stest function to allow warnings on checks that could fail that are not fatal.


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [ ] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
