### PR TITLE
Fix non null terminated buffer with readlink

### DIFF
--- a/src/util/daemon.c
+++ b/src/util/daemon.c
@@ -103,7 +103,7 @@ void daemon_init_start(void) {
     char *daemon_file = singularity_registry_get("DAEMON_FILE");
     char *daemon_name = singularity_registry_get("DAEMON_NAME");
     char *daemon_file_dir = strdup(daemon_file);
-    char *daemon_pid = (char *)malloc(256 * sizeof(char *));
+    char *daemon_pid = (char *)malloc(256 * sizeof(char));
     char *daemon_image;
     int daemon_fd;
     int lock;
@@ -120,6 +120,7 @@ void daemon_init_start(void) {
         singularity_message(DEBUG, "Successfully obtained excluse lock on %s\n", daemon_file);
 
         /* Calling readlink on /proc/self returns the PID of the thread in the host PID NS */
+        memset(daemon_pid, 0, 256);
         if ( readlink("/proc/self", daemon_pid, 256) == -1 ) { //Flawfinder: ignore
             singularity_message(ERROR, "Unable to open /proc/self: %s\n", strerror(errno));
             ABORT(255);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Since readlink doesn't append null byte, daemon_pid buffer could contain a previous buffer content:

```
$ cat ~/.singularity/daemon/pc-ced/service1 
DAEMON_PID=22811gresql:/bin/sh
cyrus:x:85:12::/usr/cyrus:/sbin/nologin
vpopmail:x:89:89::/v
DAEMON_IMAGE=/home/ced/alpine.img
DAEMON_ROOTFS=/usr/local/var/singularity/mnt/final
```
Fix by initializing buffer to make sure string is null terminated

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
