### PR TITLE
Move wrapper-suid to singularity-runtime package

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -118,9 +118,6 @@ rm -rf $RPM_BUILD_ROOT
 # Directories
 %{_libexecdir}/singularity/bootstrap-scripts
 
-#SUID programs
-%attr(4755, root, root) %{_libexecdir}/singularity/bin/wrapper-suid
-
 %files runtime
 %dir %{_libexecdir}/singularity
 %dir %{_localstatedir}/singularity
@@ -156,6 +153,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/singularity.1*
 %dir %{_sysconfdir}/bash_completion.d
 %{_sysconfdir}/bash_completion.d/singularity
+
+#SUID programs
+%attr(4755, root, root) %{_libexecdir}/singularity/bin/wrapper-suid
 
 %files devel
 %defattr(-, root, root)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This moves wrapper-suid to the singularity-runtime sub-rpm.


**This fixes or addresses the following GitHub issues:**

- Ref: #1176 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
   not relevant as it only affects the rpm
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
