### PR TITLE
adding support for manifest lists, and version specification

### DIFF
--- a/libexec/python/README.md
+++ b/libexec/python/README.md
@@ -72,16 +72,22 @@ For each, the details of required arguments are detailed in the scripts, and dis
 
 
 ### Defaults
-The following variables in [defaults.py](defaults.py) are static values that do not change. You probably don't care much about these, but they are included for reference.
-
+The following variables in [defaults.py](defaults.py) are a combination of static values, and variables that can be customized by the user via environment variables at runtime. 
 
 #### Docker
 
-**API_BASE** 
-Set as `index.docker.io`, which is the name of the registry. In the first version of Singularity we parsed the Registry argument from the build spec file, however now this is removed because it can be obtained directly from the image name (eg, `registry/namespace/repo:tag`)
+**DOCKER_API_BASE** 
+Set as `index.docker.io`, which is the name of the registry. In the first version of Singularity we parsed the Registry argument from the build spec file, however now this is removed because it can be obtained directly from the image name (eg, `registry/namespace/repo:tag`). If you don't specify a registry name for your image, this default is used.
 
-**API_VERSION**
+**DOCKER_API_VERSION**
 Is the version of the Docker Registry API currently being used, by default now is `v2`.
+
+**DOCKER_OS**
+This is exposed via the exported environment variable `SINGULARITY_DOCKER_OS` and pertains to images that reveal a version 2 manifest with a [manifest list](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list). In the case that the list is present, we must choose an operating system (this variable) and an architecture (below). The default is `linux`.
+
+**DOCKER_ARCHITECTURE**
+This is exposed via the exported environment variable `SINGULARITY_DOCKER_ARCHITECTURE` and the same applies as for the `DOCKER_OS` with regards to being used in context of a list of manifests. In the case that the list is present, we must choose an architecture (this variable) and an os (above). The default is `amd64`, and other common ones include `arm`, `arm64`, `ppc64le`, `386`, and `s390x`.
+
 
 **DOCKER_PREFIX**
 Whenever a new Docker container is imported, it brings its environment. This means that we must write the environmental variables to a file where they can be preserved. To keep a record of Docker imports, we generate a file starting with `DOCKER_PREFIX` in the environment metadata folder (see environment variable `ENV_BASE`) (default is `docker`). 

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -36,7 +36,7 @@ import pwd
 import sys
 
 
