### PR TITLE
Update/shub api

### DIFF
--- a/.travis/before_install
+++ b/.travis/before_install
@@ -1,9 +1,12 @@
 #!/bin/bash -ex
 
+wget -q -O - https://www.mongodb.org/static/pgp/server-3.2.pub | sudo apt-key add -
+
 if [ -z "$OS_TYPE" ]; then
+    echo "OS TYPE ${OS_TYPE}: "
     # default is ubuntu
     # install packages
-    sudo apt-get install -y flawfinder python-pip gcc
+    sudo apt-get update && sudo apt-get install -y flawfinder python-pip gcc
     # so that adjusted PATH propagates into sudo
     sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
     # Install updated version of pylint

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -3,7 +3,6 @@
 wget -q -O - https://www.mongodb.org/static/pgp/server-3.2.pub | sudo apt-key add -
 
 if [ -z "$OS_TYPE" ]; then
-    echo "OS TYPE ${OS_TYPE}: "
     # default is ubuntu
     # install packages
     sudo apt-get update && sudo apt-get install -y flawfinder python-pip gcc

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -13,7 +13,6 @@ rpmbuild -ta *.tar.gz
 rpm -iv ~/rpmbuild/RPMS/*/*.rpm
 
 if [ "$OS_VERSION" = 6 ]; then
-    # the test suite has not yet been ported to centos6 python, skip it
     echo "the test suite has not yet been ported to centos6 python, skipping."
     exit
 fi

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -14,6 +14,7 @@ rpm -iv ~/rpmbuild/RPMS/*/*.rpm
 
 if [ "$OS_VERSION" = 6 ]; then
     # the test suite has not yet been ported to centos6 python, skip it
+    echo "the test suite has not yet been ported to centos6 python, skipping."
     exit
 fi
 

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -152,7 +152,7 @@ DISABLE_HTTPS = convert2boolean(getenv("SINGULARITY_NOHTTPS", False))
 #######################################################################
 
 SINGULARITY_PULLFOLDER = getenv("SINGULARITY_PULLFOLDER", os.getcwd())
-SHUB_API_BASE = "singularity-hub.org"
+SHUB_API_BASE = "www.singularity-hub.org"
 SHUB_NAMEBYHASH = getenv("SHUB_NAMEBYHASH")
 SHUB_NAMEBYCOMMIT = getenv("SHUB_NAMEBYCOMMIT")
 SHUB_CONTAINERNAME = getenv("SHUB_CONTAINERNAME")

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -96,10 +96,10 @@ class SingularityApiConnection(ApiConnection):
         '''
         # make sure we have a complete url
         registry = add_http(self.image['registry'])
-        base = "%s/api/container/%s/%s:%s/" % (registry,
-                                               self.image['namespace'],
-                                               self.image['repo_name'],
-                                               self.image['repo_tag'])
+        base = "%s/api/container/%s/%s:%s" % (registry,
+                                              self.image['namespace'],
+                                              self.image['repo_name'],
+                                              self.image['repo_tag'])
         # ------------------------------------------------------
         # If we need to authenticate, will do it here
         # ------------------------------------------------------

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -96,10 +96,10 @@ class SingularityApiConnection(ApiConnection):
         '''
         # make sure we have a complete url
         registry = add_http(self.image['registry'])
-        base = "%s/api/container/%s/%s:%s" % (registry,
-                                              self.image['namespace'],
-                                              self.image['repo_name'],
-                                              self.image['repo_tag'])
+        base = "%s/api/container/%s/%s:%s/" % (registry,
+                                               self.image['namespace'],
+                                               self.image['repo_name'],
+                                               self.image['repo_tag'])
         # ------------------------------------------------------
         # If we need to authenticate, will do it here
         # ------------------------------------------------------

--- a/libexec/python/shub/main.py
+++ b/libexec/python/shub/main.py
@@ -59,7 +59,7 @@ def SIZE(image, contentfile=None):
     if 'size_mb' in manifest:  # sregistry
         size = manifest['size_mb']
     else:
