### PR TITLE
Move sourcing environment to chroot during build

### DIFF
--- a/libexec/bootstrap-scripts/deffile-sections.sh
+++ b/libexec/bootstrap-scripts/deffile-sections.sh
@@ -137,11 +137,6 @@ if [ -z "${SINGULARITY_BUILDSECTION:-}" -o "${SINGULARITY_BUILDSECTION:-}" == "e
         message 1 "Adding environment to container\n"
 
         singularity_section_get "environment" "$SINGULARITY_BUILDDEF" >> "$SINGULARITY_ROOTFS/.singularity.d/env/90-environment.sh"
-
-        # # Sourcing the environment
-        # set +u
-        # . "$SINGULARITY_ROOTFS/.singularity.d/env/90-environment.sh"
-        # set -u
     fi
 else
     message 2 "Skipping environment section\n"

--- a/libexec/bootstrap-scripts/deffile-sections.sh
+++ b/libexec/bootstrap-scripts/deffile-sections.sh
@@ -138,10 +138,10 @@ if [ -z "${SINGULARITY_BUILDSECTION:-}" -o "${SINGULARITY_BUILDSECTION:-}" == "e
 
         singularity_section_get "environment" "$SINGULARITY_BUILDDEF" >> "$SINGULARITY_ROOTFS/.singularity.d/env/90-environment.sh"
 
-        # Sourcing the environment
-        set +u
-        . "$SINGULARITY_ROOTFS/.singularity.d/env/90-environment.sh"
-        set -u
+        # # Sourcing the environment
+        # set +u
+        # . "$SINGULARITY_ROOTFS/.singularity.d/env/90-environment.sh"
+        # set -u
     fi
 else
     message 2 "Skipping environment section\n"

--- a/src/get-section.c
+++ b/src/get-section.c
@@ -66,6 +66,16 @@ int main(int argc, char ** argv) {
     }
 
     singularity_message(DEBUG, "Iterating through file looking for sections matching: %%%s\n", section);
+
+    // prepend commands to source environment to post section
+    if ( strncmp(section, "post", 4) == 0 ) {
+        printf("for script in /.singularity.d/env/*.sh; do\n");
+        printf("    if [ -f \"$script\" ]; then\n");
+        printf("        . \"$script\"\n");
+        printf("    fi\n");
+        printf("done\n");
+    }
+
     while ( fgets(line, MAX_LINE_LEN, input) != NULL ) {
         if ( strncmp(line, strjoin("%", section), strlength(section, 128) + 1) == 0 ) {
             toggle_section = 1;


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Some time ago we began sourcing `/.singularity.d/env/90-environment.sh` during build before entering the `%post` section.  This works fine for simple variable declaration, but since we do this outside of the chroot environment other things can break.  For instance, if `/.singularity.d/env/90-environment.sh` is sourcing another script (`/etc/profile` for example) it will source the script on the host system instead of the one inside the container. 

Here I'm moving the sourcing of the environment into the chrooted %post section.  I'm doing so by prepending the sourcing commands to the recipe file on behalf of the user at build time.  I'm also adding the complete loop so that all `*.sh` files in `/.singularity.d/env/` are properly sourced.  

**This fixes or addresses the following GitHub issues:**

- Ref: #1053 


**Checkoff for all PRs:**

✅  I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`

✅  This PR is NOT against the project's master branch
✅  I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
✅  This PR is ready for review and/or merge


Attn: @singularityware-admin