-def getenv(variable_key, required=False, default=None, silent=False):
+def getenv(variable_key, default=None, required=False, silent=False):
     '''getenv will attempt to get an environment variable. If the
     variable is not found, None is returned.
     :param variable_key: the variable name
@@ -79,8 +79,7 @@ RUNSCRIPT_COMMAND_ASIS = convert2boolean(getenv("SINGULARITY_COMMAND_ASIS",
 SINGULARITY_ROOTFS = getenv("SINGULARITY_ROOTFS")
 METADATA_FOLDER_NAME = ".singularity.d"
 _metadata_base = "%s/%s" % (SINGULARITY_ROOTFS, METADATA_FOLDER_NAME)
-METADATA_BASE = getenv("SINGULARITY_METADATA_FOLDER",
-                       default=_metadata_base,
+METADATA_BASE = getenv("SINGULARITY_METADATA_FOLDER", _metadata_base,
                        required=True)
 
 
@@ -88,10 +87,9 @@ METADATA_BASE = getenv("SINGULARITY_METADATA_FOLDER",
 # Plugins and Formatting
 #######################################################################
 
-PLUGIN_FIXPERMS = convert2boolean(getenv("SINGULARITY_FIX_PERMS",
-                                  default=False))
+PLUGIN_FIXPERMS = convert2boolean(getenv("SINGULARITY_FIX_PERMS", False))
 
-COLORIZE = getenv("SINGULARITY_COLORIZE", default=None)
+COLORIZE = getenv("SINGULARITY_COLORIZE", None)
 if COLORIZE is not None:
     COLORIZE = convert2boolean(COLORIZE)
 
@@ -117,6 +115,8 @@ else:
 # API
 DOCKER_API_BASE = "index.docker.io"  # registry
 DOCKER_API_VERSION = "v2"
+DOCKER_ARCHITECTURE = getenv("SINGULARITY_DOCKER_ARCHITECTURE", "amd64")
+DOCKER_OS = getenv("SINGULARITY_DOCKER_OS", "linux")
 NAMESPACE = "library"
 TAG = "latest"
 
@@ -135,23 +135,21 @@ _deffile = "%s/Singularity" % (METADATA_BASE)
 _testfile = "%s/test" % (METADATA_BASE)
 
 
-ENVIRONMENT = getenv("SINGULARITY_ENVIRONMENT", default=_environment)
-RUNSCRIPT = getenv("SINGULARITY_RUNSCRIPT", default=_runscript)
-TESTFILE = getenv("SINGULARITY_TESTFILE", default=_testfile)
-DEFFILE = getenv("SINGULARITY_DEFFILE", default=_deffile)
-HELPFILE = getenv("SINGULARITY_HELPFILE", default=_helpfile)
-ENV_BASE = getenv("SINGULARITY_ENVBASE", default=_envbase)
-LABELFILE = getenv("SINGULARITY_LABELFILE", default=_labelfile)
-INCLUDE_CMD = convert2boolean(getenv("SINGULARITY_INCLUDECMD",
-                              default=False))
-DISABLE_HTTPS = convert2boolean(getenv("SINGULARITY_NOHTTPS",
-                                default=False))
+ENVIRONMENT = getenv("SINGULARITY_ENVIRONMENT", _environment)
+RUNSCRIPT = getenv("SINGULARITY_RUNSCRIPT", _runscript)
+TESTFILE = getenv("SINGULARITY_TESTFILE", _testfile)
+DEFFILE = getenv("SINGULARITY_DEFFILE", _deffile)
+HELPFILE = getenv("SINGULARITY_HELPFILE", _helpfile)
+ENV_BASE = getenv("SINGULARITY_ENVBASE", _envbase)
+LABELFILE = getenv("SINGULARITY_LABELFILE", _labelfile)
+INCLUDE_CMD = convert2boolean(getenv("SINGULARITY_INCLUDECMD", False))
+DISABLE_HTTPS = convert2boolean(getenv("SINGULARITY_NOHTTPS", False))
 
 #######################################################################
 # Singularity Hub
 #######################################################################
 
-SINGULARITY_PULLFOLDER = getenv("SINGULARITY_PULLFOLDER", default=os.getcwd())
+SINGULARITY_PULLFOLDER = getenv("SINGULARITY_PULLFOLDER", os.getcwd())
 SHUB_API_BASE = "singularity-hub.org"
 SHUB_NAMEBYHASH = getenv("SHUB_NAMEBYHASH")
 SHUB_NAMEBYCOMMIT = getenv("SHUB_NAMEBYCOMMIT")
@@ -162,6 +160,6 @@ SHUB_CONTAINERNAME = getenv("SHUB_CONTAINERNAME")
 #######################################################################
 
 _layerfile = "%s/.layers" % (METADATA_BASE)
-LAYERFILE = getenv("SINGULARITY_CONTENTS", default=_layerfile)
+LAYERFILE = getenv("SINGULARITY_CONTENTS", _layerfile)
 
-SINGULARITY_WORKERS = int(getenv("SINGULARITY_PYTHREADS", default=9))
+SINGULARITY_WORKERS = int(getenv("SINGULARITY_PYTHREADS", 9))

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -299,7 +299,7 @@ class DockerApiConnection(ApiConnection):
             base = "%s/%s" % (base, self.repo_tag)
         bot.verbose("Obtaining manifest: %s" % base)
 
-        headers = self.headers
+        headers = self.headers.copy()
         if old_version is True:
             headers['Accept'] = 'application/json'
 
@@ -346,8 +346,8 @@ class DockerApiConnection(ApiConnection):
         if "manifests" in self.manifest:
             for entry in self.manifest['manifests']:
                 if entry['platform']['architecture'] == DOCKER_ARCHITECTURE:
-                    if entry['platform']['architecture'] == DOCKER_OS:
-                        digest = entry[digest_key]
+                    if entry['platform']['os'] == DOCKER_OS:
+                        digest = entry['digest']
                         bot.debug('Image manifest version 2.2 list found.')
                         bot.debug('Obtaining architecture: %s, OS: %s'
                                   % (DOCKER_ARCHITECTURE, DOCKER_OS))
@@ -430,11 +430,11 @@ class DockerApiConnection(ApiConnection):
         :round_up: if true, round up to nearest integer
         :return_mb: if true, defaults bytes are converted to MB
         '''
