### PR TITLE
Bind /etc/OpenCL/vendors with --nv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Fix parsing of registry (including port), namespace, tags, and version
  - Add "$@" to any CMD/ENTRYPOINT found when building from Docker
  - Added sqaushfs-tools as a dependency for building deb files
+ - Bind /etc/OpenCL/vendors when using --nv option
 
 ## [v2.4](https://github.com/singularityware/singularity/tree/v2.4) (2017-10-02)
 [Full Changelog](https://github.com/singularityware/singularity/compare/2.3.2...2.4)

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -150,6 +150,16 @@ while true; do
             else
                 message WARN "Could not find the Nvidia SMI binary to bind into container\n"
             fi
+            if [ -d "/etc/OpenCL/vendors" ]; then
+                if [ -n "${SINGULARITY_BINDPATH:-}" ]; then
+                    SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH},/etc/OpenCL/vendors"
+                else
+                    SINGULARITY_BINDPATH="/etc/OpenCL/vendors"
+                fi
+                export SINGULARITY_BINDPATH
+            else
+                message WARN "Could not find OpenCL vendor information to bind into container\n"
+            fi
         ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Per #1156 singularity should bind the OpenCL `/etc/OpenCL/vendors` profiles dir into the container when binding nvidia libs with `--nv`, so that the OpenCL config seen inside the container matches the NVIDIA libs that are bound from outside.

**This fixes or addresses the following GitHub issues:**

- Ref: #1156


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
