### PR TITLE
fixing issue with download links

### DIFF
--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -37,7 +37,7 @@ from shell import (
 from sutils import (
     add_http,
     clean_up,
-    is_gzip,
+    get_image_format,
     read_file,
     run_command
 )
@@ -170,10 +170,9 @@ class SingularityApiConnection(ApiConnection):
                                               show_progress=True)
 
         # Compressed ext3 images need extraction
-        if is_gzip(image_file):
-            extract = True
+        image_type = get_image_format(image_file)
+        if image_type == "GZIP" or extract is True:
 
-        if extract is True:
             if not image_file.endswith('.gz'):
                 os.rename(image_file, "%s.gz" % image_file)
 

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -161,9 +161,6 @@ class SingularityApiConnection(ApiConnection):
             bot.error("please try when build completed or specify tag.")
             sys.exit(1)
 
-        if not image_name.endswith('.gz'):
-            image_name = "%s.gz" % image_name
-
         if download_folder is not None:
             image_name = "%s/%s" % (download_folder, image_name)
 
@@ -171,7 +168,6 @@ class SingularityApiConnection(ApiConnection):
         image_file = self.download_atomically(url=url,
                                               file_name=image_name,
                                               show_progress=True)
-
 
         # Squashfs, folders do not get extracted
         image_format = get_image_format(image_file)
@@ -193,21 +189,28 @@ class SingularityApiConnection(ApiConnection):
 
 
 # Various Helpers -----------------------------------------------
-def get_image_name(manifest, extension='img.gz'):
-    '''return the image name for a manifest
+def get_image_name(manifest):
+    '''return the image name for a manifest. Estimates extension from file
     :param manifest: the image manifest with 'image'
                      as key with download link
-    :param use_hash: use the image hash instead of name
     '''
     from defaults import (SHUB_CONTAINERNAME,
                           SHUB_NAMEBYCOMMIT,
                           SHUB_NAMEBYHASH)
 
+    # Find the image extension based on the url
+    if ".img.gz" in manifest['image']:
+        extension = 'img.gz'
+    elif ".simg.gz" in manifest['image']:
+        extension = 'simg.gz'
+    else:
+        extension = 'simg'
+
     # First preference goes to a custom name
     default_naming = True
 
     if SHUB_CONTAINERNAME is not None:
-        for replace in [" ", ".gz", ".img"]:
+        for replace in [" ", ".gz", ".img", ".simg"]:
             SHUB_CONTAINERNAME = SHUB_CONTAINERNAME.replace(replace, "")
         image_name = "%s.%s" % (SHUB_CONTAINERNAME, extension)
         default_naming = False

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -232,10 +232,10 @@ def get_content_hash(contents):
     return hasher.hexdigest()
 
 
-def get_image_format(image_file):
+def is_gzip(image_file):
     '''
-       get image format will use the image-format executable to return the kind
-       of file type for the image
+       is gzip will assess if a file is gzip format, which needs to be
+       deecompressed.
 
        Parameters
        ==========
@@ -243,8 +243,26 @@ def get_image_format(image_file):
 
        Returns
        =======
-       GZIP, DIRECTORY, SQUASHFS, EXT3
+       True or False
+    '''
+    image_format = run_command(["file", '--brief', image_file], quiet=True)
+    if isinstance(image_format, bytes):
+        image_format = image_format.decode('utf-8')
+    if image_format.startswith("gzip"):
+        return True
+    return False
 
+
+def get_image_format(image_file):
+    '''
+       get image format will use the image-format executable to return the kind
+       of file type for the image
+       Parameters
+       ==========
+       image_file: full path to the image file to inspect
+       Returns
+       =======
+       GZIP, DIRECTORY, SQUASHFS, EXT3
     '''
     if image_file.endswith('gz'):
         bot.debug('Found compressed image')

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -232,27 +232,6 @@ def get_content_hash(contents):
     return hasher.hexdigest()
 
 
-def is_gzip(image_file):
-    '''
-       is gzip will assess if a file is gzip format, which needs to be
-       deecompressed.
-
-       Parameters
-       ==========
-       image_file: full path to the image file to inspect
-
-       Returns
-       =======
-       True or False
-    '''
-    image_format = run_command(["file", '--brief', image_file], quiet=True)
-    if isinstance(image_format, bytes):
-        image_format = image_format.decode('utf-8')
-    if image_format.startswith("gzip"):
-        return True
-    return False
-
-
 def get_image_format(image_file):
     '''
        get image format will use the image-format executable to return the kind

