### PR TITLE
Disable instance feature for old kernels

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,7 @@ if test -d "/proc/self/ns"; then
     SETNS_SYSCALL=1
     AC_MSG_RESULT([yes])
 else
+    SETNS_SYSCALL=0
     AC_MSG_RESULT([no])
 fi
 AC_SUBST(SETNS_SYSCALL)
@@ -416,4 +417,11 @@ AC_CONFIG_FILES([
    libexec/python/helpers/json/Makefile
 
 ])
+
 AC_OUTPUT
+
+if test "$SETNS_SYSCALL" = "0"; then
+    echo
+    echo "WARNING: instance feature is disabled due to lack of kernel support"
+    echo
+fi

--- a/src/util/daemon.c
+++ b/src/util/daemon.c
@@ -194,6 +194,10 @@ void daemon_init_start(void) {
 }
 
 void singularity_daemon_init(void) {
+#if defined (NO_SETNS) && !defined (SINGULARITY_SETNS_SYSCALL)
+    singularity_message(ERROR, "Instance feature is disabled, your kernel is too old\n");
+    ABORT(255);
+#else
     if ( singularity_registry_get("DAEMON_START") ) {
         daemon_init_start();
         return;
@@ -204,4 +208,5 @@ void singularity_daemon_init(void) {
         singularity_message(DEBUG, "Not joining a daemon, daemon join not set\n");
         return;
     }
+#endif
 }

--- a/src/util/setns.c
+++ b/src/util/setns.c
@@ -16,6 +16,7 @@
 #define _GNU_SOURCE
 
 #include <unistd.h>
+#include <errno.h>
 #include <sys/syscall.h>
 
 #if defined (NO_SETNS) && defined (SINGULARITY_SETNS_SYSCALL)
@@ -24,6 +25,13 @@
 
 int setns(int fd, int nstype) {
     return syscall(__NR_setns, fd, nstype);
+}
+
+#elif defined (NO_SETNS) && !defined (SINGULARITY_SETNS_SYSCALL)
+
+int setns(int fd, int nstype) {
+    errno = ENOSYS;
+    return -1;
 }
 
 #endif /* NO_SETNS && SINGULARITY_SETNS_SYCALL */

--- a/tests/29-instance.sh
+++ b/tests/29-instance.sh
@@ -16,6 +16,11 @@
 
 . ./functions
 
+if [ ! -d "/proc/self/ns" ]; then
+    echo "Instance is not supported on your host, skipping tests"
+    exit 0
+fi
+
 test_init "Instance command group tests"
 
 CONTAINER="$SINGULARITY_TESTDIR/container"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Old kernels don't support joining namespace, this PR disable start/join instance and display message accordingly

**This fixes or addresses the following GitHub issues:**

- Ref: #1056

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin