### PR TITLE
Fix issue #1005

### DIFF
--- a/libexec/handlers/image-instance.sh
+++ b/libexec/handlers/image-instance.sh
@@ -21,7 +21,7 @@ if [ -z "${DAEMON_IMAGE}" ]; then
     ABORT 255
 fi
 
-if [ ! -f "${DAEMON_IMAGE}" ]; then
+if [ ! -f "${DAEMON_IMAGE}" -a ! -d "${DAEMON_IMAGE}" ]; then
     message ERROR "Image for daemon is not found: ${DAEMON_IMAGE}\n"
     ABORT 255
 fi

--- a/tests/40-privblock.sh
+++ b/tests/40-privblock.sh
@@ -34,10 +34,8 @@ stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
 # Checking no new privs with capabilities
-stest 0 sudo singularity exec "$CONTAINER" ping localhost -c 1
-stest 1 singularity exec "$CONTAINER" ping localhost -c 1
-stest 0 sudo singularity exec "$CONTAINER" ping localhost -c 1
-stest 1 singularity exec "$CONTAINER" ping localhost -c 1
+stest 0 sudo singularity exec "$CONTAINER" chsh -s /bin/sh
+stest 1 singularity exec "$CONTAINER" chsh -s /bin/sh
 
 
 test_cleanup


### PR DESCRIPTION
**Description of the Pull Request (PR):**

With /proc/sys/net/ipv4/ping_group_range, ping can open a icmp socket without requiring setuid or file capabilities, so user can ping inside container and fail to pass test in 40-privblock.sh.
This PR change ping for chsh

Minor fix for joining instance launched from a directory

**This fixes or addresses the following GitHub issues:**

- Ref: #1005 

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
