### PR TITLE
Allow empty namespaces for docker:// images

### DIFF
--- a/.travis/centos_run
+++ b/.travis/centos_run
@@ -7,11 +7,19 @@ if [ "$OS_VERSION" = "6" ]; then
     exit
 fi
 
-
-docker run --privileged -d -ti -e "container=docker"  -v /sys/fs/cgroup:/sys/fs/cgroup -v `pwd`:/build:rw  centos:${OS_VERSION}   /usr/sbin/init
+# Mount /var/run/docker.sock and set --network=host so we can call docker from inside
+# cause some tests need it. Cannot mount to /var/run/docker.sock inside cause CentOS
+# /usr/sbin/init mounts another overlayfs on top of it
+docker run --privileged -d -ti -e "container=docker" -v /var/run/docker.sock:/docker.sock --network=host \
+       -v /sys/fs/cgroup:/sys/fs/cgroup -v `pwd`:/build:rw  centos:${OS_VERSION}   /usr/sbin/init
 DOCKER_CONTAINER_ID=$(docker ps | grep centos | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
-docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -exc "cd /build;.travis/rpmbuild_test $OS_VERSION"
+docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -exc "
+    export DOCKER_HOST=unix:///docker.sock
+    chmod o+rw /docker.sock &&
+    cd /build &&
+    .travis/rpmbuild_test $OS_VERSION
+"
 docker ps -a
 docker stop $DOCKER_CONTAINER_ID
 docker rm -v $DOCKER_CONTAINER_ID

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -5,7 +5,7 @@
 OS_VERSION="$1"
 
 # build and install
-yum install -y libtool rpm-build make squashfs-tools
+yum install -y libtool rpm-build make squashfs-tools docker
 ./autogen.sh
 ./configure
 make dist

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -5,7 +5,7 @@
 OS_VERSION="$1"
 
 # build and install
-yum install -y libtool rpm-build make squashfs-tools docker
+yum install -y libtool rpm-build make squashfs-tools
 ./autogen.sh
 ./configure
 make dist
@@ -19,7 +19,7 @@ fi
 
 # Install python 3 and pylint
 yum install -y epel-release
-yum install -y python34 python34-pip python34-setuptools
+yum install -y python34 python34-pip python34-setuptools docker
 yum install -y pylint
 
 # run the test suite
@@ -28,5 +28,6 @@ sed -i 's,^prefix=.*,prefix=/usr,' test.sh
 sed -i 's,^sysconfdir=.*,sysconfdir=/etc,' test.sh
 sed -i 's,^localstatedir=.*,localstatedir=/var,' test.sh
 useradd testuser
+echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 su testuser -c "make test"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,3 +34,4 @@
     - Ralph Castain <rhc@open-mpi.org>
     - Rémy Dernat <remy.dernat@umontpellier.fr>
     - Yaroslav Halchenko <debian@onerussian.com>
+    - Daniele Tamino <daniele.tamino@gmail.com>

--- a/libexec/bootstrap-scripts/deffile-driver-docker.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-docker.sh
@@ -51,7 +51,9 @@ if [ ! -z "${REGISTRY:-}" ]; then
     export REGISTRY
 fi
 
-if [ ! -z "${NAMESPACE:-}" ]; then
+# Note: NAMESPACE can be set to an empty string, and that's a valid namespace
+# for Docker (not so for shub://)
+if [ -n "${NAMESPACE+set}" ]; then
     message DEBUG "Custom Docker Namespace 'Namespace:' ${NAMESPACE}.\n"
     export NAMESPACE
 fi

--- a/libexec/functions
+++ b/libexec/functions
@@ -47,6 +47,16 @@ message() {
     fi
     shift
     shift
+
+    # if level is symbolic, get a numeric value
+    case "$LEVEL" in
+	INFO) LEVNUM=1 ;;
+	VERBOSE) LEVNUM=4 ;;
+	DEBUG) LEVNUM=5 ;;
+        [1-5]) LEVNUM="$LEVEL" ;;
+        *) LEVNUM=1 ;; # default to INFO
+    esac
+
     case "$LEVEL" in
         e|error|E|ERROR)
             tput -Txterm setaf 1 2>/dev/null
@@ -64,7 +74,7 @@ message() {
             tput -Txterm sgr0 2>/dev/null
         ;;
         1|INFO)
-            if [ "$LEVEL" -le "$SINGULARITY_MESSAGELEVEL" ]; then
+            if [ "$LEVNUM" -le "$SINGULARITY_MESSAGELEVEL" ]; then
                 printf "$MESSAGE" "$@"
             fi
         ;;
@@ -84,7 +94,7 @@ message() {
             tput -Txterm sgr0 2>/dev/null
         ;;
         [2-5]|VERBOSE|DEBUG)
-            if [ "$LEVEL" -le "$SINGULARITY_MESSAGELEVEL" ]; then
+            if [ "$LEVNUM" -le "$SINGULARITY_MESSAGELEVEL" ]; then
                 printf "$MESSAGE" "$@" 1>&2
             fi
         ;;

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -50,7 +50,8 @@ def getenv(variable_key, default=None, required=False, silent=False):
         sys.exit(1)
 
     if silent:
