### PR TITLE
Make the build reproducible in case the SOURCE_DATE_EPOCH is known

### DIFF
--- a/libexec/bootstrap-scripts/environment/Makefile.am
+++ b/libexec/bootstrap-scripts/environment/Makefile.am
@@ -41,7 +41,7 @@ environment.tar:
 	ln -sf .singularity.d/actions/run newroot/.run
 	ln -sf .singularity.d/actions/shell newroot/.shell
 	ln -sf .singularity.d/actions/test newroot/.test
-	cd newroot; tar czf ../environment.tar . --owner=0 --group=0
+	cd newroot; GZIP=-n tar czf ../environment.tar . --owner=0 --group=0 --sort=name --mtime="@${SOURCE_DATE_EPOCH:-$(date +%s)}"
 	rm -rf newroot
 
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
To facilitate reproducible builds in Debian

See https://wiki.debian.org/ReproducibleBuilds

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.  *Is it worth it for this one?*
- [ ] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
