### PR TITLE
adding wrapper to support legacy create function

### DIFF
--- a/libexec/cli/Makefile.am
+++ b/libexec/cli/Makefile.am
@@ -5,6 +5,7 @@ dist_cliexec_SCRIPTS = action_argparser.sh \
                     bootstrap.exec \
                     build.exec \
                     check.exec \
+                    create.exec \
                     exec.exec \
                     help.exec \
                     instance.exec \
@@ -30,6 +31,7 @@ dist_cliexec_DATA = singularity.help \
                     bootstrap.help \
                     build.help \
                     check.help \
+                    create.help \
                     exec.help \
                     instance.help \
                     instance.list.help \

--- a/libexec/cli/create.exec
+++ b/libexec/cli/create.exec
@@ -1,22 +1,17 @@
 #!/bin/bash
-#
+# 
 # Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
-#
+# 
 # See the COPYRIGHT.md file at the top-level directory of this distribution and at
 # https://github.com/singularityware/singularity/blob/master/COPYRIGHT.md.
-#
+# 
 # This file is part of the Singularity Linux container project. It is subject to the license
 # terms in the LICENSE.md file found in the top-level directory of this distribution and
 # at https://github.com/singularityware/singularity/blob/master/LICENSE.md. No part
 # of Singularity, including this file, may be copied, modified, propagated, or distributed
 # except according to the terms contained in the LICENSE.md file.
 #
-# This file also contains content that is covered under the LBNL/DOE/UC modified
-# 3-clause BSD license and is subject to the license terms in the LICENSE-LBNL.md
-# file found in the top-level directory of this distribution and at
-# https://github.com/singularityware/singularity/blob/master/LICENSE-LBNL.md.
-
-
+#
 
 ## Basic sanity
 if [ -z "$SINGULARITY_libexecdir" ]; then

--- a/libexec/cli/create.exec
+++ b/libexec/cli/create.exec
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+#
+# See the COPYRIGHT.md file at the top-level directory of this distribution and at
+# https://github.com/singularityware/singularity/blob/master/COPYRIGHT.md.
+#
+# This file is part of the Singularity Linux container project. It is subject to the license
+# terms in the LICENSE.md file found in the top-level directory of this distribution and
+# at https://github.com/singularityware/singularity/blob/master/LICENSE.md. No part
+# of Singularity, including this file, may be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE.md file.
+#
+# This file also contains content that is covered under the LBNL/DOE/UC modified
+# 3-clause BSD license and is subject to the license terms in the LICENSE-LBNL.md
+# file found in the top-level directory of this distribution and at
+# https://github.com/singularityware/singularity/blob/master/LICENSE-LBNL.md.
+
+
+
+## Basic sanity
+if [ -z "$SINGULARITY_libexecdir" ]; then
+    echo "Could not identify the Singularity libexecdir."
+    exit 1
+fi
+
+## Load functions
+if [ -f "$SINGULARITY_libexecdir/singularity/functions" ]; then
+    . "$SINGULARITY_libexecdir/singularity/functions"
+else
+    echo "Error loading functions: $SINGULARITY_libexecdir/singularity/functions"
+    exit 1
+fi
+
+PATH=/sbin:/usr/sbin:${PATH:-}
+
+while true; do
+    case ${1:-} in
+        -h|--help|help)
+            if [ -e "$SINGULARITY_libexecdir/singularity/cli/$SINGULARITY_COMMAND.help" ]; then
+                cat "$SINGULARITY_libexecdir/singularity/cli/$SINGULARITY_COMMAND.help"
+            else
+                message ERROR "No help exists for this command\n"
+                exit 1
+            fi
+            exit
+        ;;
+        *)
+            break;
+        ;;
+    esac
+done
+
+# relying on image.create for error checking
+message WARNING "The create command is deprecated and will be removed in a future release.\n"
+message WARNING "Use the build command to create and build an image in a single step.\n"
+
+exec  "$SINGULARITY_bindir"/singularity image.create "$@"
+
+message ERROR "We should never have gotten here... ARRRGGGG!!!!\n"
+exit 255

--- a/libexec/cli/create.help
+++ b/libexec/cli/create.help
@@ -1,0 +1,31 @@
+USAGE: singularity [...] image.create [create options...] <container path>
+
+******************************************************************************
+WARNING: The create command is deprecated and will be removed in a later 
+version of Singularity.  create now uses image.create to build to create a 
+writable container via the following syntax:
+
+$ singularity image.create container.img
+
+It is no longer necessary to create and bootstrap an image in 2 seperate
+commands.  You should use the build command to create and bootstrap your 
+image in a single step. 
+******************************************************************************
+
+Create a new Singularity formatted blank image.
+
+CREATE OPTIONS:
+    -s/--size   Specify a size for an operation in MiB, i.e. 1024*1024B
+                (default 768MiB)
+    -F/--force  Overwrite an image file if it exists
+
+EXAMPLES:
+
+    $ singularity image.create /tmp/Debian.img
+    $ singularity image.create -s 4096 /tmp/Debian.img
+
+For additional help, please visit our public documentation pages which are
+found at:
+
+    http://singularity.lbl.gov/
+

--- a/tests/10-help.sh
+++ b/tests/10-help.sh
@@ -28,6 +28,7 @@ ALL_COMMANDS="
     apps
     build
     check
+    create
     exec
     image
     image.create


### PR DESCRIPTION
Adding a wrapper to support the legacy `create` command (through `image.create`) so that old scripts and such will keep on working.  

Note that the tests in this PR will not build but they should after incorporating changes in https://github.com/singularityware/singularity/pull/916 and rest of the code base. 