-        bot.verbose2("%s found" % (variable_key))
+        if variable is not None:
+            bot.verbose2("%s found" % (variable_key))
     else:
         if variable is not None:
             bot.verbose2("%s found as %s" % (variable_key, variable))

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -93,9 +93,8 @@ class DockerApiConnection(ApiConnection):
         '''
         if sep is None:
             sep = "-"
-        image_uri = "%s%s%s%s%s" % (self.registry, sep,
-                                    self.namespace, sep,
-                                    self.repo_name)
+
+        image_uri = "%s%s%s" % (self.registry, sep, self.repo_name)
 
         if self.version is not None:
             image_uri = "%s@%s" % (image_uri, self.version)
@@ -133,9 +132,12 @@ class DockerApiConnection(ApiConnection):
         or name of docker image'''
 
         image = parse_image_uri(image=image, uri="docker://")
-        self.repo_name = image['repo_name']
+        if len(image['namespace']) > 0:
+            self.repo_name = "%s/%s" % (image['namespace'], image['repo_name'])
+        else:
+            self.repo_name = image['repo_name']
+
         self.repo_tag = image['repo_tag']
-        self.namespace = image['namespace']
         self.version = image['version']
         self.registry = image['registry']
         self.update_token()
@@ -196,10 +198,8 @@ class DockerApiConnection(ApiConnection):
             self.update_headers(token)
 
         except Exception:
-            msg = "Error getting token for repository "
-            msg += "%s/%s, exiting." % (self.namespace,
-                                        self.repo_name)
-            bot.error(msg)
+            bot.error("Error getting token for repository %s, exiting."
+                      % self.repo_name)
             sys.exit(1)
 
     def get_images(self, manifest=None):
@@ -259,10 +259,9 @@ class DockerApiConnection(ApiConnection):
 
         registry = add_http(registry)  # make sure we have a complete url
 
-        base = "%s/%s/%s/%s/tags/list" % (registry,
-                                          self.api_version,
-                                          self.namespace,
-                                          self.repo_name)
+        base = "%s/%s/%s/tags/list" % (registry,
+                                       self.api_version,
+                                       self.repo_name)
 
         bot.verbose("Obtaining tags: %s" % base)
 
@@ -294,10 +293,9 @@ class DockerApiConnection(ApiConnection):
         # make sure we have a complete url
         registry = add_http(registry)
 
-        base = "%s/%s/%s/%s/manifests" % (registry,
-                                          self.api_version,
-                                          self.namespace,
-                                          self.repo_name)
+        base = "%s/%s/%s/manifests" % (registry,
+                                       self.api_version,
+                                       self.repo_name)
 
         # First priority given to calling function
         if version is not None:
@@ -324,9 +322,8 @@ class DockerApiConnection(ApiConnection):
             # If the call fails, give the user a list of acceptable tags
             tags = self.get_tags()
             print("\n".join(tags))
-            repo_uri = "%s/%s:%s" % (self.namespace,
-                                     self.repo_name,
-                                     self.repo_tag)
+            repo_uri = "%s:%s" % (self.repo_name,
+                                  self.repo_tag)
 
             bot.error("Error getting manifest for %s, exiting." % repo_uri)
             sys.exit(1)
@@ -340,7 +337,7 @@ class DockerApiConnection(ApiConnection):
         '''
         bot.debug('Updating manifests.')
 
-        if self.repo_name is None and self.namespace is None:
+        if self.repo_name is None:
             bot.error("Insufficient metadata to get manifest.")
             sys.exit(1)
 
@@ -400,12 +397,11 @@ class DockerApiConnection(ApiConnection):
         # make sure we have a complete url
         registry = add_http(registry)
 
-        # The <name> variable is the namespace/repo_name
-        base = "%s/%s/%s/%s/blobs/%s" % (registry,
-                                         self.api_version,
-                                         self.namespace,
-                                         self.repo_name,
-                                         image_id)
+        # The <name> variable is repo_name
+        base = "%s/%s/%s/blobs/%s" % (registry,
+                                      self.api_version,
+                                      self.repo_name,
+                                      image_id)
         bot.verbose("Downloading layers from %s" % base)
 
         if download_folder is None:

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -208,7 +208,7 @@ def parse_image_uri(image,
     if uri == "docker://":
         uri_regexes = [ _docker_uri_re ]
 
-    image = remove_image_uri(image, uri);
+    image = remove_image_uri(image, uri)
 
     for r in uri_regexes:
         match = r.match(image)
@@ -259,7 +259,6 @@ def parse_image_uri(image,
               'namespace': namespace,
               'repo_name': repo_name,
               'repo_tag': repo_tag,
-              'version': version,
-              }
+              'version': version }
 
     return parsed

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -59,7 +59,8 @@ def get_image_uri(image, quiet=False):
 
 
 def remove_image_uri(image, image_uri=None, quiet=False):
-    '''remove_image_uri will return just the image name
+    '''remove_image_uri will return just the image name.
+    ::note this will also remove all spaces from the uri.
     '''
     if image_uri is None:
         image_uri = get_image_uri(image, quiet=quiet)
@@ -70,24 +71,111 @@ def remove_image_uri(image, image_uri=None, quiet=False):
         image = image.replace(image_uri, '')
     return image
 
