### PR TITLE
Add missing build deps to deb and RPM: uuid and ssl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,9 @@ Build-Depends:
  debhelper (>= 9),
  dh-autoreconf,
  help2man,
+ libssl-dev,
  python,
+ uuid-dev,
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity
 Vcs-Git: https://github.com/singularityware/singularity.git

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -35,6 +35,8 @@ Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 BuildRequires: python
+BuildRequires: libuuid-devel
+BuildRequires: openssl-devel
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 %else


### PR DESCRIPTION
Build fails in a clean env (mock or cowbuilder) without it.

**Description of the Pull Request (PR):**

Since the commit https://github.com/singularityware/singularity/commit/de6a020105713a49079a2c56705dd3e43c152579, It is not possible to build a RPM or a deb package in a clean environment, the configure fails if those libraries are not present.

This was tested on Debian Jesssie and RHEL 6. Not sure if the packages have the same names on Suse.


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
