### PR TITLE
Force NULL terminator into tf->filename to avoid buffer overflow

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -402,6 +402,7 @@ struct tempfile *make_logfile(char *label) {
         singularity_message(ERROR, "Label string too long\n");
         ABORT(255);
     }
+    tf->filename[sizeof(tf->filename) - 1] = '\0';
 
     if ( (tf->fd = mkstemp(tf->filename)) == -1 || (tf->fp = fdopen(tf->fd, "w+")) == NULL ) {
         if (tf->fd != -1) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Force NULL terminator into tf->filename to avoid buffer overflow


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
