### PR TITLE
Moderate warnings for unprivileged users in build

### DIFF
--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -160,7 +160,7 @@ if [ "$USERID" != "0" ]; then
 
         # Sandbox with anything else is ok
         else
-            message WARNING "Building sandbox as non-root will result in wrong file permissions\n"
+            message WARNING "Building sandbox as non-root may result in wrong file permissions\n"
         fi
     fi
 fi
@@ -269,10 +269,8 @@ esac
 if [ -f "${SINGULARITY_BUILDDEF:-}" ]; then
     if eval is_image "${SINGULARITY_BUILDDEF}"; then
         message 1 "Building from local image: $SINGULARITY_BUILDDEF\n"
-        if [ "$USERID" != "0" ]; then
-            message WARNING "You are not root! Some files may not be exported from ${SINGULARITY_BUILDDEF} due to permission errors.\n"
-        fi
-        if ! eval "${SINGULARITY_bindir}"/singularity image.export "${SINGULARITY_BUILDDEF}" | tar xBf - -C "${SINGULARITY_ROOTFS}"; then
+        nonroot_build_warning
+        if ! eval "${SINGULARITY_bindir}"/singularity image.export "${SINGULARITY_BUILDDEF}" 2>/dev/null | tar xBf - -C "${SINGULARITY_ROOTFS}" >/dev/null 2>&1; then
             message ERROR "Failed to export contents of ${SINGULARITY_BUILDDEF} to ${SINGULARITY_ROOTFS}\n"
             ABORT 255
         fi
@@ -297,10 +295,8 @@ if [ -f "${SINGULARITY_BUILDDEF:-}" ]; then
 
     elif eval is_tar "${SINGULARITY_BUILDDEF}"; then
         message 1 "Building from local tar file: $SINGULARITY_BUILDDEF\n"
-        if [ "$USERID" != "0" ]; then
-            message WARNING "You are not root! Some files may not be exported from ${SINGULARITY_BUILDDEF} due to permission errors.\n"
-        fi
-        if ! eval "zcat_compat ${SINGULARITY_BUILDDEF} | tar xf - -C ${SINGULARITY_ROOTFS}"; then
+        nonroot_build_warning
+        if ! eval "zcat_compat ${SINGULARITY_BUILDDEF} 2>/dev/null | tar xf - -C ${SINGULARITY_ROOTFS}" >/dev/null 2>&1; then
             message ERROR "Failed to export contents of ${SINGULARITY_BUILDDEF} to ${SINGULARITY_ROOTFS}\n"
             ABORT 255
         fi
@@ -311,6 +307,7 @@ if [ -f "${SINGULARITY_BUILDDEF:-}" ]; then
     fi
 
 elif [ -d "$SINGULARITY_BUILDDEF" ]; then
+    nonroot_build_warning
     if [ -z ${SINGULARITY_QUIET_SANDBOXMESSAGE:-} ]; then
         message 1 "Building image from sandbox: $SINGULARITY_BUILDDEF\n"
     fi

--- a/libexec/functions
+++ b/libexec/functions
@@ -374,6 +374,13 @@ zcat_compat() {
     fi
 }
 
+nonroot_build_warning() {
+USERID=`id -ru`
+if [ "$USERID" != "0" ]; then
+    message WARNING "Building container as an unprivileged user. If you run this container as root
+         it may be missing some functionality.\n"
+fi
+}
 
 is_deffile() {
 # check if a file looks like, walks like, and quacks like a def file


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Our warnings in `build` are too scary given the actual severity of the situation and should be moderated.  This PR:

1. Gives a more accurate warning messages about the problems that a user may encounter when building as an unprivileged user.
2. Sends redundant `tar` messages to `/dev/null` so they don't alarm the user unnecessarily.  

**This fixes or addresses the following GitHub issues:**

- Fixes #1006 


**Checkoff for all PRs:**

✅  I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`
✅  This PR is NOT against the project's master branch
✅  I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
✅  This PR is ready for review and/or merge


Attn: @singularityware-admin
