### PR TITLE
Set CLOEXEC on image file descriptor

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -75,10 +75,10 @@ int main(int argc, char **argv) {
         image = singularity_image_init(singularity_registry_get("IMAGE"), O_RDONLY);
     }
 
-    singularity_runtime_ns(SR_NS_ALL);
-
     if ( singularity_registry_get("DAEMON_JOIN") == NULL ) {
         singularity_cleanupd();
+
+        singularity_runtime_ns(SR_NS_ALL);
 
         singularity_sessiondir();
 
@@ -89,6 +89,8 @@ int main(int argc, char **argv) {
         singularity_runtime_overlayfs();
         singularity_runtime_mounts();
         singularity_runtime_files();
+    } else {
+        singularity_runtime_ns(SR_NS_ALL);
     }
 
     singularity_runtime_enter();

--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <libgen.h>
 
@@ -100,6 +101,11 @@ struct image_object singularity_image_init(char *path, int open_flags) {
         } else {
             singularity_message(ERROR, "Unknown image format/type: %s\n", path);
         }
+        ABORT(255);
+    }
+
+    if ( fcntl(image.fd, F_SETFD, FD_CLOEXEC) != 0 ) {
+        singularity_message(ERROR, "Failed to set CLOEXEC on image file descriptor\n");
         ABORT(255);
     }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Add missing CLOEXEC flag on image file descriptor
- Start cleanupd outside namespace. If executing `singularity shell -p docker://busybox`, PID namespace imply cleanupd is killed when PID 1 exit, so it can't delete runtime files

**This fixes or addresses the following GitHub issues:**

- Ref: #1063 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
