### PR TITLE
quick fix for docker import / pull

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ src/get-section
 src/stamp-h1
 src/include/stamp-h1
 src/.dirstamp
+src/sinit
+src/start
+src/start-suid
 
 src/.deps/
 src/.libs/

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -1,31 +1,31 @@
 '''
 
 defaults.py: this script acts as a gateway between variables defined at
-runtime, and defaults. Any variable that has an unchanging default value 
+runtime, and defaults. Any variable that has an unchanging default value
 can be found here. The order of operations works as follows:
-  
+
     1. First preference goes to environment variable set at runtime
     2. Second preference goes to default defined in this file
-    3. Then, if neither is found, null is returned except in the 
+    3. Then, if neither is found, null is returned except in the
        case that required = True. A required = True variable not found
        will system exit with an error.
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
@@ -35,34 +35,37 @@ import os
 import pwd
 import sys
 
-def getenv(variable_key,required=False,default=None,silent=False):
-    '''getenv will attempt to get an environment variable. If the variable
-    is not found, None is returned.
+
+def getenv(variable_key, required=False, default=None, silent=False):
+    '''getenv will attempt to get an environment variable. If the
+    variable is not found, None is returned.
     :param variable_key: the variable name
     :param required: exit with error if not found
     :param silent: Do not print debugging information for variable
     '''
     variable = os.environ.get(variable_key, default)
-    if variable == None and required:
-        bot.error("Cannot find environment variable %s, exiting." %variable_key)
+    if variable is None and required:
+        bot.error("Cannot find environment variable %s, exiting."
+                  % (variable_key))
         sys.exit(1)
 
     if silent:
-        bot.verbose2("%s found" %variable_key)
+        bot.verbose2("%s found" % (variable_key))
     else:
         if variable is not None:
-            bot.verbose2("%s found as %s" %(variable_key,variable))
+            bot.verbose2("%s found as %s" % (variable_key, variable))
         else:
-            bot.verbose2("%s not defined (None)" %variable_key)
+            bot.verbose2("%s not defined (None)" % (variable_key))
 
-    return variable 
+    return variable
+
 
 def convert2boolean(arg):
-  '''convert2boolean is used for environmental variables that must be
-  returned as boolean'''
-  if not isinstance(arg,bool):
-      return arg.lower() in ("yes", "true", "t", "1","y")
-  return arg
+    '''convert2boolean is used for environmental variables
+    that must be returned as boolean'''
+    if not isinstance(arg, bool):
+        return arg.lower() in ("yes", "true", "t", "1", "y")
+    return arg
 
 
 #######################################################################
@@ -75,10 +78,10 @@ RUNSCRIPT_COMMAND_ASIS = convert2boolean(getenv("SINGULARITY_COMMAND_ASIS",
 
 SINGULARITY_ROOTFS = getenv("SINGULARITY_ROOTFS")
 METADATA_FOLDER_NAME = ".singularity.d"
-_metadata_base = "%s/%s" %(SINGULARITY_ROOTFS,METADATA_FOLDER_NAME)
-METADATA_BASE = getenv("SINGULARITY_METADATA_FOLDER", 
-                                   default=_metadata_base,
-                                   required=True)
+_metadata_base = "%s/%s" % (SINGULARITY_ROOTFS, METADATA_FOLDER_NAME)
+METADATA_BASE = getenv("SINGULARITY_METADATA_FOLDER",
+                       default=_metadata_base,
+                       required=True)
 
 
 #######################################################################
@@ -99,15 +102,12 @@ if COLORIZE is not None:
 DISABLE_CACHE = convert2boolean(getenv("SINGULARITY_DISABLE_CACHE",
                                 default=False))
 
-if DISABLE_CACHE == True:
+if DISABLE_CACHE is True:
     SINGULARITY_CACHE = tempfile.mkdtemp()
 else:
     userhome = pwd.getpwuid(os.getuid())[5]
-    _cache = os.path.join(userhome,".singularity") 
+    _cache = os.path.join(userhome, ".singularity")
     SINGULARITY_CACHE = getenv("SINGULARITY_CACHEDIR", default=_cache)
-
-if not os.path.exists(SINGULARITY_CACHE):
-    os.mkdir(SINGULARITY_CACHE)
 
 
 #######################################################################
@@ -115,40 +115,44 @@ if not os.path.exists(SINGULARITY_CACHE):
 #######################################################################
 
 # API
-API_BASE = "index.docker.io" # registry
-API_VERSION = "v2"
+DOCKER_API_BASE = "index.docker.io"  # registry
+DOCKER_API_VERSION = "v2"
 NAMESPACE = "library"
 TAG = "latest"
 
 # Container Metadata
-DOCKER_NUMBER = 10 # number to start docker files at in ENV_DIR
+DOCKER_NUMBER = 10  # number to start docker files at in ENV_DIR
 DOCKER_PREFIX = "docker"
 SHUB_PREFIX = "shub"
 
 # Defaults for environment, runscript, labels
-_envbase = "%s/env" %(METADATA_BASE)
-_runscript = "%s/singularity" %(SINGULARITY_ROOTFS)
-_environment = "%s/environment" %(METADATA_BASE)
-_labelfile = "%s/labels.json" %(METADATA_BASE)
-_deffile = "%s/Singularity" %(METADATA_BASE)
-_testfile = "%s/test" %(METADATA_BASE)
+_envbase = "%s/env" % (METADATA_BASE)
+_runscript = "%s/singularity" % (SINGULARITY_ROOTFS)
+_environment = "%s/90-environment.sh" % (_envbase)
+_labelfile = "%s/labels.json" % (METADATA_BASE)
+_helpfile = "%s/runscript.help" % (METADATA_BASE)
+_deffile = "%s/Singularity" % (METADATA_BASE)
+_testfile = "%s/test" % (METADATA_BASE)
 
 
 ENVIRONMENT = getenv("SINGULARITY_ENVIRONMENT", default=_environment)
 RUNSCRIPT = getenv("SINGULARITY_RUNSCRIPT", default=_runscript)
 TESTFILE = getenv("SINGULARITY_TESTFILE", default=_testfile)
 DEFFILE = getenv("SINGULARITY_DEFFILE", default=_deffile)
+HELPFILE = getenv("SINGULARITY_HELPFILE", default=_helpfile)
 ENV_BASE = getenv("SINGULARITY_ENVBASE", default=_envbase)
 LABELFILE = getenv("SINGULARITY_LABELFILE", default=_labelfile)
 INCLUDE_CMD = convert2boolean(getenv("SINGULARITY_INCLUDECMD",
                               default=False))
+DISABLE_HTTPS = convert2boolean(getenv("SINGULARITY_NOHTTPS",
+                                default=False))
 
 #######################################################################
 # Singularity Hub
 #######################################################################
 
 SINGULARITY_PULLFOLDER = getenv("SINGULARITY_PULLFOLDER", default=os.getcwd())
-SHUB_API_BASE = "singularity-hub.org/api"
+SHUB_API_BASE = "singularity-hub.org"
 SHUB_NAMEBYHASH = getenv("SHUB_NAMEBYHASH")
 SHUB_NAMEBYCOMMIT = getenv("SHUB_NAMEBYCOMMIT")
 SHUB_CONTAINERNAME = getenv("SHUB_CONTAINERNAME")
@@ -157,11 +161,7 @@ SHUB_CONTAINERNAME = getenv("SHUB_CONTAINERNAME")
 # Python Internal API URI Handling
 #######################################################################
 
-_layerfile = "%s/.layers" %(METADATA_BASE)
+_layerfile = "%s/.layers" % (METADATA_BASE)
 LAYERFILE = getenv("SINGULARITY_CONTENTS", default=_layerfile)
 
-SINGULARITY_WORKERS = int(getenv("SINGULARITY_PYTHREADS",default=9))
-
-#URI_IMAGE = "img://"
-#URI_TAR = "tar://"
-#URI_TARGC = "targz://"
+SINGULARITY_WORKERS = int(getenv("SINGULARITY_PYTHREADS", default=9))

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -2,30 +2,31 @@
 
 api.py: Docker helper functions for Singularity in Python
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
-        
+
 import sys
 import math
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-sys.path.append('..') # parent directory
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                os.path.pardir)))  # noqa
+sys.path.append('..')  # noqa
 
 from base import ApiConnection
 