--- a/libexec/python/tests/test_shub_api.py
+++ b/libexec/python/tests/test_shub_api.py
@@ -127,7 +127,7 @@ class TestApi(TestCase):
 
         print("Case 1: return an image name corresponding to repo")
         image_name = get_image_name(manifest)
-        self.assertEqual('vsoch-singularity-images-mongo.img.gz',
+        self.assertEqual('vsoch-singularity-images-mongo.simg',
                          image_name)
 
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Singularity Hub (version 1) built ext3 images. This means that they were huge, and to be efficient with storage, we stored them as gzip compressed (9) and then extracted on pull. So it looked something like this:

build image on cloud builder
```
container.img
```
compress and send to storage

```
container.img.gz
```

download to local filesystem
```
singularity-hub-regional%2Fgithub.com%2Fvsoch%2Fhello-world%2Ff9cd90a7b030a9c794bfe76c123da5a518ad9962%2Fabba5a1f91b2e98ebe125fc7a5151b33.img.gz
```

knowing extension is .img and format ext3, download an image with that extension (named based on repo, or user custom name, or hash, or commit and extract with right command to gzip
```
vsoch-hello-world-master.img.gz -->  vsoch-hello-world-master.img
```

So what happened (yesterday) is that it turned out to be the case that some images didn't need to be extracted. And we could do this based on the extension. So I made a function to check and then only extract if the appropriate type:

```
        # Compressed ext3 images need extraction
        if is_gzip(image_file):
            extract = True
```

My oversight was not seeing that the image name was manipulated from the original download link to always ensure that a .img.gz was returned (as this at the time was the only option). This meant that, regardless of what file was being requested, it would be called .img.gz and then extracted. This of course breaks with squasfs, or any format other than .img.gz of course.

So the fix is to remove this hard coding of the format, and instead use `.simg` but always check for the file type gzip first.

Importantly, extraction only occurs given that we find `gzip` with the file command, and given the builders always building squashfs, I don't see needing to extend this list until something else is allowed. The one potential issue is that (current) .img files will be named with .simg. I don't see an easy way around that.

## Example use cases:

Pulling Registry Image
```
singularity pull shub://sregistry.randomroad.net/examples/docker:latest
Progress |===================================| 100.0% 
Done. Container is at: /home/vanessa/Documents/Dropbox/Code/singularity/singularity/examples-docker-latest.simg

$ ./examples-docker-latest.simg 
This is what happens when you run the container..
```
Note the above was compressed, we look at file to determine, and then decompress.

Sinularity Hub (current version) is the same:

```
singularity run shub://vsoch/hello-world
Progress |===================================| 100.0% 
RaawwWWWWWRRRR!! Avocado!
```

and here is an actual squashfs. Note that you need to specify NOHTTPS because this is a development server:

```
SINGULARITY_NOHTTPS=yes singularity pull shub://doc.fish/singularityhub/hello-world
Progress |===================================| 100.0% 
Done. Container is at: /home/vanessa/Documents/Dropbox/Code/singularity/singularity/singularityhub-hello-world-master.simg
$ ./singularityhub-hello-world-master.simg 
Tacotacotaco
```
It would be good to get other sets of eyes on this - this is an extremely important detail @GodloveD @bauerm97 @gmkurtzer. I'm working around the clock on trying to test out all these details, and I definitely apologize this has to come up so late! I couldn't get to them any faster.

Attn: @singularityware-admin
