### PR TITLE
adding test for apps, fixing bug with sinit as well

### DIFF
--- a/examples/apps/Singularity
+++ b/examples/apps/Singularity
@@ -1,0 +1,37 @@
+Bootstrap: docker
+From: ubuntu:14.04
+
+%setup
+    echo "SETUP"
+
+%appinstall foo
+
+    echo "INSTALLING FOO"
+    touch filefoo.exec
+
+%appinstall bar
+
+    echo "INSTALLING BAR"
+    touch filebar.exec
+
+%apphelp foo
+This is the help for foo!
+
+%applabels foo
+HELLOTHISIS foo
+
+%applabels bar
+HELLOTHISIS bar
+
+%appenv foo
+HELLOTHISIS=foo
+export HELLOTHISIS
+
+%apprun foo
+echo "RUNNING FOO"
+
+%runscript
+    echo "RUNSCRIPT"
+
+%post
+echo "POST"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\
 
 bindir = $(libexecdir)/singularity/bin
 
-bin_PROGRAMS = action start bootstrap copy cleanupd create expand export get-section import mount $(BUILD_SUID)
+bin_PROGRAMS = action start sinit bootstrap copy cleanupd create expand export get-section import mount $(BUILD_SUID)
 EXTRA_PROGRAMS = action-suid start-suid create-suid expand-suid export-suid import-suid mount-suid
 
 cleanupd_SOURCES = cleanupd.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c

--- a/tests/23-bootstrap_apps.sh
+++ b/tests/23-bootstrap_apps.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+# Copyright (c) 2017, Vanessa Sochat. All rights reserved.
+#
+# See the COPYRIGHT.md file at the top-level directory of this distribution and at
+# https://github.com/singularityware/singularity/blob/master/COPYRIGHT.md.
+#
+# This file is part of the Singularity Linux container project. It is subject to the license
+# terms in the LICENSE.md file found in the top-level directory of this distribution and
+# at https://github.com/singularityware/singularity/blob/master/LICENSE.md. No part
+# of Singularity, including this file, may be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE.md file.
+
+. ./functions
+
+test_init "Standard Integration Format (SCI-F) Apps bootstrap tests"
+
+
+CONTAINER="$SINGULARITY_TESTDIR/container.img"
+DEFFILE="$SINGULARITY_TESTDIR/example.def"
+
+# Be consistent to bootstrap from Ubuntu 14.04
+stest 0 grep ubuntu:14.04 ../examples/apps/Singularity
+
+# Create the container with apps recipe
+stest 0 cp ../examples/apps/Singularity "$DEFFILE"
+stest 0 singularity create -F -s 568 "$CONTAINER"
+stest 0 sudo singularity bootstrap "$CONTAINER" "$DEFFILE"
+
+# Testing exec command
+stest 0 singularity exec "$CONTAINER" true
+stest 0 singularity exec "$CONTAINER" /bin/true
+stest 1 singularity exec "$CONTAINER" false
+stest 1 singularity exec "$CONTAINER" /bin/false
+
+# Testing folder organization
+stest 0 singularity exec "$CONTAINER" test -d "/scif"
+stest 0 singularity exec "$CONTAINER" test -d "/scif/apps"
+stest 0 singularity exec "$CONTAINER" test -d "/scif/data"
+stest 0 singularity exec "$CONTAINER" test -d "/scif/apps/foo"
+stest 0 singularity exec "$CONTAINER" test -d "/scif/apps/bar"
+stest 0 singularity exec "$CONTAINER" test -f "/scif/apps/foo/filefoo.exec"
+stest 0 singularity exec "$CONTAINER" test -f "/scif/apps/bar/filebar.exec"
+stest 0 singularity exec "$CONTAINER" test -d "/scif/data/foo/output"
+stest 0 singularity exec "$CONTAINER" test -d "/scif/data/foo/input"
+
+# Metadata folder
+stest 0 singularity exec "$CONTAINER" test -f "/scif/apps/foo/scif/Singularity"
+stest 0 singularity exec "$CONTAINER" test -f "/scif/apps/foo/scif/environment"
+stest 0 singularity exec "$CONTAINER" test -f "/scif/apps/foo/scif/labels.json"
+stest 0 singularity exec "$CONTAINER" test -f "/scif/apps/foo/scif/runscript"
+stest 0 singularity exec "$CONTAINER" test -f "/scif/apps/foo/scif/runscript.help"
+
+# Testing help
+stest 0 sh -c "singularity help '$CONTAINER' | grep 'No runscript help is defined for this image.'"
+stest 0 sh -c "singularity help --app foo '$CONTAINER' | grep 'This is the help for foo!'"
+stest 0 sh -c "singularity help --app bar '$CONTAINER' | grep 'No runscript help is defined for this application.'"
+
+# Testing apps
+stest 0 sh -c "singularity apps '$CONTAINER' | grep 'foo'"
+stest 0 sh -c "singularity apps '$CONTAINER' | grep 'bar'"
+
+# Testing inspect
+stest 0 sh -c "singularity inspect --app foo '$CONTAINER' | grep HELLOTHISIS"
+stest 0 sh -c "singularity inspect --app foo '$CONTAINER' | grep foo"
+
+# Testing run
+stest 0 sh -c "singularity run --app foo '$CONTAINER' | grep 'RUNNING FOO'"
+stest 0 sh -c "singularity run --app bar '$CONTAINER' | grep 'No Singularity runscript for contained app: bar'"
+
+test_cleanup


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR will add basic functionality for testing apps, along with fixing the bug with the missing sinit in the Makefile (this did not trigger an error on Travis as it was a warning during ./autogen.sh). Specifically, I test that:

- the structure of files / folders for apps and data is as expected
- the help command works for the container
- the help command works for an app when a `runscript.help` exists
- the help command works for an app when a `runscript.help` doesn't exist
- listing of apps contains the installed apps foo and bar
- inspecting an app returns labels specific to it
- running an app with a runscript runs it
- running an app without a runscript tells the user it doens't have one.


Attn: @singularityware-admin