@@ -38,8 +39,8 @@ from sutils import (
 )
 
 from defaults import (
-    API_BASE,
-    API_VERSION,
+    DOCKER_API_BASE,
+    DOCKER_API_VERSION,
     DOCKER_NUMBER,
     DOCKER_PREFIX,
     ENV_BASE,
@@ -62,17 +63,18 @@ except ImportError:
     from urllib2 import HTTPError
 
 
-# Docker API Class  ----------------------------------------------------------------------------
+# Docker API Class  ---------------------------------------
 
 class DockerApiConnection(ApiConnection):
 
-    def __init__(self,**kwargs):
+    def __init__(self, **kwargs):
         self.auth = None
         self.token = None
         self.token_url = None
-        self.api_base = API_BASE
-        self.api_version = API_VERSION
+        self.api_base = DOCKER_API_BASE
+        self.api_version = DOCKER_API_VERSION
         self.manifest = None
+        self.manifestv1 = None
 
         if 'auth' in kwargs:
             self.auth = kwargs['auth']
@@ -81,37 +83,53 @@ class DockerApiConnection(ApiConnection):
         super(DockerApiConnection, self).__init__(**kwargs)
         if 'image' in kwargs:
             self.load_image(kwargs['image'])
-        
 
-    def assemble_uri(self,sep=None):
+    def assemble_uri(self, sep=None):
         '''re-assemble the image uri, for components defined.
         '''
         if sep is None:
             sep = "-"
-        image_uri = "%s%s%s%s%s" %(self.registry,sep,
-                                   self.namespace,sep,
-                                   self.repo_name)
+        image_uri = "%s%s%s%s%s" % (self.registry, sep,
+                                    self.namespace, sep,
+                                    self.repo_name)
 
         if self.version is not None:
-            image_uri = "%s@%s" %(image_uri,self.version)
+            image_uri = "%s@%s" % (image_uri, self.version)
         else:
-            image_uri = "%s:%s" %(image_uri,self.repo_tag)
+            image_uri = "%s:%s" % (image_uri, self.repo_tag)
 
         return image_uri
 
-
     def _init_headers(self):
-        # specify wanting version 2 schema, meaning the correct order of digests 
+        # specify wanting version 2 schema
+        # meaning the correct order of digests
         # returned (base to child)
-        return {"Accept":'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json',
-               'Content-Type':'application/json; charset=utf-8'}
 
+        return {"Accept": 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/json',  # noqa
+               'Content-Type': 'application/json; charset=utf-8'}  # noqa
 
-    def load_image(self,image):
-        '''load_image parses the image uri, and loads the different image parameters into
-        the client. The image should be a docker uri (eg docker://) or name of docker image.
+    def check_errors(self, response, exit=True):
+        '''take a response with errors key,
+        iterate through errors in expected format and exit upon completion
         '''
-        image = parse_image_uri(image=image,uri="docker://")
+        if "errors" in response:
+            for error in response['errors']:
+                bot.error("%s: %s" % (error['code'],
+                                      error['message']))
+                if error['code'] == "UNAUTHORIZED":
+                    msg = "Check existence, naming, and permissions"
+                    bot.error(msg)
+            if exit:
+                sys.exit(1)
+        return response
+
+    def load_image(self, image):
+        '''load_image parses the image uri, and loads the
+        different image parameters into the client.
+        The image should be a docker uri (eg docker://)
+        or name of docker image'''
+
+        image = parse_image_uri(image=image, uri="docker://")
         self.repo_name = image['repo_name']
         self.repo_tag = image['repo_tag']
         self.namespace = image['namespace']
@@ -119,27 +137,30 @@ class DockerApiConnection(ApiConnection):
         self.registry = image['registry']
         self.update_token()
 
-
-    def update_token(self,response=None,auth=None):
-        '''update_token uses HTTP basic authentication to get a token for 
+    def update_token(self, response=None, auth=None):
+        '''update_token uses HTTP basic authentication to get a token for
         Docker registry API V2 operations. We get here if a 401 is
-        returned for a request. https://docs.docker.com/registry/spec/auth/token/
+        returned for a request.
+        https://docs.docker.com/registry/spec/auth/token/
         '''
         if self.token_url is None:
 
-            if response == None:
+            if response is None:
                 response = self.get_tags(return_response=True)
 
             if not isinstance(response, HTTPError):
                 bot.verbose3('Response on obtaining token is None.')
                 return None
 
-            if response.code != 401 or "Www-Authenticate" not in response.headers:
+            not_asking_auth = "Www-Authenticate" not in response.headers
+            if response.code != 401 or not_asking_auth:
                 bot.error("Authentication error, exiting.")
                 sys.exit(1)
 
             challenge = response.headers["Www-Authenticate"]
-            match = re.match('^Bearer\s+realm="(.+)",service="(.+)",scope="(.+)",?', challenge)
+            regexp = '^Bearer\s+realm="(.+)",service="(.+)",scope="(.+)",?'
+            match = re.match(regexp, challenge)
+
             if not match:
                 bot.error("Unrecognized authentication challenge, exiting.")
                 sys.exit(1)
@@ -148,9 +169,11 @@ class DockerApiConnection(ApiConnection):
             service = match.group(2)
             scope = match.group(3).split(',')[0]
 
-            self.token_url = "%s?service=%s&expires_in=9000&scope=%s" %(realm,service,scope)
+            self.token_url = ("%s?service=%s&expires_in=9000&scope=%s"
+                              % (realm, service, scope))
 
         headers = dict()
+
         # First priority comes to auth supplied directly to function
         if auth is not None:
             headers.update(auth)
@@ -165,52 +188,70 @@ class DockerApiConnection(ApiConnection):
 
         try:
             token = json.loads(response)["token"]
-            token = {"Authorization": "Bearer %s" %(token) }
+            token = {"Authorization": "Bearer %s" % token}
             self.token = token
             self.update_headers(token)
-        except:
-            bot.error("Error getting token for repository %s/%s, exiting." %(self.namespace,
-                                                                             self.repo_name))
+
+        except Exception:
+            msg = "Error getting token for repository "
+            msg += "%s/%s, exiting." % (self.namespace,
+                                        self.repo_name)
+            bot.error(msg)
             sys.exit(1)
 
-
-    def get_images(self):
-        '''get_images is a wrapper for get_manifest, but it additionally parses the repo_name and tag's
-        images and returns the complete ids
-        :param repo_name: the name of the repo, eg "ubuntu"
-        :param namespace: the namespace for the image, default is "library"
-        :param repo_tag: the repo tag, default is "latest"
-        :param registry: the docker registry url, default will use index.docker.io
+    def get_images(self, manifest=None):
+        '''get_images will return a list of layers from a manifest.
+        The function is intended to work with both version
+        1 and 2 of the schema
+        :param manifest: the manifest to read_layers from
         '''
+        if manifest is None:
+            self.update_manifests()
+            manifest = self.manifestv1
 
-        # Get full image manifest, using version 2.0 of Docker Registry API
-        if self.manifest is None:
-            if self.repo_name is not None and self.namespace is not None:
-                self.manifest = self.get_manifest()
+        digests = []
 
-            else:
-                bot.error("No namespace and repo name OR manifest provided, exiting.")
-                sys.exit(1)
+        # https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest  # noqa
+        if 'layers' in manifest:
+            layer_key = 'layers'
+            digest_key = 'digest'
+            bot.debug('Image manifest version 2.2 found.')
 
-        digests = read_digests(self.manifest)
+        # https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md#example-manifest  # noqa
+        elif 'fsLayers' in manifest:
+            layer_key = 'fsLayers'
+            digest_key = 'blobSum'
+            bot.debug('Image manifest version 2.1 found.')
+
+        else:
+            msg = "Improperly formed manifest, "
+            msg += "layers or fsLayers must be present"
+            bot.error(msg)
+            sys.exit(1)
+
+        for layer in manifest[layer_key]:
+            if digest_key in layer:
+                if layer[digest_key] not in digests:
+                    bot.debug("Adding digest %s" % layer[digest_key])
+                    digests.append(layer[digest_key])
         return digests
 
-
-    def get_tags(self,return_response=False):
-        '''get_tags will return the tags for a repo using the Docker Version 2.0 Registry API
-        :param namespace: the namespace (eg, "library")
-        :param repo_name: the name for the repo (eg, "ubuntu")
-        :param registry: the docker registry to use (default will use index.docker.io)
-        :param auth: authorization header (default None)
+    def get_tags(self, return_response=False):
+        '''get_tags will return the tags for a repo using the
+        Docker Version 2.0 Registry API
         '''
         registry = self.registry
-        if registry == None:
+        if registry is None:
             registry = self.api_base
-        
-        registry = add_http(registry) # make sure we have a complete url
 
-        base = "%s/%s/%s/%s/tags/list" %(registry,self.api_version,self.namespace,self.repo_name)
-        bot.verbose("Obtaining tags: %s" %base)
+        registry = add_http(registry)  # make sure we have a complete url
+
+        base = "%s/%s/%s/%s/tags/list" % (registry,
+                                          self.api_version,
+                                          self.namespace,
+                                          self.repo_name)
+
+        bot.verbose("Obtaining tags: %s" % base)
 
         # We use get_tags for a testing endpoint in update_token
         response = self.get(base,
@@ -222,79 +263,119 @@ class DockerApiConnection(ApiConnection):
         try:
             response = json.loads(response)
             return response['tags']
-        except:
-            bot.error("Error obtaining tags: %s" %base)
+        except Exception:
+            bot.error("Error obtaining tags: %s" % base)
             sys.exit(1)
 
-
-    def get_manifest(self,old_version=False):
-        '''get_manifest should return an image manifest for a particular repo and tag. 
-        The image details are extracted when the client is generated.
-        :param old_version: return version 1 (for cmd/entrypoint), default False
+    def get_manifest(self, old_version=False):
+        '''get_manifest should return an image manifest
+        for a particular repo and tag.  The image details
+        are extracted when the client is generated.
+        :param old_version: return version 1
+                            (for cmd/entrypoint), default False
         '''
         registry = self.registry
-        if registry == None:
+        if registry is None:
             registry = self.api_base
-        registry = add_http(registry) # make sure we have a complete url
 
-        base = "%s/%s/%s/%s/manifests" %(registry,self.api_version,self.namespace,self.repo_name)
+        # make sure we have a complete url
+        registry = add_http(registry)
+
+        base = "%s/%s/%s/%s/manifests" % (registry,
+                                          self.api_version,
+                                          self.namespace,
+                                          self.repo_name)
         if self.version is not None:
-            base = "%s/%s" %(base,self.version)
+            base = "%s/%s" % (base, self.version)
         else:
-            base = "%s/%s" %(base,self.repo_tag)
-        bot.verbose("Obtaining manifest: %s" %base)
-    
-        headers = self.headers
-        if old_version == True:
-            headers['Accept'] = 'application/json' 
+            base = "%s/%s" % (base, self.repo_tag)
+        bot.verbose("Obtaining manifest: %s" % base)
 
-        response = self.get(base,headers=self.headers)
+        headers = self.headers
+        if old_version is True:
+            headers['Accept'] = 'application/json'
+
+        response = self.get(base, headers=self.headers)
 
         try:
             response = json.loads(response)
 
-        except:
+        except Exception:
+
             # If the call fails, give the user a list of acceptable tags
             tags = self.get_tags()
             print("\n".join(tags))
-            repo_uri = "%s/%s:%s" %(self.namespace,self.repo_name,self.repo_tag)
-            bot.error("Error getting manifest for %s, exiting." %repo_uri)
+            repo_uri = "%s/%s:%s" % (self.namespace,
+                                     self.repo_name,
+                                     self.repo_tag)
+
+            bot.error("Error getting manifest for %s, exiting." % repo_uri)
             sys.exit(1)
 
-        return response
+        # If we have errors, don't continue
+        return self.check_errors(response)
 
+    def update_manifests(self):
+        '''update manifests ensures that each of a version1 and version2
+        manifest are present
+        '''
+        if self.repo_name is None and self.namespace is None:
+            bot.error("Insufficient metadata to get manifest.")
+            sys.exit(1)
 
-    def get_layer(self,image_id,download_folder=None,change_perms=False,return_tmp=False):
-        '''get_layer will download an image layer (.tar.gz) to a specified download folder.
+        # Get full image manifest, using version 2.0 of Docker Registry API
+        if self.manifest is None:
+            self.manifest = self.get_manifest()
+        if self.manifestv1 is None:
+            self.manifestv1 = self.get_manifest(old_version=True)
+
+    def get_layer(self,
+                  image_id,
+                  download_folder=None,
+                  change_perms=False,
+                  return_tmp=False):
+
+        '''get_layer will download an image layer (.tar.gz)
+        to a specified download folder.
         :param download_folder: if specified, download to folder.
-        Otherwise return response with raw data (not recommended)
-        :param change_perms: change permissions additionally (default False to support 
-        multiprocessing)
-        :param return_tmp: If true, return the temporary file name (and don't rename to the file's final
-        name). Default is False, should be True for multiprocessing that requires extra permission changes
+                                Otherwise return response with raw data
+        :param change_perms: change permissions additionally
+                             (default False to support multiprocessing)
+        :param return_tmp: If true, return the temporary file name (and
+                             don't rename to the file's final name). Default
+                             is False, should be True for multiprocessing
+                             that requires extra permission changes
         '''
         registry = self.registry
-        if registry == None:
+        if registry is None:
             registry = self.api_base
-        registry = add_http(registry) # make sure we have a complete url
+
+        # make sure we have a complete url
+        registry = add_http(registry)
 
         # The <name> variable is the namespace/repo_name
-        base = "%s/%s/%s/%s/blobs/%s" %(registry,self.api_version,self.namespace,self.repo_name,image_id)
-        bot.verbose("Downloading layers from %s" %base)
-    
-        if download_folder is None:        
+        base = "%s/%s/%s/%s/blobs/%s" % (registry,
+                                         self.api_version,
+                                         self.namespace,
+                                         self.repo_name,
+                                         image_id)
+        bot.verbose("Downloading layers from %s" % base)
+
+        if download_folder is None:
             download_folder = tempfile.mkdtemp()
 
-        download_folder = "%s/%s.tar.gz" %(download_folder,image_id)
+        download_folder = "%s/%s.tar.gz" % (download_folder, image_id)
 
         # Update user what we are doing
-        bot.debug("Downloading layer %s" %image_id)
+        bot.debug("Downloading layer %s" % image_id)
 
         # Step 1: Download the layer atomically
-        file_name = "%s.%s" %(download_folder,next(tempfile._get_candidate_names()))
+        file_name = "%s.%s" % (download_folder,
+                               next(tempfile._get_candidate_names()))
         tar_download = self.download_atomically(url=base,
                                                 file_name=file_name)
-        bot.debug('Download of raw file (pre permissions fix) is %s' %tar_download)
+        bot.debug('Download of raw file (pre permissions fix) is %s'
+                  % tar_download)
 
         # Step 2: Fix Permissions?
         if change_perms:
@@ -304,15 +385,16 @@ class DockerApiConnection(ApiConnection):
             return tar_download
 
         try:
-            os.rename(tar_download,download_folder)
-        except:
-            bot.error("Cannot untar layer %s, was there a problem with download?" %tar_download)
+            os.rename(tar_download, download_folder)
+        except Exception:
+            msg = "Cannot untar layer %s," % tar_download
+            msg += " was there a problem with download?"
+            bot.error(msg)
             sys.exit(1)
         return download_folder
 
-
-    def get_size(self,add_padding=True,round_up=True,return_mb=True):
-        '''get_size will return the image size (must use version 2 manifest)
+    def get_size(self, add_padding=True, round_up=True, return_mb=True):
+        '''get_size will return the image size (must use v.2.0 manifest)
         :add_padding: if true, return reported size * 5
         :round_up: if true, round up to nearest integer
         :return_mb: if true, defaults bytes are converted to MB
@@ -324,12 +406,12 @@ class DockerApiConnection(ApiConnection):
             for layer in manifest["layers"]:
                 if "size" in layer:
                     size += layer['size']
-            
+
             if add_padding is True:
                 size = size * 5
 
             if return_mb is True:
-                size = size / (1024*1024) # 1MB = 1024*1024 bytes
+                size = size / (1024 * 1024)  # 1MB = 1024*1024 bytes
 
             if round_up is True:
                 size = math.ceil(size)
@@ -337,13 +419,13 @@ class DockerApiConnection(ApiConnection):
 
         return size
 
-
-    def get_config(self,spec="Entrypoint",delim=None,old_version=False):
-        '''get_config returns a particular spec (default is Entrypoint) 
+    def get_config(self, spec="Entrypoint", delim=None, old_version=False):
+        '''get_config returns a particular spec (default is Entrypoint)
         from a VERSION 1 manifest obtained with get_manifest.
         :param manifest: the manifest obtained from get_manifest
         :param spec: the key of the spec to return, default is "Entrypoint"
-        :param delim: Given a list, the delim to use to join the entries. Default is newline
+        :param delim: Given a list, the delim to use to join the entries.
+                      Default is newline
         '''
         manifest = self.get_manifest(old_version=old_version)
 
@@ -360,49 +442,14 @@ class DockerApiConnection(ApiConnection):
                                 cmd = entry["config"][spec]
 
             # Standard is to include commands like ['/bin/sh']
-            if isinstance(cmd,list):
+            if isinstance(cmd, list):
                 if delim is None:
                     delim = "\n"
                 cmd = delim.join(cmd)
-            bot.verbose("Found Docker config (%s) %s" %(spec,cmd))
+            bot.verbose("Found Docker config (%s) %s" % (spec, cmd))
 
         else:
             if "config" in manifest:
                 if spec in manifest['config']:
                     cmd = manifest['config'][spec]
         return cmd
-
-
-# API Helper functions
-
-def read_digests(manifest):
-    '''read_layers will return a list of layers from a manifest. The function is
-    intended to work with both version 1 and 2 of the schema
-    :param manifest: the manifest to read_layers from
-    '''
-
-    digests = []
-
-    # https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest
-    if 'layers' in manifest:
-        layer_key = 'layers'
-        digest_key = 'digest'
-        bot.debug('Image manifest version 2.2 found.')
-
-    # https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md#example-manifest
-    elif 'fsLayers' in manifest:
-        layer_key = 'fsLayers'
-        digest_key = 'blobSum'
-        bot.debug('Image manifest version 2.1 found.')
-
-    else:
-        bot.error('Improperly formed manifest, layers or fsLayers must be present')
-        sys.exit(1)
-
-    for layer in manifest[layer_key]:
-        if digest_key in layer:
-            if layer[digest_key] not in digests:
-                bot.debug("Adding digest %s" %layer[digest_key])
-                digests.append(layer[digest_key])
-    return digests
-

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -1,21 +1,22 @@
 '''
 shell.py: General shell parsing functions for Singularity in Python
 
-Copyright (c) 2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2017, Vanessa Sochat. All rights reserved.
+
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
@@ -25,66 +26,83 @@ import os
 from message import bot
 
 from defaults import (
-    API_BASE as default_registry,
-    NAMESPACE as default_namespace,
-    TAG as default_tag
+    DOCKER_API_BASE,
+    NAMESPACE,
+    TAG
 )
 
-from sutils import is_number
 import json
 import re
 import os
 
 
-def get_image_uri(image,quiet=False):
-    '''get_image_uri will parse a uri sent from Singularity to determine if it's 
-    singularity (shub://) or docker (docker://)
+def get_image_uri(image, quiet=False):
+    '''get_image_uri will parse a uri sent from Singularity
+       to determine if it's  singularity (shub://)
+       or docker (docker://)
     :param image: the complete image uri (example: docker://ubuntu:latest
     '''
     image_uri = None
-    image = image.replace(' ','')
-    match = re.findall('^[A-Za-z0-9-]+[:]//',image)
+    image = image.replace(' ', '')
+    match = re.findall('^[A-Za-z0-9-]+[:]//', image)
 
     if len(match) == 0:
         if not quiet:
-            bot.warning("Could not detect any uri in %s" %image)
+            bot.warning("Could not detect any uri in %s" % image)
     else:
         image_uri = match[0].lower()
         if not quiet:
-            bot.debug("Found uri %s" %image_uri)
+            bot.debug("Found uri %s" % (image_uri))
     return image_uri
 
 
-def remove_image_uri(image,image_uri=None,quiet=False):
+def remove_image_uri(image, image_uri=None, quiet=False):
     '''remove_image_uri will return just the image name
     '''
-    if image_uri == None:
-        image_uri = get_image_uri(image,quiet=quiet)
+    if image_uri is None:
+        image_uri = get_image_uri(image, quiet=quiet)
 
-    image = image.replace(' ','')
-        
-    if image_uri != None:
-        image = image.replace(image_uri,'')
+    image = image.replace(' ', '')
+
+    if image_uri is not None:
+        image = image.replace(image_uri, '')
     return image
 
 
-def parse_image_uri(image,uri=None,quiet=False):
-    '''parse_image_uri will return a json structure with a registry, 
+def parse_image_uri(image,
+                    uri=None,
+                    quiet=False,
+                    default_registry=None,
+                    default_namespace=None,
+                    default_tag=None):
+
+    '''parse_image_uri will return a json structure with a registry,
     repo name, tag, and namespace, intended for Docker.
-    :param image: the string provided on command line for the image name, eg: ubuntu:latest
+    :param image: the string provided on command line for
+                  the image name, eg: ubuntu:latest
     :param uri: the uri (eg, docker:// to remove), default uses ""
-    ::note uri is maintained as a variable so we have some control over allowed
+    ::note uri is maintained as variable so we have some control over allowed
     :returns parsed: a json structure with repo_name, repo_tag, and namespace
     '''
 
-    if uri == None:
+    if uri is None:
         uri = ""
+
+    # Default to most common use case, Docker
+    if default_registry is None:
+        default_registry = DOCKER_API_BASE
+
+    if default_namespace is None:
+        default_namespace = NAMESPACE
+
+    if default_tag is None:
+        default_tag = TAG
 
     # Be absolutely sure there are not comments
     image = image.split('#')[0]
-    
+
     # Get rid of any uri, and split the tag
-    image = image.replace(uri,'')
+    image = image.replace(uri, '')
 
     # Does the uri have a digest or Github tag (version)?
     image = image.split('@')
@@ -98,7 +116,7 @@ def parse_image_uri(image,uri=None,quiet=False):
     # If there are three parts, we have port and tag
     if len(image) == 3:
         repo_tag = image[2]
-        image = "%s:%s" %(image[0],image[1])
+        image = "%s:%s" % (image[0], image[1])
 
     # If there are two parts, we have port or tag
     elif len(image) == 2:
@@ -108,7 +126,7 @@ def parse_image_uri(image,uri=None,quiet=False):
             image = image[0]
         # Otherwise we have a port and we merge the path
         else:
-            image = "%s:%s" %(image[0],image[1])
+            image = "%s:%s" % (image[0], image[1])
             repo_tag = default_tag
     else:
         image = image[0]
@@ -117,10 +135,10 @@ def parse_image_uri(image,uri=None,quiet=False):
     # Now look for registry, namespace, repo
     image = image.split('/')
 
-    if len(image) == 3:
+    if len(image) > 2:
         registry = image[0]
-        namespace = image[1]
-        repo_name = image[2]
+        namespace = "/".join(image[1:-1])
+        repo_name = image[-1]
 
     elif len(image) == 2:
         registry = default_registry
@@ -133,24 +151,24 @@ def parse_image_uri(image,uri=None,quiet=False):
         repo_name = image[0]
 
     if not quiet:
-        bot.verbose("Registry: %s" %registry)
-        bot.verbose("Namespace: %s" %namespace)
-        bot.verbose("Repo Name: %s" %repo_name)
-        bot.verbose("Repo Tag: %s" %repo_tag)
-        bot.verbose("Version: %s" %version)
+        bot.verbose("Registry: %s" % registry)
+        bot.verbose("Namespace: %s" % namespace)
+        bot.verbose("Repo Name: %s" % repo_name)
+        bot.verbose("Repo Tag: %s" % repo_tag)
+        bot.verbose("Version: %s" % version)
 
-    parsed = {'registry':registry,
-              'namespace':namespace, 
-              'repo_name':repo_name,
-              'repo_tag':repo_tag }
+    parsed = {'registry': registry,
+              'namespace': namespace,
+              'repo_name': repo_name,
+              'repo_tag': repo_tag}
 
     # No field should be empty
-    for fieldname,value in parsed.items():
+    for fieldname, value in parsed.items():
         if len(value) == 0:
-            bot.error("%s found empty, check uri! Exiting." %value)
+            bot.error("%s found empty, check uri! Exiting." % value)
             sys.exit(1)
 
     # Version is not required
-    parsed['version'] = version 
+    parsed['version'] = version
 
     return parsed

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -4,38 +4,41 @@
 
 api.py: Singularity Hub helper functions for python
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
 import sys
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-sys.path.append('..') # parent directory
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                os.path.pardir)))  # noqa
+sys.path.append('..')  # noqa
 
 from shell import (
-    remove_image_uri
+    parse_image_uri,
+    remove_image_uri,
 )
 
 from sutils import (
     add_http,
-    is_number,
-    read_file
+    clean_up,
+    read_file,
+    run_command
 )
 
 from base import ApiConnection
@@ -51,131 +54,189 @@ import json
 import re
 
 try:
-    from urllib import unquote 
-except:
+    from urllib import unquote
+except Exception:
     from urllib.parse import unquote
 
 
-# Shub API Class  ----------------------------------------------------------------------------
+# Shub API Class  ----------------------------------------------
 
 class SingularityApiConnection(ApiConnection):
 
-    def __init__(self,**kwargs):
+    def __init__(self, **kwargs):
         self.token = None
         self.api_base = SHUB_API_BASE
+
         if 'image' in kwargs:
             self.load_image(kwargs['image'])
+
         if 'token' in kwargs:
             self.token = kwargs['token']
         super(SingularityApiConnection, self).__init__(**kwargs)
 
+    def load_image(self, image):
+        self.image = parse_image_uri(image=image,
+                                     uri='shub://',
+                                     default_registry=SHUB_API_BASE,
+                                     quiet=True)
 
-    def load_image(self,image):
-        self.image = image
-        if not is_number(image):
-            self.image = remove_image_uri(image,quiet=True)
-          
+    def get_manifest(self):
+        '''get_image will return a json object with image metadata
+        based on a unique id.
 
+        Parameters
+        ==========
+        :param image: the image name, either an id
+                      or a repo name, tag, etc.
 
-    def get_manifest(self,image=None,registry=None):
-        '''get_image will return a json object with image metadata, based on a unique id.
-        :param image: the image name, either an id, or a repo name, tag, etc.
-        :param registry: the registry (hub) to use, if not defined, default is used
+        Returns
+        =======
+        manifest: a json manifest from the registry
         '''
-        if image == None:
-            image = self.image
-        if registry == None:
-            registry = self.api_base
-        registry = add_http(registry) # make sure we have a complete url
+        # make sure we have a complete url
+        registry = add_http(self.image['registry'])
+        base = "%s/api/container/%s/%s:%s" % (registry,
+                                              self.image['namespace'],
+                                              self.image['repo_name'],
+                                              self.image['repo_tag'])
+        # ------------------------------------------------------
+        # If we need to authenticate, will do it here
+        # ------------------------------------------------------
 
-        # Numeric images have slightly different endpoint from named
-        if is_number(image) == True:
-            base = "%s/containers/%s" %(registry,image)
-        else:
-            base = "%s/container/%s" %(registry,image)
-
-        # ---------------------------------------------------------------
-        # If we eventually have private images, need to authenticate here       
-        # --------------------------------------------------------------- 
-
-        response = self.get(base)
-        try:
-            response = json.loads(response)
-        except:
-            print("Error getting image manifest using url %s" %(base))
+        # If the Hub returns 404, the image name is likely wrong
+        response = self.get(base, return_response=True)
+        if response.code == 404:
+            msg = "Cannot find image."
+            msg += " Is your capitalization correct?"
+            bot.error(msg)
             sys.exit(1)
+
+        try:
+            response = response.read().decode('utf-8')
+            response = json.loads(response)
+
+        except Exception:
+            print("Error getting image manifest using url %s" % base)
+            sys.exit(1)
+
         return response
 
+    def download_image(self,
+                       manifest,
+                       image_name=None,
+                       download_folder=None,
+                       extract=True):
 
-    def download_image(self,manifest,download_folder=None,extract=True):
-        '''download_image will download a singularity image from singularity
+        '''
+
+        download_image will download a singularity image from singularity
         hub to a download_folder, named based on the image version (commit id)
+
+        Parameters
+        ==========
         :param manifest: the manifest obtained with get_manifest
         :param download_folder: the folder to download to, if None, will be pwd
         :param extract: if True, will extract image to .img and return that.
+
+        Returns
+        =======
+        image_file: the full path to the downloaded image
+
         '''
-        image_file = get_image_name(manifest)
+        if image_name is None:
+            image_name = get_image_name(manifest)
 
         if not bot.is_quiet():
-            print("Found image %s:%s" %(manifest['name'],
-                                        manifest['branch']))
+            print("Found image %s:%s" % (manifest['name'],
+                                         manifest['branch']))
 
-            print("Downloading image... %s" %(image_file))
+            print("Downloading image... %s" % image_name)
+
+        url = manifest['image']
+
+        if url is None:
+            bot.error("%s is not ready for download" % image_name)
+            bot.error("please try when build completed or specify tag.")
+            sys.exit(1)
+
+        if not image_name.endswith('.gz'):
+            image_name = "%s.gz" % image_name
 
         if download_folder is not None:
-            image_file = "%s/%s" %(download_folder,image_file)
-        url = manifest['image']
+            image_name = "%s/%s" % (download_folder, image_name)
 
         # Download image file atomically, streaming
         image_file = self.download_atomically(url=url,
-                                              file_name=image_file,
+                                              file_name=image_name,
                                               show_progress=True)
 
-        if extract == True:
+        if extract is True:
             if not bot.is_quiet():
-                print("Decompressing %s" %image_file)
-            os.system('gzip -d -f %s' %(image_file))
-            image_file = image_file.replace('.gz','')
+                print("Decompressing %s" % image_file)
+            output = run_command(['gzip', '-d', '-f', image_file])
+            image_file = image_file.replace('.gz', '')
+
+            # Any error in extraction (return code not 0) will return None
+            if output is None:
+                bot.error('Error extracting image, cleaning up.')
+                clean_up([image_file, "%s.gz" % image_file])
+
         return image_file
 
 
-
-# Various Helpers ---------------------------------------------------------------------------------
-def get_image_name(manifest,extension='img.gz'):
-    '''get_image_name will return the image name for a manifest
-    :param manifest: the image manifest with 'image' as key with download link
+# Various Helpers -----------------------------------------------
+def get_image_name(manifest, extension='img.gz'):
+    '''return the image name for a manifest
+    :param manifest: the image manifest with 'image'
+                     as key with download link
     :param use_hash: use the image hash instead of name
     '''
-    from defaults import ( SHUB_CONTAINERNAME, 
-                           SHUB_NAMEBYCOMMIT, 
-                           SHUB_NAMEBYHASH )
-   
+    from defaults import (SHUB_CONTAINERNAME,
+                          SHUB_NAMEBYCOMMIT,
+                          SHUB_NAMEBYHASH)
+
     # First preference goes to a custom name
+    default_naming = True
+
     if SHUB_CONTAINERNAME is not None:
-        for replace in [" ",".gz",".img"]:
-            SHUB_CONTAINERNAME = SHUB_CONTAINERNAME.replace(replace,"")
-        image_name = "%s.%s" %(SHUB_CONTAINERNAME,extension)
+        for replace in [" ", ".gz", ".img"]:
+            SHUB_CONTAINERNAME = SHUB_CONTAINERNAME.replace(replace, "")
+        image_name = "%s.%s" % (SHUB_CONTAINERNAME, extension)
+        default_naming = False
 
     # Second preference goes to commit
-    elif SHUB_NAMEBYCOMMIT is not None:
-        image_name = "%s.%s" %(manifest['version'],extension)
+    elif SHUB_NAMEBYCOMMIT is not None and manifest['version'] is not None:
+        image_name = "%s.%s" % (manifest['version'], extension)
+        default_naming = False
 
     elif SHUB_NAMEBYHASH is not None:
         image_url = os.path.basename(unquote(manifest['image']))
-        image_name = re.findall(".+[.]%s" %(extension),image_url)[0]
-    
+        image_name = re.findall(".+[.]%s" % (extension), image_url)[0]
+        default_naming = False
+
     # Default uses the image name-branch
-    else:
-        image_name = "%s-%s.%s" %(manifest['name'].replace('/','-'),
-                                  manifest['branch'].replace('/','-'),
-                                  extension)          
+    if default_naming is True:
+
+        # Tag is derived from branch for Shub, tag from sregistry
+        tag_source = 'branch'
+        if tag_source not in manifest:
+            tag_source = 'tag'
+
+        # sregistry images store collection/name separately
+        name = manifest['name']
+        source = "Hub"
+        if 'frozen' in manifest:
+            source = "Registry"
+            name = '%s-%s' % (manifest['collection'], name)
+        image_name = "%s-%s.%s" % (name.replace('/', '-'),
+                                   manifest[tag_source].replace('/', '-'),
+                                   extension)
     if not bot.is_quiet():
-        print("Singularity Hub Image: %s" %image_name)
+        print("Singularity %s Image: %s" % (source, image_name))
     return image_name
 
 
-
-def extract_metadata(manifest,labelfile=None,prefix=None):
+def extract_metadata(manifest, labelfile=None, prefix=None):
     '''extract_metadata will write a file of metadata from shub
     :param manifest: the manifest to use
     '''
@@ -183,19 +244,24 @@ def extract_metadata(manifest,labelfile=None,prefix=None):
         prefix = ""
     prefix = prefix.upper()
 
+    source = 'Hub'
+    if 'frozen' in manifest:
+        source = 'Registry'
+
     metadata = manifest.copy()
-    remove_fields = ['files','spec','metrics']
+    remove_fields = ['files', 'spec', 'metrics']
     for remove_field in remove_fields:
         if remove_field in metadata:
             del metadata[remove_field]
 
     if labelfile is not None:
-        for key,value in metadata.items():
-            key = "%s%s" %(prefix,key)
+        for key, value in metadata.items():
+            key = "%s%s" % (prefix, key)
             value = ADD(key=key,
                         value=value,
                         jsonfile=labelfile,
                         force=True)
 
-        bot.verbose("Saving Singularity Hub metadata to %s" %labelfile)    
+        bot.verbose("Saving Singularity %s metadata to %s" % (source,
+                                                              labelfile))
     return metadata

--- a/libexec/python/tests/test_core.py
+++ b/libexec/python/tests/test_core.py
@@ -1,24 +1,25 @@
 '''
 
-test_core.py: Python testing for core functions for Singularity in Python,
+test_core.py: Python testing for core functions for
+              Singularity in Python,
               including defaults, utils, and shell functions.
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
@@ -26,7 +27,7 @@ import os
 import re
 import sys
 import tarfile
-sys.path.append('..') # directory with client
+sys.path.append('..')  # noqa
 
 from unittest import TestCase
 import shutil
@@ -34,7 +35,8 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s BASE TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s BASE TESTING START ***" % VERSION)
+
 
 class TestShell(TestCase):
 
@@ -52,7 +54,7 @@ class TestShell(TestCase):
         self.REPO_TAG = 'latest'
         self.tmpdir = tempfile.mkdtemp()
         os.environ['SINGULARITY_ROOTFS'] = self.tmpdir
-        
+
         print("\n---START----------------------------------------")
 
     def tearDown(self):
@@ -67,20 +69,19 @@ class TestShell(TestCase):
         from shell import get_image_uri
         print("Case 1: No image uri should return None")
         image_uri = get_image_uri('namespace/repo:tag')
-        self.assertEqual(image_uri, None) 
+        self.assertEqual(image_uri, None)
 
         print("Case 2: testing return of shub://")
         image_uri = get_image_uri('shub://namespace/repo:tag')
-        self.assertEqual(image_uri, 'shub://') 
+        self.assertEqual(image_uri, 'shub://')
 
         print("Case 3: testing return of docker uri")
         image_uri = get_image_uri('docker://namespace/repo:tag')
-        self.assertEqual(image_uri, 'docker://') 
+        self.assertEqual(image_uri, 'docker://')
 
         print("Case 4: weird capitalization should return lowercase")
         image_uri = get_image_uri('DocKer://namespace/repo:tag')
-        self.assertEqual(image_uri, 'docker://') 
-
+        self.assertEqual(image_uri, 'docker://')
 
     def test_remove_image_uri(self):
         '''test_remove_image_uri removes the uri
@@ -88,12 +89,11 @@ class TestShell(TestCase):
         from shell import remove_image_uri
         print("Case 1: No image_uri should estimate first")
         image = remove_image_uri('myuri://namespace/repo:tag')
-        self.assertEqual(image, "namespace/repo:tag") 
+        self.assertEqual(image, "namespace/repo:tag")
 
         print("Case 2: Missing image uri should return image")
         image = remove_image_uri('namespace/repo:tag')
-        self.assertEqual(image, "namespace/repo:tag") 
-
+        self.assertEqual(image, "namespace/repo:tag")
 
     def test_parse_image_uri(self):
         '''test_parse_image_uri ensures that the correct namespace,
@@ -108,54 +108,59 @@ class TestShell(TestCase):
         self.assertEqual(cm.exception.code, 1)
 
         print("Case 2: Checking for correct output tags in digest...")
-        image_name = "%s/%s" %(self.namespace,self.repo_name)
+        image_name = "%s/%s" % (self.namespace, self.repo_name)
         digest = parse_image_uri(image=image_name)
-        for tag in ['registry','repo_name','repo_tag','namespace']:
+        for tag in ['registry', 'repo_name', 'repo_tag', 'namespace']:
             self.assertTrue(tag in digest)
 
         print("Case 3: Specifying only an image should return defaults")
         image = parse_image_uri(image="shub://lizardleezle",
-                                uri = "shub://")
-        self.assertTrue(isinstance(image,dict))
-        self.assertEqual(image["namespace"],self.NAMESPACE)
-        self.assertEqual(image["repo_tag"],self.REPO_TAG)
-        self.assertEqual(image["repo_name"],'lizardleezle')
-        self.assertEqual(image["registry"],self.REGISTRY)
+                                uri="shub://")
+        self.assertTrue(isinstance(image, dict))
+        self.assertEqual(image["namespace"], self.NAMESPACE)
+        self.assertEqual(image["repo_tag"], self.REPO_TAG)
+        self.assertEqual(image["repo_name"], 'lizardleezle')
+        self.assertEqual(image["registry"], self.REGISTRY)
 
         print("Case 4: Tag when speciifed should be returned.")
-        image_name = "%s/%s:%s" %(self.namespace,self.repo_name,"pusheenasaurus")
+        image_name = "%s/%s:%s" % (self.namespace,
+                                   self.repo_name,
+                                   "pusheenasaurus")
+
         digest = parse_image_uri(image_name)
         self.assertTrue(digest['repo_tag'] == 'pusheenasaurus')
 
         print("Case 5: Repo name and tag without namespace...")
-        image_name = "%s:%s" %(self.repo_name,self.tag)
+        image_name = "%s:%s" % (self.repo_name, self.tag)
         digest = parse_image_uri(image_name)
         self.assertTrue(digest['repo_tag'] == self.tag)
         self.assertTrue(digest['namespace'] == 'library')
         self.assertTrue(digest['repo_name'] == self.repo_name)
 
         print("Case 6: Changing default namespace should not use library.")
-        image_name = "meow/%s:%s" %(self.repo_name,self.tag)
+        image_name = "meow/%s:%s" % (self.repo_name, self.tag)
         digest = parse_image_uri(image_name)
         self.assertTrue(digest['namespace'] == 'meow')
-        
-        print("Case 7: Changing default registry should not use index.docker.io.")
-        image_name = "meow/mix/%s:%s" %(self.repo_name,self.tag)
+
+        print("Case 7: Changing default shouldn't use index.docker.io.")
+        image_name = "meow/mix/%s:%s" % (self.repo_name, self.tag)
         digest = parse_image_uri(image_name)
         self.assertTrue(digest['registry'] == 'meow')
         self.assertTrue(digest['namespace'] == 'mix')
 
         print("Case 8: Custom uri should use it.")
-        image_name = "catdog://meow/mix/%s:%s" %(self.repo_name,self.tag)
-        digest = parse_image_uri(image_name,uri="catdog://")
+        image_name = "catdog://meow/mix/tenders/%s:%s" % (self.repo_name,
+                                                          self.tag)
+        digest = parse_image_uri(image_name, uri="catdog://")
         self.assertTrue(digest['registry'] == 'meow')
-        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['namespace'] == 'mix/tenders')
 
         print("Case 9: Digest version should be parsed")
