### PR TITLE
Properly pass exit code of build subcommand in pull.exec (to development branch)

### DIFF
--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -151,7 +151,7 @@ case "$SINGULARITY_CONTAINER" in
 
          if [ -x "${SINGULARITY_bindir}/singularity" ]; then
              ${SINGULARITY_bindir}/singularity build ${SINGULARITY_IMAGE} ${SINGULARITY_CONTAINER}
-             exit $?
+             RETVAL=$?
          else
              message ERROR "Could not locate the Singularity binary: $SINGULARITY_home/singularity\n"
              exit 1

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -151,7 +151,7 @@ case "$SINGULARITY_CONTAINER" in
 
          if [ -x "${SINGULARITY_bindir}/singularity" ]; then
              ${SINGULARITY_bindir}/singularity build ${SINGULARITY_IMAGE} ${SINGULARITY_CONTAINER}
-             exit 0
+             exit $?
          else
              message ERROR "Could not locate the Singularity binary: $SINGULARITY_home/singularity\n"
              exit 1

--- a/tests/23-pull.sh
+++ b/tests/23-pull.sh
@@ -40,4 +40,6 @@ stest 0 sudo singularity pull --force --size 10 docker://busybox
 
 stest 0 sudo rm -rf "${CONTAINER}"
 
+stest 1 singularity pull docker://this_should_not/exist
+
 test_cleanup


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Hello everyone,

This is a simple fix to ensure that the `build` subcommand's exit code is passed to the `pull` subcommand correctly. I stumbled on this error when trying to pull from a docker repository with a nonexistent image URL (`e.g. singularity pull docker://quay.io/biocontainers/samtool`). Running this command, I noticed that even though Singularity correctly detected that there is an error, it did not pass the correct error exit code. This was done in the 2.4 release of Singularity.

Tracing the error starting from the Python API, I see that the `singularity build` command in the patched `pull.exec` file always exits with 0, which I believe is incorrect behavior knowing that `build` may exit with an error.

I should say that I have not filed any issues as I consider the fix to be very simple. I did run the test locally (and on [Travis](https://travis-ci.org/bow/singularity/builds/288647406)) and nothing seems to be broken because of this. Still, please let me know if you prefer that an actual issue be opened for this. I also did not add any regression test, but am open to do so if you think it is required.

Thanks in advance for checking this.


**This fixes or addresses the following GitHub issues:**

- Ref: (see description above, no issue was filed yet)


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
