### PR TITLE
 Exclude aufs whiteout files from docker extraction (Alternative C/libarchive impl.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - squashfs-tools
       - uuid-dev
       - libssl-dev
+      - libarchive-dev
 
 env:
   global:

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -5,7 +5,7 @@
 OS_VERSION="$1"
 
 # build and install
-yum install -y libtool rpm-build make squashfs-tools openssl-devel libuuid-devel
+yum install -y libtool rpm-build make squashfs-tools openssl-devel libuuid-devel libarchive-devel
 ./autogen.sh
 ./configure
 make dist

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -7,7 +7,7 @@ OS_VERSION="$1"
 # build and install
 yum install -y libtool rpm-build make yum-utils
 ./autogen.sh
-yum-builddep singularity.spec
+yum-builddep -y singularity.spec
 ./configure
 make dist
 rpmbuild -ta *.tar.gz

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -1,12 +1,13 @@
 #!/bin/bash -ex
 
-# this script runs as root under docker 
+# this script runs as root under docker
 
 OS_VERSION="$1"
 
 # build and install
-yum install -y libtool rpm-build make squashfs-tools openssl-devel libuuid-devel libarchive-devel
+yum install -y libtool rpm-build make yum-utils
 ./autogen.sh
+yum-builddep singularity.spec
 ./configure
 make dist
 rpmbuild -ta *.tar.gz

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -5,7 +5,7 @@
 OS_VERSION="$1"
 
 # build and install
-yum install -y libtool rpm-build make yum-utils
+yum install -y libtool rpm-build make yum-utils squashfs-tools
 ./autogen.sh
 yum-builddep -y singularity.spec
 ./configure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Add capability support and secure build #934
  - Boot/start instance #1032
  - Put /usr/local/{bin,sbin} in front of the default PATH
+ - Handle docker layer aufs whiteout files correctly (requires libarchive).
 
 ## [v2.4.2](https://github.com/singularityware/singularity/tree/release-2.4)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,3 +38,5 @@
     - Josef Hrabal <josef.hrabal@vsb.cz>
     - Daniele Tamino <daniele.tamino@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
+    - David Trudgian <david.trudgian@utsouthwestern.edu>
+

--- a/bin/singularity.in
+++ b/bin/singularity.in
@@ -147,3 +147,4 @@ fi
 
 # We should never get here...
 exit 255
+

--- a/configure.ac
+++ b/configure.ac
@@ -389,6 +389,15 @@ AC_SEARCH_LIBS([SHA1], [crypto], [], [
 	AC_MSG_ERROR([unable to find the SHA1(), need package openssl-devel (libssl-dev on Debian/Ubuntu)])
 ])
 
+# check for libarchive needed by docker-extract
+AC_CHECK_HEADERS([archive.h],
+[archive_header_found=yes; break;])
+AS_IF([test "x$archive_header_found" != "xyes"],
+[AC_MSG_ERROR([Unable to find the libarchive headers, need package libarchive-devel (libarchive-dev on Debian/Ubuntu)])])
+AC_SEARCH_LIBS([archive_read_new], [archive], [], [
+AC_MSG_ERROR([unable to find libarchive, need package libarchive-devel (libarchive-de on Debian/Ubuntu)])
+])
+
 CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector --param ssp-buffer-size=4"
 
 AC_CONFIG_FILES([

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,10 @@ Build-Depends:
  debhelper (>= 9),
  dh-autoreconf,
  help2man,
+ libarchive-dev,
+ libssl-dev,
  python,
+ uuid-dev,
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity
 Vcs-Git: https://github.com/singularityware/singularity.git

--- a/libexec/bootstrap-scripts/deffile-driver-docker.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-docker.sh
@@ -81,8 +81,8 @@ eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"
 umask 0002
 for i in `cat "$SINGULARITY_CONTENTS"`; do
     name=`basename "$i"`
-    message 1 "Exploding layer: $name\n"
-    zcat "$i" | (cd "$SINGULARITY_ROOTFS"; tar --exclude=dev/* -xf -) || exit $?
+    message 2 "Exploding layer: $name\n"
+    $SINGULARITY_libexecdir/singularity/bin/docker-extract "$i"
 done
 
 rm -f "$SINGULARITY_CONTENTS"

--- a/libexec/bootstrap-scripts/main-dockerhub.sh
+++ b/libexec/bootstrap-scripts/main-dockerhub.sh
@@ -50,8 +50,8 @@ eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"
 
 for i in `cat "$SINGULARITY_CONTENTS"`; do
     name=`basename "$i"`
-    message 1 "Exploding layer: $name\n"
-    zcat "$i" | (cd "$SINGULARITY_ROOTFS"; tar --exclude=dev/* -xf -) || exit $?
+    message 2 "Exploding layer: $name\n"
+    $SINGULARITY_libexecdir/singularity/bin/docker-extract "$i"
 done
 
 rm -f "$SINGULARITY_CONTENTS"

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -1,25 +1,25 @@
 #!/bin/bash
-# 
+#
 # Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 #
 # Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
-# 
+#
 # Copyright (c) 2016-2017, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
-# 
+#
 # This software is licensed under a customized 3-clause BSD license.  Please
 # consult LICENSE file distributed with the sources of this project regarding
 # your rights to use or distribute this software.
-# 
+#
 # NOTICE.  This Software was developed under funding from the U.S. Department of
 # Energy and the U.S. Government consequently retains certain rights. As such,
 # the U.S. Government has been granted for itself and others acting on its
 # behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 # to reproduce, distribute copies to the public, prepare derivative works, and
-# perform publicly and display publicly, and to permit other to do so. 
-# 
-# 
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
 set -e
 
 ## Basic sanity
@@ -181,7 +181,7 @@ if [ "$USERID" != "0" ]; then
     if [ -n "${SINGULARITY_SANDBOX:-}" ]; then
 
         # Sandbox with deffile is no go.
-        if eval is_deffile "${SINGULARITY_BUILDDEF}"; then 
+        if eval is_deffile "${SINGULARITY_BUILDDEF}"; then
             message ERROR "You must be the root user to sandbox from a Singularity recipe file\n"
             exit 1
 
@@ -200,11 +200,11 @@ fi
 # if the container exists, build into it (or delete it if -F was passed)
 if [ -e "$SINGULARITY_CONTAINER_OUTPUT" ]; then
     if eval is_image "${SINGULARITY_CONTAINER_OUTPUT}"; then
-        if [ -z "${SINGULARITY_FORCE:-}" ]; then 
+        if [ -z "${SINGULARITY_FORCE:-}" ]; then
             message 1 "Building into existing container: $SINGULARITY_CONTAINER_OUTPUT\n"
             SINGULARITY_BTSTRP_2EXISTING=1
         elif [ -n "${SINGULARITY_FORCE:-}" ]; then
-            # this may be a directory, so rm -rf 
+            # this may be a directory, so rm -rf
             rm -rf "$SINGULARITY_CONTAINER_OUTPUT" 2> /dev/null
         fi
     else
@@ -233,7 +233,7 @@ else
     fi
     SINGULARITY_IMAGE="$SINGULARITY_ROOTFS"
 
-    # create a temporary placeholder location to build file system 
+    # create a temporary placeholder location to build file system
      if ! SINGULARITY_TEMP_FS=`mktemp "${SINGULARITY_TMPDIR:-/tmp}"/.singularity-temp-fs.XXXXXX`; then
         message ERROR "Failed to create temporary file system\n"
         ABORT 255
@@ -265,8 +265,6 @@ case $SINGULARITY_BUILDDEF in
         for i in `cat "$SINGULARITY_CONTENTS"`; do
             name=`basename "$i"`
             message 2 "Exploding layer: $name\n"
-            echo ${SINGULARITY_ROOTFS}
-            echo $SINGULARITY_libexecdir/singularity/bin/docker-extract "$i"
             $SINGULARITY_libexecdir/singularity/bin/docker-extract "$i"
         done
 
@@ -291,7 +289,7 @@ case $SINGULARITY_BUILDDEF in
         # relying on pull.py for error checking here
         ${SINGULARITY_libexecdir}/singularity/python/pull.py
 
-        # switch $SINGULARITY_CONTAINER from remote to local 
+        # switch $SINGULARITY_CONTAINER from remote to local
         SINGULARITY_BUILDDEF=`cat $SINGULARITY_CONTENTS`
         SINGULARITY_CLEANUP=1
     ;;
@@ -316,7 +314,7 @@ if [ -f "${SINGULARITY_BUILDDEF:-}" ]; then
             ABORT 255
         fi
 
-    elif eval is_deffile "${SINGULARITY_BUILDDEF}"; then 
+    elif eval is_deffile "${SINGULARITY_BUILDDEF}"; then
         message 1 "Using container recipe deffile: $SINGULARITY_BUILDDEF\n"
         if [ "$USERID" != "0" ]; then
             message ERROR "You must be the root user to build from a Singularity recipe file\n"
@@ -365,7 +363,7 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
 
         if [ -z "${SINGULARITY_BTSTRP_2EXISTING:-}" ]; then
             CONTAINER_SIZE=`du -sm ${SINGULARITY_ROOTFS} | cut -f 1`
-            # using the let builtin instead of bc which is not guaranteed 
+            # using the let builtin instead of bc which is not guaranteed
             let "IMAGE_SIZE=(${CONTAINER_SIZE:-768} * 125)/100"
             if [ "$IMAGE_SIZE" -lt 10 ]; then
                 IMAGE_SIZE=10

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -263,8 +263,11 @@ case $SINGULARITY_BUILDDEF in
         zcat "$SINGULARITY_libexecdir/singularity/bootstrap-scripts/environment.tar" | tar xBf - -C "${SINGULARITY_ROOTFS}" || exit $?
 
         for i in `cat "$SINGULARITY_CONTENTS"`; do
-            message 1 "Importing: $i\n"
-            zcat "$i" | (cd "$SINGULARITY_ROOTFS"; tar --exclude=dev/* -xf - ) || exit $?
+            name=`basename "$i"`
+            message 2 "Exploding layer: $name\n"
+            echo ${SINGULARITY_ROOTFS}
+            echo $SINGULARITY_libexecdir/singularity/bin/docker-extract "$i"
+            $SINGULARITY_libexecdir/singularity/bin/docker-extract "$i"
         done
 
         SINGULARITY_BUILDDEF="$SINGULARITY_ROOTFS"

--- a/libexec/handlers/image-docker.sh
+++ b/libexec/handlers/image-docker.sh
@@ -40,18 +40,7 @@ zcat $SINGULARITY_libexecdir/singularity/bootstrap-scripts/environment.tar | (cd
 for i in `cat "$SINGULARITY_CONTENTS"`; do
     name=`basename "$i"`
     message 2 "Exploding layer: $name\n"
-    # Settings of file privileges must be buffered
-    files=$( zcat "$i" | (cd "$SINGULARITY_ROOTFS"; tar --overwrite --exclude=dev/* -xvf -)) || exit $?
-    for file in $files; do
-        if [ -L "$SINGULARITY_ROOTFS/$file" ]; then
-            # Skipping symlinks
-            true
-        elif [ -f "$SINGULARITY_ROOTFS/$file" ]; then
-            chmod u+rw "$SINGULARITY_ROOTFS/$file" >/dev/null 2>&1
-        elif [ -d "$SINGULARITY_ROOTFS/$file" ]; then
-            chmod u+rwx "$SINGULARITY_ROOTFS/${file%/}" >/dev/null 2>&1
-        fi
-    done
+    $SINGULARITY_libexecdir/singularity/bin/docker-extract "$i"
 done
 
 rm -f "$SINGULARITY_CONTENTS"

--- a/secbuildimg.sh.in
+++ b/secbuildimg.sh.in
@@ -57,7 +57,7 @@ From: ubuntu:latest
     export LC_LANG=C
     apt-get update
     apt-get install -y git gcc python make automake autoconf libtool
-    apt-get install -y squashfs-tools curl uuid-dev libssl-dev
+    apt-get install -y squashfs-tools curl uuid-dev libssl-dev libarchive-dev
     apt-get install -y debootstrap yum zypper
     apt-get clean
     apt-get autoclean

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -35,6 +35,9 @@ Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 BuildRequires: python
+BuildRequires: libuuid-devel
+BuildRequires: libarchive-devel
+BuildRequires: openssl-devel
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 %else

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -114,6 +114,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/bin/mount
 %{_libexecdir}/singularity/bin/image-type
 %{_libexecdir}/singularity/bin/sif
+%{_libexecdir}/singularity/bin/docker-extract
 
 # Directories
 %{_libexecdir}/singularity/bootstrap-scripts
@@ -147,6 +148,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/bin/start
 %{_libexecdir}/singularity/bin/image-type
 %{_libexecdir}/singularity/bin/wrapper
+%{_libexecdir}/singularity/bin/docker-extract
 %{_libexecdir}/singularity/functions
 %{_libexecdir}/singularity/capabilities
 %dir %{_sysconfdir}/singularity

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = -DBINDIR=\"$(bindir)\" -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATE
 
 lexecdir = $(libexecdir)/singularity/bin
 
-lexec_PROGRAMS = action builddef cleanupd get-section image-type mount start sif wrapper $(BUILD_SUID)
+lexec_PROGRAMS = action builddef cleanupd docker-extract get-section image-type mount start sif wrapper $(BUILD_SUID)
 EXTRA_PROGRAMS = wrapper-suid
 
 cleanupd_SOURCES = cleanupd.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c util/capability.c util/suid.c
@@ -23,6 +23,11 @@ builddef_SOURCES = builddef.c util/util.c util/file.c util/registry.c util/sessi
 builddef_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la bootstrap-lib/libinternal.la -luuid
 builddef_CPPFLAGS = $(AM_CPPFLAGS)
 builddef_LDFLAGS = -static
+
+docker_extract_SOURCES = docker-extract.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c util/capability.c util/suid.c
+docker_extract_LDADD = -larchive
+docker_extract_CPPFLAGS = $(AM_CPPFLAGS)
+docker_extract_LDFLAGS = -static
 
 start_SOURCES = start.c util/util.c util/file.c util/registry.c util/privilege.c util/sessiondir.c util/suid.c util/cleanupd.c util/fork.c util/daemon.c util/signal.c util/capability.c util/mount.c
 start_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la action-lib/libinternal.la -luuid

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -35,8 +35,9 @@ int apply_opaque(const char *opq_marker, char *rootfs_dir) {
     strncpy(opq_dir, opq_marker, length);
     opq_dir[length] = 0;
 
-    char *opq_dir_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(opq_dir) + 1);
-    sprintf(opq_dir_rootfs, "%s/%s", rootfs_dir, opq_dir);
+    size_t buff_len = strlen(rootfs_dir) + 1 + strlen(opq_dir) + 1;
+    char *opq_dir_rootfs = malloc(buff_len);
+    snprintf(opq_dir_rootfs, buff_len, "%s/%s", rootfs_dir, opq_dir);
 
     if (is_dir(opq_dir_rootfs) == 0) {
         s_rmdir(opq_dir_rootfs);
@@ -70,8 +71,9 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
     wh_path[token_pos] = 0;
     strcat(wh_path, token + 4);
 
-    char *wh_path_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(wh_path) + 1);
-    sprintf(wh_path_rootfs, "%s/%s", rootfs_dir, wh_path);
+    size_t buff_len = strlen(rootfs_dir) + 1 + strlen(wh_path) + 1;
+    char *wh_path_rootfs = malloc(buff_len);
+    snprintf(wh_path_rootfs, buff_len, "%s/%s", rootfs_dir, wh_path);
 
     if (is_dir(wh_path_rootfs) == 0) {
         retval = s_rmdir(wh_path_rootfs);

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -1,0 +1,270 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <archive.h>
+#include <archive_entry.h>
+
+#include "config.h"
+#include "util/util.h"
+#include "util/message.h"
+#include "util/file.h"
+
+int apply_opaque(char* pathname, char* rootfs_dir) {
+    int retval = 0;
+    char *token = strrchr(pathname, '/');
+
+    if( token == NULL ){
+        singularity_message(ERROR, "Error getting dirname for opaque marker\n");
+        ABORT(255);
+    }
+
+    size_t length = token - pathname;
+    char *opq_dir = malloc(length + 1);
+    strncpy(opq_dir, pathname, length);
+    opq_dir[length] = 0;
+
+    char *opq_dir_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(opq_dir) + 1 );
+    sprintf(opq_dir_rootfs, "%s/%s", rootfs_dir, opq_dir);
+
+    if( is_dir(opq_dir_rootfs) == 0 ){
+        s_rmdir(opq_dir_rootfs);
+    }
+
+    free(opq_dir);
+    free(opq_dir_rootfs);
+
+    return retval;
+}
+
+
+int apply_whiteout(char* pathname, char* rootfs_dir) {
+    int retval = 0;
+    char *token = strstr(pathname, ".wh.");
+
+    if( token == NULL ){
+        singularity_message(ERROR, "Error getting filename for whiteout marker\n");
+        ABORT(255);
+    }
+
+    size_t token_pos = strlen(pathname) - strlen(token);
+    size_t length = strlen(pathname) - strlen(".wh.") + 1;
+    char *wht_path = malloc(length);
+    strncpy(wht_path, pathname, token_pos + 1 );
+    wht_path[token_pos] = 0;
+    strcat(wht_path, token + 4);
+
+    char *wht_path_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(wht_path) + 1 );
+    sprintf(wht_path_rootfs, "%s/%s", rootfs_dir, wht_path);
+
+    if( is_dir(wht_path_rootfs) == 0 ) {
+        retval = s_rmdir(wht_path_rootfs);
+    }else if(is_file(wht_path_rootfs) == 0 ) {
+        singularity_message(DEBUG, "Removing whiteout-ed file: %s\n", wht_path_rootfs);
+        retval = unlink(wht_path_rootfs);
+    }
+
+    free(wht_path);
+    free(wht_path_rootfs);
+
+    return retval;
+}
+
+
+int apply_whiteouts(char *tarfile, char *rootfs_dir) {
+    int ret = 0;
+    int errcode = 0;
+
+    struct archive *a;
+    struct archive_entry *entry;
+
+    a = archive_read_new();
+    archive_read_support_filter_all(a);
+    archive_read_support_format_all(a);
+    ret = archive_read_open_filename(a, tarfile, 10240);
+    if (ret != ARCHIVE_OK)
+        return(1);
+
+    char *pathname;
+
+    while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
+
+        pathname = archive_entry_pathname(entry);
+
+        if (strstr(pathname, "/.wh..wh..opq")){
+            singularity_message(DEBUG, "Opaque Marker %s\n", pathname);
+            errcode = apply_opaque(pathname, rootfs_dir);
+            if ( errcode != 0) {
+                break;
+            }
+        }else if (strstr(pathname, "/.wh.")){
+            singularity_message(DEBUG, "Whiteout Marker %s\n", pathname);
+            errcode = apply_whiteout(pathname, rootfs_dir);
+            if ( errcode != 0) {
+                break;
+            }
+        }
+
+    }
+    ret = archive_read_free(a);  // Note 3
+    if (ret != ARCHIVE_OK)
+        return(1);
+
+    return errcode;
+
+}
+
+
+static int copy_data(struct archive *ar, struct archive *aw)
+{
+    int r;
+    const void *buff;
+    size_t size;
+    int64_t offset;
+
+    for (;;) {
+        r = archive_read_data_block(ar, &buff, &size, &offset);
+        if (r == ARCHIVE_EOF)
+            return (ARCHIVE_OK);
+        if (r < ARCHIVE_OK)
+            return (r);
+        r = archive_write_data_block(aw, buff, size, offset);
+        if (r < ARCHIVE_OK) {
+            fprintf(stderr, "%s\n", archive_error_string(aw));
+            return (r);
+        }
+    }
+}
+
+
+int extract_tar(char* tarfile, char* rootfs_dir) {
+    int retval = 0;
+    struct archive *a;
+    struct archive *ext;
+    struct archive_entry *entry;
+    int flags;
+    int r;
+    char *orig_dir;
+
+    orig_dir = getcwd(orig_dir,  0);
+
+    /* Select which attributes we want to restore. */
+    flags = ARCHIVE_EXTRACT_TIME;
+    flags |= ARCHIVE_EXTRACT_PERM;
+    flags |= ARCHIVE_EXTRACT_ACL;
+    flags |= ARCHIVE_EXTRACT_FFLAGS;
+
+
+    a = archive_read_new();
+    archive_read_support_format_all(a);
+    archive_read_support_compression_all(a);
+    ext = archive_write_disk_new();
+    archive_write_disk_set_options(ext, flags);
+    archive_write_disk_set_standard_lookup(ext);
+    if ((r = archive_read_open_filename(a, tarfile, 10240)))
+        exit(1);
+
+    chdir(rootfs_dir);
+
+    for (;;) {
+        r = archive_read_next_header(a, &entry);
+
+        if (r == ARCHIVE_EOF)
+            break;
+
+        if (r < ARCHIVE_OK)
+            singularity_message(WARNING, "A%s\n", archive_error_string(a));
+        if (r < ARCHIVE_WARN) {
+            singularity_message(ERROR, "A%s\n", archive_error_string(a));
+            ABORT(255);
+        }
+
+        char *pathname = archive_entry_pathname(entry);
+        int pathtype = archive_entry_filetype(entry);
+
+        if (strstr(pathname, "/.wh.") ||
+            pathtype == AE_IFSOCK     ||
+            pathtype == AE_IFCHR      ||
+            pathtype == AE_IFBLK      ||
+            pathtype == AE_IFIFO
+        ) {
+          continue;
+        }
+
+        r = archive_write_header(ext, entry);
+        if (r < ARCHIVE_OK)
+            singularity_message(WARNING, "%s\n", archive_error_string(ext));
+        else if (archive_entry_size(entry) > 0) {
+            r = copy_data(a, ext);
+            if (r < ARCHIVE_OK)
+                singularity_message(WARNING, "%s\n", archive_error_string(ext));
+            if (r < ARCHIVE_WARN) {
+                singularity_message(ERROR, "%Bs\n", archive_error_string(ext));
+                ABORT(255);
+            }
+        }
+        r = archive_write_finish_entry(ext);
+        if (r < ARCHIVE_OK)
+            singularity_message(WARNING, "%s\n", archive_error_string(ext));
+        if (r < ARCHIVE_WARN) {
+            singularity_message(ERROR, "%Cs\n", archive_error_string(ext));
+            ABORT(255);
+        }
+    }
+    archive_read_close(a);
+    archive_read_free(a);
+    archive_write_close(ext);
+    archive_write_free(ext);
+
+    chdir(orig_dir);
+    free(orig_dir);
+
+    return(retval);
+
+}
+
+
+int main(int argc, char **argv) {
+    int retval = 0;
+    char *rootfs_dir = envar_path("SINGULARITY_ROOTFS");
+    char *tarfile = NULL;
+
+    if ( rootfs_dir == NULL ) {
+      singularity_message(ERROR, "Environment is not properly setup\n");
+      ABORT(255);
+    }
+
+    if (is_dir(rootfs_dir) < 0 ){
+        singularity_message(ERROR, "SINGULARITY_ROOTFS does not exist\n");
+        ABORT(255);
+    }
+
+    if (argc != 2) {
+        singularity_message(ERROR, "Provide a single docker tar file to extract\n");
+        ABORT(255);
+    }
+
+    tarfile = argv[1];
+
+    singularity_message(DEBUG, "Applying whiteouts for tar file %s\n", tarfile);
+
+    retval = apply_whiteouts(tarfile, rootfs_dir);
+
+    if ( retval != 0){
+        singularity_message(ERROR, "Error applying layer whiteouts\n");
+        ABORT(255);
+    }
+
+    singularity_message(DEBUG, "Extracting docker tar file %s\n", tarfile);
+
+    retval = extract_tar(tarfile, rootfs_dir);
+
+    return(retval);
+}
+
+

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -100,7 +100,11 @@ int apply_whiteouts(char *tarfile, char *rootfs_dir) {
     struct archive_entry *entry;
 
     a = archive_read_new();
+#if ARCHIVE_VERSION_NUMBER <= 3000000
     archive_read_support_compression_all(a);
+#else
+    archive_read_support_filter_all(a);
+#endif
     archive_read_support_format_all(a);
     ret = archive_read_open_filename(a, tarfile, 10240);
     if (ret != ARCHIVE_OK)
@@ -124,7 +128,11 @@ int apply_whiteouts(char *tarfile, char *rootfs_dir) {
             }
         }
     }
+#if ARCHIVE_VERSION_NUMBER <= 3000000
     ret = archive_read_finish(a);
+#else
+    ret = archive_read_free(a);
+#endif
     if (ret != ARCHIVE_OK){
         singularity_message(ERROR, "Error freeing archive\n");
         ABORT(255);
@@ -179,7 +187,11 @@ int extract_tar(const char *tarfile, const char *rootfs_dir) {
 
     a = archive_read_new();
     archive_read_support_format_all(a);
+#if ARCHIVE_VERSION_NUMBER <= 3000000
     archive_read_support_compression_all(a);
+#else
+    archive_read_support_filter_all(a);
+#endif
     ext = archive_write_disk_new();
     archive_write_disk_set_options(ext, flags);
     archive_write_disk_set_standard_lookup(ext);
@@ -239,10 +251,17 @@ int extract_tar(const char *tarfile, const char *rootfs_dir) {
         }
     }
     archive_read_close(a);
+#if ARCHIVE_VERSION_NUMBER <= 3000000
     archive_read_finish(a);
+#else
+    archive_read_free(a);
+#endif
     archive_write_close(ext);
+#if ARCHIVE_VERSION_NUMBER <= 3000000
     archive_write_finish(ext);
-
+#else
+    archive_write_free(ext);
+#endif
     r = chdir(orig_dir);
     if (r < 0 ){
         singularity_message(ERROR, "Could not chdir back to %s\n", orig_dir);

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -11,28 +11,34 @@
 #include <archive_entry.h>
 
 #include "config.h"
-#include "util/util.h"
-#include "util/message.h"
 #include "util/file.h"
+#include "util/message.h"
+#include "util/util.h"
 
-int apply_opaque(char* pathname, char* rootfs_dir) {
+/* apply_opaque
+ *  Given opq_marker as a path to a whiteout opaque marker
+ *    e.g. usr/share/doc/test/.wh..wh..opq
+ *  Make the directory containing the make opaque for this layer by removing it
+ *  if it exists under rootfs_dir
+ */
+int apply_opaque(const char *opq_marker, char *rootfs_dir) {
     int retval = 0;
-    char *token = strrchr(pathname, '/');
+    char *token = strrchr(opq_marker, '/');
 
-    if( token == NULL ){
+    if (token == NULL) {
         singularity_message(ERROR, "Error getting dirname for opaque marker\n");
         ABORT(255);
     }
 
-    size_t length = token - pathname;
+    size_t length = token - opq_marker;
     char *opq_dir = malloc(length + 1);
-    strncpy(opq_dir, pathname, length);
+    strncpy(opq_dir, opq_marker, length);
     opq_dir[length] = 0;
 
-    char *opq_dir_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(opq_dir) + 1 );
+    char *opq_dir_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(opq_dir) + 1);
     sprintf(opq_dir_rootfs, "%s/%s", rootfs_dir, opq_dir);
 
-    if( is_dir(opq_dir_rootfs) == 0 ){
+    if (is_dir(opq_dir_rootfs) == 0) {
         s_rmdir(opq_dir_rootfs);
     }
 
@@ -42,40 +48,48 @@ int apply_opaque(char* pathname, char* rootfs_dir) {
     return retval;
 }
 
-
-int apply_whiteout(char* pathname, char* rootfs_dir) {
+/* apply_whiteout
+ *  Given wh_marker as a path to a whiteout marker
+ *    e.g. usr/share/doc/test/.wh.deletedfile
+ *  Whiteout the referenced file for this layer by removing it if it exists
+ *  under rootfs_dir
+ */
+int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
     int retval = 0;
-    char *token = strstr(pathname, ".wh.");
+    char *token = strstr(wh_marker, ".wh.");
 
-    if( token == NULL ){
+    if (token == NULL) {
         singularity_message(ERROR, "Error getting filename for whiteout marker\n");
         ABORT(255);
     }
 
-    size_t token_pos = strlen(pathname) - strlen(token);
-    size_t length = strlen(pathname) - strlen(".wh.") + 1;
-    char *wht_path = malloc(length);
-    strncpy(wht_path, pathname, token_pos + 1 );
-    wht_path[token_pos] = 0;
-    strcat(wht_path, token + 4);
+    size_t token_pos = strlen(wh_marker) - strlen(token);
+    size_t length = strlen(wh_marker) - strlen(".wh.") + 1;
+    char *wh_path = malloc(length);
+    strncpy(wh_path, wh_marker, token_pos + 1);
+    wh_path[token_pos] = 0;
+    strcat(wh_path, token + 4);
 
-    char *wht_path_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(wht_path) + 1 );
-    sprintf(wht_path_rootfs, "%s/%s", rootfs_dir, wht_path);
+    char *wh_path_rootfs = malloc(strlen(rootfs_dir) + 1 + strlen(wh_path) + 1);
+    sprintf(wh_path_rootfs, "%s/%s", rootfs_dir, wh_path);
 
-    if( is_dir(wht_path_rootfs) == 0 ) {
-        retval = s_rmdir(wht_path_rootfs);
-    }else if(is_file(wht_path_rootfs) == 0 ) {
-        singularity_message(DEBUG, "Removing whiteout-ed file: %s\n", wht_path_rootfs);
-        retval = unlink(wht_path_rootfs);
+    if (is_dir(wh_path_rootfs) == 0) {
+        retval = s_rmdir(wh_path_rootfs);
+    } else if (is_file(wh_path_rootfs) == 0) {
+        singularity_message(DEBUG, "Removing whiteout-ed file: %s\n",
+                            wh_path_rootfs);
+        retval = unlink(wh_path_rootfs);
     }
 
-    free(wht_path);
-    free(wht_path_rootfs);
+    free(wh_path);
+    free(wh_path_rootfs);
 
     return retval;
 }
 
-
+/* apply_whiteouts
+ *  Process tarfile and apply any aufs opaque/whiteouts on rootfs_dir
+ */
 int apply_whiteouts(char *tarfile, char *rootfs_dir) {
     int ret = 0;
     int errcode = 0;
@@ -84,44 +98,41 @@ int apply_whiteouts(char *tarfile, char *rootfs_dir) {
     struct archive_entry *entry;
 
     a = archive_read_new();
-    archive_read_support_filter_all(a);
+    archive_read_support_compression_all(a);
     archive_read_support_format_all(a);
     ret = archive_read_open_filename(a, tarfile, 10240);
     if (ret != ARCHIVE_OK)
-        return(1);
-
-    char *pathname;
+        return (1);
 
     while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
 
-        pathname = archive_entry_pathname(entry);
+        const char *pathname = archive_entry_pathname(entry);
 
-        if (strstr(pathname, "/.wh..wh..opq")){
+        if (strstr(pathname, "/.wh..wh..opq")) {
             singularity_message(DEBUG, "Opaque Marker %s\n", pathname);
             errcode = apply_opaque(pathname, rootfs_dir);
-            if ( errcode != 0) {
+            if (errcode != 0) {
                 break;
             }
-        }else if (strstr(pathname, "/.wh.")){
+        } else if (strstr(pathname, "/.wh.")) {
             singularity_message(DEBUG, "Whiteout Marker %s\n", pathname);
             errcode = apply_whiteout(pathname, rootfs_dir);
-            if ( errcode != 0) {
+            if (errcode != 0) {
                 break;
             }
         }
-
     }
-    ret = archive_read_free(a);  // Note 3
-    if (ret != ARCHIVE_OK)
-        return(1);
+    ret = archive_read_finish(a);
+    if (ret != ARCHIVE_OK){
+        singularity_message(ERROR, "Error freeing archive\n");
+        ABORT(255);
+    }
 
     return errcode;
-
 }
 
-
-static int copy_data(struct archive *ar, struct archive *aw)
-{
+/* See  https://github.com/libarchive/libarchive/wiki/Examples#A_Complete_Extractor */
+static int copy_data(struct archive *ar, struct archive *aw) {
     int r;
     const void *buff;
     size_t size;
@@ -135,14 +146,19 @@ static int copy_data(struct archive *ar, struct archive *aw)
             return (r);
         r = archive_write_data_block(aw, buff, size, offset);
         if (r < ARCHIVE_OK) {
-            fprintf(stderr, "%s\n", archive_error_string(aw));
+            singularity_message(ERROR, "tar extraction error: %s\n", archive_error_string(aw));
             return (r);
         }
     }
 }
 
-
-int extract_tar(char* tarfile, char* rootfs_dir) {
+/* extract_tar
+ *  Extract a tar file to rootfs_dir using libarchive. Handles compression.
+ *  Exclude any .wh. whiteout files, and device/pipe/fifo entries
+ *
+ * See https://github.com/libarchive/libarchive/wiki/Examples#A_Complete_Extractor
+ */
+int extract_tar(const char *tarfile, const char *rootfs_dir) {
     int retval = 0;
     struct archive *a;
     struct archive *ext;
@@ -151,7 +167,7 @@ int extract_tar(char* tarfile, char* rootfs_dir) {
     int r;
     char *orig_dir;
 
-    orig_dir = getcwd(orig_dir,  0);
+    orig_dir = get_current_dir_name();
 
     /* Select which attributes we want to restore. */
     flags = ARCHIVE_EXTRACT_TIME;
@@ -159,17 +175,23 @@ int extract_tar(char* tarfile, char* rootfs_dir) {
     flags |= ARCHIVE_EXTRACT_ACL;
     flags |= ARCHIVE_EXTRACT_FFLAGS;
 
-
     a = archive_read_new();
     archive_read_support_format_all(a);
     archive_read_support_compression_all(a);
     ext = archive_write_disk_new();
     archive_write_disk_set_options(ext, flags);
     archive_write_disk_set_standard_lookup(ext);
-    if ((r = archive_read_open_filename(a, tarfile, 10240)))
-        exit(1);
+    if ((r = archive_read_open_filename(a, tarfile, 10240))){
+        singularity_message(ERROR, "Error opening tar file %s\n", tarfile);
+        ABORT(255);
+    }
 
-    chdir(rootfs_dir);
+    // Extract into the SINGULARITY_ROOTFS
+    r = chdir(rootfs_dir);
+    if (r < 0 ){
+        singularity_message(ERROR, "Could not chdir to SINGULARITY_ROOTFS %s\n", rootfs_dir);
+        ABORT(255);
+    }
 
     for (;;) {
         r = archive_read_next_header(a, &entry);
@@ -178,68 +200,69 @@ int extract_tar(char* tarfile, char* rootfs_dir) {
             break;
 
         if (r < ARCHIVE_OK)
-            singularity_message(WARNING, "A%s\n", archive_error_string(a));
+            singularity_message(WARNING, "Warning reading tar header: %s\n", archive_error_string(a));
         if (r < ARCHIVE_WARN) {
-            singularity_message(ERROR, "A%s\n", archive_error_string(a));
+            singularity_message(ERROR, "Error reading tar header: %s\n", archive_error_string(a));
             ABORT(255);
         }
 
-        char *pathname = archive_entry_pathname(entry);
+        const char *pathname = archive_entry_pathname(entry);
         int pathtype = archive_entry_filetype(entry);
 
-        if (strstr(pathname, "/.wh.") ||
-            pathtype == AE_IFSOCK     ||
-            pathtype == AE_IFCHR      ||
-            pathtype == AE_IFBLK      ||
-            pathtype == AE_IFIFO
-        ) {
-          continue;
+        // Do not extract whiteout markers (handled in apply_whiteouts)
+        // Do not extract sockers, chr/blk devices, pipes
+        if (strstr(pathname, "/.wh.") || pathtype == AE_IFSOCK ||
+            pathtype == AE_IFCHR || pathtype == AE_IFBLK || pathtype == AE_IFIFO) {
+            continue;
         }
 
         r = archive_write_header(ext, entry);
         if (r < ARCHIVE_OK)
-            singularity_message(WARNING, "%s\n", archive_error_string(ext));
+            singularity_message(WARNING, "Warning handling tar header: %s\n", archive_error_string(ext));
         else if (archive_entry_size(entry) > 0) {
             r = copy_data(a, ext);
             if (r < ARCHIVE_OK)
-                singularity_message(WARNING, "%s\n", archive_error_string(ext));
+                singularity_message(WARNING, "Warning handling tar header: %s\n", archive_error_string(ext));
             if (r < ARCHIVE_WARN) {
-                singularity_message(ERROR, "%Bs\n", archive_error_string(ext));
+                singularity_message(ERROR, "Error handling tar header: %s\n", archive_error_string(ext));
                 ABORT(255);
             }
         }
         r = archive_write_finish_entry(ext);
         if (r < ARCHIVE_OK)
-            singularity_message(WARNING, "%s\n", archive_error_string(ext));
+            singularity_message(WARNING, "Warning freeing archive entry: %s\n", archive_error_string(ext));
         if (r < ARCHIVE_WARN) {
-            singularity_message(ERROR, "%Cs\n", archive_error_string(ext));
+            singularity_message(ERROR, "Error freeing archive entry: %s\n", archive_error_string(ext));
             ABORT(255);
         }
     }
     archive_read_close(a);
-    archive_read_free(a);
+    archive_read_finish(a);
     archive_write_close(ext);
-    archive_write_free(ext);
+    archive_write_finish(ext);
 
-    chdir(orig_dir);
+    r = chdir(orig_dir);
+    if (r < 0 ){
+        singularity_message(ERROR, "Could not chdir back to %s\n", orig_dir);
+        ABORT(255);
+    }
+
     free(orig_dir);
 
-    return(retval);
-
+    return (retval);
 }
-
 
 int main(int argc, char **argv) {
     int retval = 0;
     char *rootfs_dir = envar_path("SINGULARITY_ROOTFS");
     char *tarfile = NULL;
 
-    if ( rootfs_dir == NULL ) {
-      singularity_message(ERROR, "Environment is not properly setup\n");
-      ABORT(255);
+    if (rootfs_dir == NULL) {
+        singularity_message(ERROR, "Environment is not properly setup\n");
+        ABORT(255);
     }
 
-    if (is_dir(rootfs_dir) < 0 ){
+    if (is_dir(rootfs_dir) < 0) {
         singularity_message(ERROR, "SINGULARITY_ROOTFS does not exist\n");
         ABORT(255);
     }
@@ -251,20 +274,26 @@ int main(int argc, char **argv) {
 
     tarfile = argv[1];
 
-    singularity_message(DEBUG, "Applying whiteouts for tar file %s\n", tarfile);
+    if (is_file(tarfile) < 0) {
+        singularity_message(ERROR, "tar file does not exist: %s\n", tarfile);
+        ABORT(255);
+    }
 
+    singularity_message(DEBUG, "Applying whiteouts for tar file %s\n", tarfile);
     retval = apply_whiteouts(tarfile, rootfs_dir);
 
-    if ( retval != 0){
+    if (retval != 0) {
         singularity_message(ERROR, "Error applying layer whiteouts\n");
         ABORT(255);
     }
 
     singularity_message(DEBUG, "Extracting docker tar file %s\n", tarfile);
-
     retval = extract_tar(tarfile, rootfs_dir);
 
-    return(retval);
+    if (retval != 0) {
+        singularity_message(ERROR, "Error extracting tar file\n");
+        ABORT(255);
+    }
+
+    return (retval);
 }
-
-

--- a/tests/21-build_docker.sh
+++ b/tests/21-build_docker.sh
@@ -60,6 +60,12 @@ stest 1 sudo singularity build -F "$CONTAINER" docker://something_that_doesnt_ex
 stest 1 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
+# AUFS sanity tests
+stest 0 sudo singularity build -F "$CONTAINER" docker://dctrud/docker-aufs-sanity
+stest 0 singularity exec "$CONTAINER" ls /test/whiteout-dir/file2 /test/whiteout-file/file2 /test/normal-dir/file2
+stest 1 singularity exec "$CONTAINER" ls /test/whiteout-dir/file1 /test/whiteout-file/file1
+stest 1 singularity exec "$CONTAINER" ls /test/*/.wh*
+
 if singularity_which docker >/dev/null 2>&1; then
 # make sure local test does not exist, ignore errors
 sudo docker kill registry >/dev/null 2>&1


### PR DESCRIPTION
**Description of the Pull Request (PR):**

**This is an alternative implementation of PR #1106 using C code and libarchive to provide libexec/bin/docker-extract for aufs whiteout handling instead of complex shell code.**

Docker layer tars can contain .wh.* files/dirs that are whiteout files from aufs. When extracted to a singularity image this causes problems. E.g.

singularity pull docker://nvidia/digits:6.0
singularity run digits-6.0.img

... will fail with python errors related to permission issues as python tries to scan .wh* files and dirs.

The aufs whiteout files instruct container software how to remove files from previous layers, that were removed during a later Dockerfile 'RUN' step. These removals must be performed by Singularity to ensure a container contains the same content as when run with docker.

The issue is illustrated with the test container at this Git repository:

https://github.com/dctrud/docker-aufs-sanity

**This fixes or addresses the following GitHub issues:**

- Ref: #571 #884 #1132 (part of issue)


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