-        image_name = "catdog://meow/mix/%s:%s@sha:256xxxxxxxxxxxxxxx" %(self.repo_name,self.tag)
-        digest = parse_image_uri(image_name,uri="catdog://")
+        image_name = ("catdog://meow/mix/original/choice/%s:%s@sha:256xxxxxxxxxxxxxxx"  # noqa
+                      % (self.repo_name, self.tag))
+        digest = parse_image_uri(image_name, uri="catdog://")
         self.assertTrue(digest['registry'] == 'meow')
-        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['namespace'] == 'mix/original/choice')
         self.assertTrue(digest['version'] == 'sha:256xxxxxxxxxxxxxxx')
 
 
@@ -182,40 +187,39 @@ class TestUtils(TestCase):
         # Default is https
         url = 'registry.docker.io'
         http = add_http(url)
-        self.assertEqual(url_https,http)
+        self.assertEqual(url_https, http)
 
         # http
         print("Case 2: adding http to url with nothing specified...")
-        http = add_http(url,use_https=False)
-        self.assertEqual(url_http,http)
+        http = add_http(url, use_https=False)
+        self.assertEqual(url_http, http)
 
         # This should not change. Note - is url is http, stays http
         print("Case 3: url already has https, should not change...")
         url = 'https://registry.docker.io'
         http = add_http(url)
