### PR TITLE
Bug/docker url namespaces

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,3 +29,4 @@
     - Rémy Dernat <remy.dernat@umontpellier.fr>
     - Mark Egan-Fuller <markeganfuller@googlemail.com>
     - Petr Votava <votava.petr@gene.com>
+    - George Hartzell <hartzell@alerce.com>

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -120,9 +120,9 @@ def parse_image_uri(image, uri=None, quiet=False):
     # Now look for registry, namespace, repo
     image = image.split('/')
 
-    if len(image) == 3:
+    if len(image) > 2:
         registry = image[0]
-        namespace = image[1]
+        namespace = "/".join(image[1:-1])
         repo_name = image[2]
 
     elif len(image) == 2:

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -123,7 +123,7 @@ def parse_image_uri(image, uri=None, quiet=False):
     if len(image) > 2:
         registry = image[0]
         namespace = "/".join(image[1:-1])
-        repo_name = image[2]
+        repo_name = image[-1]
 
     elif len(image) == 2:
         registry = default_registry

--- a/libexec/python/tests/test_core.py
+++ b/libexec/python/tests/test_core.py
@@ -149,18 +149,18 @@ class TestShell(TestCase):
         self.assertTrue(digest['namespace'] == 'mix')
 
         print("Case 8: Custom uri should use it.")
-        image_name = "catdog://meow/mix/%s:%s" % (self.repo_name,
+        image_name = "catdog://meow/mix/tenders/%s:%s" % (self.repo_name,
                                                   self.tag)
         digest = parse_image_uri(image_name, uri="catdog://")
         self.assertTrue(digest['registry'] == 'meow')
-        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['namespace'] == 'mix/tenders')
 
         print("Case 9: Digest version should be parsed")
-        image_name = ("catdog://meow/mix/%s:%s@sha:256xxxxxxxxxxxxxxx"
+        image_name = ("catdog://meow/mix/original/choice/%s:%s@sha:256xxxxxxxxxxxxxxx"
                       % (self.repo_name, self.tag))
         digest = parse_image_uri(image_name, uri="catdog://")
         self.assertTrue(digest['registry'] == 'meow')
-        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['namespace'] == 'mix/original/choice')
         self.assertTrue(digest['version'] == 'sha:256xxxxxxxxxxxxxxx')
 
 

--- a/libexec/python/tests/test_core.py
+++ b/libexec/python/tests/test_core.py
@@ -150,13 +150,13 @@ class TestShell(TestCase):
 
         print("Case 8: Custom uri should use it.")
         image_name = "catdog://meow/mix/tenders/%s:%s" % (self.repo_name,
-                                                  self.tag)
+                                                          self.tag)
         digest = parse_image_uri(image_name, uri="catdog://")
         self.assertTrue(digest['registry'] == 'meow')
         self.assertTrue(digest['namespace'] == 'mix/tenders')
 
         print("Case 9: Digest version should be parsed")
-        image_name = ("catdog://meow/mix/original/choice/%s:%s@sha:256xxxxxxxxxxxxxxx"
+        image_name = ("catdog://meow/mix/original/choice/%s:%s@sha:256xxxxxxxxxxxxxxx" # noqa
                       % (self.repo_name, self.tag))
         digest = parse_image_uri(image_name, uri="catdog://")
         self.assertTrue(digest['registry'] == 'meow')

--- a/libexec/python/tests/test_core.py
+++ b/libexec/python/tests/test_core.py
@@ -156,7 +156,7 @@ class TestShell(TestCase):
         self.assertTrue(digest['namespace'] == 'mix/tenders')
 
         print("Case 9: Digest version should be parsed")
-        image_name = ("catdog://meow/mix/original/choice/%s:%s@sha:256xxxxxxxxxxxxxxx" # noqa
+        image_name = ("catdog://meow/mix/original/choice/%s:%s@sha:256xxxxxxxxxxxxxxx"  # noqa
                       % (self.repo_name, self.tag))
         digest = parse_image_uri(image_name, uri="catdog://")
         self.assertTrue(digest['registry'] == 'meow')


### PR DESCRIPTION
There can be multiple components in the namespace, e.g.:

```
docker://myregistry.example.com:5000/name/space/repo_name@sha256:570b5227f93f870aff05c040c5b1f27c15b5978dbf7704e877b71691ed58ede2
```

Where the registry is: `myregistry.example.com:5000`

and the namespace is `name/space`

and the repo_name is `repo_name`.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
