### PR TITLE
Make tar file creation reproducible

### DIFF
--- a/libexec/bootstrap-scripts/environment/Makefile.am
+++ b/libexec/bootstrap-scripts/environment/Makefile.am
@@ -41,7 +41,8 @@ environment.tar:
 	ln -sf .singularity.d/actions/run newroot/.run
 	ln -sf .singularity.d/actions/shell newroot/.shell
 	ln -sf .singularity.d/actions/test newroot/.test
-	cd newroot; tar czf ../environment.tar . --owner=0 --group=0
+	[ -n "${SOURCE_DATE_EPOCH}" ] && tar --help|grep -q sort= && taropts="--sort=name --clamp-mtime --mtime @${SOURCE_DATE_EPOCH} --format=gnu" ;\
+	cd newroot; tar c . --owner=0 --group=0 $$taropts | gzip -n9 > ../environment.tar
 	rm -rf newroot
 
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
in order to make package builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Requires GNU tar-1.28 or later to be reproducible
Using gzip -n to not add a timestamp to the .gz header
OTOH I'm not sure if it was really intended to use gzip, because the file is just named .tar and very small anyway - then we could just call tar cf