### PR TITLE
Explicitly set permissions of newroot in environment.tar

### DIFF
--- a/libexec/bootstrap-scripts/environment/Makefile.am
+++ b/libexec/bootstrap-scripts/environment/Makefile.am
@@ -8,6 +8,7 @@ dist_environment_DATA = environment.tar
 .PHONY: environment.tar
 
 environment.tar:
+	install -d -m 0755 newroot
 	install -d -m 0755 newroot/.singularity.d
 	install -d -m 0755 newroot/.singularity.d/env
 	install -d -m 0755 newroot/.singularity.d/actions


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Explicitly set permissions of newroot in environment.tar this fixes issues encountered with creating containers when Singularity was compiled in a directory with facl set to remove other access e.g.

```
$ getfacl
...
default:other::---
...
```


**This fixes or addresses the following GitHub issues:**

- Ref: #835 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