-        self.assertEqual(url_https,http)
+        self.assertEqual(url_https, http)
 
         # This should not change. Note - is url is http, stays http
         print("Case 4: url already has http, should not change...")
         url = 'http://registry.docker.io'
-        http = add_http(url,use_https=False)
-        self.assertEqual(url_http,http)
+        http = add_http(url, use_https=False)
+        self.assertEqual(url_http, http)
 
         print("Case 5: url has http, should change to https")
         url = 'http://registry.docker.io'
         http = add_http(url)
-        self.assertEqual(url_https,http)
+        self.assertEqual(url_https, http)
 
         print("Case 6: url has https, should change to http")
         url = 'https://registry.docker.io'
-        http = add_http(url,use_https=False)
-        self.assertEqual(url_http,http)
+        http = add_http(url, use_https=False)
+        self.assertEqual(url_http, http)
 
         print("Case 7: url should have trailing slash stripped")
         url = 'https://registry.docker.io/'
-        http = add_http(url,use_https=False)
-        self.assertEqual(url_http,http)
-
+        http = add_http(url, use_https=False)
+        self.assertEqual(url_http, http)
 
     def test_headers(self):
         '''test_add_http ensures that http is added to a url
@@ -223,14 +227,13 @@ class TestUtils(TestCase):
         print("Testing utils header functions...")
 
         from sutils import basic_auth_header
-        
+
         # Basic auth header
-        print("Case 4: basic_auth_header - ask for custom authentication header")
+        print("Case 4: ask for custom authentication header")
         auth = basic_auth_header(username='vanessa',
                                  password='pancakes')
         self.assertEqual(auth['Authorization'],
                          'Basic dmFuZXNzYTpwYW5jYWtlcw==')
-
 
     def test_run_command(self):
         '''test_run_command tests sending a command to commandline
