### PR TITLE
Create a new configuration option to mount a new devpts

### DIFF
--- a/etc/singularity.conf.in
+++ b/etc/singularity.conf.in
@@ -73,14 +73,11 @@
 
 
 # MOUNT DEVPTS: [BOOL]
-# DEFAULT: no
+# DEFAULT: yes
 # Should we mount a new instance of devpts if there is a 'minimal'
 # /dev, or -C is passed?  Note, this requires that your kernel was
 # configured with CONFIG_DEVPTS_MULTIPLE_INSTANCES=y, or that you're
-# running kernel 4.7 or newer.  The Default is no, as enabling it on
-# systems without support for multiple devpts instances could result
-# in a shared devpts filesystem, and could potentially make the host
-# system mount of devpts unusable.
+# running kernel 4.7 or newer.
 @MOUNT_DEVPTS@ = @MOUNT_DEVPTS_DEFAULT@
 
 

--- a/etc/singularity.conf.in
+++ b/etc/singularity.conf.in
@@ -72,6 +72,18 @@
 @MOUNT_DEV@ = @MOUNT_DEV_DEFAULT@
 
 
+# MOUNT DEVPTS: [BOOL]
+# DEFAULT: no
+# Should we mount a new instance of devpts if there is a 'minimal'
+# /dev, or -C is passed?  Note, this requires that your kernel was
+# configured with CONFIG_DEVPTS_MULTIPLE_INSTANCES=y, or that you're
+# running kernel 4.7 or newer.  The Default is no, as enabling it on
+# systems without support for multiple devpts instances could result
+# in a shared devpts filesystem, and could potentially make the host
+# system mount of devpts unusable.
+@MOUNT_DEVPTS@ = @MOUNT_DEVPTS_DEFAULT@
+
+
 # MOUNT HOME: [BOOL]
 # DEFAULT: @MOUNT_HOME_DEFAULT@
 # Should we automatically determine the calling user's home directory and

--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -1,23 +1,23 @@
-/* 
+/*
  * Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
  *
  * Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
- * 
+ *
  * Copyright (c) 2016-2017, The Regents of the University of California,
  * through Lawrence Berkeley National Laboratory (subject to receipt of any
  * required approvals from the U.S. Dept. of Energy).  All rights reserved.
- * 
+ *
  * This software is licensed under a customized 3-clause BSD license.  Please
  * consult LICENSE file distributed with the sources of this project regarding
  * your rights to use or distribute this software.
- * 
+ *
  * NOTICE.  This Software was developed under funding from the U.S. Department of
  * Energy and the U.S. Government consequently retains certain rights. As such,
  * the U.S. Government has been granted for itself and others acting on its
  * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
  * to reproduce, distribute copies to the public, prepare derivative works, and
- * perform publicly and display publicly, and to permit other to do so. 
- * 
+ * perform publicly and display publicly, and to permit other to do so.
+ *
 */
 
 #include <errno.h>
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <grp.h>
 
 #include "util/file.h"
 #include "util/util.h"
@@ -80,6 +81,21 @@ int _singularity_runtime_mount_dev(void) {
             ABORT(255);
         }
 
+        if ( singularity_config_get_bool_char(MOUNT_DEVPTS) > 0 ) {
+            struct stat multi_instance_devpts;
+            
+            if( stat("/dev/pts/ptmx", &multi_instance_devpts) < 0 ) {
+                singularity_message(ERROR, "Multiple devpts instances unsupported and \"%s\" configured\n", MOUNT_DEVPTS);
+                ABORT(255);
+            }
+            singularity_message(DEBUG, "Creating staged /dev/pts\n");
+            if ( s_mkpath(joinpath(devdir, "/pts"), 0755) != 0 ) {
+                singularity_message(ERROR, "Failed creating /dev/pts %s: %s\n", joinpath(devdir, "/pts"), strerror(errno));
+                ABORT(255);
+            }
+            bind_dev(sessiondir, "/dev/tty");
+        }
+
         bind_dev(sessiondir, "/dev/null");
         bind_dev(sessiondir, "/dev/zero");
         bind_dev(sessiondir, "/dev/random");
