### PR TITLE
adding application/json to end of header list

### DIFF
--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -104,7 +104,7 @@ class DockerApiConnection(ApiConnection):
         # meaning the correct order of digests
         # returned (base to child)
 
-        return {"Accept": 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json',  # noqa
+        return {"Accept": 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/json',  # noqa
                'Content-Type': 'application/json; charset=utf-8'}  # noqa
 
     def check_errors(self, response, exit=True):


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a tiny fix to add an `application/json` to accept headers, which I didn't know would be needed by local registries (note docker hub has notes to specify the latter to in order to ask for a version 2 manifest). Thanks to @hartzell for looking into this and figuring out the fix, the only adjustment I made was to put `application/json` last to specify the order of preference.

Attn: @singularityware-admin
