### PR TITLE
Add/python file logging

### DIFF
--- a/libexec/bootstrap-scripts/environment/test
+++ b/libexec/bootstrap-scripts/environment/test
@@ -7,7 +7,7 @@ for script in /.singularity.d/env/*.sh; do
 done
 
 
-if test -z "${SINGULARITY_APPNAME:-}"; then
+if test -n "${SINGULARITY_APPNAME:-}"; then
 
     if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test"; then
         exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test" "$@"

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -34,6 +34,8 @@ The following levels do nothing (quiet)
 
 0
 
+SINGULARITY_LOGFILE, when defined, outputs to the file with level DEBUG
+
 Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 
 "Singularity" Copyright (c) 2016, The Regents of the University of California,
@@ -55,6 +57,7 @@ perform publicly and display publicly, and to permit other to do so.
 
 import os
 import sys
+import io
 
 ABRT = -4
 ERROR = -3
@@ -71,8 +74,9 @@ DEBUG = 5
 class SingularityMessage:
 
     def __init__(self, MESSAGELEVEL=None):
-        self.level = get_logging_level()
         self.history = []
+        self.logfile = os.environ.get("SINGULARITY_LOGFILE")
+        self.level = get_logging_level()
         self.errorStream = sys.stderr
         self.outputStream = sys.stdout
         self.colorize = self.useColor()
@@ -139,14 +143,12 @@ class SingularityMessage:
             return True
         return False
 
-    def emit(self, level, message, prefix=None):
-        '''emit is the main function to print the message
-        optionally with a prefix
-        :param level: the level of the message
-        :param message: the message to print
-        :param prefix: a prefix for the message
-        '''
 
+    def format(self, level, message, prefix=None):
+        ''' format will take a message and an output
+            level and given that a file is not being used
+            format the message (color and add the prefix)
+        '''
         if prefix is not None:
             prefix = self.addColor(level, "%s " % (prefix))
         else:
@@ -158,10 +160,24 @@ class SingularityMessage:
 
         if not message.endswith('\n'):
             message = "%s\n" % (message)
+        return message
+
+
+    def emit(self, level, message, prefix=None):
+        '''emit is the main function to print the message
+        optionally with a prefix
+        :param level: the level of the message
+        :param message: the message to print
+        :param prefix: a prefix for the message
+        '''
+        message = self.format(level, message, prefix)
 
         # If the level is quiet, only print to error
         if self.level == QUIET:
             pass
+
+        elif self.logfile is not None:
+            self._emit_file(message)
 
         # Otherwise if in range print to stdout and stderr
         elif self.isEnabledFor(level):
@@ -172,6 +188,21 @@ class SingularityMessage:
 
         # Add all log messages to history
         self.history.append(message)
+
+    def _emit_file(self, level, message, prefix=""):
+        '''emit writes a message to the logfile, not including
+           special coloring or formatting. The log level should
+           be set to DEBUG (5). If the file doesn't exist, we exit.
+        '''
+        if self.logfile is not None:
+            if not os.path.exists(self.logfile):
+                print('ERROR: Logfile %s is not found.')
+                sys.exit(1)
+
+        # Otherwise write to file, DEBUG always in range
+        if self.isEnabledFor(level):
+            with io.open(self.logfile, 'a') as filey:
+                filey.write(message)
 
     def write(self, stream, message):
         '''write will write a message to a stream,
@@ -275,34 +306,37 @@ class SingularityMessage:
         return True
 
 
-def get_logging_level():
-    '''get_logging_level will configure a logging to
-    standard out based on the user's selected level,
-    which should be in an environment variable called
-    SINGULARITY_MESSAGELEVEL. if SINGULARITY_MESSAGELEVEL
-    is not set, the maximum level (5) is assumed (all
-    messages).
+    def get_logging_level():
+        '''get_logging_level will configure a logging to
+        standard out based on the user's selected level,
+        which should be in an environment variable called
+        SINGULARITY_MESSAGELEVEL. if SINGULARITY_MESSAGELEVEL
+        is not set, the maximum level (5) is assumed (all
+        messages).
 
-    #define ABRT -4
-    #define ERROR -3
-    #define WARNING -2
-    #define LOG -1
-    #define INFO 1
+        #define ABRT -4
+        #define ERROR -3
+        #define WARNING -2
+        #define LOG -1
+        #define INFO 1
 
-    implied define: QUIET 0
+        implied define: QUIET 0
 
-    #define VERBOSE 2
-    #define VERBOSE1 2
-    #define VERBOSE2 3
-    #define VERBOSE3 4
-    #define DEBUG 5
-    '''
+        #define VERBOSE 2
+        #define VERBOSE1 2
+        #define VERBOSE2 3
+        #define VERBOSE3 4
+        #define DEBUG 5
 
-    return int(os.environ.get("SINGULARITY_MESSAGELEVEL", 5))
+        '''
+        # SINGULARITY_LOGFILE --> DEBUG
+        if self.logfile is not None:
+            return 5
+        return int(os.environ.get("SINGULARITY_MESSAGELEVEL", 5))
 
 
 def get_user_color_preference():
-    COLORIZE = os.environ.get('SINGULARITY_COLORIZE', None)
+    COLORIZE = os.environ.get('SINGULARITY_COLORIZE')
     if COLORIZE is not None:
         COLORIZE = convert2boolean(COLORIZE)
     return COLORIZE

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -167,6 +167,11 @@ class SingularityMessage:
 
         if not message.endswith('\n'):
             message = "%s\n" % (message)
+
+        # Ensure proper format
+        if isinstance(message, bytes):
+            message = message.decode('utf-8')
+
         return message
 
 
@@ -214,8 +219,6 @@ class SingularityMessage:
         '''write will write a message to a stream,
         first checking the encoding
         '''
-        if isinstance(message, bytes):
-            message = message.decode('utf-8')
         stream.write(message)
 
     def get_logs(self, join_newline=True):

--- a/libexec/python/tests/test_base.py
+++ b/libexec/python/tests/test_base.py
@@ -37,7 +37,7 @@ VERSION = sys.version_info[0]
 print("*** PYTHON VERSION %s BASE TESTING START ***" % VERSION)
 
 
-class TestShell(TestCase):
+class TestBase(TestCase):
 
     def setUp(self):
 

--- a/libexec/python/tests/test_message.py
+++ b/libexec/python/tests/test_message.py
@@ -1,0 +1,74 @@
+'''
+
+test_base.py: Test client initialized with python modules
+
+Copyright (c) 2017, Vanessa Sochat. All rights reserved.
+
+"Singularity" Copyright (c) 2016, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+
+This software is licensed under a customized 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
+
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights. As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so.
+
+'''
+
+import os
+import re
+import sys
+import tarfile
+sys.path.append('..')  # noqa
+
+from message import SingularityMessage
+from sutils import read_file
+from unittest import TestCase
+import shutil
+import tempfile
+
+VERSION = sys.version_info[0]
+
+print("*** PYTHON VERSION %s BASE TESTING START ***" % VERSION)
+
+
+class TestMessage(TestCase):
+
+    def setUp(self):
+        self.logfile = tempfile.mktemp()
+        
+    def tearDown(self):
+        os.remove(self.logfile)
+
+    def test_logger(self):
+        print('Testing message not written to file')
+        bot = SingularityMessage()
+        self.assertTrue(bot.logfile==None)
+        bot.debug("This is a message log, not a message dog.")
+        self.assertTrue(os.path.exists(self.logfile)==False)
+
+        print('Testing that message is written to created logfile')
+        os.environ['SINGULARITY_LOGFILE'] = self.logfile
+        bot = SingularityMessage()
+        self.assertEqual(bot.logfile, self.logfile)
+        message = 'This is a message log, not a message dog.'
+        bot.debug(message)
+        self.assertTrue(os.path.exists(self.logfile))
+        content = read_file(bot.logfile)
+        self.assertTrue("DEBUG %s\n" % message in content) 
+
+        print('Testing that message is appended to existing logfile')
+        message = 'Line number two.'
+        bot.info(message)
+        content = read_file(bot.logfile)   
+        self.assertTrue("%s\n" % message in content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -27,35 +27,37 @@ test_init "Checking Python unit tests"
 cd ../libexec/python
 
 if which python2 >/dev/null 2>&1; then
-    stest 0 python2 -m unittest tests.test_json
-    stest 0 python2 -m unittest tests.test_helpers
     stest 0 python2 -m unittest tests.test_base
     stest 0 python2 -m unittest tests.test_core
-    stest 0 python2 -m unittest tests.test_docker_import
-    stest 0 python2 -m unittest tests.test_docker_api
-    stest 0 python2 -m unittest tests.test_docker_tasks
-    stest 0 python2 -m unittest tests.test_shub_pull
-    stest 0 python2 -m unittest tests.test_shub_api
     stest 0 python2 -m unittest tests.test_custom_cache
     stest 0 python2 -m unittest tests.test_default_cache
     stest 0 python2 -m unittest tests.test_disable_cache
+    stest 0 python2 -m unittest tests.test_docker_api
+    stest 0 python2 -m unittest tests.test_docker_import
+    stest 0 python2 -m unittest tests.test_docker_tasks
+    stest 0 python2 -m unittest tests.test_helpers
+    stest 0 python2 -m unittest tests.test_json
+    stest 0 python2 -m unittest tests.test_message
+    stest 0 python2 -m unittest tests.test_shub_api
+    stest 0 python2 -m unittest tests.test_shub_pull
 else
     echo "Skipping python2 tests: not installed"
 fi
 
 if which python3 >/dev/null 2>&1; then
-    stest 0 python3 -m unittest tests.test_json
-    stest 0 python3 -m unittest tests.test_helpers
     stest 0 python3 -m unittest tests.test_base
     stest 0 python3 -m unittest tests.test_core
-    stest 0 python3 -m unittest tests.test_docker_import
-    stest 0 python3 -m unittest tests.test_docker_api
-    stest 0 python3 -m unittest tests.test_docker_tasks
-    stest 0 python3 -m unittest tests.test_shub_pull
-    stest 0 python3 -m unittest tests.test_shub_api
     stest 0 python3 -m unittest tests.test_custom_cache
     stest 0 python3 -m unittest tests.test_default_cache
     stest 0 python3 -m unittest tests.test_disable_cache
+    stest 0 python3 -m unittest tests.test_docker_api
+    stest 0 python3 -m unittest tests.test_docker_import
+    stest 0 python3 -m unittest tests.test_docker_tasks
+    stest 0 python3 -m unittest tests.test_helpers
+    stest 0 python3 -m unittest tests.test_json
+    stest 0 python3 -m unittest tests.test_message
+    stest 0 python3 -m unittest tests.test_shub_api
+    stest 0 python3 -m unittest tests.test_shub_pull
 else
     echo "Skipping python3 tests: not installed"
 fi

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -29,9 +29,6 @@ cd ../libexec/python
 if which python2 >/dev/null 2>&1; then
     stest 0 python2 -m unittest tests.test_base
     stest 0 python2 -m unittest tests.test_core
-    stest 0 python2 -m unittest tests.test_custom_cache
-    stest 0 python2 -m unittest tests.test_default_cache
-    stest 0 python2 -m unittest tests.test_disable_cache
     stest 0 python2 -m unittest tests.test_docker_api
     stest 0 python2 -m unittest tests.test_docker_import
     stest 0 python2 -m unittest tests.test_docker_tasks
@@ -40,6 +37,9 @@ if which python2 >/dev/null 2>&1; then
     stest 0 python2 -m unittest tests.test_message
     stest 0 python2 -m unittest tests.test_shub_api
     stest 0 python2 -m unittest tests.test_shub_pull
+    stest 0 python2 -m unittest tests.test_custom_cache
+    stest 0 python2 -m unittest tests.test_default_cache
+    stest 0 python2 -m unittest tests.test_disable_cache
 else
     echo "Skipping python2 tests: not installed"
 fi
@@ -47,9 +47,6 @@ fi
 if which python3 >/dev/null 2>&1; then
     stest 0 python3 -m unittest tests.test_base
     stest 0 python3 -m unittest tests.test_core
-    stest 0 python3 -m unittest tests.test_custom_cache
-    stest 0 python3 -m unittest tests.test_default_cache
-    stest 0 python3 -m unittest tests.test_disable_cache
     stest 0 python3 -m unittest tests.test_docker_api
     stest 0 python3 -m unittest tests.test_docker_import
     stest 0 python3 -m unittest tests.test_docker_tasks
@@ -58,6 +55,9 @@ if which python3 >/dev/null 2>&1; then
     stest 0 python3 -m unittest tests.test_message
     stest 0 python3 -m unittest tests.test_shub_api
     stest 0 python3 -m unittest tests.test_shub_pull
+    stest 0 python3 -m unittest tests.test_custom_cache
+    stest 0 python3 -m unittest tests.test_default_cache
+    stest 0 python3 -m unittest tests.test_disable_cache
 else
     echo "Skipping python3 tests: not installed"
 fi


### PR DESCRIPTION
**Description of the Pull Request (PR):**

# Python File Logging
This PR is intended to support @bauerm97 work in progress to allow for logging to a file with the command:

```
singularity run --log /tmp/pancakes.txt container.img
```

specifically, adding the same logic to the python logger to ensure that content is appended to the file. The logic works as follows:

1. Given that the environmentvariable `SINGULARITY_LOGFILE` is found, the logger captures it. This (I think) means that the code that @bauerm97 is working on will export it for python to find.
2. Given `SINGULARITY_LOGFILE`, the level is automatically set to `DEBUG`
3. If the logfile doesn't exist, it is created
4. Subsequent logging commands are appended to the file.

Here is an example cat of a logfile with three messages printed:
```
cat /tmp/tmp01byskrw 
DEBUG This is a message log, not a message dog.
DEBUG Another thing.
WARNING A warning!
```

## Concern - Atomicity
My primary concern is that of atomic writing to file. We want to be sure that two processes aren't trying to grab the same file at the same time. This shouldn't be a concern for the functions we have that use multiprocessing (they stream the progress bars to stdout) but it could be a concern if a single logfile is used across multiple containers. The traditional approach for doing this would be to write to a temporary version of the file, and then copy to the actual file name only when finished (this is how we download Docker layers), but this still would have race conditions if two containers using the same file copy different versions (and then some content is missing depending on time of copy). 

So we should chat about how to avoid this case. Either it might be that the user provides a prefix and then new processes (different containers) grab a different prefix, or we explicitly say the log file i intended for logging one container process (so there can't be race conditions).

## Logger History
Also notice that (and I added this a long time ago) the logger has a complete history of himself. First let's log some things:

```
bot.debug("This is a message log, not a message dog.")
bot.debug('Another thing.')
bot.warning('A warning!')
```
Regardless of where that is printing (screen or file) I can, at any point, ask to see the entire history (it's in a list)

```
print(bot.history)
  ['DEBUG This is a message log, not a message dog.\n',
   'DEBUG Another thing.\n',
    'WARNING A warning!\n']
```
which of course formats when I join the list

```
print(''.join(bot.history))
DEBUG This is a message log, not a message dog.
DEBUG Another thing.
WARNING A warning!
```

This is useful potentially for two reasons. 1 - we can drastically reduce the number of times needed to write (at least for python) if we do a dump of everything at once, after it's done. Given that any error arises that would have excited, we make sure to print right before exit.  This might help with the race condition issue, if one exists, although it wouldn't fix it. 2 - it means that we could potentially expose some "on demand" generation of a log. This probably doesn't make a lot of sense now, but imagine that you have a container instance and you want to run the equivalent of "docker-compose logs" to see logs.

## Tests
I also made a new set of tests for the message logger, and made the python tests in ABC order. It was bothering me, lol.

# Fixing bug in `test`
In this PR I'm also fixing the bug found in the "test" script this morning. After discussion, we can go about integration in any way - this branch merged before @bauerm97 will be working fine even without the bash export.

# Other Things to Think About
This idea of logging is really interesting because it opens up the door to different use cases. For example, if a container is running as a service, it might actually want to send log messages to a web endpoint, and so the user would specify the endpoint and they would be POSTed. We might want to send more of status messages about state - like "the container run is started / done / errored" or "the container is started / stopped" and that would fit very well with our current messages module too.

Attn: @singularityware-admin