@@ -87,9 +103,56 @@ int _singularity_runtime_mount_dev(void) {
 
         singularity_priv_escalate();
         singularity_message(DEBUG, "Mounting tmpfs for staged /dev/shm\n");
-        if ( mount("/dev/shm", joinpath(devdir, "/shm"), "tmpfs", MS_NOSUID, "") < 0 ){
+        if ( mount("/dev/shm", joinpath(devdir, "/shm"), "tmpfs", MS_NOSUID, "") < 0 ) {
             singularity_message(ERROR, "Failed to mount %s: %s\n", joinpath(devdir, "/shm"), strerror(errno));
             ABORT(255);
+        }
+
+        if ( singularity_config_get_bool_char(MOUNT_DEVPTS) > 0 ) {
+            struct group *ttygid;
+            char *devpts_opts_base="mode=0620,newinstance,ptmxmode=0666,gid=";
+            char *devpts_opts;
+            unsigned int max_sz, gd, gd_n;
+
+            if ( (ttygid=getgrnam("tty")) == NULL ) {
+                singularity_message(ERROR, "Problem resolving 'tty' group GID: %s\n", strerror(errno));
+                ABORT(255);
+            }
+
+            /* number of digits in gid */
+            if ( ttygid->gr_gid == 0 ) {
+                gd_n = 1;
+            }
+            else {
+                gd_n = 0;
+                gd = ttygid->gr_gid;
+                while ( gd ) {
+                    gd /= 10;
+                    gd_n++;
+                }
+            }
+
+            /* length of gid string + mount options + terminator + padding */
+            max_sz = gd_n + strlen(devpts_opts_base) + 1 + 16;
+            if ( (devpts_opts=malloc(max_sz)) == NULL ) {
+                    singularity_message(ERROR, "Memory allocation failure: %s\n", strerror(errno));
+                    ABORT(255);
+            }
+            bzero(devpts_opts, max_sz);
+            snprintf(devpts_opts, max_sz-1, "%s%d", devpts_opts_base, ttygid->gr_gid);
+
+            singularity_message(DEBUG, "Mounting devpts for staged /dev/pts\n");
+            if ( mount("devpts", joinpath(devdir, "/pts"), "devpts", MS_NOSUID|MS_NOEXEC, devpts_opts) < 0 ) {
+                singularity_message(ERROR, "Failed to mount %s: %s\n", joinpath(devdir, "/pts"), strerror(errno));
+                ABORT(255);
+            }
+            free(devpts_opts);
+
+            singularity_message(DEBUG, "Creating staged /dev/ptmx symlink\n");
+            if ( symlink("/dev/pts/ptmx", joinpath(devdir, "/ptmx")) < 0 ) {
+                singularity_message(ERROR, "Failed to create /dev/ptmx symlink: %s\n", strerror(errno));
+                ABORT(255);
+            }
         }
 
         singularity_message(DEBUG, "Mounting minimal staged /dev into container\n");
@@ -174,5 +237,3 @@ static int bind_dev(char *tmpdir, char *dev) {
 
     return(0);
 }
-
-

--- a/src/util/config_defaults.h
+++ b/src/util/config_defaults.h
@@ -59,6 +59,9 @@
 #define MOUNT_DEV "mount dev"
 #define MOUNT_DEV_DEFAULT "yes"
 
+#define MOUNT_DEVPTS "mount devpts"
+#define MOUNT_DEVPTS_DEFAULT "no"
+
 #define MOUNT_HOME "mount home"
 #define MOUNT_HOME_DEFAULT 1
 

--- a/src/util/config_defaults.h
+++ b/src/util/config_defaults.h
@@ -60,7 +60,7 @@
 #define MOUNT_DEV_DEFAULT "yes"
 
 #define MOUNT_DEVPTS "mount devpts"
-#define MOUNT_DEVPTS_DEFAULT "no"
+#define MOUNT_DEVPTS_DEFAULT "yes"
 
 #define MOUNT_HOME "mount home"
 #define MOUNT_HOME_DEFAULT 1


### PR DESCRIPTION
instance in containers with a minimal /dev.  Verify
support in the kernel before attempting to mount.

**Description of the Pull Request (PR):**

Add a new configuration option, "mount devpts",  which when enabled
(default = no), will mount a new devpts instance in containers with
a minimal /dev (dev = minimal, or -C is passed).  If enabled, support
for multi instance devpts is first checked in the kernel (determined by
the existence of "/dev/pts/ptmx").  This should preserve containment,
while allowing applications which perform pseudoterminal allocation
to function.


**This fixes or addresses the following GitHub issues:**

- Ref: # 857


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
