### PR TITLE
Adding registry and namespace definition to recipe

### DIFF
--- a/libexec/bootstrap-scripts/deffile-driver-docker.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-docker.sh
@@ -42,9 +42,25 @@ if [ -z "${FROM:-}" ]; then
     exit 1
 fi
 
+################################################################################
+# Docker Customizations
+################################################################################
+
+if [ ! -z "${REGISTRY:-}" ]; then
+    message DEBUG "Custom Docker Registry 'Registry:' ${REGISTRY}.\n"
+    export REGISTRY
+fi
+
+if [ ! -z "${NAMESPACE:-}" ]; then
+    message DEBUG "Custom Docker Namespace 'Namespace:' ${NAMESPACE}.\n"
+    export NAMESPACE
+fi
+
 if [ -z "${INCLUDECMD:-}" ]; then
     export SINGULARITY_INCLUDECMD="yes"
 fi
+
+
 
 SINGULARITY_CONTAINER="docker://$FROM"
 SINGULARITY_LABELFILE="$SINGULARITY_ROOTFS/.singularity.d/labels.json"

--- a/libexec/bootstrap-scripts/deffile-driver-shub.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-shub.sh
@@ -38,6 +38,21 @@ if [ -z "${FROM:-}" ]; then
 fi
 
 
+################################################################################
+# Singularity Hub/Registry Customizations
+################################################################################
+
+if [ ! -z "${REGISTRY:-}" ]; then
+    message DEBUG "Custom Singularity Registry 'Registry:' ${REGISTRY}.\n"
+    export REGISTRY
+fi
+
+if [ ! -z "${NAMESPACE:-}" ]; then
+    message DEBUG "Custom Singularity Registry Namespace 'Namespace:' ${NAMESPACE}.\n"
+    export NAMESPACE
+fi
+
+
 ########## BEGIN BOOTSTRAP SCRIPT ##########
 SINGULARITY_CONTAINER="shub://${FROM}"
 if ! SINGULARITY_CONTENTS=`mktemp ${TMPDIR:-/tmp}/.singularity-layerfile.XXXXXX`; then

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -114,10 +114,12 @@ else:
 
 # API
 DOCKER_API_BASE = "index.docker.io"  # registry
+CUSTOM_REGISTRY = getenv("REGISTRY")
+NAMESPACE = "library"
+CUSTOM_NAMESPACE = getenv('NAMESPACE')
 DOCKER_API_VERSION = "v2"
 DOCKER_ARCHITECTURE = getenv("SINGULARITY_DOCKER_ARCHITECTURE", "amd64")
 DOCKER_OS = getenv("SINGULARITY_DOCKER_OS", "linux")
-NAMESPACE = "library"
 TAG = "latest"
 
 # Container Metadata

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -28,6 +28,8 @@ from message import bot
 from defaults import (
     DOCKER_API_BASE,
     NAMESPACE,
+    CUSTOM_REGISTRY,
+    CUSTOM_NAMESPACE,
     TAG
 )
 
@@ -149,6 +151,12 @@ def parse_image_uri(image,
         registry = default_registry
         namespace = default_namespace
         repo_name = image[0]
+
+    # if user gave custom registry / namespace, use
+    if CUSTOM_NAMESPACE is not None:
+        namespace = CUSTOM_NAMESPACE
+    if CUSTOM_REGISTRY is not None:
+        registry = CUSTOM_REGISTRY
 
     if not quiet:
         bot.verbose("Registry: %s" % registry)

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -104,7 +104,6 @@ class TestApi(TestCase):
         ubuntu_tags = ['xenial', 'latest', 'trusty', 'yakkety']
         [self.assertTrue(x in tags) for x in ubuntu_tags]
 
-
     def test_get_layer(self):
         '''test_get_layer will download docker layers
         '''

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -82,25 +82,12 @@ class TestApi(TestCase):
         print("Case 3: Bad tag should print valid tags and exit")
         client = DockerApiConnection(image="ubuntu:mmm.avocado")
 
-        # Should work for custom registries
-        print("Case 4: Obtain manifest from custom registry")
-        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")
-        manifest = client.get_manifest(old_version=True)
-        self.assertTrue("fsLayers" in manifest or "layers" in manifest)
-
     def test_get_images(self):
         '''test_get_images will obtain a list of images
         '''
         from docker.api import DockerApiConnection
 
-        print("Case 1: Ask for images")
         images = self.client.get_images()
-        self.assertTrue(isinstance(images, list))
-        self.assertTrue(len(images) > 1)
-
-        print("Case 2: Ask for images from custom registry")
-        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")
-        images = client.get_images()
         self.assertTrue(isinstance(images, list))
         self.assertTrue(len(images) > 1)
 
@@ -117,12 +104,6 @@ class TestApi(TestCase):
         ubuntu_tags = ['xenial', 'latest', 'trusty', 'yakkety']
         [self.assertTrue(x in tags) for x in ubuntu_tags]
 
-        print("Case 2: Ask for tags from custom registry")
-        client = DockerApiConnection(image="gcr.io/tensorflow/tensorflow")
-        tags = client.get_tags()
-        self.assertTrue(isinstance(tags, list))
-        self.assertTrue(len(tags) > 1)
-        [self.assertTrue(x in tags) for x in ['latest', 'latest-gpu']]
 
     def test_get_layer(self):
         '''test_get_layer will download docker layers


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This adds the ability for a user to directly name the `Registry:` and `Namespace:` in a recipe header, to be used over what is parsed from the URI. The image tag/hash are still parsed from the uri, as that function is pretty consistent. This will need to be added to the docs.


Attn: @singularityware-admin
