### PR TITLE
fixing env var in build help

### DIFF
--- a/libexec/cli/build.info
+++ b/libexec/cli/build.info
@@ -90,7 +90,7 @@ DEFFILE SECTION EXAMPLES:
     %setup
         echo "This is a scriptlet that will be executed on the host, as root, after"
         echo "the container has been bootstrapped. To install things into the container"
-        echo "reference the file system location with \$SINGULARITY_BUILDROOT"
+        echo "reference the file system location with \$SINGULARITY_ROOTFS"
 
     %post
         echo "This scriptlet section will be executed from within the container after"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Build help is lists the wrong env var used to reference the root file system during the %setup section.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