-        size = json.loads(manifest['metrics'].replace("'", '"'))['size']
+        size = manifest['metrics']['size']
     if contentfile is not None:
         write_file(contentfile, str(size), mode="w")
     return size

--- a/libexec/python/tests/test_helpers.py
+++ b/libexec/python/tests/test_helpers.py
@@ -107,7 +107,7 @@ class TestJson(TestCase):
                   'return_code': t[1]}
         self.assertEqual(result['return_code'], 0)
         result = read_file(self.file)[0]
-        self.assertEqual('331', result)
+        self.assertEqual('260', result)
 
 
 if __name__ == '__main__':

--- a/libexec/python/tests/test_helpers.py
+++ b/libexec/python/tests/test_helpers.py
@@ -91,7 +91,7 @@ class TestJson(TestCase):
         shub_cont = "shub://vsoch/singularity-hello-world"
         os.environ['SINGULARITY_CONTAINER'] = shub_cont
         os.environ['SINGULARITY_CONTENTS'] = self.file
-        os.environ['SINGULARITY_MESSAGELEVEL'] = 5
+        os.environ['SINGULARITY_MESSAGELEVEL'] = "5"
 
         script_path = "%s/size.py" % self.here
         if VERSION == 2:

--- a/libexec/python/tests/test_helpers.py
+++ b/libexec/python/tests/test_helpers.py
@@ -91,7 +91,6 @@ class TestJson(TestCase):
         shub_cont = "shub://vsoch/singularity-hello-world"
         os.environ['SINGULARITY_CONTAINER'] = shub_cont
         os.environ['SINGULARITY_CONTENTS'] = self.file
-        os.environ['SINGULARITY_MESSAGELEVEL'] = "5"
 
         script_path = "%s/size.py" % self.here
         if VERSION == 2:
@@ -107,7 +106,10 @@ class TestJson(TestCase):
         t = output.communicate()[0], output.returncode
         result = {'message': t[0],
                   'return_code': t[1]}
-        print(result['message'])
+
+        if result['return_code'] != 0:
+            print(result['message'])
+
         self.assertEqual(result['return_code'], 0)
         result = read_file(self.file)[0]
         self.assertEqual('260', result)

--- a/libexec/python/tests/test_helpers.py
+++ b/libexec/python/tests/test_helpers.py
@@ -82,5 +82,33 @@ class TestJson(TestCase):
         result = int(read_file(self.file)[0])
         self.assertTrue(250 <= result <= 251)
 
+    def test_shub_size(self):
+        '''test the function to return Singularity Hub Image Size
+        '''
+        print('Testing Singularity Hub Size')
+        from sutils import read_file
+
+        shub_cont = "shub://vsoch/singularity-hello-world"
+        os.environ['SINGULARITY_CONTAINER'] = shub_cont
+        os.environ['SINGULARITY_CONTENTS'] = self.file
+
+        script_path = "%s/size.py" % self.here
+        if VERSION == 2:
+            testing_command = ["python2", script_path]
+        else:
+            testing_command = ["python3", script_path]
+
+        output = Popen(testing_command,
+                       stderr=STDOUT,
+                       stdout=PIPE)
+
+        t = output.communicate()[0], output.returncode
+        result = {'message': t[0],
+                  'return_code': t[1]}
+        self.assertEqual(result['return_code'], 0)
+        result = read_file(self.file)[0]
+        self.assertEqual('260', result)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_helpers.py
+++ b/libexec/python/tests/test_helpers.py
@@ -82,33 +82,5 @@ class TestJson(TestCase):
         result = int(read_file(self.file)[0])
         self.assertTrue(250 <= result <= 251)
 
