### PR TITLE
Don't pass gid mount parameter for devpts when running without setuid

### DIFF
--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -157,8 +157,8 @@ int _singularity_runtime_mount_dev(void) {
                 singularity_priv_drop();
 
                 if (errno == EINVAL) {
-                    // This is the error when unprivileged on RHEL7.4
-                    singularity_message(VERBOSE, "Couldn't mount %s, continuing\n", joinpath(devdir, "/pts"));
+                    // This is the error when unprivileged on RHEL7.4 
+                    singularity_message(WARNING, "Couldn't mount %s, continuing\n", joinpath(devdir, "/pts"));
                 } else {
                     singularity_message(ERROR, "Failed to mount %s: %s\n", joinpath(devdir, "/pts"), strerror(errno));
                     ABORT(255);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR allows the devpts filesystem to be mounted when setuid is disabled (and user namespaces are enabled), for kernels where this is supported.  On systems where this functionality isn't supported, and "mounts devpts = yes" is configured, a non-fatal warning message is displayed, even without verbose output enabled.  This PR also slightly reduces the amount of code running with privilege in the setuid case. 

**This fixes or addresses the following GitHub issues:**

- Ref: #1186 


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
