### PR TITLE
Allow all proxy vars for build

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -342,7 +342,11 @@ int envclean(void) {
 
         key = strtok_r(envclone[i], "=", &tok);
 
-        if ( strcmp(key, "http_proxy") == 0 ) {
+        if ( (strcasecmp(key, "http_proxy")  == 0) ||
+             (strcasecmp(key, "https_proxy") == 0) ||
+             (strcasecmp(key, "no_proxy")    == 0) ||
+             (strcasecmp(key, "all_proxy")   == 0)
+           ) {
             singularity_message(DEBUG, "Leaving environment variable set: %s\n", key);
         } else {
             singularity_message(DEBUG, "Unsetting environment variable: %s\n", key);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Avoid sanitizing all of the following standard proxy variables, so that they are passed through to singularity build to allow bootstrap from dockerhub etc.

- http_proxy 
- https_proxy
- all_proxy
- no_proxy

NB - we use strcasecmp to allow upper case versions which are also commonly seen.

**This fixes or addresses the following GitHub issues:**

- Ref: #764 #1098 

Previous proxy change only passed through http_proxy which is not sufficient for singularity build from docker hub.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