+# Quick python regex syntax reference for referring back to matched groups:
+# (?:stuff) matches stuff, just like (stuff) but won't appear in m.groups()
+# (?P<name>stuff) matches stuff, and can be retrieved by m.group('name')
+
+# Regular expression used to parse docker:// uris, which have slightly
+# different rules than shub://, namely:
+# - registry must include :port or a . in the name (e.g. docker.io)
+# - namespace is completely optional
+_docker_uri_re = re.compile(
+    # Optionally match a registry if it contains a '.' or a ':',
+    # may contain any character but '/', and terminated by '/'
+    # Note the use of (?:) to make sure the group "registry" does
+    # not contain the / at the end. Also, registry includes the port
+    "(?:(?P<registry>[^/]+[.:][^/]*)/)?"
+    # Optionally match a namespace, matched as any characters but
+    # ':' or '/', followed by '/'. Note the match will include the final /
+    "(?P<namespace>(?:[^:@/]+/)+)?"
+    # Match a repo name, mandatory. Any character but ':' or '/'
+    "(?P<repo>[^:@/]+)"
+    # Match :tag (optional)
+    "(?::(?P<tag>[^:]+))?"
+    # Match @digest (optional)
+    "(?:@(?P<version>[^@]+))?"
+    # we need to match the whole string, make sure there's no leftover
+    "$"
+    )
+
+
+# Reduced regex, matches registry:port/repo or registry.com/repo
+# (registry must include : or .) with optional tag or version.
+# Also matches repo only, e.g. reponame[:tag|@version].
+# This is tried before _default_uri_re, so that namespace/repo takes
+# precedence over registry/repo.
+_reduced_uri_no_ns_re = re.compile(
+    # match a registry, optional, may include a : or .
+    "(?:(?P<registry>[^/]+[.:][^/]*)/)?"
+    # Match a repo name, mandatory. Any character but ':' or '/'
+    "(?P<repo>[^:@/]+)"
+    # Match :tag (optional)
+    "(?::(?P<tag>[^:]+))?"
+    # Match @digest (optional)
+    "(?:@(?P<version>[^@]+))?"
+    # we need to match the whole string, make sure there's no leftover
+    "$"
+    # dummy group that will never match, but will add a 'namespace' entry
+    "(?P<namespace>.)?"
+    )
+
+# Regular expression used to parse other images and uris (e.g. shub://)
+# This version expects a namespace, and won't match otherwise
+# but the registry is optional. In cases like a/b/c, the first component
+# is taken to be the registry in this regex.
+_default_uri_re = re.compile(
+    # must be either registry[:port]/namespace[/more/namespaces]/repo
+    # or namespace/repo, at least one namespace is required
+    # Match registry, if specified
+    "(?:(?P<registry>[^/]+)/)?"
+    # Match a namespace, matched as any characters but
+    # ':' or '@', ended by a '/'. Note the match will include the final /
+    "(?P<namespace>(?:[^:@/]+/)+)"
+    # Match a repo name, mandatory. Any character but ':' or '/'
+    "(?P<repo>[^:@/]+)"
+    # Match :tag (optional)
+    "(?::(?P<tag>[^:]+))?"
+    # Match @digest (optional)
+    "(?:@(?P<version>[^@]+))?"
+    # we need to match the whole string, make sure there's no leftover
+    "$"
+    )
+
 def parse_image_uri(image,
                     uri=None,
                     quiet=False,
                     default_registry=None,
                     default_namespace=None,
                     default_tag=None):
+    '''parse_image_uri will parse a docker or shub uri and return
+    a json structure with a registry, repo name, tag, namespace and version.
+    Tag and version are optional, namespace is optional for docker:// uris.
+    URIs are of this general form:
+        myuri://[registry.com:port/][namespace/nested/]repo[:tag][@version]
+    (parts in [] are optional)
+    Parsing rules are slightly different if the uri is a docker:// uri:
+    - registry must include a :port or a . in its name, else will be parsed
+      as a namespace. For non-docker uris, instead, if there are three or
+      more parts separated by /, the first one is taken to be the registry
+    - namespace can be empty if a registry is specified, else default
+      namespace will be used (e.g. docker://registry.com/repo:tag).
+      For non-docker uris, namespace cannot be empty and default will be used
 
-    '''parse_image_uri will return a json structure with a registry,
-    repo name, tag, and namespace, intended for Docker.
     :param image: the string provided on command line for