@@ -239,39 +242,18 @@ class TestUtils(TestCase):
         print("Testing utils.run_command...")
 
         from sutils import run_command
-        
+
         # An error should return None
         print("Case 1: Command errors returns None ")
-        none  = run_command(['exec','whaaczasd'])
-        self.assertEqual(none,None)
+        none = run_command(['exec', 'whaaczasd'])
+        self.assertEqual(none, None)
 
         # A success should return console output
         print("Case 2: Command success returns output")
-        hello  = run_command(['echo','hello'])
-        if not isinstance(hello,str): # python 3 support
+        hello = run_command(['echo', 'hello'])
+        if not isinstance(hello, str):  # python 3 support
             hello = hello.decode('utf-8')
-        self.assertEqual(hello,'hello\n')
-
-    def test_is_number(self):
-        '''test_is_number should return True for any string or
-        number that turns to a number, and False for everything else
-        '''
-        print("Testing utils.is_number...")
-
-        from sutils import is_number
-
-        print("Case 1: Testing string and float numbers returns True")
-        self.assertTrue(is_number("4"))
-        self.assertTrue(is_number(4))
-        self.assertTrue(is_number("2.0"))
-        self.assertTrue(is_number(2.0))
-
-        print("Case 2: Testing repo names, tags, commits, returns False")
-        self.assertFalse(is_number("vsoch/singularity-images"))
-        self.assertFalse(is_number("vsoch/singularity-images:latest"))
-        self.assertFalse(is_number("44ca6e7c6c35778ab80b34c3fc940c32f1810f39"))
-
-
+        self.assertEqual(hello, 'hello\n')
 
     def test_extract_tar(self):
         '''test_extract_tar will test extraction of a tar.gz file
@@ -281,91 +263,92 @@ class TestUtils(TestCase):
         # First create a temporary tar file
         from sutils import extract_tar
         from glob import glob
-        import tarfile 
-        
+        import tarfile
+
         # Create and close a temporary tar.gz
         print("Case 1: Testing tar.gz...")
         creation_dir = tempfile.mkdtemp()
-        archive,files = create_test_tar(creation_dir)
+        archive, files = create_test_tar(creation_dir)
 
         # Extract to different directory
         extract_dir = tempfile.mkdtemp()
         extract_tar(archive=archive,
                     output_folder=extract_dir)
-        extracted_files = [x.replace(extract_dir,'') for x in glob("%s/tmp/*" %(extract_dir))]
+        extracted_files = [x.replace(extract_dir, '')
+                           for x in glob("%s/tmp/*" % extract_dir)]
         [self.assertTrue(x in files) for x in extracted_files]
-        
+
         # Clean up
-        for dirname in [extract_dir,creation_dir]:
+        for dirname in [extract_dir, creation_dir]:
             shutil.rmtree(dirname)
 
         print("Case 2: Testing tar...")
         creation_dir = tempfile.mkdtemp()
-        archive,files = create_test_tar(creation_dir,compressed=False)
+        archive, files = create_test_tar(creation_dir,
+                                         compressed=False)
 
         # Extract to different directory
         extract_dir = tempfile.mkdtemp()
         extract_tar(archive=archive,
                     output_folder=extract_dir)
-        extracted_files = [x.replace(extract_dir,'') for x in glob("%s/tmp/*" %(extract_dir))]
+        extracted_files = [x.replace(extract_dir, '')
+                           for x in glob("%s/tmp/*" % extract_dir)]
         [self.assertTrue(x in files) for x in extracted_files]
-        
 
         print("Case 3: Testing that extract_tar returns None on error...")
         creation_dir = tempfile.mkdtemp()
-        archive,files = create_test_tar(creation_dir,compressed=False)
+        archive, files = create_test_tar(creation_dir,
+                                         compressed=False)
         extract_dir = tempfile.mkdtemp()
         shutil.rmtree(extract_dir)
         output = extract_tar(archive=archive,
                              output_folder=extract_dir)
-        self.assertEqual(output,None)
-
+        self.assertEqual(output, None)
 
     def test_write_read_files(self):
-        '''test_write_read_files will test the functions write_file and read_file
+        '''test_write_read_files will test the
+        functions write_file and read_file
         '''
         print("Testing utils.write_file...")
         from sutils import write_file
         import json
         tmpfile = tempfile.mkstemp()[1]
         os.remove(tmpfile)
