### PR TITLE
always use 'try' for overlayfs functionality.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -255,20 +255,6 @@ fi
 AC_SUBST(SETNS_SYSCALL)
 
 
-AC_MSG_CHECKING([for overlayfs])
-KVERS=`uname -r`
-if test -f "/lib/modules/$KVERS/modules.dep"; then
-    if grep -q 'overlay.ko' "/lib/modules/$KVERS/modules.dep"; then
-        AC_MSG_RESULT([yes])
-        OVERLAY_FS=1 # this adds it to testing
-    else
-        AC_MSG_RESULT([maybe])
-    fi
-else
-    AC_MSG_RESULT([maybe])
-fi
-
-
 # ---------------------------------------------------------------------
 # PYTHON
 # ---------------------------------------------------------------------
@@ -294,7 +280,6 @@ else
 
 fi
 
-AC_SUBST(OVERLAY_FS)
 AC_SUBST(SINGULARITY_DEFINES)
 
 AC_MSG_CHECKING([--with-slurm])

--- a/configure.ac
+++ b/configure.ac
@@ -260,17 +260,13 @@ KVERS=`uname -r`
 if test -f "/lib/modules/$KVERS/modules.dep"; then
     if grep -q 'overlay.ko' "/lib/modules/$KVERS/modules.dep"; then
         AC_MSG_RESULT([yes])
-        ENABLE_OVERLAY_CONFIG_DEFAULT="yes"
         OVERLAY_FS=1 # this adds it to testing
     else
-        AC_MSG_RESULT([no])
-        ENABLE_OVERLAY_CONFIG_DEFAULT="no"
+        AC_MSG_RESULT([maybe])
     fi
 else
     AC_MSG_RESULT([maybe])
-    ENABLE_OVERLAY_CONFIG_DEFAULT="try"
 fi
-AC_SUBST(ENABLE_OVERLAY_CONFIG_DEFAULT)
 
 
 # ---------------------------------------------------------------------

--- a/src/util/config_defaults.h.in
+++ b/src/util/config_defaults.h.in
@@ -38,7 +38,7 @@
 #define ALLOW_USER_NS_DEFAULT 1
 
 #define ENABLE_OVERLAY "enable overlay"
-#define ENABLE_OVERLAY_DEFAULT "@ENABLE_OVERLAY_CONFIG_DEFAULT@"
+#define ENABLE_OVERLAY_DEFAULT "try"
 
 #define CONFIG_PASSWD "config passwd"
 #define CONFIG_PASSWD_DEFAULT 1

--- a/test.sh.in
+++ b/test.sh.in
@@ -29,8 +29,14 @@ sysconfdir="@sysconfdir@"
 localstatedir="@localstatedir@"
 bindir="@bindir@"
 
-SINGULARITY_OVERLAY_FS="@OVERLAY_FS@"
 SINGULARITY_USER_NS="@USER_NS@"
+SINGULARITY_OVERLAY_FS="0"
+KVERS=`uname -r`
+if test -f "/lib/modules/$KVERS/modules.dep"; then
+    if grep -q 'overlay.ko' "/lib/modules/$KVERS/modules.dep"; then
+        SINGULARITY_OVERLAY_FS="1"
+    fi
+fi
 
 SINGULARITY_libexecdir="$libexecdir"
 SINGULARITY_sysconfdir="$sysconfdir"


### PR DESCRIPTION
Finding the module on build host is neither a guarantee it will
exist in the runtime environment, nor is absence of the module
a guarantee overlayfs is not supported (may be compiled into
kernel).
So don't deduce runtime environment from build host,
but always use the new 'try' feature.
For testing, activate that if the module is found.

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>

**This fixes or addresses the following GitHub issues:**

- Ref: #1044


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin

Note: I did not run `make test`, that makes no sense on my machine, since I have overlayfs support compiled in. 