### PR TITLE
add sinit, start, and start-suid libexec bin files to rpm

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,3 +29,4 @@
     - Rémy Dernat <remy.dernat@umontpellier.fr>
     - Mark Egan-Fuller <markeganfuller@googlemail.com>
     - Petr Votava <votava.petr@gene.com>
+    - Dave Dykstra <dwd@fnal.gov>

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -138,6 +138,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/bin/get-section
 %{_libexecdir}/singularity/bin/import
 %{_libexecdir}/singularity/bin/mount
+%{_libexecdir}/singularity/bin/sinit
+%{_libexecdir}/singularity/bin/start
+%{_libexecdir}/singularity/bin/start-suid
 
 # Scripts
 %{_libexecdir}/singularity/functions


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This simply adds 3 missing files to the RPM spec %files section so that an rpmbuild succeeds.


**This fixes or addresses the following GitHub issues:**

None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`
      (not relevant as this is a fix to the rpm only)
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
