### PR TITLE
fixing bug with docker pull folder

### DIFF
--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -103,6 +103,8 @@ if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`
     message ERROR "Failed to create temporary directory\n"
     ABORT 255
 fi
+
+# If cache is set, set pull folder to it (first priority)
 if [ -n "${SINGULARITY_CACHEDIR:-}" ]; then
     SINGULARITY_PULLFOLDER="$SINGULARITY_CACHEDIR"
 else
@@ -119,6 +121,8 @@ case "$SINGULARITY_CONTAINER" in
     docker://*)
         if [ -z "${SINGULARITY_IMAGE:-}" ]; then
             SINGULARITY_IMAGE=`basename "$SINGULARITY_CONTAINER.img" | sed -e 's/:/-/g'`
+            SINGULARITY_IMAGE="$SINGULARITY_PULLFOLDER/$SINGULARITY_IMAGE"
+            message 3 "Singularity Image: $SINGULARITY_IMAGE"
             export SINGULARITY_IMAGE
         fi
 

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -120,7 +120,14 @@ export SINGULARITY_CONTAINER SINGULARITY_PULLFOLDER SINGULARITY_CONTENTS
 case "$SINGULARITY_CONTAINER" in
     docker://*)
         if [ -z "${SINGULARITY_IMAGE:-}" ]; then
-            SINGULARITY_IMAGE=`basename "$SINGULARITY_CONTAINER.img" | sed -e 's/:/-/g'`
+
+            # If name given, use that
+            if [ -n "${SHUB_CONTAINERNAME:-}" ]; then
+                SINGULARITY_IMAGE=`basename "$SHUB_CONTAINERNAME.img" | sed -e 's/.img//g'`".img"   
+            else
+                SINGULARITY_IMAGE=`basename "$SINGULARITY_CONTAINER.img" | sed -e 's/:/-/g'`
+            fi
+
             SINGULARITY_IMAGE="$SINGULARITY_PULLFOLDER/$SINGULARITY_IMAGE"
             message 3 "Singularity Image: $SINGULARITY_IMAGE"
             export SINGULARITY_IMAGE


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a quick fix for #847 that the `docker://` uri pull doesn't respect `SINGULARITY_PULLFOLDER` or `SINGULARITY_CACHEDIR`. This is likely happened because these extra specifications were originally just for Singularity Hub images. Specifically:

### Case 1: Both pull folder and cache set, cache takes preference
```
SINGULARITY_PULLFOLDER=/tmp SINGULARITY_CACHEDIR=$PWD singularity pull docker://ubuntu
>> $PWD/ubuntu.img
```
### Case 2: Just cache folder set, cache takes preference
```
SINGULARITY_CACHEDIR=/tmp singularity pull docker://ubuntu
>> /tmp/ubuntu.img
```
### Case 3: Just pull folder set, pull folder takes preference
```
SINGULARITY_PULLFOLDER=/tmp SINGULARITY_CACHEDIR= singularity pull docker://ubuntu
>> /tmp/ubuntu.img
```
### Case 4: Neither set, $PWD is used
```
SINGULARITY_PULLFOLDER= SINGULARITY_CACHEDIR= singularity pull docker://ubuntu
./ubuntu.img
```
I also noticed that `docker://` wasn't respecting the `--name` argument, and adjusted that too:

### Case 5: pulling name without extension to $PWD when `name.img` exists
```
$ SINGULARITY_PULLFOLDER= singularity pull --name meatball docker://ubuntu
ERROR: Image file exists, not overwriting.
```

### Case 6: pulling name without extension when image doesn't exist
```
SINGULARITY_PULLFOLDER=/tmp singularity pull --name meatball docker://ubuntu
/tmp/meatball.img
```

### Case 7: pulling name without extension without PULL or cache goes to $PWD
```
singularity pull --name meatball docker://ubuntu
./meatball.img
```
### Case 8: pulling name with extension doesn't double it up

```
 singularity pull --name meatball.img docker://ubuntu
./meatball.img
```

**This fixes or addresses the following GitHub issues:**

- Ref: #847 

Attn: @singularityware-admin
