### PR TITLE
Fix terminal echo problem when using PID namespace and killing shell process

### DIFF
--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -213,12 +213,14 @@ static int wait_child() {
         }
     } while( child_ok );
 
-    /* Catch the exit status of the child process */
-    retval = 0;
+    /* Catch the exit status or kill signal of the child process */
     waitpid(child_pid, &tmpstatus, 0);
-    retval = WEXITSTATUS(tmpstatus);
-    
-    return(retval);
+    if (WIFEXITED(tmpstatus)) {
+        return(WEXITSTATUS(tmpstatus));
+    } else if (WIFSIGNALED(tmpstatus)) {
+        kill(getpid(), WTERMSIG(tmpstatus));
+    }
+    return(-1);
 }
 
 /* */


### PR DESCRIPTION
**Description of the Pull Request (PR):**

By killing shell container process when requesting PID namespace, terminal doesn't echo input characters anymore

Steps to reproduce:
First terminal:
$ singularity shell -p docker://busybox
Second terminal:
$ kill -9 </bin/sh pid>
Type something on first terminal

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
