### PR TITLE
Fixing quotes for runscript from Docker

### DIFF
--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -99,8 +99,8 @@ def extract_runscript(manifest, includecmd=False):
         # If the command is a list, join. (eg ['/usr/bin/python','hello.py']
         if not isinstance(cmd, list):
             cmd = [cmd]
-    
-        cmd = " ".join(['"%s"' %x for x in cmd])
+
+        cmd = " ".join(['"%s"' % x for x in cmd])
 
         if not RUNSCRIPT_COMMAND_ASIS:
             cmd = 'exec %s' % cmd
@@ -170,7 +170,7 @@ def extract_env(manifest):
     '''
     environ = get_config(manifest, 'Env')
     if environ is not None:
-        if not isinstance(environ,list):
+        if not isinstance(environ, list):
             environ = [environ]
 
         lines = []

--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -83,7 +83,7 @@ def extract_runscript(manifest, includecmd=False):
     commands = ["Entrypoint", "Cmd"]
     if includecmd is True:
         commands.reverse()
-    configs = get_configs(manifest, commands, delim=" ")
+    configs = get_configs(manifest, commands)
 
     # Look for non "None" command
     for command in commands:
@@ -97,12 +97,14 @@ def extract_runscript(manifest, includecmd=False):
         bot.debug(cmd)
 
         # If the command is a list, join. (eg ['/usr/bin/python','hello.py']
-        if isinstance(cmd, list):
-            cmd = " ".join(cmd)
+        if not isinstance(cmd, list):
+            cmd = [cmd]
+    
+        cmd = " ".join(['"%s"' %x for x in cmd])
 
         if not RUNSCRIPT_COMMAND_ASIS:
-            cmd = 'exec %s "$@"' % cmd
-        cmd = "#!/bin/bash\n\n%s" % cmd
+            cmd = 'exec %s' % cmd
+        cmd = "#!/bin/sh\n\n%s\n" % cmd
         return cmd
 
     bot.debug("CMD and ENTRYPOINT not found, skipping runscript.")
@@ -168,11 +170,16 @@ def extract_env(manifest):
     '''
     environ = get_config(manifest, 'Env')
     if environ is not None:
-        environ = re.findall("(?P<var_name>.+)=(?P<var_value>.+)", environ)
-        environ = ['%s="%s"' % (x[0], x[1]) for x in environ]
-        environ = "\n".join(environ)
-        environ = ["export %s" % x for x in environ.split('\n')]
-        environ = "\n".join(environ)
+        if not isinstance(environ,list):
+            environ = [environ]
+
+        lines = []
+        for line in environ:
+            line = re.findall("(?P<var_name>.+)=(?P<var_value>.+)", line)
+            line = ['export %s="%s"' % (x[0], x[1]) for x in line]
+            lines = lines + line
+
+        environ = "\n".join(lines)
         bot.verbose3("Found Docker container environment!")
     return environ
 
@@ -235,9 +242,8 @@ def get_config(manifest, spec="Entrypoint", delim=None):
 
     # Standard is to include commands like ['/bin/sh']
     if isinstance(cmd, list):
-        if delim is None:
-            delim = "\n"
-        cmd = delim.join(cmd)
+        if delim is not None:
+            cmd = delim.join(cmd)
     bot.verbose3("Found Docker command (%s) %s" % (spec, cmd))
 
     return cmd

--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -94,7 +94,6 @@ def extract_runscript(manifest, includecmd=False):
     if cmd is not None:
         bot.verbose3("Adding Docker %s as Singularity runscript..."
                      % command.upper())
-        bot.debug(cmd)
 
         # If the command is a list, join. (eg ['/usr/bin/python','hello.py']
         if not isinstance(cmd, list):

--- a/libexec/python/tests/test_docker_tasks.py
+++ b/libexec/python/tests/test_docker_tasks.py
@@ -49,11 +49,9 @@ class TestApi(TestCase):
         manifest = self.client.get_manifest(old_version=True)
 
         print("Case 1: Asking for CMD when none defined")
-        default_cmd = 'exec /bin/bash "$@"'
+        default_cmd = 'exec "/bin/bash"'
         runscript = extract_runscript(manifest=manifest,
                                       includecmd=True)
-        # Commands are always in format exec [] "$@"
-        # 'exec echo \'Hello World\' "$@"'
         self.assertTrue(default_cmd in runscript)
 
         print("Case 2: Asking for ENTRYPOINT when none defined")
@@ -65,12 +63,12 @@ class TestApi(TestCase):
 
         print("Case 3: Asking for ENTRYPOINT when defined")
         runscript = extract_runscript(manifest=manifest)
-        self.assertTrue('exec /run_mriqc "$@"' in runscript)
+        self.assertTrue('exec "/run_mriqc"' in runscript)
 
         print("Case 4: Asking for CMD when defined")
         runscript = extract_runscript(manifest=manifest,
                                       includecmd=True)
-        self.assertTrue('exec --help "$@"' in runscript)
+        self.assertTrue('exec "--help"' in runscript)
 
         print("Case 5: Asking for ENTRYPOINT when None, should return CMD")
         from docker.tasks import get_configs
@@ -80,7 +78,7 @@ class TestApi(TestCase):
         configs = get_configs(manifest, ['Cmd', 'Entrypoint'])
         self.assertEqual(configs['Entrypoint'], None)
         runscript = extract_runscript(manifest=manifest)
-        self.assertTrue(configs['Cmd'] in runscript)
+        self.assertTrue(configs['Cmd'][0] in runscript)
 
     def test_get_config(self):
         '''test_get_config will obtain parameters
@@ -100,7 +98,7 @@ class TestApi(TestCase):
         print("Case 2: Ask for custom command (Cmd)")
         entrypoint = get_config(manifest=manifest,
                                 spec="Cmd")
-        self.assertEqual(entrypoint, '/bin/bash')
+        self.assertTrue('/bin/bash' in entrypoint)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This will make sure that the runscript CMD, along with labels, env, are properly quoted, and shell uses bash:

```
singularity shell docker://nginx
Docker image path: index.docker.io/library/nginx:latest
Cache folder set to /home/vanessa/.singularity/docker
Creating container runtime...
Singularity: Invoking an interactive shell within container...

Singularity nginx:~/Documents/Dropbox/Code/singularity/singularity> cat /.singularity.d/runscript 
#!/bin/sh

exec "nginx" "-g" "daemon off;"
Singularity nginx:~/Documents/Dropbox/Code/singularity/singularity> cat /.singularity.d/env/10-docker.sh 
export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
export NGINX_VERSION="1.13.5-1~stretch"
export NJS_VERSION="1.13.5.0.1.13-1~stretch"Singularity nginx:~/Documents/Dropbox/Code/singularity/singularity> cat /.singularity.d/labels.json 
{
    "maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"
}
```
Thanks @bauerm97 for catching this!