-        manifest = self.get_manifest()
+        self.update_manifests()
         size = None
-        if "layers" in manifest:
+        if "layers" in self.manifest:
             size = 0
-            for layer in manifest["layers"]:
+            for layer in self.manifest["layers"]:
                 if "size" in layer:
                     size += layer['size']
 

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -342,7 +342,7 @@ class DockerApiConnection(ApiConnection):
             bot.debug('MANIFEST (Metadata): not found, making initial call.')
             self.manifestv1 = self.get_manifest(old_version=True)
 
-        # https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list  #noqa
+        # https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list
         if "manifests" in self.manifest:
             for entry in self.manifest['manifests']:
                 if entry['platform']['architecture'] == DOCKER_ARCHITECTURE:

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -41,6 +41,8 @@ from sutils import (
 from defaults import (
     DOCKER_API_BASE,
     DOCKER_API_VERSION,
+    DOCKER_ARCHITECTURE,
+    DOCKER_OS,
     DOCKER_NUMBER,
     DOCKER_PREFIX,
     ENV_BASE,
@@ -207,14 +209,14 @@ class DockerApiConnection(ApiConnection):
         '''
         if manifest is None:
             self.update_manifests()
-            manifest = self.manifestv1
+            manifest = self.manifest
 
         digests = []
+        layer_key = 'layers'
+        digest_key = 'digest'
 
         # https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest  # noqa
         if 'layers' in manifest:
-            layer_key = 'layers'
-            digest_key = 'digest'
             bot.debug('Image manifest version 2.2 found.')
 
         # https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md#example-manifest  # noqa
@@ -225,7 +227,7 @@ class DockerApiConnection(ApiConnection):
 
         else:
             msg = "Improperly formed manifest, "
-            msg += "layers or fsLayers must be present"
+            msg += "layers, manifests, or fsLayers must be present"
             bot.error(msg)
             sys.exit(1)
 
@@ -267,7 +269,7 @@ class DockerApiConnection(ApiConnection):
             bot.error("Error obtaining tags: %s" % base)
             sys.exit(1)
 
-    def get_manifest(self, old_version=False):
+    def get_manifest(self, old_version=False, version=None):
         '''get_manifest should return an image manifest
         for a particular repo and tag.  The image details
         are extracted when the client is generated.
@@ -285,8 +287,14 @@ class DockerApiConnection(ApiConnection):
                                           self.api_version,
                                           self.namespace,
                                           self.repo_name)
-        if self.version is not None:
+
+        # First priority given to calling function
+        if version is not None:
+            base = "%s/%s" % (base, version)
+
+        elif self.version is not None:
             base = "%s/%s" % (base, self.version)
+
         else:
             base = "%s/%s" % (base, self.repo_tag)
         bot.verbose("Obtaining manifest: %s" % base)
@@ -295,7 +303,7 @@ class DockerApiConnection(ApiConnection):
         if old_version is True:
             headers['Accept'] = 'application/json'
 
-        response = self.get(base, headers=self.headers)
+        response = self.get(base, headers=headers)
 
         try:
             response = json.loads(response)
@@ -319,15 +327,38 @@ class DockerApiConnection(ApiConnection):
         '''update manifests ensures that each of a version1 and version2
         manifest are present
         '''
+        bot.debug('Updating manifests.')
+
         if self.repo_name is None and self.namespace is None:
             bot.error("Insufficient metadata to get manifest.")
             sys.exit(1)
 
         # Get full image manifest, using version 2.0 of Docker Registry API
         if self.manifest is None:
+            bot.debug('MANIFEST (Primary): not found, making initial call.')
             self.manifest = self.get_manifest()
+
         if self.manifestv1 is None:
+            bot.debug('MANIFEST (Metadata): not found, making initial call.')
             self.manifestv1 = self.get_manifest(old_version=True)
+
+        # https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list  #noqa
+        if "manifests" in self.manifest:
+            for entry in self.manifest['manifests']:
+                if entry['platform']['architecture'] == DOCKER_ARCHITECTURE:
+                    if entry['platform']['architecture'] == DOCKER_OS:
+                        digest = entry[digest_key]
+                        bot.debug('Image manifest version 2.2 list found.')
+                        bot.debug('Obtaining architecture: %s, OS: %s'
+                                  % (DOCKER_ARCHITECTURE, DOCKER_OS))
+
+                        # Obtain specific os, architecture
+                        self.manifest = self.get_manifest(version=digest)
+                        break
+
+        # If we didn't get a new manifest, fall back to version 1
+        if "manifests" in self.manifest:
+            self.manifest = self.manifestv1
 
     def get_layer(self,
                   image_id,


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is an update to the initial fix to allow for the new version of the manifest. Specifically, the following happens:

 **1**. The `update_manifests` functions is expected to provide two manifests:
   - manifestv1: the oldest version, which notably is the only one with environment / labels (and other metadata), and also has layers
   - manifest (version 2+): This version has the layers **and** sizes.

Our old default was to retrieve the version 2, and ask it for layers (and by default our header asks for version 2+). With the update, the API now returns a [LIST of manifests](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list). This broke most import / shell / exec because we needed to first choose one in the list, then retrieve the manifest, then grab the layers. Thus,

**2**. The update_manifest function uses the environment variables (`SINGULARITY_DOCKER_OS` and `SINGULARITY_DOCKER_ARCHITECTURE` with defaults `linux` and `amd64`) as keys to find the manifest digest. The user can also export these variables to ask for a different one.

**3**. If the manifest is found and obtained, great, we use it for layers and it also (still has size). Note that for the quick fix fallback, we just resorted to version 1 anyway, and didn't have size.

**4**. If the manifest isn't found, we fall back to the version 1. It will provide metadata and layers, but not size.

At runtime, it looks like this:

```
DEBUG 
*** STARTING DOCKER IMPORT PYTHON  ****
```
This is the initialization of the Docker client, it's parsing the image name provided
```
DEBUG Starting Docker IMPORT, includes env, runscript, and metadata.
VERBOSE Docker image: ubuntu:14.04
VERBOSE2 Specified Docker ENTRYPOINT as %runscript.
DEBUG Headers found: Content-Type,Accept
VERBOSE Registry: index.docker.io
VERBOSE Namespace: library
VERBOSE Repo Name: ubuntu
VERBOSE Repo Tag: 14.04
VERBOSE Version: None
```
The initial poke to Docker hub asks for tags, to determine if we need some kind of token
```
VERBOSE Obtaining tags: https://index.docker.io/v2/library/ubuntu/tags/list
DEBUG GET https://index.docker.io/v2/library/ubuntu/tags/list
```

401 means that we do, and with the response the API sends back the scope and other details we need to make to request it

```
DEBUG Http Error with code 401
```

Here we are requesting it
```
DEBUG GET https://auth.docker.io/token?service=registry.docker.io&expires_in=9000&scope=repository:library/ubuntu:pull
DEBUG Headers found: Content-Type,Authorization,Accept
```
This means that we sent the correct header this time, and this is a public image
```
VERBOSE3 Response on obtaining token is None.
```
Here is the new bit. Instead of blindly doing one call, we have a function to update two versions of the manifest - the older (with metadata) and some version of the newer (with layers and size) with a fallback to use the version 1
```
DEBUG Updating manifests.

# Here is version 2+
DEBUG MANIFEST (Primary): not found, making initial call.
VERBOSE Obtaining manifest: https://index.docker.io/v2/library/busybox/manifests/latest
DEBUG GET https://index.docker.io/v2/library/busybox/manifests/latest

# Here is version 1 (Metadata)
DEBUG MANIFEST (Metadata): not found, making initial call.
VERBOSE Obtaining manifest: https://index.docker.io/v2/library/busybox/manifests/latest
DEBUG GET https://index.docker.io/v2/library/busybox/manifests/latest
```
Notice that the two calls are the same - that's because the headers are actually different, to request different ones.

And here is the (new) indication that we found a list
```
DEBUG Image manifest version 2.2 list found.
```
Here is the default architecture / os
```
DEBUG Obtaining architecture: amd64, OS: linux
```
And the specific call to get it
```
VERBOSE Obtaining manifest: https://index.docker.io/v2/library/busybox/manifests/sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af
DEBUG GET https://index.docker.io/v2/library/busybox/manifests/sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af
```

So - with this fix - we can still have a working `singularity pull docker://busybox` that can get the size automatically. 


Attn: @singularityware-admin
