### PR TITLE
tweaking pull folder for build

### DIFF
--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -18,6 +18,7 @@ if [ "$OS_VERSION" = 6 ]; then
 fi
 
 # Install python 3 and pylint
+yum install -y epel-release
 yum install -y python34 python34-pip python34-setuptools
 pip install pylint
 

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -20,7 +20,7 @@ fi
 # Install python 3 and pylint
 yum install -y epel-release
 yum install -y python34 python34-pip python34-setuptools
-pip install pylint
+yum install -y pylint
 
 # run the test suite
 yum install -y libtool sudo which e2fsprogs

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -17,6 +17,10 @@ if [ "$OS_VERSION" = 6 ]; then
     exit
 fi
 
+# Install python 3 and pylint
+yum install -y python34 python34-pip python34-setuptools
+pip install pylint
+
 # run the test suite
 yum install -y libtool sudo which e2fsprogs
 sed -i 's,^prefix=.*,prefix=/usr,' test.sh

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -214,17 +214,12 @@ case $SINGULARITY_BUILDDEF in
             ABORT 255
         fi
 
-        # If cache is set, set pull folder to it (first priority)
-        if [ -n "${SINGULARITY_CACHEDIR:-}" ]; then
-            SINGULARITY_PULLFOLDER="$SINGULARITY_CACHEDIR"
+        # If not set, don't export PULLFOLDER. PULL in shub/main.py will default to it
+        if [ ! -n "${SINGULARITY_PULLFOLDER:-}" ]; then
+            export SINGULARITY_CONTENTS SINGULARITY_CONTAINER
         else
-            # Only set the pull folder to be $PWD if not set by user
-            if [ ! -n "${SINGULARITY_PULLFOLDER:-}" ]; then
-                SINGULARITY_PULLFOLDER="."
-            fi
+            export SINGULARITY_PULLFOLDER SINGULARITY_CONTENTS SINGULARITY_CONTAINER
         fi
-
-        export SINGULARITY_CONTENTS SINGULARITY_CONTAINER SINGULARITY_PULLFOLDER
 
         # relying on pull.py for error checking here
         ${SINGULARITY_libexecdir}/singularity/python/pull.py

--- a/libexec/python/pull.py
+++ b/libexec/python/pull.py
@@ -53,7 +53,7 @@ def main():
 
     # What image is the user asking for?
     container = getenv("SINGULARITY_CONTAINER", required=True)
-    pull_folder = getenv("SINGULARITY_PULLFOLDER", required=True)
+    pull_folder = getenv("SINGULARITY_PULLFOLDER")
 
     image_uri = get_image_uri(container)
     container = remove_image_uri(container, quiet=True)

--- a/libexec/python/shub/main.py
+++ b/libexec/python/shub/main.py
@@ -81,6 +81,8 @@ def PULL(image, download_folder=None, layerfile=None):
     else:
         cache_base = os.path.abspath(download_folder)
 
+    bot.debug("Pull folder set to %s" % cache_base)
+
     # The image name is the md5 hash, download if it's not there
     image_name = get_image_name(manifest)
 

--- a/tests/29-instance.sh
+++ b/tests/29-instance.sh
@@ -23,7 +23,7 @@ CONTAINER="$SINGULARITY_TESTDIR/container"
 stest 0 sudo singularity build "$CONTAINER" "../examples/busybox/Singularity"
 stest 0 singularity instance.start "$CONTAINER" service1
 stest 0 sh -c "ps -ef | grep -q sinit"
-stest 0 sh -c "singularity exec instance://service1 ps -ef | grep -q sinit"
+stest 0 sh -c "singularity -x exec instance://service1 ps -ef | grep -q sinit"
 export PID=`singularity exec instance://service1 ps -ef | grep sinit | awk '{print $1}'`
 stest 0 sh -c "echo $PID | grep -q 1" 
 stest 1 singularity instance.start "$CONTAINER" service1


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This will change the build.exec to, when using a shub image to build from, import it to the following places, ordered by preference:

 - if the user has defined the SINGULARITY_PULLFOLDER, honor it
 - if not, default to cache subfolder "shub"

Attn: @singularityware-admin