-    def test_shub_size(self):
-        '''test the function to return Singularity Hub Image Size
-        '''
-        print('Testing Singularity Hub Size')
-        from sutils import read_file
-
-        shub_cont = "shub://vsoch/singularity-hello-world"
-        os.environ['SINGULARITY_CONTAINER'] = shub_cont
-        os.environ['SINGULARITY_CONTENTS'] = self.file
-
-        script_path = "%s/size.py" % self.here
-        if VERSION == 2:
-            testing_command = ["python2", script_path]
-        else:
-            testing_command = ["python3", script_path]
-
-        output = Popen(testing_command,
-                       stderr=STDOUT,
-                       stdout=PIPE)
-
-        t = output.communicate()[0], output.returncode
-        result = {'message': t[0],
-                  'return_code': t[1]}
-        self.assertEqual(result['return_code'], 0)
-        result = read_file(self.file)[0]
-        self.assertEqual('260', result)
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/libexec/python/tests/test_helpers.py
+++ b/libexec/python/tests/test_helpers.py
@@ -91,6 +91,7 @@ class TestJson(TestCase):
         shub_cont = "shub://vsoch/singularity-hello-world"
         os.environ['SINGULARITY_CONTAINER'] = shub_cont
         os.environ['SINGULARITY_CONTENTS'] = self.file
+        os.environ['SINGULARITY_MESSAGELEVEL'] = 5
 
         script_path = "%s/size.py" % self.here
         if VERSION == 2:
@@ -98,6 +99,7 @@ class TestJson(TestCase):
         else:
             testing_command = ["python3", script_path]
 
+        print(' '.join(testing_command))
         output = Popen(testing_command,
                        stderr=STDOUT,
                        stdout=PIPE)
@@ -105,6 +107,7 @@ class TestJson(TestCase):
         t = output.communicate()[0], output.returncode
         result = {'message': t[0],
                   'return_code': t[1]}
+        print(result['message'])
         self.assertEqual(result['return_code'], 0)
         result = read_file(self.file)[0]
         self.assertEqual('260', result)

--- a/libexec/python/tests/test_shub_api.py
+++ b/libexec/python/tests/test_shub_api.py
@@ -61,8 +61,8 @@ class TestApi(TestCase):
         '''
         print("Case 1: Testing retrieval of singularity-hub manifest")
         manifest = self.client.get_manifest()
-        keys = ['files', 'version', 'collection', 'branch',
-                'name', 'id', 'metrics', 'spec', 'image']
+        keys = ['version', 'tag', 'branch',
+                'name', 'id', 'commit', 'image']
         [self.assertTrue(x in manifest) for x in keys]
 
     def test_download_image(self):

--- a/libexec/python/tests/test_shub_api.py
+++ b/libexec/python/tests/test_shub_api.py
@@ -96,28 +96,11 @@ class TestApi(TestCase):
         image_name = get_image_name(manifest)
 
         fullname = "%s/%s" % (self.user_name, self.repo_name)
-        print("Case 1: ask for image and ask for master branch (tag)")
-        client = self.connect(image="%s:master" % fullname)
+        print("Case 1: ask for image by tag.")
+        client = self.connect(image="%s:latest" % fullname)
         manifest = client.get_manifest()
         image_name = get_image_name(manifest)
         self.assertEqual(image_name, get_image_name(manifest))
-
-        print("Case 2: ask for different tag (mongo)")
-        client = self.connect(image="%s:mongo" % fullname)
-        manifest = client.get_manifest()
-        mongo = get_image_name(manifest)
-        self.assertFalse(image_name == mongo)
-
-        print("Case 3: image without tag (should be latest across tags)")
-        client = self.connect(image="%s" % fullname)
-        manifest = client.get_manifest()
-        self.assertEqual(mongo, get_image_name(manifest))
-
-        print("Case 4: ask for latest tag (should be latest across tags)")
-        client = self.connect(image="%s/%s:latest"
-                              % (self.user_name, self.repo_name))
-        manifest = client.get_manifest()
-        self.assertEqual(mongo, get_image_name(manifest))
 
     def test_get_image_name(self):
         '''test_get_image_name will return the image name from the manifest
@@ -127,7 +110,7 @@ class TestApi(TestCase):
 
         print("Case 1: return an image name corresponding to repo")
         image_name = get_image_name(manifest)
