### PR TITLE
apprun script backslash removal fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 ## [v2.4.1](https://github.com/singularityware/singularity/tree/development) (development)
 
+### apprun script backslash removal fix
+ - Fixed the unwanted removal of backslashes in apprun scripts
+
 ### Security related fixes
  - Fixed container path and owner limitations (original merge was lost)
  - Check of overlay upper/work images are symlinks

--- a/libexec/bootstrap-scripts/functions
+++ b/libexec/bootstrap-scripts/functions
@@ -74,7 +74,7 @@ get_section() {
     RECIPE="$2"
     FOUND="no"
 
-    while read line
+    while read -r line
     do
 
  


### PR DESCRIPTION
Hi,

during image generation unescaped backslashes are removed from the %apprun script section. This behavior is different to the %runscript section which preserves backslashes. To make both script sections behave the same and make it possible to copy and paste existing shell code to the apprun section without modifications the bash read command needs the option -r to ignore (preserve) backslashes.

Example:

$ cat test-image.def
Bootstrap: docker
From: fedora:26
%runscript
  echo "foo\nbar\n"
%apprun test
  echo "foo\nbar\n"


$ singularity build test1.simg test-image.def
$ singularity exec test1.simg bash
Singularity> cat /singularity 
#!/bin/sh 

  echo "foo\nbar\n"
Singularity> cat /scif/apps/test/scif/runscript
  echo "foonbarn"

Cheers
Richard

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
  -> I've tested the new image build with success
- [X] This PR is NOT against the project's master branch
- [-] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
  -> no, for this small fix I didn't think it necessary to be listed as contributor
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin
