### PR TITLE
Prevent instance.start from exiting if no startscript exists in container

### DIFF
--- a/src/start.c
+++ b/src/start.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     singularity_daemon_init();
 
     singularity_message(DEBUG, "We are ready to recieve jobs, sending signal_go_ahead to parent\n");
-
+    
     singularity_runtime_enter();
     singularity_priv_drop_perm();
 
@@ -106,8 +106,6 @@ int main(int argc, char **argv) {
     }
 
     singularity_install_signal_handler();
-
-    singularity_message(DEBUG, "Exited sigfd\n");
 
     daemon_fd = atoi(singularity_registry_get("DAEMON_FD"));
 
@@ -143,6 +141,7 @@ int main(int argc, char **argv) {
             }
         } else {
             singularity_message(WARNING, "Start script not found\n");
+            kill(1, SIGCONT);
         }
     } else if ( child > 0 ) {
         singularity_message(DEBUG, "Waiting for signals\n");


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Prevent instance.start from exiting if no startscript exists in container


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
