### PR TITLE
Make tar file creation reproducible

### DIFF
--- a/libexec/bootstrap-scripts/environment/Makefile.am
+++ b/libexec/bootstrap-scripts/environment/Makefile.am
@@ -41,7 +41,8 @@ environment.tar:
 	ln -sf .singularity.d/actions/run newroot/.run
 	ln -sf .singularity.d/actions/shell newroot/.shell
 	ln -sf .singularity.d/actions/test newroot/.test
-	cd newroot; tar czf ../environment.tar . --owner=0 --group=0
+	[ -n "${SOURCE_DATE_EPOCH}" ] && tar --help|grep -q sort= && taropts="--sort=name --clamp-mtime --mtime @${SOURCE_DATE_EPOCH} --format=gnu" ;\
+	cd newroot; tar c . --owner=0 --group=0 $$taropts | gzip -n9 > ../environment.tar
 	rm -rf newroot
 
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
See also #1083 

Make tar file creation reproducible
in order to make package builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Requires GNU tar-1.28 or later to be reproducible
Using gzip -n to not add a timestamp to the .gz header

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a openSUSE package build
- [ ] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
