### PR TITLE
adding SUPPORT.md to docs

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,22 @@
+# Singularity Support
+
+Need help? We have several ways to reach us, depending on your preferences and needs.
+
+## Documentation
+If you haven't already, search our [user quick start](http://singularity.lbl.gov/quickstart), [docs base](http://singularity.lbl.gov/docs-quick-start-installation), and [other guides](http://singularity.lbl.gov/links) from the community. If you have a good resource, please [let us know](https://github.com/singularityware/singularity/issues).
+
+
+## Github
+For issues with code and sharing debug output, we recommend Github issues boards.
+
+ - [Singularity Issues](https://github.com/singularityware/singularity/issues): is recommended for most issues with the Singularity software.
+ - [Singularity Hub Issues](https://github.com/singularityhub/singularityhub.github.io/issues): is the board for issues relevant to Singularity Hub.
+ - [Documentation Issues](https://github.com/singularityware/singularityware.github.io/issues): documentation questions, feedback, and suggestions should go here. Feel free to create an issue on a board and additionally request more documentation here.
+
+## Google Group
+You can reach the community quickly by way of joining our [Google Group](https://groups.google.com/a/lbl.gov/forum/#!forum/singularity).
+
+## Slack
+For real time support from the community, you can join our community on slack at [https://singularity-container.slack.com/](https://singularity-container.slack.com/). Ping the Google Group or one of the admins here to request to be added.
+
+Is there something missing here you'd like to see? Please [let us know](https://github.com/singularityware/singularity/issues).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -3,15 +3,15 @@
 Need help? We have several ways to reach us, depending on your preferences and needs.
 
 ## Documentation
-If you haven't already, search our [user quick start](http://singularity.lbl.gov/quickstart), [docs base](http://singularity.lbl.gov/docs-quick-start-installation), and [other guides](http://singularity.lbl.gov/links) from the community. If you have a good resource, please [let us know](https://github.com/singularityware/singularity/issues).
+If you haven't already, search our [user quick start](http://singularity.lbl.gov/quickstart), [docs base](http://singularity.lbl.gov/docs-quick-start-installation), and [other guides](http://singularity.lbl.gov/links) from the community. These docs have common use cases, and might be helpful to browse before submitting an issue. If you have a good resource, please [let us know](https://github.com/singularityware/singularity/issues).
 
 
 ## Github
-For issues with code and sharing debug output, we recommend Github issues boards.
+For issues with code (and especially if you need to share debug output) we recommend Github issues boards.
 
  - [Singularity Issues](https://github.com/singularityware/singularity/issues): is recommended for most issues with the Singularity software.
  - [Singularity Hub Issues](https://github.com/singularityhub/singularityhub.github.io/issues): is the board for issues relevant to Singularity Hub.
- - [Documentation Issues](https://github.com/singularityware/singularityware.github.io/issues): documentation questions, feedback, and suggestions should go here. Feel free to create an issue on a board and additionally request more documentation here.
+ - [Documentation Issues](https://github.com/singularityware/singularityware.github.io/issues): documentation questions, feedback, and suggestions should go here. Feel free to create an issue on a board and additionally request updated content here.
 
 ## Google Group
 You can reach the community quickly by way of joining our [Google Group](https://groups.google.com/a/lbl.gov/forum/#!forum/singularity).


### PR DESCRIPTION
This is a quick PR to add a [SUPPORT.md](https://github.com/blog/2400-support-file-support) file to the docs, which will edit this little line:

![image](https://user-images.githubusercontent.com/814322/28465976-96b2b804-6ddf-11e7-803f-7d38085f2386.png)

to link to a file with more robust information for getting help. This was just announced yesterday, and seems like a good idea to provide as much help / guidance as possible before the user creates an issue, in case that the question can be answered better elsewhere.

Note I am PRing to master so it shows up immediately, there are no changes to master code other than this file.