### PR TITLE
Don't delete sandbox when building from a sandbox

### DIFF
--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -310,6 +310,7 @@ elif [ -d "$SINGULARITY_BUILDDEF" ]; then
     nonroot_build_warning
     if [ -z ${SINGULARITY_QUIET_SANDBOXMESSAGE:-} ]; then
         message 1 "Building image from sandbox: $SINGULARITY_BUILDDEF\n"
+        SINGULARITY_NOCLEANUP=1 # don't delete when building directly from sandbox
     fi
     SINGULARITY_ROOTFS="$SINGULARITY_BUILDDEF"
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

`build` is basically the swiss army knife of containers.  In addition to being able to build from just about anything you can also use `build` to convert your container from one format to another.
```
      squasfs
      /     \
writable -- sandbox
```
You can convert your image from a writable (ext3) to a sandbox (directory) for example.  If you do so, you now have 2 containers.  But if you convert from a sandbox, we automatically delete the sandbox afterward.  This may be unexpected and is probably unsafe.  When I `tar` a directory `tar` does not delete the directory when it is finished.  Why should we do so when creating images.  

This PR fixes the problem (in an admittedly very hacky way).  

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
