### PR TITLE
fixing docker variable environment quoting

### DIFF
--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -168,8 +168,9 @@ def extract_env(manifest):
     '''
     environ = get_config(manifest, 'Env')
     if environ is not None:
-        if isinstance(environ, list):
-            environ = "\n".join(environ)
+        environ = re.findall("(?P<var_name>.+)=(?P<var_value>.+)", environ)
+        environ = ['%s="%s"' % (x[0], x[1]) for x in environ]
+        environ = "\n".join(environ)
         environ = ["export %s" % x for x in environ.split('\n')]
         environ = "\n".join(environ)
         bot.verbose3("Found Docker container environment!")


### PR DESCRIPTION
**Description of the Pull Request (PR):**
This is a quick fix to add regular expression parsing of environment lines. This needs to be tested for cases when a user doesn't provide an "=" sign in the Dockerfile - we need to make sure the manifest still includes it. This will close #1008 . @ArangoGutierrez would you have some bandwidth to test this against a Dockerfile with an environment variable like:

```
ENV KEY VALUE
```
and make sure it is included? If the manifest doesn't add the "=" then we will have to do a separate check for these lines after we find the original matches with the regular expression.

Attn: @singularityware-admin
