### PR TITLE
Do not close cleanupd fd on instance start

### DIFF
--- a/src/start.c
+++ b/src/start.c
@@ -50,7 +50,7 @@
 int started = 0;
 
 int main(int argc, char **argv) {
-    int i, daemon_fd;
+    int i, daemon_fd, cleanupd_fd;
     struct image_object image;
     pid_t child;
     siginfo_t siginfo;
@@ -108,11 +108,12 @@ int main(int argc, char **argv) {
     singularity_install_signal_handler();
 
     daemon_fd = atoi(singularity_registry_get("DAEMON_FD"));
-
+    cleanupd_fd = atoi(singularity_registry_get("CLEANUPD_FD"));
+    
     /* Close all open fd's that may be present besides daemon info file fd */
     singularity_message(DEBUG, "Closing open fd's\n");
     for( i = sysconf(_SC_OPEN_MAX); i > 2; i-- ) {
-        if ( i != daemon_fd ) {
+        if ( i != daemon_fd && i != cleanupd_fd ) {
             if ( fstat(i, &filestat) == 0 ) {
                 if ( S_ISFIFO(filestat.st_mode) != 0 ) {
                     continue;

--- a/src/util/cleanupd.c
+++ b/src/util/cleanupd.c
@@ -91,6 +91,8 @@ int singularity_cleanupd(void) {
             ABORT(255);
         }
 
+        singularity_registry_set("CLEANUPD_FD", int2str(trigger_fd));
+        
     } else {
         singularity_message(DEBUG, "Using existing cleanup trigger file: %s\n", trigger);
     }

--- a/src/util/cleanupd.c
+++ b/src/util/cleanupd.c
@@ -49,6 +49,8 @@ int singularity_cleanupd(void) {
     char *cleanup_dir = singularity_registry_get("CLEANUPDIR");
     int trigger_fd = -1;
 
+    singularity_registry_set("CLEANUPD_FD", "-1");
+    
     if ( singularity_registry_get("DAEMON_JOIN") ) {
         singularity_message(ERROR, "Internal Error - This function should not be called when joining an instance\n");
     }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Do not close trigger fd when instance is starting to prevent docker container directory from being removed.


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [Author's file](https://github.com/singularityware/singularity/blob/master/AUTHORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