-        write_file(tmpfile,"hello!")
-        self.assertTrue(os.path.exists(tmpfile))        
+        write_file(tmpfile, "hello!")
+        self.assertTrue(os.path.exists(tmpfile))
 
         print("Testing utils.read_file...")
         from sutils import read_file
         content = read_file(tmpfile)[0]
-        self.assertEqual("hello!",content)
+        self.assertEqual("hello!", content)
 
         from sutils import write_json
         print("Testing utils.write_json...")
         print("Case 1: Providing bad json")
-        bad_json = {"Wakkawakkawakka'}":[{True},"2",3]}
-        tmpfile = tempfile.mkstemp()[1]
-        os.remove(tmpfile)        
-        with self.assertRaises(TypeError) as cm:
-            write_json(bad_json,tmpfile)
-
-        print("Case 2: Providing good json")        
-        good_json = {"Wakkawakkawakka":[True,"2",3]}
+        bad_json = {"Wakkawakkawakka'}": [{True}, "2", 3]}
         tmpfile = tempfile.mkstemp()[1]
         os.remove(tmpfile)
-        write_json(good_json,tmpfile)
-        content = json.load(open(tmpfile,'r'))
-        self.assertTrue(isinstance(content,dict))
-        self.assertTrue("Wakkawakkawakka" in content)
+        with self.assertRaises(TypeError) as cm:
+            write_json(bad_json, tmpfile)
 
+        print("Case 2: Providing good json")
+        good_json = {"Wakkawakkawakka": [True, "2", 3]}
+        tmpfile = tempfile.mkstemp()[1]
+        os.remove(tmpfile)
+        write_json(good_json, tmpfile)
+        content = json.load(open(tmpfile, 'r'))
+        self.assertTrue(isinstance(content, dict))
+        self.assertTrue("Wakkawakkawakka" in content)
 
     def test_clean_path(self):
         '''test_clean_path will test the clean_path function
         '''
         print("Testing utils.clean_path...")
         from sutils import clean_path