-        self.assertEqual('vsoch-singularity-images-mongo.simg',
+        self.assertEqual('vsoch-singularity-images-master-latest.simg',
                          image_name)
 
 

--- a/libexec/python/tests/test_shub_pull.py
+++ b/libexec/python/tests/test_shub_pull.py
@@ -50,6 +50,7 @@ class TestImport(TestCase):
 
         # Variables are obtained from environment
         os.environ["SINGULARITY_CONTAINER"] = "shub://vsoch/singularity-images"
+        os.environ["SINGULARITY_MESSAGELEVEL"] = 5
         os.environ["SINGULARITY_PULLFOLDER"] = self.tmpdir
         os.environ["SINGULARITY_CONTENTS"] = "%s/.layers" % self.tmpdir
 
@@ -68,12 +69,16 @@ class TestImport(TestCase):
         else:
             testing_command = ["python3", script_path]
 
+        print(' '.join(testing_command))
         output = Popen(testing_command,
                        stderr=STDOUT,
                        stdout=PIPE)
         t = output.communicate()[0], output.returncode
         result = {'message': t[0],
                   'return_code': t[1]}
+
+        print(result['message'])
+
         self.assertEqual(result['return_code'], 0)
 
 

--- a/libexec/python/tests/test_shub_pull.py
+++ b/libexec/python/tests/test_shub_pull.py
@@ -50,7 +50,6 @@ class TestImport(TestCase):
 
         # Variables are obtained from environment
         os.environ["SINGULARITY_CONTAINER"] = "shub://vsoch/singularity-images"
-        os.environ["SINGULARITY_MESSAGELEVEL"] = "5"
         os.environ["SINGULARITY_PULLFOLDER"] = self.tmpdir
         os.environ["SINGULARITY_CONTENTS"] = "%s/.layers" % self.tmpdir
 
@@ -77,7 +76,8 @@ class TestImport(TestCase):
         result = {'message': t[0],
                   'return_code': t[1]}
 
-        print(result['message'])
+        if result['return_code'] != 0:
+            print(result['message'])
 
         self.assertEqual(result['return_code'], 0)
 

--- a/libexec/python/tests/test_shub_pull.py
+++ b/libexec/python/tests/test_shub_pull.py
@@ -50,7 +50,7 @@ class TestImport(TestCase):
 
         # Variables are obtained from environment
         os.environ["SINGULARITY_CONTAINER"] = "shub://vsoch/singularity-images"
-        os.environ["SINGULARITY_MESSAGELEVEL"] = 5
+        os.environ["SINGULARITY_MESSAGELEVEL"] = "5"
         os.environ["SINGULARITY_PULLFOLDER"] = self.tmpdir
         os.environ["SINGULARITY_CONTENTS"] = "%s/.layers" % self.tmpdir
 

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -24,12 +24,6 @@
 
 test_init "Checking Python unit tests"
 
-# /usr/local doesn't exist on centos
-
-#sudo mv ../libexec/python/tests /usr/local/libexec/singularity/python/tests
-#sudo chmod u+x /usr/local/libexec/singularity/python/tests/test*
-#cd /usr/local/libexec/singularity/python
-echo $PWD
 cd ../libexec/python
 
 if which python2 >/dev/null 2>&1; then

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -24,9 +24,13 @@
 
 test_init "Checking Python unit tests"
 
-sudo mv ../libexec/python/tests /usr/local/libexec/singularity/python/tests
-sudo chmod u+x /usr/local/libexec/singularity/python/tests/test*
-cd /usr/local/libexec/singularity/python
+# /usr/local doesn't exist on centos
+
+#sudo mv ../libexec/python/tests /usr/local/libexec/singularity/python/tests
+#sudo chmod u+x /usr/local/libexec/singularity/python/tests/test*
+#cd /usr/local/libexec/singularity/python
+echo $PWD
+cd ../libexec/python
 
 if which python2 >/dev/null 2>&1; then
     stest 0 python2 -m unittest tests.test_json

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -24,7 +24,9 @@
 
 test_init "Checking Python unit tests"
 
-cd ../libexec/python
+mv ../libexec/python/tests /usr/local/libexec/singularity/python/tests
+chmod u+x /usr/local/libexec/singularity/python/tests/test*
+cd /usr/local/libexec/singularity/python
 
 if which python2 >/dev/null 2>&1; then
     stest 0 python2 -m unittest tests.test_json

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -24,8 +24,8 @@
 
 test_init "Checking Python unit tests"
 
-mv ../libexec/python/tests /usr/local/libexec/singularity/python/tests
-chmod u+x /usr/local/libexec/singularity/python/tests/test*
+sudo mv ../libexec/python/tests /usr/local/libexec/singularity/python/tests
+sudo chmod u+x /usr/local/libexec/singularity/python/tests/test*
 cd /usr/local/libexec/singularity/python
 
 if which python2 >/dev/null 2>&1; then


### PR DESCRIPTION
This PR will add more specificity to how users can ask for and name containers, and update the tests and size function for the new Singularity Hub 2.0. Specifically, since the new version of Singularity Hub allows for multiple container builds associated with a commit and branch, we need to add this level of specificity to the naming of the files. Here is a review:

## Old Singularity Hub
The old Singularity Hub used a commit as a version, and provided the hash only as 
a special / different preference specified by the user:

```
singularity pull --hash shub://vsoch/hello-world
Progress |===================================| 100.0% 
Done. Container is at: abba5a1f91b2e98ebe125fc7a5151b33.img
```
This still works. The hash is indeed the hash of the file:

```
md5sum abba5a1f91b2e98ebe125fc7a5151b33.img 
abba5a1f91b2e98ebe125fc7a5151b33  abba5a1f91b2e98ebe125fc7a5151b33.img
```
The hash itself was extracted from the filename in storage. Note that we do better now - it's stored in the database and delivered in the manifest. You can also still pull by commit
```
singularity pull --commit shub://vsoch/hello-world
Progress |===================================| 100.0% 
Done. Container is at: f9cd90a7b030a9c794bfe76c123da5a518ad9962.simg
```

and default naming goes to as it was before, only the branch (aka "tag" for Singularity Hub v1.0)

```
singularity pull shub://vsoch/hello-world
Progress |===================================| 100.0% 
Done. Container is at: vsoch-hello-world-master.simg
```
Of course we see the issues with this - given two different commands with default naming, we could return different containers (but call them the same thing). For the new version of Singularity Hub, this would produce the same file (but different containers)

```
singularity pull shub://vsoch/hello-world:apps
singularity pull shub://vsoch/hello-world:latest
```
Thus, we need to integrate the tag (AND the branch) into the default name. I will describe the changes below.

## New Singularity Hub
The new Singularity Hub uses version as the content hash, and commit as commit. As it should have been.

Here is an example pulling by commit
```
singularity pull --commit shub://doc.fish/vsoch/hello-world
Progress |===================================| 100.0% 
Done. Container is at: e279432e6d3962777bb7b5e8d54f30f4347d867e.simg
```

```
singularity pull --hash shub://doc.fish/vsoch/hello-world
Progress |===================================| 100.0% 
Done. Container is at: 865f2d7bc8eb64e454162955d4c35bb2.simg
```

checking...
```
md5sum 865f2d7bc8eb64e454162955d4c35bb2.simg 
865f2d7bc8eb64e454162955d4c35bb2  865f2d7bc8eb64e454162955d4c35bb2.simg
```

Note for default naming belong, we now have a branch and tag.

```
singularity pull shub://doc.fish/vsoch/hello-world
Progress |===================================| 100.0% 
Done. Container is at: vsoch-hello-world-master-latest.simg
```
So for our conflict above, the two containers would be appropriately named:

```
singularity pull shub://vsoch/hello-world:apps --> vsoch-hello-world-master-apps.simg
singularity pull shub://vsoch/hello-world:latest --> vsoch-hello-world-master-latest.simg
```

I've written about the naming and recommendation to always name by hash [here](https://github.com/singularityhub/singularityhub.github.io/wiki/Deploy#naming-your-container), and will also link this issue there.

Attn: @singularityware-admin