### PR TITLE
Add setns syscall for old glibc systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,17 @@ AC_CHECK_FUNCS(setns, [
 AC_SUBST(NO_SETNS)
 
 
+AC_MSG_CHECKING([for setns syscall support])
+if test -d "/proc/self/ns"; then
+    SINGULARITY_DEFINES="$SINGULARITY_DEFINES -DSINGULARITY_SETNS_SYSCALL"
+    SETNS_SYSCALL=1
+    AC_MSG_RESULT([yes])
+else
+    AC_MSG_RESULT([no])
+fi
+AC_SUBST(SETNS_SYSCALL)
+
+
 AC_MSG_CHECKING([for overlayfs])
 KVERS=`uname -r`
 if test -f "/lib/modules/$KVERS/modules.dep"; then

--- a/src/lib/runtime/Makefile.am
+++ b/src/lib/runtime/Makefile.am
@@ -11,7 +11,7 @@ distincludedir = $(includedir)/singularity
 
 noinst_LTLIBRARIES = libinternal.la
 libinternal_la_LIBADD = ns/libinternal.la mounts/libinternal.la files/libinternal.la enter/libinternal.la overlayfs/libinternal.la environment/libinternal.la autofs/libinternal.la
-libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c
+libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c ../../util/setns.c
 libinternal_la_CFLAGS = $(AM_CFLAGS) # This fixes duplicate sources in library and progs
 
 distinclude_HEADERS = runtime.h

--- a/src/lib/runtime/ns/ipc/ipc.c
+++ b/src/lib/runtime/ns/ipc/ipc.c
@@ -40,6 +40,7 @@
 #include "util/privilege.h"
 #include "util/fork.h"
 #include "util/registry.h"
+#include "util/setns.h"
 
 
 static int enabled = -1;

--- a/src/lib/runtime/ns/mnt/mnt.c
+++ b/src/lib/runtime/ns/mnt/mnt.c
@@ -38,6 +38,8 @@
 #include "util/message.h"
 #include "util/config_parser.h"
 #include "util/privilege.h"
+#include "util/setns.h"
+
 
 static int enabled = -1;
 

--- a/src/lib/runtime/ns/net/net.c
+++ b/src/lib/runtime/ns/net/net.c
@@ -29,6 +29,7 @@
 #include "util/privilege.h"
 #include "util/fork.h"
 #include "util/registry.h"
+#include "util/setns.h"
 
 
 static int enabled = -1;

--- a/src/lib/runtime/ns/pid/pid.c
+++ b/src/lib/runtime/ns/pid/pid.c
@@ -40,6 +40,7 @@
 #include "util/privilege.h"
 #include "util/fork.h"
 #include "util/registry.h"
+#include "util/setns.h"
 
 
 int _singularity_runtime_ns_pid(void) {

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -28,4 +28,6 @@ EXTRA_DIST = cleanupd.c \
 			 suid.h \
 			 util.c \
 			 util.h \
+			 setns.c \
+			 setns.h \
 			 config_defaults.h

--- a/src/util/setns.c
+++ b/src/util/setns.c
@@ -1,0 +1,36 @@
+/* 
+ * Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+ *
+ * Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
+ * 
+ * Copyright (c) 2016-2017, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of any
+ * required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ * 
+ * This software is licensed under a customized 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ * 
+ * NOTICE.  This Software was developed under funding from the U.S. Department of
+ * Energy and the U.S. Government consequently retains certain rights. As such,
+ * the U.S. Government has been granted for itself and others acting on its
+ * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+ * to reproduce, distribute copies to the public, prepare derivative works, and
+ * perform publicly and display publicly, and to permit other to do so. 
+ * 
+ */
+
+#define _GNU_SOURCE
+
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#if defined (NO_SETNS) && defined (SINGULARITY_SETNS_SYSCALL)
+
+#include "util/setns.h"
+
+int setns(int fd, int nstype) {
+    return syscall(__NR_setns, fd, nstype);
+}
+
+#endif /* NO_SETNS && SINGULARITY_SETNS_SYCALL */

--- a/src/util/setns.h
+++ b/src/util/setns.h
@@ -1,0 +1,56 @@
+/* 
+ * Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+ *
+ * Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
+ * 
+ * Copyright (c) 2016-2017, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of any
+ * required approvals from the U.S. Dept. of Energy).  All rights reserved.
+ * 
+ * This software is licensed under a customized 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ * 
+ * NOTICE.  This Software was developed under funding from the U.S. Department of
+ * Energy and the U.S. Government consequently retains certain rights. As such,
+ * the U.S. Government has been granted for itself and others acting on its
+ * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+ * to reproduce, distribute copies to the public, prepare derivative works, and
+ * perform publicly and display publicly, and to permit other to do so. 
+ * 
+ */
+
+#ifndef __SETNS_H_
+#define __SETNS_H_
+
+#ifndef __NR_setns
+#  if defined (__x86_64__)
+#    define __NR_setns 308
+#  elif defined (__i386__)
+#    define __NR_setns 346
+#  elif defined (__alpha__)
+#    define __NR_setns 501
+#  elif defined (__arm__)
+#    define __NR_setns 375
+#  elif defined (__aarch64__)
+#    define __NR_setns 375
+#  elif defined (__ia64__)
+#    define __NR_setns 1330
+#  elif defined (__sparc__)
+#    define __NR_setns 337
+#  elif defined (__powerpc__)
+#    define __NR_setns 350
+#  elif defined (__s390__)
+#    define __NR_setns 339
+#  endif
+#endif
+
+#ifdef __NR_setns
+
+extern int setns(int fd, int nstype);
+
+#else /* !__NR_setns */
+#  error Please determine the syscall number for setns on your architecture
+#endif
+
+#endif /* __SETNS_H_ */


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add setns syscall for old glibc systems

**This fixes or addresses the following GitHub issues:**

- Ref: #896 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