-                  the image name, eg: ubuntu:latest
-    :param uri: the uri (eg, docker:// to remove), default uses ""
+                  the image name, eg: ubuntu:latest or
+                  docker://local.registry/busybox@12345
+    :param uri: the uri type (eg, docker://), default autodetects
     ::note uri is maintained as variable so we have some control over allowed
+    :param quiet: If True, don't show verbose messages with the parsed values
+    :default_registry: Which registry to use if image doesn't contain one.
+                       if None, use defaults.REGISTRY
+    :default_namespace: Which namespace to use if image doesn't contain one.
+                       if None, use defaults.NAMESPACE. Also, check out the
+                       note above about docker:// and empty namespaces.
+    :default_tag: Which tag to use if image doesn't contain one.
+                       if None, use defaults.REPO_TAG
     :returns parsed: a json structure with repo_name, repo_tag, and namespace
     '''
-
-    if uri is None:
-        uri = ""
 
     # Default to most common use case, Docker
     if default_registry is None:
@@ -99,63 +187,66 @@ def parse_image_uri(image,
     if default_tag is None:
         default_tag = TAG
 
-    # Be absolutely sure there are not comments
+    # if user gave custom registry / namespace, make them the default
+    if CUSTOM_NAMESPACE is not None:
+        default_namespace = CUSTOM_NAMESPACE
+
+    if CUSTOM_REGISTRY is not None:
+        default_registry = CUSTOM_REGISTRY
+
+    # candidate regex for matching, in order of preference
+    uri_regexes = [ _reduced_uri_no_ns_re,
+                    _default_uri_re ]
+
+    # Be absolutely sure there are no comments
     image = image.split('#')[0]
 
-    # Get rid of any uri, and split the tag
-    image = image.replace(uri, '')
+    if not uri:
+        uri = get_image_uri(image, quiet=True)
 
-    # Does the uri have a digest or Github tag (version)?
-    image = image.split('@')
-    version = None
-    if len(image) == 2:
-        version = image[1]
+    # docker images require slightly different rules
+    if uri == "docker://":
+        uri_regexes = [ _docker_uri_re ]
 
-    image = image[0]
-    image = image.split(':')
+    image = remove_image_uri(image, uri);
 
-    # If there are three parts, we have port and tag
-    if len(image) == 3:
-        repo_tag = image[2]
-        image = "%s:%s" % (image[0], image[1])
+    for r in uri_regexes:
+        match = r.match(image)
+        if match:
+            break
 
-    # If there are two parts, we have port or tag
-    elif len(image) == 2:
-        # If there isn't a slash in second part, we have a tag
-        if image[1].find("/") == -1:
-            repo_tag = image[1]
-            image = image[0]
-        # Otherwise we have a port and we merge the path
+    if not match:
+        bot.error('Could not parse image "%s"! Exiting.' % image)
+        sys.exit(1)
+
+    registry = match.group('registry')
+    namespace = match.group('namespace')
+    repo_name = match.group('repo')
+    repo_tag = match.group('tag')
+    version = match.group('version')
+
+    if namespace:
+        # strip trailing /
+        namespace = namespace.rstrip('/')
+
+    # repo_name is required and enforced by the re (in theory)
+    # if not provided, re should not match
+    assert(repo_name)
+
+    # replace empty fields with defaults
+    if not namespace:
+        # for docker, if a registry was specified, don't
+        # inject a namespace in between
+        if registry and uri == "docker://":
+            namespace = ""
         else:
-            image = "%s:%s" % (image[0], image[1])
-            repo_tag = default_tag
-    else:
-        image = image[0]
+            namespace = default_namespace
+    if not registry:
+        registry = default_registry
+    if not repo_tag:
         repo_tag = default_tag
+    # version is not mandatory, don't check that
 
-    # Now look for registry, namespace, repo
-    image = image.split('/')
-
-    if len(image) > 2:
-        registry = image[0]
-        namespace = "/".join(image[1:-1])
-        repo_name = image[-1]
-
-    elif len(image) == 2:
-        registry = default_registry
-        namespace = image[0]
-        repo_name = image[1]
-
-    else:
-        registry = default_registry
-        namespace = default_namespace
-        repo_name = image[0]
-
-    # if user gave custom registry / namespace, use
-    if CUSTOM_NAMESPACE is not None:
-        namespace = CUSTOM_NAMESPACE
-    if CUSTOM_REGISTRY is not None:
-        registry = CUSTOM_REGISTRY
 
     if not quiet:
         bot.verbose("Registry: %s" % registry)
@@ -167,15 +258,8 @@ def parse_image_uri(image,
     parsed = {'registry': registry,
               'namespace': namespace,
               'repo_name': repo_name,
-              'repo_tag': repo_tag}
-
-    # No field should be empty
-    for fieldname, value in parsed.items():
-        if len(value) == 0:
-            bot.error("%s found empty, check uri! Exiting." % value)
-            sys.exit(1)
-
-    # Version is not required
-    parsed['version'] = version
+              'repo_tag': repo_tag,
+              'version': version,
+              }
 
     return parsed

--- a/libexec/python/shell.py
+++ b/libexec/python/shell.py
@@ -81,19 +81,19 @@ def remove_image_uri(image, image_uri=None, quiet=False):
 # - namespace is completely optional
 _docker_uri_re = re.compile(
     # Optionally match a registry if it contains a '.' or a ':',
-    # may contain any character but '/', and terminated by '/'
+    # may contain any character but '/' or '@', and terminated by '/'
     # Note the use of (?:) to make sure the group "registry" does
     # not contain the / at the end. Also, registry includes the port
-    "(?:(?P<registry>[^/]+[.:][^/]*)/)?"
+    "(?:(?P<registry>[^/@]+[.:][^/@]*)/)?"
     # Optionally match a namespace, matched as any characters but
     # ':' or '/', followed by '/'. Note the match will include the final /
     "(?P<namespace>(?:[^:@/]+/)+)?"
     # Match a repo name, mandatory. Any character but ':' or '/'
     "(?P<repo>[^:@/]+)"
     # Match :tag (optional)
-    "(?::(?P<tag>[^:]+))?"
+    "(?::(?P<tag>[^:@]+))?"
     # Match @digest (optional)
-    "(?:@(?P<version>[^@]+))?"
+    "(?:@(?P<version>.+))?"
     # we need to match the whole string, make sure there's no leftover
     "$"
     )
@@ -105,14 +105,14 @@ _docker_uri_re = re.compile(
 # This is tried before _default_uri_re, so that namespace/repo takes
 # precedence over registry/repo.
 _reduced_uri_no_ns_re = re.compile(
-    # match a registry, optional, may include a : or .
-    "(?:(?P<registry>[^/]+[.:][^/]*)/)?"
+    # match a registry, optional, may include a : or ., but not a @
+    "(?:(?P<registry>[^/@]+[.:][^/@]*)/)?"
     # Match a repo name, mandatory. Any character but ':' or '/'
     "(?P<repo>[^:@/]+)"
     # Match :tag (optional)
-    "(?::(?P<tag>[^:]+))?"
+    "(?::(?P<tag>[^:@]+))?"
     # Match @digest (optional)
-    "(?:@(?P<version>[^@]+))?"
+    "(?:@(?P<version>.+))?"
     # we need to match the whole string, make sure there's no leftover
     "$"
     # dummy group that will never match, but will add a 'namespace' entry
@@ -127,16 +127,16 @@ _default_uri_re = re.compile(
     # must be either registry[:port]/namespace[/more/namespaces]/repo
     # or namespace/repo, at least one namespace is required
     # Match registry, if specified
-    "(?:(?P<registry>[^/]+)/)?"
+    "(?:(?P<registry>[^/@]+)/)?"
     # Match a namespace, matched as any characters but
     # ':' or '@', ended by a '/'. Note the match will include the final /
     "(?P<namespace>(?:[^:@/]+/)+)"
     # Match a repo name, mandatory. Any character but ':' or '/'
     "(?P<repo>[^:@/]+)"
     # Match :tag (optional)
-    "(?::(?P<tag>[^:]+))?"
+    "(?::(?P<tag>[^:@]+))?"
     # Match @digest (optional)
-    "(?:@(?P<version>[^@]+))?"
+    "(?:@(?P<version>.+))?"
     # we need to match the whole string, make sure there's no leftover
     "$"
     )

--- a/libexec/python/shub/api.py
+++ b/libexec/python/shub/api.py
@@ -80,6 +80,11 @@ class SingularityApiConnection(ApiConnection):
                                      uri='shub://',
                                      default_registry=SHUB_API_BASE,
                                      quiet=True)
+        # parse_image_uri may return an empty namespace cause that's allowed
+        # with docker://, but not with shub://
+        if len(self.image["namespace"]) == 0:
+            bot.error("Namespace cannot be empty for shub:// url!")
+            sys.exit(1)
 
     def get_manifest(self):
         '''get_image will return a json object with image metadata

--- a/libexec/python/tests/test_core.py
+++ b/libexec/python/tests/test_core.py
@@ -122,7 +122,7 @@ class TestShell(TestCase):
         self.assertEqual(image["repo_name"], 'lizardleezle')
         self.assertEqual(image["registry"], self.REGISTRY)
 
-        print("Case 4: Tag when speciifed should be returned.")
+        print("Case 4: Tag when specified should be returned.")
         image_name = "%s/%s:%s" % (self.namespace,
                                    self.repo_name,
                                    "pusheenasaurus")
@@ -134,15 +134,15 @@ class TestShell(TestCase):
         image_name = "%s:%s" % (self.repo_name, self.tag)
         digest = parse_image_uri(image_name)
         self.assertTrue(digest['repo_tag'] == self.tag)
-        self.assertTrue(digest['namespace'] == 'library')
+        self.assertTrue(digest['namespace'] == self.NAMESPACE)
         self.assertTrue(digest['repo_name'] == self.repo_name)
 
-        print("Case 6: Changing default namespace should not use library.")
+        print("Case 6: Changing namespace should not use default.")
         image_name = "meow/%s:%s" % (self.repo_name, self.tag)
         digest = parse_image_uri(image_name)
         self.assertTrue(digest['namespace'] == 'meow')
 
-        print("Case 7: Changing default shouldn't use index.docker.io.")
+        print("Case 7: Changing registry shouldn't use index.docker.io.")
         image_name = "meow/mix/%s:%s" % (self.repo_name, self.tag)
         digest = parse_image_uri(image_name)
         self.assertTrue(digest['registry'] == 'meow')
@@ -162,6 +162,218 @@ class TestShell(TestCase):
         self.assertTrue(digest['registry'] == 'meow')
         self.assertTrue(digest['namespace'] == 'mix/original/choice')
         self.assertTrue(digest['version'] == 'sha:256xxxxxxxxxxxxxxx')
+
+        # now test some tricky cases
+
+        print("Case 10: registry and namespace, @version contains / and : (docker://)")
+        image_name = "some.registry.com/mix/mux/repo@me/version-1:3:2"
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == 'some.registry.com')
+        self.assertTrue(digest['repo_tag'] == self.REPO_TAG)
+        self.assertTrue(digest['namespace'] == 'mix/mux')
+        self.assertTrue(digest['repo_name'] == 'repo')
+        self.assertTrue(digest['version'] == 'me/version-1:3:2')
+
+        print("Case 11: registry and namespace, @version contains / and : (generic)")
+        image_name = "registry/mix/mux/repo@me/version-1:3:2"
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'registry')
+        self.assertTrue(digest['repo_tag'] == self.REPO_TAG)
+        self.assertTrue(digest['namespace'] == 'mix/mux')
+        self.assertTrue(digest['repo_name'] == 'repo')
+        self.assertTrue(digest['version'] == 'me/version-1:3:2')
+
+        print("Case 12: Namespaces can include / characters i.e. can be nested")
+        image_name = "meow/mix/barf/baz/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow')
+        self.assertTrue(digest['namespace'] == 'mix/barf/baz')
+
+        print("Case 13: Namespaces can include '.'")
+        image_name = "meow/mix.max/barf.baz/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow')
+        self.assertTrue(digest['namespace'] == 'mix.max/barf.baz')
+        self.assertTrue(digest['repo_tag'] == self.tag)
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+
+        print("Case 14: registry contains ., default namespace")
+        image_name = "meow.io/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == self.NAMESPACE)
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 15: registry contains :port, default namespace")
+        # namespace is not allowed to be empty except for docker:// uris
+        # so in this case, the default namespace is used
+        image_name = "meow:123/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow:123')
+        self.assertTrue(digest['namespace'] == self.NAMESPACE)
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 16: Namespace cannot be empty with full non-docker uri")
+        image_name = "myuri://meow.io/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == self.NAMESPACE)
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 17: comments at the end of the line")
+        image_name = "myuri://meow.io/mix/%s:%s # comment hel.lo/test:blah@stuff" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+
+    def test_parse_image_uri_docker(self):
+        """
+        Docker-specific uri parsing rules
+        """
+
+        from shell import parse_image_uri
+
+        print("Case 1: just image, default everything else")
+        digest = parse_image_uri(self.repo_name, uri="docker://")
+        self.assertTrue(digest['registry'] == self.REGISTRY)
+        self.assertTrue(digest['namespace'] == self.NAMESPACE)
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.REPO_TAG)
+
+        print("Case 2: just image and tag, default everything else")
+        image_name = "%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == self.REGISTRY)
+        self.assertTrue(digest['namespace'] == self.NAMESPACE)
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 3: image, namespace and tag")
+        image_name = "mix/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == self.REGISTRY)
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 4: image, namespace, tag and version")
+        image_name = "mix/%s:%s@sha:256xxxxxxxxxxxxxxx" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == self.REGISTRY)
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+        self.assertTrue(digest['version'] == 'sha:256xxxxxxxxxxxxxxx')
+
+        print("Case 5: image, several namespaces and tag")
+        # for docker, registry must have a . or a :port, else it's parsed
+        # as a namespace. In this case, no registry is specified
+        image_name = "mix/max/blitz/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == self.REGISTRY)
+        self.assertTrue(digest['namespace'] == 'mix/max/blitz')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 6: image, namespace, tag and version")
+        image_name = "mix/max/blitz/%s:%s@sha:256xxxxxxxxxxxxxxx" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == self.REGISTRY)
+        self.assertTrue(digest['namespace'] == 'mix/max/blitz')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+        self.assertTrue(digest['version'] == 'sha:256xxxxxxxxxxxxxxx')
+
+        print("Case 7: registry with ., image and tag, empty namespace")
+        # with docker://, if registry is present in uri, and namespace is empty,
+        # we parse the namespace as empty
+        image_name = "meow.io/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == '')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 8: registry with :port, image and tag, empty namespace")
+        image_name = "meow:5000/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == 'meow:5000')
+        self.assertTrue(digest['namespace'] == '')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 9: registry with . and :port, image and tag")
+        image_name = "meow.io:5000/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == 'meow.io:5000')
+        self.assertTrue(digest['namespace'] == '')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 10: registry with . and :port, image, no tag. empty namespace")
+        image_name = "meow.io:5000/%s" % (self.repo_name)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == 'meow.io:5000')
+        self.assertTrue(digest['namespace'] == '')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.REPO_TAG)
+
+        print("Case 11: registry, image, namespace and tag")
+        image_name = "meow.io/mix/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 12: registry, image, several namespaces and tag")
+        image_name = "meow:5000/mix/max/blitz/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == 'meow:5000')
+        self.assertTrue(digest['namespace'] == 'mix/max/blitz')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 13: no registry, several namespaces containing . and tag")
+        # a registry is matched if it contains : or ., but it must be the first one
+        # before any other namespace, else it's just a namespace
+        image_name = "mix/max.nix/blitz.krieg/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name, uri="docker://")
+        self.assertTrue(digest['registry'] == self.REGISTRY)
+        self.assertTrue(digest['namespace'] == 'mix/max.nix/blitz.krieg')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 15: full docker:// uri with registry")
+        image_name = "docker://meow.io/mix/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 16: full docker uri with registry, empty namespace")
+        image_name = "docker://meow:5000/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow:5000')
+        self.assertTrue(digest['namespace'] == '')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 17: Namespace can be empty when full docker:// uri specified")
+        # note: registry must include a . or a :port, else will be parsed as a namespace
+        image_name = "docker://meow.io/%s:%s" % (self.repo_name, self.tag)
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == '')
+        self.assertTrue(digest['repo_name'] == self.repo_name)
+        self.assertTrue(digest['repo_tag'] == self.tag)
 
 
 class TestUtils(TestCase):

