### PR TITLE
Restore autofs bug path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 ## [v2.4.2](https://github.com/singularityware/singularity/tree/release-2.4)
 
-This fixed an issue for support of older distributions and kernels with regards to `setns()`
-functionality.
+ - This fixed an issue for support of older distributions and kernels with regards to `setns()`
+   functionality.
+ - Fixed autofs bug path (lost during merge)
 
 ## [v2.4.1](https://github.com/singularityware/singularity/tree/release-2.4) (2017-11-22)
 

--- a/src/action.c
+++ b/src/action.c
@@ -65,6 +65,8 @@ int main(int argc, char **argv) {
     singularity_priv_userns();
     singularity_priv_drop();
 
+    singularity_runtime_autofs();
+
     singularity_daemon_init();
 
     if ( singularity_registry_get("WRITABLE") != NULL ) {

--- a/src/mount.c
+++ b/src/mount.c
@@ -56,6 +56,8 @@ int main(int argc, char **argv) {
     singularity_registry_init();
     singularity_priv_drop();
 
+    singularity_runtime_autofs();
+
     if ( singularity_registry_get("WRITABLE") != NULL ) {
         singularity_message(VERBOSE3, "Instantiating writable container image object\n");
         image = singularity_image_init(singularity_registry_get("IMAGE"), O_RDWR);

--- a/src/start.c
+++ b/src/start.c
@@ -66,6 +66,8 @@ int main(int argc, char **argv) {
     singularity_priv_userns();
     singularity_priv_drop();
 
+    singularity_runtime_autofs();
+
     singularity_registry_set("UNSHARE_PID", "1");
     singularity_registry_set("UNSHARE_IPC", "1");
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Restore autofs bug path lost during merge (https://github.com/singularityware/singularity/pull/877). autofs bug path address issues below

**This fixes or addresses the following GitHub issues:**

- Ref: #347, #757

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
