### PR TITLE
fix suse squashfs package name in RPM dep

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -35,7 +35,11 @@ Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 BuildRequires: python
+%if "%{_target_vendor}" == "suse"
+Requires: squashfs
+%else
 Requires: squashfs-tools
+%endif
 
 Requires: %{name}-runtime = %{version}-%{release}
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

squashfs support is provided in SUSE by the package `squashfs` and not `squashfs-tools` as set in the RPM spec. This pull request should fix it.

**This fixes or addresses the following GitHub issues:**

- Ref: #1162

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
