### PR TITLE
scratch to warn without infinite loop

### DIFF
--- a/src/lib/runtime/mounts/scratch/scratch.c
+++ b/src/lib/runtime/mounts/scratch/scratch.c
@@ -76,7 +76,6 @@ int _singularity_runtime_mount_scratch(void) {
             return(0);
         }
     }
-    printf("%s\n", tmpdir_path);
 
     sourcedir_path = joinpath(tmpdir_path, "/scratch");
 

--- a/src/lib/runtime/mounts/scratch/scratch.c
+++ b/src/lib/runtime/mounts/scratch/scratch.c
@@ -76,6 +76,7 @@ int _singularity_runtime_mount_scratch(void) {
             return(0);
         }
     }
+    printf("%s\n", tmpdir_path);
 
     sourcedir_path = joinpath(tmpdir_path, "/scratch");
 
@@ -104,10 +105,12 @@ int _singularity_runtime_mount_scratch(void) {
                 singularity_priv_drop();
                 if ( r < 0 ) {
                     singularity_message(VERBOSE, "Skipping scratch directory mount, could not create dir inside container %s: %s\n", current, strerror(errno));
+                    current = strtok_r(NULL, ",", &outside_token);
                     continue;
                 }
             } else {
                 singularity_message(WARNING, "Skipping scratch directory mount, target directory does not exist: %s\n", current);
+                current = strtok_r(NULL, ",", &outside_token);
                 continue;
             }
         }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The error is described in the Google Group [here](https://groups.google.com/a/lbl.gov/forum/#!topic/singularity/BCcV4DiLU04).  The short story is that if you set `enable overlay = no` in `singularity.conf` and then attempt to use the `-S` option, you will get caught in an infinite loop of warning messages.  I think this should fix the issue.

Attn: @singularityware-admin
