### PR TITLE
ensuring app bases are sourced before specific app

### DIFF
--- a/libexec/bootstrap-scripts/deffile-sections.sh
+++ b/libexec/bootstrap-scripts/deffile-sections.sh
@@ -378,9 +378,9 @@ for app in ${SINGULARITY_ROOTFS}/scif/apps/*; do
     if [ -d "$app" ]; then
         app="${app##*/}"
         app=(`echo $app | sed -e "s/-/_/g"`)
-        echo "APPDATA_$app=/scif/data/$app" >> "$SINGULARITY_ROOTFS/.singularity.d/env/95-apps.sh"
-        echo "APPROOT_$app=/scif/apps/$app" >> "$SINGULARITY_ROOTFS/.singularity.d/env/95-apps.sh"
-        echo "export APPDATA_$app APPROOT_$app"  >> "$SINGULARITY_ROOTFS/.singularity.d/env/95-apps.sh"
+        echo "APPDATA_$app=/scif/data/$app" >> "$SINGULARITY_ROOTFS/.singularity.d/env/94-appsbase.sh"
+        echo "APPROOT_$app=/scif/apps/$app" >> "$SINGULARITY_ROOTFS/.singularity.d/env/94-appsbase.sh"
+        echo "export APPDATA_$app APPROOT_$app"  >> "$SINGULARITY_ROOTFS/.singularity.d/env/94-appsbase.sh"
     fi
 done
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a quick fix to ensure that app bases (for data and executables) are sourced in the environment BEFORE the app specific environments. This is because it is common to want to reference another app in the environment, eg, here I want to use a file from `reference` during `mapping` and the file should predictibly be at `$APPROOT_reference`

```
%appenv mapping
    all_reads=${SINGULARITY_DATA}/all_reads.fastq
    reference_genome=${APPROOT_reference}/lambda_ecoli.fa
    bwa_threads="${CSEQ_BWATHREADS:-1}"
    q_score="${CSEQ_QSCORE:-9}"
    output_folder="${SINGULARITY_APPDATA}"
    export all_reads reference_genome bwa_threads q_score output_folder
```

but as it is now, we haven't defined the `APPROOT_reference` until after calling the above, so we don't see it. The variable is empty and it looks like the file is at the room:

```
singularity exec --app mapping carrierseq.img env | grep reference
APPDATA_reference=/scif/data/reference
APPROOT_reference=/scif/apps/reference
reference_genome=/lambda_ecoli.fa
```
 but with the fix, we do!

```
singularity exec --app mapping carrierseq.img env | grep reference
APPDATA_reference=/scif/data/reference
APPROOT_reference=/scif/apps/reference
reference_genome=/scif/apps/reference/lambda_ecoli.fa
```

**This fixes or addresses the following GitHub issues:**

- Ref: #970 


Attn: @singularityware-admin