--- a/libexec/python/tests/test_core.py
+++ b/libexec/python/tests/test_core.py
@@ -231,6 +231,27 @@ class TestShell(TestCase):
         self.assertTrue(digest['repo_name'] == self.repo_name)
         self.assertTrue(digest['repo_tag'] == self.tag)
 
+        print("Case 18: tag cannot contain @, version without : should be parsed")
+	# apparently there was a bug where if @version doesn't contain any : character
+	# it will get mis-parsed as part of the tag, which is clearly wrong
+        image_name = "myuri://meow.io/mix/my-repo:tag-1.2.3@master"
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == 'my-repo')
+        self.assertTrue(digest['repo_tag'] == 'tag-1.2.3')
+        self.assertTrue(digest['version'] == 'master')
+
+        print("Case 19: tag cannot contain @, version without : should be parsed")
+	# apparently there was a bug where if @version doesn't contain any : character
+	# it will get mis-parsed as part of the tag, which is clearly wrong
+        image_name = "myuri://meow.io/mix/my-repo:tag@2.2"
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == 'my-repo')
+        self.assertTrue(digest['repo_tag'] == 'tag')
+        self.assertTrue(digest['version'] == '2.2')
 
     def test_parse_image_uri_docker(self):
         """
@@ -374,6 +395,28 @@ class TestShell(TestCase):
         self.assertTrue(digest['namespace'] == '')
         self.assertTrue(digest['repo_name'] == self.repo_name)
         self.assertTrue(digest['repo_tag'] == self.tag)
+
+        print("Case 18: tag cannot contain @, version without : should be parsed")
+	# apparently there was a bug where if @version doesn't contain any : character
+	# it will get mis-parsed as part of the tag, which is clearly wrong
+        image_name = "docker://meow.io/mix/my-repo:tag-1.2.3@master"
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == 'my-repo')
+        self.assertTrue(digest['repo_tag'] == 'tag-1.2.3')
+        self.assertTrue(digest['version'] == 'master')
+
+        print("Case 19: tag cannot contain @, version without : should be parsed")
+	# apparently there was a bug where if @version doesn't contain any : character
+	# it will get mis-parsed as part of the tag, which is clearly wrong
+        image_name = "docker://meow.io/mix/my-repo:tag@2.2"
+        digest = parse_image_uri(image_name)
+        self.assertTrue(digest['registry'] == 'meow.io')
+        self.assertTrue(digest['namespace'] == 'mix')
+        self.assertTrue(digest['repo_name'] == 'my-repo')
+        self.assertTrue(digest['repo_tag'] == 'tag')
+        self.assertTrue(digest['version'] == '2.2')
 
 
 class TestUtils(TestCase):

--- a/libexec/python/tests/test_docker_api.py
+++ b/libexec/python/tests/test_docker_api.py
@@ -70,8 +70,7 @@ class TestApi(TestCase):
         '''
         from docker.api import DockerApiConnection
 
-        print("Case 1: Obtain manifest for %s/%s" % (self.client.namespace,
-                                                     self.client.repo_name))
+        print("Case 1: Obtain manifest for %s" % self.client.repo_name)
 
         manifest = self.client.get_manifest(old_version=True)
 
@@ -96,8 +95,7 @@ class TestApi(TestCase):
         '''
         from docker.api import DockerApiConnection
 
-        full_name = "%s/%s" % (self.client.namespace, self.client.repo_name)
-        print("Case 1: Ask for tags from standard %s" % full_name)
+        print("Case 1: Ask for tags from standard %s" % self.client.repo_name)
         tags = self.client.get_tags()
         self.assertTrue(isinstance(tags, list))
         self.assertTrue(len(tags) > 1)

--- a/src/builddef.c
+++ b/src/builddef.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
     envar_set("SINGULARITY_DOCKER_PASSWORD", singularity_registry_get("DOCKER_PASSWORD"), 1);
     envar_set("SINGULARITY_DOCKER_USERNAME", singularity_registry_get("DOCKER_USERNAME"), 1);
     envar_set("SINGULARITY_CACHEDIR", singularity_registry_get("CACHEDIR"), 1);
-    envar_set("SINGULARITY_MESSAGELEVEL", singularity_registry_get("MESSAGELEVEL"), 1);
+    envar_set("SINGULARITY_NOHTTPS", singularity_registry_get("NOHTTPS"), 1);
     envar_set("SINGULARITY_version", singularity_registry_get("VERSION"), 1);
     envar_set("HOME", singularity_priv_home(), 1);
     envar_set("LANG", "C", 1);

--- a/src/builddef.c
+++ b/src/builddef.c
@@ -109,30 +109,34 @@ int main(int argc, char **argv) {
 
             char *bootdef_value;
 
-            if ( ( bootdef_value = strtok(NULL, "\n") ) != NULL ) {
-
+            bootdef_value = strtok(NULL, "\n");
+            char empty[] = "";
+            if (bootdef_value == NULL) {
+                bootdef_value = empty;
+            } else {
                 chomp_comments(bootdef_value);
-                singularity_message(VERBOSE2, "Got bootstrap definition key/val '%s' = '%s'\n", bootdef_key, bootdef_value);
-
-                if ( envar_defined(strjoin("SINGULARITY_DEFFILE_", uppercase(bootdef_key))) == 0 ) {
-                    singularity_message(ERROR, "Duplicate bootstrap definition key found: '%s'\n", bootdef_key);
-                    ABORT(255);
-                }
-
-                if ( strcasecmp(bootdef_key, "import") == 0 ) {
-                    // Do this again for an imported deffile
-                    bootstrap_keyval_parse(bootdef_value);
-                }
-
-                if ( strcasecmp(bootdef_key, "bootstrap") == 0 ) {
-                    singularity_registry_set("DRIVER", bootdef_value);
-                }
-
-                // Cool little feature, every key defined in def file is transposed
-                // to environment
-                envar_set(uppercase(bootdef_key), bootdef_value, 1);
-                envar_set(strjoin("SINGULARITY_DEFFILE_", uppercase(bootdef_key)), bootdef_value, 1);
             }
+
+            singularity_message(VERBOSE2, "Got bootstrap definition key/val '%s' = '%s'\n", bootdef_key, bootdef_value);
+
+            if ( envar_defined(strjoin("SINGULARITY_DEFFILE_", uppercase(bootdef_key))) == 0 ) {
+                singularity_message(ERROR, "Duplicate bootstrap definition key found: '%s'\n", bootdef_key);
+                ABORT(255);
+            }
+
+            if ( strcasecmp(bootdef_key, "import") == 0 ) {
+                // Do this again for an imported deffile
+                bootstrap_keyval_parse(bootdef_value);
+            }
+
+            if ( strcasecmp(bootdef_key, "bootstrap") == 0 ) {
+                singularity_registry_set("DRIVER", bootdef_value);
+            }
+
+            // Cool little feature, every key defined in def file is transposed
+            // to environment
+            envar_set(uppercase(bootdef_key), bootdef_value, 1);
+            envar_set(strjoin("SINGULARITY_DEFFILE_", uppercase(bootdef_key)), bootdef_value, 1);
         }
     }
 

--- a/test.sh.in
+++ b/test.sh.in
@@ -45,7 +45,9 @@ if [ -z "$CLEAN_SHELL" ]; then
     /bin/echo "Building/Installing Singularity to temporary directory"
     /bin/echo "Reinvoking in a clean shell"
     sleep 1
-    exec env -i CLEAN_SHELL=1 PATH="$SINGULARITY_PATH:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin" bash "$0" "$@"
+    # Keep docker host for travis under centos 7, which runs the whole test suite in a docker container
+    exec env -i CLEAN_SHELL=1 PATH="$SINGULARITY_PATH:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin" \
+                DOCKER_HOST="$DOCKER_HOST" bash "$0" "$@"
 fi
 
 if [ ! -d "tests" ]; then

--- a/tests/21-build_docker.sh
+++ b/tests/21-build_docker.sh
@@ -60,5 +60,55 @@ stest 1 sudo singularity build -F "$CONTAINER" docker://something_that_doesnt_ex
 stest 1 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
+# make sure local test does not exist, ignore errors
+sudo docker kill registry >/dev/null 2>&1
+sudo docker rm registry >/dev/null 2>&1
+
+# start local docker registry
+stest 0 sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
+# pull busybox from docker and push to local registry
+stest 0 sudo docker pull busybox
+stest 0 sudo docker tag busybox localhost:5000/my-busybox
+stest 0 sudo docker push localhost:5000/my-busybox
+
+# alright, now we have a local registry to test with
+
+# test with custom registry and custom namespace (including empty namespace)
+# from squashfs to squashfs (via def file)
+cat >"$DEFFILE" <<EOF
+Bootstrap: docker
+From: localhost:5000/my-busybox
+EOF
+
+stest 0 sudo SINGULARITY_NOHTTPS=true singularity build -F "$CONTAINER" "$DEFFILE"
+stest 0 singularity exec "$CONTAINER" true
+stest 1 singularity exec "$CONTAINER" false
+
+cat >"$DEFFILE" <<EOF
+Bootstrap: docker
+From: my-busybox
+Registry: localhost:5000
+EOF
+
+# this will fail, as it will try to use the default namespace
+stest 1 sudo SINGULARITY_NOHTTPS=true singularity build -F "$CONTAINER" "$DEFFILE"
+
+cat >"$DEFFILE" <<EOF
+Bootstrap: docker
+From: my-busybox
+Registry: localhost:5000
+Namespace:
+EOF
+
+# remove registry container, not needed now
+stest 0 sudo SINGULARITY_NOHTTPS=true singularity build -F "$CONTAINER" "$DEFFILE"
+stest 0 singularity exec "$CONTAINER" true
+stest 1 singularity exec "$CONTAINER" false
+# note: technically this doesn't clean everything, the volume the registry
+# created, containing out pushed my-busybox, is still there
+
+# destroy registry container once done
+stest 0 sudo docker kill registry
+stest 0 sudo docker rm registry
 
 test_cleanup


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Docker allows local/private registries to have images in the top-level namespace, as in `docker://local.registry:5000/someimage` but currently singularity enforces a default namespace, which results in errors if that is not required. The main docker hub (index.docker.io) *does* require a 'library' namespace, so it's a good default to have this, but there should be a way to override this.
This pull requests does that in a couple of ways:
* docker:// URI parsing now follows more closely docker's own rules, so that an image specified as above will parse with an empty namespace (the specific rule is that a custom registry must be present in the image)
* deffiles are allowed to have empty values, so one can use `Namespace:` (no value after `:`) to enforce an empty namespace

As to which rules one should use to parse docker:// image uris, there doesn't seem to be a lot of documentation from docker itself. I found these articles which seem to imply certain rules:
* https://docs.docker.com/registry/deploying/: shows how to set up a local registry, and the example uses the top level namespace
* https://blog.docker.com/2013/07/how-to-use-your-own-registry/: while a little dated, hopefully this quote still applies: 

    > It’s important to note that we’re using a domain containing a “.” here, i.e. `localhost.domain`. Docker looks for either a “.” (domain separator) or “:” (port separator) to learn that the first part of the repository name is a location and not a user name. If you just had `localhost` without either `.localdomain` or `:5000` (either one would do) then Docker would believe that localhost is a username, as in `localhost/ubuntu` or `samalba/hipache`

    where of course what docker calls username is what singularity calls namespace.

Based on that, I decided to enforce the same rule for the registry to contain either "." or ":", and when a registry is specified, allow the namespace to be empty. If the registry is not specified, use the default namespace ('library').

I originally tried to make simple incremental modifications to `parse_image_uri` in `shell.py`, but the code got very complicated quickly, to the point that I decide to switch using regular expressions instead. I know how they can be cryptic sometimes, so I added plenty of comments, and I believe it's still much clearer than how it would've turned out otherwise.

This is meant mostly for review, I can squash commits, or split this into multiple PRs if needed, just let me know. It is otherwise, in my opinion, ready for merge (but please review!).

**This fixes or addresses the following GitHub issues:**

- Ref: #1087


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
