### PR TITLE
Cleanup build folders and files

### DIFF
--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -42,6 +42,8 @@ if ! which mksquashfs > /dev/null 2>&1; then
 fi
 
 build_cleanup() {
+    message 1 "Cleaning up...\n";
+
     if [ -f "${SINGULARITY_CONTENTS:-}" ]; then
         rm -f "${SINGULARITY_CONTENTS:-}"
     fi
@@ -52,7 +54,6 @@ build_cleanup() {
 
     if [ -z "${SINGULARITY_NOCLEANUP:-}" ]; then
         if [ -d "${SINGULARITY_ROOTFS:-}" ]; then
-            message 1 "Cleaning up...\n";
             rm -rf "${SINGULARITY_ROOTFS:-}"
         fi
     fi

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -52,7 +52,7 @@ build_cleanup() {
         rm -f "${SINGULARITY_BUILDDEF:-}"
     fi
 
-    if [ -z "${SINGULARITY_NOCLEANUP:-}" ]; then
+    if [ -z "${SINGULARITY_NOCLEANUP:-}" -a -z "${SINGULARITY_SANDBOX:-}" ]; then
         if [ -d "${SINGULARITY_ROOTFS:-}" ]; then
             rm -rf "${SINGULARITY_ROOTFS:-}"
         fi

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -41,6 +41,25 @@ if ! which mksquashfs > /dev/null 2>&1; then
     ABORT 255
 fi
 
+build_cleanup() {
+    if [ -f "${SINGULARITY_CONTENTS:-}" ]; then
+        rm -f "${SINGULARITY_CONTENTS:-}"
+    fi
+
+    if [ -n "${SINGULARITY_CLEANUP:-}" ]; then
+        rm -f "${SINGULARITY_BUILDDEF:-}"
+    fi
+
+    if [ -z "${SINGULARITY_NOCLEANUP:-}" ]; then
+        if [ -d "${SINGULARITY_ROOTFS:-}" ]; then
+            message 1 "Cleaning up...\n";
+            rm -rf "${SINGULARITY_ROOTFS:-}"
+        fi
+    fi
+}
+
+atexit build_cleanup
+
 USERID=`id -ru`
 
 SINGULARITY_CHECKS="no"
@@ -237,7 +256,6 @@ case $SINGULARITY_BUILDDEF in
 
         SINGULARITY_BUILDDEF="$SINGULARITY_ROOTFS"
         SINGULARITY_QUIET_SANDBOXMESSAGE=1
-        rm -f "$SINGULARITY_CONTENTS"
     ;;
 
     shub://*)
@@ -260,7 +278,6 @@ case $SINGULARITY_BUILDDEF in
         # switch $SINGULARITY_CONTAINER from remote to local 
         SINGULARITY_BUILDDEF=`cat $SINGULARITY_CONTENTS`
         SINGULARITY_CLEANUP=1
-        rm -f "$SINGULARITY_CONTENTS"
     ;;
 
 esac
@@ -281,9 +298,6 @@ if [ -f "${SINGULARITY_BUILDDEF:-}" ]; then
         if ! eval "${SINGULARITY_bindir}"/singularity image.export "${SINGULARITY_BUILDDEF}" 2>/dev/null | tar xBf - -C "${SINGULARITY_ROOTFS}" >/dev/null 2>&1; then
             message ERROR "Failed to export contents of ${SINGULARITY_BUILDDEF} to ${SINGULARITY_ROOTFS}\n"
             ABORT 255
-        fi
-        if [ -n "${SINGULARITY_CLEANUP:-}" ]; then
-            rm -f "$SINGULARITY_BUILDDEF"
         fi
 
     elif eval is_deffile "${SINGULARITY_BUILDDEF}"; then 
@@ -360,10 +374,6 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
 	exit 1
     fi
 
-    if [ -z "${SINGULARITY_NOCLEANUP:-}" ]; then
-        message 1 "Cleaning up...\n";
-        rm -rf "$SINGULARITY_ROOTFS"
-    fi
     chmod a+x "$SINGULARITY_CONTAINER_OUTPUT"
 fi
 

--- a/libexec/functions
+++ b/libexec/functions
@@ -526,6 +526,10 @@ scheck() {
     return $CODE
 }
 
+atexit() {
+    trap "$1" EXIT
+}
+
 if [ -n "${SHELL_DEBUG:-}" ]; then
     set -x
 fi


### PR DESCRIPTION
**Description of the Pull Request (PR):**

When errors occurs or process is interrupted during build, folders/files aren't deleted and it can left many /tmp/.singularity-build.XXX folders and /tmp/.singularity-layers.XXX which fill disk space.
An "atexit" function has been added which allow to register a function called when shell exit (useful for cleanup)

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
