### PR TITLE
Fix check for image type before image offset calculation

### DIFF
--- a/src/lib/image/offset/offset.c
+++ b/src/lib/image/offset/offset.c
@@ -51,8 +51,8 @@ int _singularity_image_offset(struct image_object *image) {
         ABORT(255);
     }
 
-    if ( singularity_image_check(image) != 0 ) {
-        singularity_message(DEBUG, "File is not a Singularity image, returning zero offset\n");
+    if ( image->type == SQUASHFS ) {
+        singularity_message(DEBUG, "File is a SquashFS image, returning zero offset\n");
         return(0);
     }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes #817. Tested with the SquashFS file that used to fail, seems fine now.

**This fixes or addresses the following GitHub issues:**

- Ref: #817

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
