### PR TITLE
Multi-layer docker image fix

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,3 +34,4 @@
     - Ralph Castain <rhc@open-mpi.org>
     - Rémy Dernat <remy.dernat@umontpellier.fr>
     - Yaroslav Halchenko <debian@onerussian.com>
+    - Josef Hrabal <josef.hrabal@vsb.cz>

--- a/libexec/handlers/image-docker.sh
+++ b/libexec/handlers/image-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 # Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
 
@@ -36,11 +36,13 @@ eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"
 message 1 "Creating container runtime...\n"
 message 2 "Importing: base Singularity environment\n"
 zcat $SINGULARITY_libexecdir/singularity/bootstrap-scripts/environment.tar | (cd $SINGULARITY_ROOTFS; tar -xf -) || exit $?
- 
+
 for i in `cat "$SINGULARITY_CONTENTS"`; do
     name=`basename "$i"`
     message 2 "Exploding layer: $name\n"
-    ( zcat "$i" | (cd "$SINGULARITY_ROOTFS"; tar --overwrite --exclude=dev/* -xvf -) || exit $? ) | while read file; do
+    # Settings of file privileges must be buffered
+    files=$( zcat "$i" | (cd "$SINGULARITY_ROOTFS"; tar --overwrite --exclude=dev/* -xvf -)) || exit $?
+    for file in $files; do
         if [ -L "$SINGULARITY_ROOTFS/$file" ]; then
             # Skipping symlinks
             true


### PR DESCRIPTION
This fixes the problem with files and folders privileges when exploding multilayer docker image.

**Description of the Pull Request (PR):**

Individual docker layers have to be extracted to the same folder in right order. To do this, all folders have to be writable so files can be added to it. TAR command is outputting extracted file names unbuffered. File and folder permissions are set immediately after extraction. When TAR extract another file to the same folder, permissions of the folder are restored and files from another layer can't be extracted. This patch fixes it by buffering extracted file names and setting permissions after TAR close.

**This fixes or addresses the following GitHub issues:**

- Ref: #1060


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [ ] This PR is ready for review and/or merge


Attn: @singularityware-admin
