### PR TITLE
Add/http domains

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,3 +29,4 @@
     - Rémy Dernat <remy.dernat@umontpellier.fr>
     - Mark Egan-Fuller <markeganfuller@googlemail.com>
     - Petr Votava <votava.petr@gene.com>
+    - Tarcisio Fedrizzi <taracisio.fedrizzi@gmail.com>

--- a/libexec/python/README.md
+++ b/libexec/python/README.md
@@ -101,6 +101,9 @@ Is the default tag, `latest`.
 **DISABLE_HTTPS**
 If you export the variable `SINGULARITY_NOHTTPS` you can force the software to not use https when interacting with a Docker registry. This use case is typically for use of a local registry.
 
+**HTTP_REGISTRIES**
+If you specify a space separated list of registries in the `SINGULARITY_HTTP_REGISTRIES` variable these are invoked with HTTP instead of HTTPS.
+
 
 #### Singularity Hub
 

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -146,6 +146,7 @@ INCLUDE_CMD = convert2boolean(getenv("SINGULARITY_INCLUDECMD",
                               default=False))
 DISABLE_HTTPS = convert2boolean(getenv("SINGULARITY_NOHTTPS",
                                 default=False))
+HTTP_REGISTRIES = getenv("SINGULARITY_HTTP_REGISTRIES", default="").split(" ")
 
 #######################################################################
 # Singularity Hub

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -67,7 +67,8 @@ def add_http(url, use_https=True):
     parsed = re.sub('.*//', '', url)
 
     scheme = "https://"
-    if use_https is False or DISABLE_HTTPS is True or parsed in HTTP_REGISTRIES:
+    if use_https is False or DISABLE_HTTPS is True \
+      or parsed in HTTP_REGISTRIES:
         scheme = "http://"
 
     return "%s%s" % (scheme, parsed.rstrip('/'))

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -24,7 +24,8 @@ perform publicly and display publicly, and to permit other to do so.
 
 from defaults import (
     SINGULARITY_CACHE,
-    DISABLE_HTTPS
+    DISABLE_HTTPS,
+    HTTP_REGISTRIES
 )
 from message import bot
 import datetime
@@ -60,14 +61,14 @@ def add_http(url, use_https=True):
     :param url: the url to add the prefix to
     :param use_https: should we default to https? default is True
     '''
-    scheme = "https://"
-    if use_https is False or DISABLE_HTTPS is True:
-        scheme = "http://"
-
     # remove scheme from url
     # urlparse is buggy in Python 2.6
     # https://bugs.python.org/issue754016, use regex instead
     parsed = re.sub('.*//', '', url)
+
+    scheme = "https://"
+    if use_https is False or DISABLE_HTTPS is True or parsed in HTTP_REGISTRIES:
+        scheme = "http://"
 
     return "%s%s" % (scheme, parsed.rstrip('/'))
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds the possiblity to specify a list of docker registries
that will be accessed with HTTP instead of HTTPS. It is similar
to PR #850 but in my opionion is a little bit more convenient in
the fact that it allows a user to have a fixed list of http registries
that can be added to a .bashrc or .bash_profile. Moreover it
allows to use both self-hosted and other servers without
having to act on environment variables in order to disable/enable
HTTPS.
This solution peacfully co-exists with @vsoch solution but I would
say that having both would add probably a bit of redundancy.
I had the idea after seeing @vsoch PR and this is the reason I
haven't created the PR before @vsoch's got merged.

**This fixes or addresses the following GitHub issues:**

- Ref: #849 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge

I've tried to run the tests (make test) but I always run into some problem (and I'm pretty confident that this doesn't depend on the code I wrote).

I've tested however the code on my machine and it works correctly.


Attn: @singularityware-admin
