### PR TITLE
Add/bootstrap minsize check

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,3 +29,4 @@
     - Rémy Dernat <remy.dernat@umontpellier.fr>
     - Mark Egan-Fuller <markeganfuller@googlemail.com>
     - Petr Votava <votava.petr@gene.com>
+    - Isaac Yonemoto <isaac.yonemoto@gmail.com>

--- a/libexec/bootstrap-scripts/main-deffile.sh
+++ b/libexec/bootstrap-scripts/main-deffile.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
-# 
+#
 # Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 #
 # Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
-# 
+#
 # Copyright (c) 2016-2017, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
-# 
+#
 # This software is licensed under a customized 3-clause BSD license.  Please
 # consult LICENSE file distributed with the sources of this project regarding
 # your rights to use or distribute this software.
-# 
+#
 # NOTICE.  This Software was developed under funding from the U.S. Department of
 # Energy and the U.S. Government consequently retains certain rights. As such,
 # the U.S. Government has been granted for itself and others acting on its
 # behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 # to reproduce, distribute copies to the public, prepare derivative works, and
-# perform publicly and display publicly, and to permit other to do so. 
-# 
-# 
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
 
 ## Basic sanity
 if [ -z "$SINGULARITY_libexecdir" ]; then
@@ -38,6 +38,24 @@ fi
 if [ -z "${SINGULARITY_ROOTFS:-}" ]; then
     message ERROR "Singularity root file system not defined\n"
     exit 1
+fi
+
+## For deffile bootstraps, we can implement a "minsize" guard.  This triggers a
+## size check against the image we're trying to bootstrap into, so we don't
+## waste time building into an image file that will be too small.
+#this environment variable might not be defined, so we can make it null.
+MINSIZE=${MINSIZE:-}
+if [ -n "$MINSIZE" ]; then
+  #report that it's been included in the def file.
+  echo "Minimum image size has been set: $MINSIZE M"
+  #get the size of the image, in megabytes.
+  IMAGE_SIZE=$(du --apparent-size -m $SINGULARITY_IMAGE | cut -f 1)
+  echo "Detected size of the image: $IMAGE_SIZE"
+  #do the check.
+  if [ "$IMAGE_SIZE" -lt "$MINSIZE" ]; then
+    message ERROR "Size of $SINGULARITY_IMAGE insufficient to accomodate bootstrap minimum $MINSIZE M\n"
+    exit 1
+  fi
 fi
 
 

--- a/tests/20-bootstrap.sh
+++ b/tests/20-bootstrap.sh
@@ -65,8 +65,29 @@ stest 0 sh -c "sudo singularity bootstrap '$CONTAINER' '$SINGULARITY_TESTDIR/Sin
 stest 0 singularity create -F -s 568 "$CONTAINER"
 stest 1 sh -c "sudo singularity bootstrap --notest '$CONTAINER' '$SINGULARITY_TESTDIR/Singularity' | grep 'test123'"
 
-
 stest 0 sudo rm -rf "$CONTAINERDIR"
 
+
+################################################################################
+# bootstrap minsize testing
+
+MINSIZE_CONTAINERDIR="$SINGULARITY_TESTDIR/minsize"
+MINSIZE_DEFFILE="$MINSIZE_CONTAINERDIR/minsize.def"
+MINSIZE_IMGFILE="$MINSIZE_CONTAINERDIR/minsize.img"
+
+stest 0 mkdir -p $MINSIZE_CONTAINERDIR
+
+cat > $MINSIZE_DEFFILE <<EOF
+Bootstrap:docker
+From:alpine:latest
+Minsize:1024
+EOF
+
+stest 0 singularity create -F -s 512 "$MINSIZE_IMGFILE"
+stest 1 sudo singularity bootstrap "$MINSIZE_IMGFILE" "$MINSIZE_DEFFILE"
+stest 0 rm "$MINSIZE_IMGFILE"
+stest 0 singularity create -F -s 1024 "$MINSIZE_IMGFILE"
+stest 0 sudo singularity bootstrap "$MINSIZE_IMGFILE" "$MINSIZE_DEFFILE"
+stest 0 rm -rf "$MINSIZE_CONTAINERDIR"
 
 test_cleanup


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Implements a "minsize" keyword for def file bootstraps which will guard against trying to use an image that isn't big enough to fit the intended contents.  It's still up to the def file author to make sure that the reported minsize is correct.  def files which don't implement minsize are still supported.

**This fixes or addresses the following GitHub issues:**

- Ref: # https://github.com/singularityware/singularity/issues/646


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
