### PR TITLE
init: put /usr/local first in PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
  - Feature sif sign #1143
  - Add capability support and secure build #934
+ - Put /usr/local/{bin,sbin} in front of the default PATH
 
 ## [v2.4.2](https://github.com/singularityware/singularity/tree/release-2.4)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,3 +36,4 @@
     - Yaroslav Halchenko <debian@onerussian.com>
     - Josef Hrabal <josef.hrabal@vsb.cz>
     - Daniele Tamino <daniele.tamino@gmail.com>
+    - Thomas Hamel <hmlth@t-hamel.fr>

--- a/etc/init
+++ b/etc/init
@@ -12,9 +12,9 @@ unset BASH_ENV
 
 # Provide a sane path within the container
 if [ -z ${SINGULARITYENV_PATH+x} ]; then
-    SINGULARITYENV_PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+    SINGULARITYENV_PATH="/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin"
 else
-    SINGULARITYENV_PATH="$SINGULARITYENV_PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+    SINGULARITYENV_PATH="$SINGULARITYENV_PATH:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin"
 fi
 
 # Don't save the shell's HISTFILE


### PR DESCRIPTION
On most distribution, /usr/local is first in the PATH. Having it
last can break wrappers that are put there during image build.

**Description of the Pull Request (PR):**

On singularity 2.2, the host PATH was prepended to a generic PATH. This behavior makes "/usr/local/bin" first in the PATH on all distribution I looked at (Debian, RHEL, Arch). This permitted to override binaries in /usr/bin with wrappers in /usr/local/bin during image build (we use such a wrapper for ssh).

On singularity 2.4, the host PATH is not used and replaced with only the generic PATH by default, but this PATH puts /usr/local at the end, rendering those wrappers useless (and breaking the images backward compatibility in singularity 2.4). This PR puts /usr/local first, I think this is a better default because it mirrors a behavior that is common (AFAIK) to all main Linux distributions.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin
