### PR TITLE
adding optional https to docker

### DIFF
--- a/libexec/python/README.md
+++ b/libexec/python/README.md
@@ -98,6 +98,9 @@ Is not obtained from the environment, but is a hard coded default (`"/bin/bash"`
 **TAG**
 Is the default tag, `latest`.
 
+**DISABLE_HTTPS**
+If you export the variable `SINGULARITY_NOHTTPS` you can force the software to not use https when interacting with a Docker registry. This use case is typically for use of a local registry.
+
 
 #### Singularity Hub
 

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -142,6 +142,8 @@ ENV_BASE = getenv("SINGULARITY_ENVBASE", default=_envbase)
 LABELFILE = getenv("SINGULARITY_LABELFILE", default=_labelfile)
 INCLUDE_CMD = convert2boolean(getenv("SINGULARITY_INCLUDECMD",
                               default=False))
+DISABLE_HTTPS = convert2boolean(getenv("SINGULARITY_NOHTTPS",
+                                default=False))
 
 #######################################################################
 # Singularity Hub

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -23,7 +23,8 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 from defaults import (
-    SINGULARITY_CACHE
+    SINGULARITY_CACHE,
+    DISABLE_HTTPS
 )
 from message import bot
 import datetime
@@ -60,7 +61,7 @@ def add_http(url, use_https=True):
     :param use_https: should we default to https? default is True
     '''
     scheme = "https://"
-    if use_https is False:
+    if use_https is False or DISABLE_HTTPS is True:
         scheme = "http://"
 
     # remove scheme from url


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR will add an environment variable, `SINGULARITY_NOHTTPS` that will disable using https for interacting with a Docker registry. This option is primarily intended for users running a local registry that cannot support (or don't want to set up) a certificate, which is a very reasonable thing to do. This first snippet shows exporting the variable, and that it shows up as being found:
```
SINGULARITY_NOHTTPS=yes
export SINGULARITY_NOHTTPS
singularity --debug run docker://ubuntu:14.04
Enabling debugging
Ending argument loop
Singularity version: 2.3.1-add/https-optional.ga78190c
Exec'ing: /usr/local/libexec/singularity/cli/run.exec
Evaluating args: 'docker://ubuntu:14.04'
VERBOSE2 SINGULARITY_COMMAND_ASIS found as False
VERBOSE2 SINGULARITY_ROOTFS found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04
VERBOSE2 SINGULARITY_METADATA_FOLDER found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04/.singularity.d
VERBOSE2 SINGULARITY_FIX_PERMS found as False
VERBOSE2 SINGULARITY_COLORIZE not defined (None)
VERBOSE2 SINGULARITY_DISABLE_CACHE found as False
VERBOSE2 SINGULARITY_CACHEDIR found as /home/vanessa/.singularity
VERBOSE2 SINGULARITY_ENVIRONMENT found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04/.singularity.d/environment
VERBOSE2 SINGULARITY_RUNSCRIPT found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04/singularity
VERBOSE2 SINGULARITY_TESTFILE found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04/.singularity.d/test
VERBOSE2 SINGULARITY_DEFFILE found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04/.singularity.d/Singularity
VERBOSE2 SINGULARITY_ENVBASE found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04/.singularity.d/env
VERBOSE2 SINGULARITY_LABELFILE found as /tmp/.singularity-runtime.cTWaCjRb/ubuntu:14.04/.singularity.d/labels.json
VERBOSE2 SINGULARITY_INCLUDECMD found as False
VERBOSE2 SINGULARITY_NOHTTPS found as yes
VERBOSE2 SINGULARITY_PULLFOLDER found as /home/vanessa/Desktop/singularity
VERBOSE2 SHUB_NAMEBYHASH not defined (None)
VERBOSE2 SHUB_NAMEBYCOMMIT not defined (None)
VERBOSE2 SHUB_CONTAINERNAME not defined (None)
VERBOSE2 SINGULARITY_CONTENTS found as /tmp/.singularity-layers.8nCdMI3u
VERBOSE2 SINGULARITY_PYTHREADS found as 9
VERBOSE2 SINGULARITY_CONTAINER found as docker://ubuntu:14.04
DEBUG Found uri docker://
DEBUG 
*** STARTING DOCKER IMPORT PYTHON  ****
DEBUG Docker layers and metadata will be written to: /tmp/.singularity-layers.8nCdMI3u
VERBOSE2 SINGULARITY_DOCKER_USERNAME not defined (None)
VERBOSE2 SINGULARITY_DOCKER_PASSWORD found
DEBUG Starting Docker IMPORT, includes environment, runscript, and metadata.
VERBOSE Docker image: ubuntu:14.04
VERBOSE2 Specified Docker ENTRYPOINT as %runscript.
DEBUG Headers found: Content-Type,Accept
VERBOSE Registry: index.docker.io
VERBOSE Namespace: library
VERBOSE Repo Name: ubuntu
VERBOSE Repo Tag: 14.04
VERBOSE Version: None
VERBOSE Obtaining tags: http://index.docker.io/v2/library/ubuntu/tags/list
```
and here finally is the confirmation:

```
DEBUG GET http://index.docker.io/v2/library/ubuntu/tags/list
DEBUG Http Error with code 401
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&expires_in=9000&scope=repository:library/ubuntu:pull
DEBUG Headers found: Content-Type,Authorization,Accept
VERBOSE3 Response on obtaining token is None.
Docker image path: index.docker.io/library/ubuntu:14.04
VERBOSE Obtaining manifest: http://index.docker.io/v2/library/ubuntu/manifests/14.04
DEBUG GET http://index.docker.io/v2/library/ubuntu/manifests/14.04
DEBUG Image manifest version 2.2 found.
DEBUG Adding digest sha256:7ee37f18131817cc7cf143cf1efe11db9f06306aa7f2c5a5b8f7af2ce71e852d
DEBUG Adding digest sha256:df5ffabe5e97a3594ebcdf78b5fcb20452b46a89068d7a771f96d15f8ced9e73
DEBUG Adding digest sha256:ae2040ed51a16afd9e12e007d9034fd405c6f500033f9e465232d45cd171a0e3
DEBUG Adding digest sha256:3ce7010d244b7d77247234ca2eabb2ae29829976c81651e85a7daf0fa60f4bbc
DEBUG Adding digest sha256:2538b201d2a69851a91852923a2eb6306a55d0b7919c6167858ff9eaf931922b
VERBOSE Obtaining manifest: http://index.docker.io/v2/library/ubuntu/manifests/14.04
DEBUG GET http://index.docker.io/v2/library/ubuntu/manifests/14.04
Cache folder set to /home/vanessa/.singularity/docker
DEBUG Using 9 workers for multiprocess.
[1/5] ||----------------------------------|   0.0% DEBUG Starting multiprocess
VERBOSE Downloading layers from http://index.docker.io/v2/library/ubuntu/blobs/sha256:
Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.7ee37f18131817cc7cf143cf1efe11db9f06306aa7f2c5a5b8f7af2ce71e852d
DEBUG Downloading layer sha256:7ee37f18131817cc7cf143cf1efe11db9f06306aa7f2c5a5b8f7af2ce71e852d
VERBOSE Downloading layers from http://index.docker.io/v2/library/ubuntu/blobs/sha256:df5ffabe5e97a3594ebcdf78b5fcb20452b46a89068d7a771f96d15f8ced9e73
DEBUG Downloading layer sha256:df5ffabe5e97a3594ebcdf78b5fcb20452b46a89068d7a771f96d15f8ced9e73
VERBOSE Downloading layers from http://index.docker.io/v2/library/ubuntu/blobs/sha256:ae2040ed51a16afd9e12e007d9034fd405c6f500033f9e465232d45cd171a0e3
DEBUG Downloading layer sha256:ae2040ed51a16afd9e12e007d9034fd405c6f500033f9e465232d45cd171a0e3
DEBUG GET (stream) http://index.docker.io/v2/library/ubuntu/blobs/sha256:df5ffabe5e97a3594ebcdf78b5fcb20452b46a89068d7a771f96d15f8ced9e73
VERBOSE Downloading layers from http://index.docker.io/v2/library/ubuntu/blobs/sha256:2538b201d2a69851a91852923a2eb6306a55d0b7919c6167858ff9eaf931922b
DEBUG Downloading layer sha256:2538b201d2a69851a91852923a2eb6306a55d0b7919c6167858ff9eaf931922b
DEBUG GET (stream) http://index.docker.io/v2/library/ubuntu/blobs/sha256:2538b201d2a69851a91852923a2eb6306a55d0b7919c6167858ff9eaf931922b
VERBOSE Downloading layers from http://index.docker.io/v2/library/ubuntu/blobs/sha256:3ce7010d244b7d77247234ca2eabb2ae29829976c81651e85a7daf0fa60f4bbc
DEBUG Downloading layer sha256:3ce7010d244b7d77247234ca2eabb2ae29829976c81651e85a7daf0fa60f4bbc
DEBUG GET (stream) http://index.docker.io/v2/library/ubuntu/blobs/sha256:3ce7010d244b7d77247234ca2eabb2ae29829976c81651e85a7daf0fa60f4bbc
DEBUG GET (stream) http://index.docker.io/v2/library/ubuntu/blobs/sha256:7ee37f18131817cc7cf143cf1efe11db9f06306aa7f2c5a5b8f7af2ce71e852d
DEBUG GET (stream) http://index.docker.io/v2/library/ubuntu/blobs/sha256:ae2040ed51a16afd9e12e007d9034fd405c6f500033f9e465232d45cd171a0e3
DEBUG Download of raw file (pre permissions fix) is /home/vanessa/.singularity/docker/sha256:df5ffabe5e97a3594ebcdf78b5fcb20452b46a89068d7a771f96d15f8ced9e73.tar.gz.B7kk_L
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&expires_in=9000&scope=repository:library/ubuntu:pull
DEBUG Download of raw file (pre permissions fix) is /home/vanessa/.singularity/docker/sha256:2538b201d2a69851a91852923a2eb6306a55d0b7919c6167858ff9eaf931922b.tar.gz.3VRCdC
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&expires_in=9000&scope=repository:library/ubuntu:pull
DEBUG Download of raw file (pre permissions fix) is /home/vanessa/.singularity/docker/sha256:3ce7010d244b7d77247234ca2eabb2ae29829976c81651e85a7daf0fa60f4bbc.tar.gz._GVxr8
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&expires_in=9000&scope=repository:library/ubuntu:pull
DEBUG Download of raw file (pre permissions fix) is /home/vanessa/.singularity/docker/sha256:ae2040ed51a16afd9e12e007d9034fd405c6f500033f9e465232d45cd171a0e3.tar.gz.hWND58
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&expires_in=9000&scope=repository:library/ubuntu:pull
DEBUG Headers found: Content-Type,Accept,Authorization
```


**This fixes or addresses the following GitHub issues:**

- Ref: #849 


Attn: @singularityware-admin
