### PR TITLE
Do not allow --writable when using squashfs image type

### DIFF
--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -44,6 +44,7 @@
 
 struct image_object singularity_image_init(char *path, int open_flags) {
     struct image_object image;
+    int retval = 0;
 
     if ( path == NULL ) {
         singularity_message(ERROR, "No container image path defined\n");
@@ -74,7 +75,11 @@ struct image_object singularity_image_init(char *path, int open_flags) {
         singularity_message(DEBUG, "got image_init type for ext3\n");
         image.type = EXT3;
     } else {
-        singularity_message(ERROR, "Unknown image format/type: %s\n", path);
+        if ( errno == EROFS ) {
+            singularity_message(ERROR, "Unable to open squashfs image in read-write mode: %s\n", strerror(errno));
+        } else {
+            singularity_message(ERROR, "Unknown image format/type: %s\n", path);
+        }
         ABORT(255);
     }
 

--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -44,7 +44,6 @@
 
 struct image_object singularity_image_init(char *path, int open_flags) {
     struct image_object image;
-    int retval = 0;
 
     if ( path == NULL ) {
         singularity_message(ERROR, "No container image path defined\n");

--- a/src/lib/image/squashfs/init.c
+++ b/src/lib/image/squashfs/init.c
@@ -42,7 +42,12 @@ int _singularity_image_squashfs_init(struct image_object *image, int open_flags)
     static char buf[1024];
     char *p;
 
-
+    singularity_message(DEBUG, "Checking if writable image requested\n");
+    if ( open_flags == O_RDWR ) {
+        errno = EROFS;
+        return(-1);
+    }
+    
     singularity_message(DEBUG, "Opening file descriptor to image: %s\n", image->path);
     if ( ( image_fd = open(image->path, open_flags, 0755) ) < 0 ) {
         singularity_message(ERROR, "Could not open image %s: %s\n", image->path, strerror(errno));


### PR DESCRIPTION
**Description of the Pull Request (PR):**

As title says, this disallows --writable when using squashfs as the image type.


**This fixes or addresses the following GitHub issues:**

- Ref: #955 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