-        ideal_path = '/home/vanessa/Desktop/stuff'
-        self.assertEqual(clean_path('/home/vanessa/Desktop/stuff/'),ideal_path)
-        self.assertEqual(clean_path('/home/vanessa/Desktop/stuff//'),ideal_path)
-        self.assertEqual(clean_path('/home/vanessa//Desktop/stuff/'),ideal_path)
-
+        ideal_path = '/home/vanessa/stuff'
+        self.assertEqual(clean_path('/home/vanessa/stuff/'), ideal_path)
+        self.assertEqual(clean_path('/home/vanessa/stuff//'), ideal_path)
+        self.assertEqual(clean_path('/home/vanessa//stuff/'), ideal_path)
 
     def test_get_fullpath(self):
         '''test_get_fullpath will test the get_fullpath function
@@ -375,7 +358,7 @@ class TestUtils(TestCase):
         tmpfile = tempfile.mkstemp()[1]
 
         print("Case 1: File exists, should return full path")
-        self.assertEqual(get_fullpath(tmpfile),tmpfile)
+        self.assertEqual(get_fullpath(tmpfile), tmpfile)
 
         print("Case 2: File doesn't exist, should return error")
         os.remove(tmpfile)
@@ -383,16 +366,16 @@ class TestUtils(TestCase):
             get_fullpath(tmpfile)
         self.assertEqual(cm.exception.code, 1)
 
-        print("Case 3: File doesn't exist, but not required, should return None")
-        self.assertEqual(get_fullpath(tmpfile,required=False),None)
-
+        print("Case 3: File doesn't exist, should return None")
+        self.assertEqual(get_fullpath(tmpfile,
+                                      required=False), None)
 
     def test_write_singularity_infos(self):
         '''test_get_fullpath will test the get_fullpath function
         '''
         print("Testing utils.write_singuarity_infos...")
         from sutils import write_singularity_infos
-        base_dir = '%s/ROOTFS' %(self.tmpdir)
+        base_dir = '%s/ROOTFS' % self.tmpdir
         prefix = 'docker'
         start_number = 0
         content = "export HELLO=MOTO"
@@ -411,35 +394,40 @@ class TestUtils(TestCase):
                                             prefix=prefix,
                                             start_number=start_number,
                                             content=content)
-        self.assertEqual(info_file,"%s/%s-%s" %(base_dir,start_number,prefix))
+        self.assertEqual(info_file, "%s/%s-%s" % (base_dir,
+                                                  start_number,
+                                                  prefix))
 
         print("Case 3: Adding another equivalent prefix should return next")
         info_file = write_singularity_infos(base_dir=base_dir,
                                             prefix=prefix,
                                             start_number=start_number,
                                             content=content)
-        self.assertEqual(info_file,"%s/%s-%s" %(base_dir,start_number+1,prefix))
-        
+        self.assertEqual(info_file, "%s/%s-%s" % (base_dir,
+                                                  start_number+1,
+                                                  prefix))
+
         print("Case 4: Files have correct content.")
-        with open(info_file,'r') as filey:
+        with open(info_file, 'r') as filey:
             written_content = filey.read()
-        self.assertEqual(content,written_content)
+        self.assertEqual(content, written_content)
 
 
 # Supporting Test Functions
-def create_test_tar(tmpdir,compressed=True):
-    archive = "%s/toodles.tar.gz" %tmpdir
-    if compressed == False:
-        archive = "%s/toodles.tar" %tmpdir
+def create_test_tar(tmpdir, compressed=True):
+    archive = "%s/toodles.tar.gz" % tmpdir
+    if compressed is False:
+        archive = "%s/toodles.tar" % tmpdir
     mode = "w:gz"
-    if compressed == False:
+    if compressed is False:
         mode = "w"
-    print("Creating %s" %(archive))
+    print("Creating %s" % archive)
     tar = tarfile.open(archive, mode)
     files = [tempfile.mkstemp()[1] for x in range(3)]
     [tar.add(x) for x in files]
     tar.close()
-    return archive,files
+    return archive, files
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_custom_cache.py
+++ b/libexec/python/tests/test_custom_cache.py
@@ -2,29 +2,29 @@
 
 test_custom_cache.py: Testing custom cache function
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
 import os
 import re
 import sys
-sys.path.append('..') # base_directory
+sys.path.append('..')  # noqa
 
 from unittest import TestCase
 import shutil
@@ -32,14 +32,15 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s CLIENT TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s CLIENT TESTING START ***" % VERSION)
+
 
 class TestCustomCache(TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
-        self.custom_cache = '%s/cache' %(self.tmpdir)
-        os.environ['SINGULARITY_CACHEDIR'] = self.custom_cache 
+        self.custom_cache = '%s/cache' % self.tmpdir
+        os.environ['SINGULARITY_CACHEDIR'] = self.custom_cache
         os.environ['SINGULARITY_ROOTFS'] = self.tmpdir
         print("\n---START----------------------------------------")
 
@@ -53,8 +54,7 @@ class TestCustomCache(TestCase):
         '''
         print("Testing get_cache with environment set")
         from defaults import SINGULARITY_CACHE
-        self.assertEqual(self.custom_cache,SINGULARITY_CACHE)   
-        self.assertTrue(os.path.exists(SINGULARITY_CACHE))
+        self.assertEqual(self.custom_cache, SINGULARITY_CACHE)
 
 
 if __name__ == '__main__':

--- a/libexec/python/tests/test_default_cache.py
+++ b/libexec/python/tests/test_default_cache.py
@@ -2,30 +2,29 @@
 
 test_default_cache.py: Testing default cache function
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
 import os
 import re
 import sys
-import tarfile
-sys.path.append('..') # base directory
+sys.path.append('..')  # noqa
 
 from unittest import TestCase
 import shutil
@@ -33,7 +32,8 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s CLIENT TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s CLIENT TESTING START ***" % VERSION)
+
 
 class TestDefaultCache(TestCase):
 
@@ -55,12 +55,12 @@ class TestDefaultCache(TestCase):
         using subprocess
         '''
         print("Testing get_cache...")
-        
+
         # If there is no cache_base, we should get default
         print("Case 1: No cache base in environment returns default")
         from defaults import SINGULARITY_CACHE
         home = os.environ['HOME']
-        self.assertEqual("%s/.singularity" %home,SINGULARITY_CACHE)
+        self.assertEqual("%s/.singularity" % home, SINGULARITY_CACHE)
         self.assertTrue(os.path.exists(SINGULARITY_CACHE))
 
 

--- a/libexec/python/tests/test_disable_cache.py
+++ b/libexec/python/tests/test_disable_cache.py
@@ -2,29 +2,29 @@
 
 test_disable_cache.py: Testing disabled cache function
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
 import os
 import re
 import sys
-sys.path.append('..') # base directory
+sys.path.append('..')  # noqa
 
 from unittest import TestCase
 import shutil
@@ -32,14 +32,14 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s CLIENT TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s CLIENT TESTING START ***" % VERSION)
 
 
 class TestDisabledCache(TestCase):
 
     def setUp(self):
         os.environ['SINGULARITY_DISABLE_CACHE'] = "yes"
-        self.tmpdir = tempfile.mkdtemp() 
+        self.tmpdir = tempfile.mkdtemp()
         os.environ['SINGULARITY_ROOTFS'] = self.tmpdir
         print("\n---START----------------------------------------")
 
@@ -50,7 +50,8 @@ class TestDisabledCache(TestCase):
     def test_cache_disabled(self):
         print("Case 3: Testing that cache gets disabled.")
         from defaults import DISABLE_CACHE
-        self.assertEqual(DISABLE_CACHE,True)
+        self.assertEqual(DISABLE_CACHE, True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -2,29 +2,29 @@
 
 test_docker_api.py: Docker testing functions for Singularity in Python
 
-Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved. 
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved.
- 
+
 This software is licensed under a customized 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
- 
+
 NOTICE.  This Software was developed under funding from the U.S. Department of
 Energy and the U.S. Government consequently retains certain rights. As such,
 the U.S. Government has been granted for itself and others acting on its
 behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so. 
+perform publicly and display publicly, and to permit other to do so.
 
 '''
 
 import os
 import re
 import sys
-sys.path.append('..') # directory with docker
+sys.path.append('..')  # noqa
 
 from unittest import TestCase
 import shutil
@@ -32,7 +32,8 @@ import tempfile
 
 VERSION = sys.version_info[0]
 
-print("*** PYTHON VERSION %s API TESTING START ***" %(VERSION))
+print("*** PYTHON VERSION %s API TESTING START ***" % VERSION)
+
 
 class TestApi(TestCase):
 
@@ -40,7 +41,7 @@ class TestApi(TestCase):
         self.image = 'docker://ubuntu:latest'
         self.tmpdir = tempfile.mkdtemp()
         os.environ['SINGULARITY_ROOTFS'] = self.tmpdir
-        os.mkdir('%s/.singularity.d' %(self.tmpdir))
+        os.mkdir('%s/.singularity.d' % self.tmpdir)
         from docker.api import DockerApiConnection
         self.client = DockerApiConnection(image=self.image)
 
@@ -51,43 +52,41 @@ class TestApi(TestCase):
 
         print("---END------------------------------------------")
 
-
-
     def test_get_token(self):
-        '''test_get_token will obtain a token from the Docker registry for a namepspace
-        and repo. 
+        '''test_get_token will obtain a token from
+           the Docker registry for a namepspace
+           and repo.
         '''
         from docker.api import DockerApiConnection
-        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow:1.0.0")        
+        docker_image = "gcr.io/tensorflow/tensorflow:1.0.0"
+        client = DockerApiConnection(image=docker_image)
 
         print("Case 1: Ask when we don't need token returns None")
         token = client.update_token()
-        self.assertEqual(token,None)
-
+        self.assertEqual(token, None)
 
     def test_get_manifest(self):
         '''test_get_manifest will obtain a library/repo manifest
         '''
         from docker.api import DockerApiConnection
 
-        print("Case 1: Obtain manifest for %s/%s" %(self.client.namespace,
-                                                    self.client.repo_name))
+        print("Case 1: Obtain manifest for %s/%s" % (self.client.namespace,
+                                                     self.client.repo_name))
 
-        manifest = self.client.get_manifest()
+        manifest = self.client.get_manifest(old_version=True)
 
         # Default tag should be latest
-        self.assertTrue("fsLayers" in manifest or "layers" in manifest)
+        self.assertTrue("fsLayers" in manifest)
 
         # Giving a bad tag sould return error
         print("Case 3: Bad tag should print valid tags and exit")
-        client = DockerApiConnection(image="ubuntu:mmm.avocado")        
-        
+        client = DockerApiConnection(image="ubuntu:mmm.avocado")
+
         # Should work for custom registries
         print("Case 4: Obtain manifest from custom registry")
-        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")        
-        manifest = client.get_manifest()
+        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")
+        manifest = client.get_manifest(old_version=True)
         self.assertTrue("fsLayers" in manifest or "layers" in manifest)
-
 
     def test_get_images(self):
         '''test_get_images will obtain a list of images
