### PR TITLE
Spoil the lolcow fun :-( - don't fetch a remote image that user has not requested

### DIFF
--- a/libexec/cli/run.exec
+++ b/libexec/cli/run.exec
@@ -57,12 +57,7 @@ if [ -z "${SINGULARITY_IMAGE:-}" ]; then
 fi
 
 if [ -z "${SINGULARITY_IMAGE:-}" ]; then
-    if [ $(( RANDOM % 10 )) != 0 ]; then
-        exec "$SINGULARITY_libexecdir/singularity/cli/help.exec" "$SINGULARITY_COMMAND"
-    else
-        message 1 "               ***** COW SIGHTING! *****\n"
-        SINGULARITY_IMAGE="shub://GodloveD/lolcow"
-    fi
+    exec "$SINGULARITY_libexecdir/singularity/cli/help.exec" "$SINGULARITY_COMMAND"
 fi
 
 if [ -n "${SINGULARITY_DAEMON_JOIN:-}" ]; then


### PR DESCRIPTION
**Description of the Pull Request (PR):**

**Note - writing this feels like I'm a miserable boring person, so please close this and I'll patch locally if people love the cows :-)**

Roughly every 10th time you run `singularity run` without an image spec it'll instead run @GodloveD 's rather fun lolcow image.

Cows are fun. I like cows! Unfortunately we might need to do things like:

- Guarantee from a system that we never pull an image from an external resource. Pulling lolcow randomly could lead to trouble if singularityhub was compromised. Arguable we should blackhole if security is this much of an issue - but this can then cause an issue below:

- Demo singularity to users in a training session, happen to use `singularity run` to show some options and get a stacktrace if no internet connection, which looks a bit weird to those watching, and confused me.

```
21:11 $ singularity run
               ***** COW SIGHTING! *****
^[[ATraceback (most recent call last):
  File "/usr/local/libexec/singularity/python/pull.py", line 74, in <module>
    main()
  File "/usr/local/libexec/singularity/python/pull.py", line 66, in main
    layerfile=LAYERFILE)
  File "/usr/local/libexec/singularity/python/shub/main.py", line 77, in PULL
    manifest = client.get_manifest()
  File "/usr/local/libexec/singularity/python/shub/api.py", line 108, in get_manifest
    response = self.get(base, return_response=True)
  File "/usr/local/libexec/singularity/python/base.py", line 262, in get
    return_response=return_response)
  File "/usr/local/libexec/singularity/python/base.py", line 278, in submit_request
    response = urlopen(request)
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 1258, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "/usr/lib64/python2.7/urllib2.py", line 1214, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [Errno -2] Name or service not known>
ABORT: Aborting with RETVAL=255
```

- Run singularity on a machine where external web access is black-holed (gotta love strict firewalls and proxies). Leads to a long wait and then a urllib timeout/stacktrace.

This change sends the cows out to pasture :-(

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
