### PR TITLE
Remove non-printable characters after setns.h in src/util/Makefile.am

### DIFF
--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -29,5 +29,5 @@ EXTRA_DIST = cleanupd.c \
 			 util.c \
 			 util.h \
 			 setns.c \
-			 setns.h \
+			 setns.h \
 			 config_defaults.h


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This removes extraneous non-printable characters after 'setns.h' in src/util/Makefile.am that were introduced in pr #902.  The non-printable characters apparently don't affect 'make' but they break 'make dist'.


**This fixes or addresses the following GitHub issues:**

None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