@@ -96,36 +95,34 @@ class TestApi(TestCase):
 
         print("Case 1: Ask for images")
         images = self.client.get_images()
-        self.assertTrue(isinstance(images,list))
-        self.assertTrue(len(images)>1)
+        self.assertTrue(isinstance(images, list))
+        self.assertTrue(len(images) > 1)
 
         print("Case 2: Ask for images from custom registry")
-        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")        
+        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")
         images = client.get_images()
-        self.assertTrue(isinstance(images,list))
-        self.assertTrue(len(images)>1)
-
+        self.assertTrue(isinstance(images, list))
+        self.assertTrue(len(images) > 1)
 
     def test_get_tags(self):
         '''test_get_tags will obtain a list of tags
         '''
         from docker.api import DockerApiConnection
 
-        print("Case 1: Ask for tags from standard %s/%s" %(self.client.namespace,
-                                                           self.client.repo_name))
+        full_name = "%s/%s" % (self.client.namespace, self.client.repo_name)
+        print("Case 1: Ask for tags from standard %s" % full_name)
         tags = self.client.get_tags()
-        self.assertTrue(isinstance(tags,list))
-        self.assertTrue(len(tags)>1)
-        [self.assertTrue(x in tags) for x in ['xenial','latest','trusty','yakkety']]
+        self.assertTrue(isinstance(tags, list))
+        self.assertTrue(len(tags) > 1)
+        ubuntu_tags = ['xenial', 'latest', 'trusty', 'yakkety']
+        [self.assertTrue(x in tags) for x in ubuntu_tags]
 
         print("Case 2: Ask for tags from custom registry")
-        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")        
+        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")
         tags = client.get_tags()
-        self.assertTrue(isinstance(tags,list))
-        self.assertTrue(len(tags)>1)
-        [self.assertTrue(x in tags) for x in ['latest','latest-gpu']]
-  
-
+        self.assertTrue(isinstance(tags, list))
+        self.assertTrue(len(tags) > 1)
+        [self.assertTrue(x in tags) for x in ['latest', 'latest-gpu']]
 
     def test_get_layer(self):
         '''test_get_layer will download docker layers
@@ -133,10 +130,10 @@ class TestApi(TestCase):
         from docker.api import DockerApiConnection
 
         images = self.client.get_images()
-        
+
         print("Case 1: Download an existing layer, should succeed")
-        layer_file = self.client.get_layer(image_id=images[0], 
-                                           download_folder = self.tmpdir)
+        layer_file = self.client.get_layer(image_id=images[0],
+                                           download_folder=self.tmpdir)
         self.assertTrue(os.path.exists(layer_file))
 
 

--- a/libexec/python/tests/test_shub_api.py
+++ b/libexec/python/tests/test_shub_api.py
@@ -1,0 +1,141 @@
+'''
+
+test_shub.py: Singularity Hub testing functions for Singularity in Python
+
+Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
+
+"Singularity" Copyright (c) 2016, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+
+This software is licensed under a customized 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
+
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights. As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so.
+
+'''
+
+import os
+import sys
+sys.path.append('..')  # noqa
+
+from unittest import TestCase
+from sutils import read_file
+from glob import glob
+import shutil
+import tempfile
+
+VERSION = sys.version_info[0]
+
+print("*** PYTHON VERSION %s SINGULARITY HUB API TESTING START ***" % VERSION)
+
+
+class TestApi(TestCase):
+
+    def setUp(self):
+        from shub.api import SingularityApiConnection
+        self.connect = SingularityApiConnection
+        self.image = "shub://vsoch/singularity-images"
+        self.client = SingularityApiConnection(image=self.image)
+
+        self.user_name = "vsoch"
+        self.repo_name = "singularity-images"
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ['SINGULARITY_ROOTFS'] = self.tmpdir
+        os.mkdir('%s/.singularity.d' % self.tmpdir)
+        print("\n---START----------------------------------------")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+        print("---END------------------------------------------")
+
+    def test_get_manifest(self):
+        '''test_get_manifest should return the shub manifest
+        '''
+        print("Case 1: Testing retrieval of singularity-hub manifest")
+        manifest = self.client.get_manifest()
+        keys = ['files', 'version', 'collection', 'branch',
+                'name', 'id', 'metrics', 'spec', 'image']
+        [self.assertTrue(x in manifest) for x in keys]
+
+    def test_download_image(self):
+        '''test_download_image will ensure that
+        an image is downloaded to an
+        appropriate location (tmpdir) or cache
+        '''
+        print("Case 1: Specifying a directory downloads to it")
+        image_name = "tacos.img"
+        manifest = self.client.get_manifest()
+        image = self.client.download_image(manifest=manifest,
+                                           image_name=image_name,
+                                           download_folder=self.tmpdir)
+        self.assertEqual(os.path.dirname(image), self.tmpdir)
+
+        print("Case 2: Not specifying a directory downloads to PWD")
+        os.chdir(self.tmpdir)
+        image = self.client.download_image(manifest,
+                                           image_name=image_name)
+        self.assertEqual(os.getcwd(), self.tmpdir)
+        print(image)
+        self.assertTrue(image in glob("*"))
+        os.remove(image)
+
+        print("Case 3: Image should not be extracted.")
+        image = self.client.download_image(manifest,
+                                           image_name=image_name,
+                                           extract=False)
+        self.assertTrue(image.endswith('.img.gz'))
+
+    def test_uri(self):
+        '''test_uri will make sure that the endpoint returns the equivalent
+        image for all different uri options
+        '''
+        from shub.api import get_image_name
+        manifest = self.client.get_manifest()
+        image_name = get_image_name(manifest)
+
+        fullname = "%s/%s" % (self.user_name, self.repo_name)
+        print("Case 1: ask for image and ask for master branch (tag)")
+        client = self.connect(image="%s:master" % fullname)
+        manifest = client.get_manifest()
+        image_name = get_image_name(manifest)
+        self.assertEqual(image_name, get_image_name(manifest))
+
+        print("Case 2: ask for different tag (mongo)")
+        client = self.connect(image="%s:mongo" % fullname)
+        manifest = client.get_manifest()
+        mongo = get_image_name(manifest)
+        self.assertFalse(image_name == mongo)
+
+        print("Case 3: image without tag (should be latest across tags)")
+        client = self.connect(image="%s" % fullname)
+        manifest = client.get_manifest()
+        self.assertEqual(mongo, get_image_name(manifest))
+
+        print("Case 4: ask for latest tag (should be latest across tags)")
+        client = self.connect(image="%s/%s:latest"
+                              % (self.user_name, self.repo_name))
+        manifest = client.get_manifest()
+        self.assertEqual(mongo, get_image_name(manifest))
+
+    def test_get_image_name(self):
+        '''test_get_image_name will return the image name from the manifest
+        '''
+        from shub.api import get_image_name
+        manifest = self.client.get_manifest()
+
+        print("Case 1: return an image name corresponding to repo")
+        image_name = get_image_name(manifest)
+        self.assertEqual('vsoch-singularity-images-mongo.img.gz',
+                         image_name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -36,7 +36,6 @@ if which python2 >/dev/null 2>&1; then
     stest 0 python2 -m unittest tests.test_docker_tasks
     stest 0 python2 -m unittest tests.test_shub_import
     stest 0 python2 -m unittest tests.test_shub_pull
-    stest 0 python2 -m unittest tests.test_shub
     stest 0 python2 -m unittest tests.test_custom_cache
     stest 0 python2 -m unittest tests.test_default_cache
     stest 0 python2 -m unittest tests.test_disable_cache
@@ -54,7 +53,6 @@ if which python3 >/dev/null 2>&1; then
     stest 0 python3 -m unittest tests.test_docker_tasks
     stest 0 python3 -m unittest tests.test_shub_import
     stest 0 python3 -m unittest tests.test_shub_pull
-    stest 0 python3 -m unittest tests.test_shub
     stest 0 python3 -m unittest tests.test_custom_cache
     stest 0 python3 -m unittest tests.test_default_cache
     stest 0 python3 -m unittest tests.test_disable_cache

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -36,6 +36,7 @@ if which python2 >/dev/null 2>&1; then
     stest 0 python2 -m unittest tests.test_docker_tasks
     stest 0 python2 -m unittest tests.test_shub_import
     stest 0 python2 -m unittest tests.test_shub_pull
+    stest 0 python2 -m unittest tests.test_shub_api
     stest 0 python2 -m unittest tests.test_custom_cache
     stest 0 python2 -m unittest tests.test_default_cache
     stest 0 python2 -m unittest tests.test_disable_cache
@@ -53,6 +54,7 @@ if which python3 >/dev/null 2>&1; then
     stest 0 python3 -m unittest tests.test_docker_tasks
     stest 0 python3 -m unittest tests.test_shub_import
     stest 0 python3 -m unittest tests.test_shub_pull
+    stest 0 python3 -m unittest tests.test_shub_api
     stest 0 python3 -m unittest tests.test_custom_cache
     stest 0 python3 -m unittest tests.test_default_cache
     stest 0 python3 -m unittest tests.test_disable_cache


### PR DESCRIPTION
**Description of the Pull Request (PR):**

In case this is needed, it's a quick fix to force the older manifest and correctly get the layers. Note that this doesn't parse the "lists of manifests" but forces return of the older version, the one that doesn't have size information. @gmkurtzer we talked about this yesterday - bug if we have some logic for choosing a particular architecture we can use the newest "manifest list." With this current workaround (forcing version 1) we may run into the issue of losing the automatically calculated size for images where this applies, but since we are moving to squashfs this probably isn't a huge issue. I'm also not sure the extent to which we want to have a fix if the new release is coming out soon? (given that users and admins would need to re-install anyway). For those that have dire need, we might even recommend development branch, and for others, to wait until 2.4. @GodloveD and @gmkurtzer @bauerm97 let me know your thoughts!

Attn: @singularityware-admin
