### PR TITLE
Support multiarch (32 and 64bits) in containlibs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - squashfs-tools
       - uuid-dev
       - libssl-dev
+      - libelf-dev
 
 env:
   global:

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -5,7 +5,7 @@
 OS_VERSION="$1"
 
 # build and install
-yum install -y libtool rpm-build make squashfs-tools openssl-devel libuuid-devel
+yum install -y libtool rpm-build make squashfs-tools openssl-devel libuuid-devel elfutils-libelf-devel
 ./autogen.sh
 ./configure
 make dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Add capability support and secure build #934
  - Boot/start instance #1032
  - Put /usr/local/{bin,sbin} in front of the default PATH
+ - containlibs (used by --nv) supports multiarch
 
 ## [v2.4.2](https://github.com/singularityware/singularity/tree/release-2.4)
 

--- a/configure.ac
+++ b/configure.ac
@@ -389,6 +389,15 @@ AC_SEARCH_LIBS([SHA1], [crypto], [], [
 	AC_MSG_ERROR([unable to find the SHA1(), need package openssl-devel (libssl-dev on Debian/Ubuntu)])
 ])
 
+# check for libelf needed for sorting libraries
+AC_CHECK_HEADERS([libelf.h],
+	[elf_header_found=yes; break;])
+AS_IF([test "x$elf_header_found" != "xyes"],
+	[AC_MSG_ERROR([Unable to find the libelf headers, need package elfutils-libelf-devel (libelf-dev on Debian/Ubuntu)])])
+AC_SEARCH_LIBS([elf_begin], [elf], [], [
+	AC_MSG_ERROR([unable to find the elf_begin(), need package elfutils-libelf-devel (libelf-dev on Debian/Ubuntu)])
+])
+
 CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector --param ssp-buffer-size=4"
 
 AC_CONFIG_FILES([

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends:
  debhelper (>= 9),
  dh-autoreconf,
  help2man,
+ libelf-dev,
  python,
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity

--- a/secbuildimg.sh.in
+++ b/secbuildimg.sh.in
@@ -57,7 +57,7 @@ From: ubuntu:latest
     export LC_LANG=C
     apt-get update
     apt-get install -y git gcc python make automake autoconf libtool
-    apt-get install -y squashfs-tools curl uuid-dev libssl-dev
+    apt-get install -y squashfs-tools curl uuid-dev libssl-dev libelf-dev
     apt-get install -y debootstrap yum zypper
     apt-get clean
     apt-get autoclean

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -35,6 +35,7 @@ Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 BuildRequires: python
+BuildRequires: elfutils-libelf-devel
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 %else

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,25 +15,25 @@ EXTRA_PROGRAMS = wrapper-suid
 cleanupd_SOURCES = cleanupd.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c util/capability.c util/suid.c
 cleanupd_CPPFLAGS = $(AM_CPPFLAGS)
 
-action_SOURCES = action.c util/util.c util/file.c util/registry.c util/privilege.c util/sessiondir.c util/suid.c util/cleanupd.c util/daemon.c util/capability.c util/mount.c
-action_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la action-lib/libinternal.la -luuid
+action_SOURCES = action.c util/util.c util/file.c util/registry.c util/privilege.c util/sessiondir.c util/suid.c util/cleanupd.c util/daemon.c util/capability.c util/mount.c util/binary.c
+action_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la action-lib/libinternal.la -luuid -lelf
 action_CPPFLAGS = $(AM_CPPFLAGS)
 
-builddef_SOURCES = builddef.c util/util.c util/file.c util/registry.c util/sessiondir.c util/capability.c
-builddef_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la bootstrap-lib/libinternal.la -luuid
+builddef_SOURCES = builddef.c util/util.c util/file.c util/registry.c util/sessiondir.c util/capability.c util/binary.c
+builddef_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la bootstrap-lib/libinternal.la -luuid -lelf
 builddef_CPPFLAGS = $(AM_CPPFLAGS)
 builddef_LDFLAGS = -static
 
-start_SOURCES = start.c util/util.c util/file.c util/registry.c util/privilege.c util/sessiondir.c util/suid.c util/cleanupd.c util/fork.c util/daemon.c util/signal.c util/capability.c util/mount.c
-start_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la action-lib/libinternal.la -luuid
+start_SOURCES = start.c util/util.c util/file.c util/registry.c util/privilege.c util/sessiondir.c util/suid.c util/cleanupd.c util/fork.c util/daemon.c util/signal.c util/capability.c util/mount.c util/binary.c
+start_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la action-lib/libinternal.la -luuid -lelf
 start_CPPFLAGS = $(AM_CPPFLAGS)
 
-mount_SOURCES = mount.c util/util.c util/file.c util/registry.c util/suid.c util/privilege.c util/capability.c util/mount.c
-mount_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la -luuid
+mount_SOURCES = mount.c util/util.c util/file.c util/registry.c util/suid.c util/privilege.c util/capability.c util/mount.c util/binary.c
+mount_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la -luuid -lelf
 mount_CPPFLAGS = $(AM_CPPFLAGS)
 
-sif_SOURCES = sif.c util/util.c
-sif_LDADD = lib/image/libsingularity-image.la lib/signing/libsingularity-signing.la lib/sif/libsingularity-sif.la -luuid -lcrypto
+sif_SOURCES = sif.c util/util.c util/binary.c
+sif_LDADD = lib/image/libsingularity-image.la lib/signing/libsingularity-signing.la lib/sif/libsingularity-sif.la -luuid -lcrypto -lelf
 sif_CPPFLAGS = $(AM_CPPFLAGS)
 
 get_section_SOURCES = get-section.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c util/capability.c util/suid.c
@@ -43,8 +43,8 @@ image_type_SOURCES = image-type.c util/util.c util/message.c util/config_parser.
 image_type_LDADD = lib/image/libsingularity-image.la lib/sif/libsingularity-sif.la -luuid
 image_type_CPPFLAGS = $(AM_CPPFLAGS)
 
-wrapper_SOURCES = wrapper.c util/util.c util/file.c util/registry.c util/suid.c util/privilege.c util/capability.c
-wrapper_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la -luuid
+wrapper_SOURCES = wrapper.c util/util.c util/file.c util/registry.c util/suid.c util/privilege.c util/capability.c util/binary.c
+wrapper_LDADD = lib/image/libsingularity-image.la lib/runtime/libsingularity-runtime.la lib/sif/libsingularity-sif.la -luuid -lelf
 wrapper_CPPFLAGS = $(AM_CPPFLAGS)
 
 wrapper_suid_SOURCES = $(wrapper_SOURCES)

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -37,4 +37,6 @@ EXTRA_DIST = capability.c \
 			 setns.h \
 			 signal.c \
 			 signal.h \
+			 binary.c \
+			 binary.h \
 			 config_defaults.h

--- a/src/util/binary.c
+++ b/src/util/binary.c
@@ -1,0 +1,72 @@
+/* 
+ * Copyright (c) 2017, EDF, SA. All rights reserved.
+ * 
+ * This software is licensed under a 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ * 
+ */
+
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <errno.h>
+#include <libelf.h>
+
+#include "util/message.h"
+#include "util/binary.h"
+
+int singularity_binary_arch(char* path){
+    FILE* fp;
+    Elf* elf_file;
+    Elf32_Ehdr* hdr32 = NULL;
+    Elf64_Ehdr* hdr64 = NULL;
+
+    fp = fopen(path, "rb");
+    if (fp == NULL) {
+        singularity_message(WARNING, "Failed to open binary: %s (error=%d)\n", path, errno);
+        return(BINARY_ARCH_UNKNOWN);
+    }
+    if (elf_version(EV_CURRENT) == EV_NONE) {
+        singularity_message(WARNING, "Failed to initialize ELF library: %s\n", elf_errmsg(-1));
+        return(BINARY_ARCH_UNKNOWN);
+    }
+    elf_file = elf_begin(fileno(fp), ELF_C_READ, NULL);
+    if (elf_file == NULL) {
+        singularity_message(DEBUG, "Failed initialize elf parsing on file %s: %s\n", path, elf_errmsg(-1));
+        // Not an ELF BINARY
+        return(BINARY_ARCH_UNKNOWN);
+    }
+    hdr32 = elf32_getehdr(elf_file);
+    if (hdr32 == NULL) {
+        hdr64 = elf64_getehdr(elf_file);
+    }
+    fclose(fp);
+    if (hdr32 == NULL) {
+        if (hdr64 == NULL) {
+            singularity_message(DEBUG, "No ELF headers on binary file %s: (%s)\n", path, elf_errmsg(-1));
+            // Not an ELF BINARY
+            return(BINARY_ARCH_UNKNOWN);
+        } else {
+            if (hdr64->e_machine == EM_X86_64) {
+                // x86_64
+                return(BINARY_ARCH_X86_64);
+            } else {
+                // Unkown 64 bits arch
+                return(BINARY_ARCH_UNKNOWN);
+            }
+        }
+    } else {
+        switch(hdr32->e_machine) {
+            case EM_X86_64 :
+                // x32
+                return(BINARY_ARCH_X32);
+            case EM_386 : 
+                // i386
+                return(BINARY_ARCH_I386);
+            default :
+                // Unkown 32 bits arch
+                return(BINARY_ARCH_UNKNOWN);
+        }
+    }
+}

--- a/src/util/binary.h
+++ b/src/util/binary.h
@@ -1,0 +1,21 @@
+/* 
+ * Copyright (c) 2017, EDF, SA. All rights reserved.
+ * 
+ * This software is licensed under a 3-clause BSD license.  Please
+ * consult LICENSE file distributed with the sources of this project regarding
+ * your rights to use or distribute this software.
+ * 
+ */
+
+
+#ifndef __BINARY_H_
+#define __BINARY_H_
+
+#define BINARY_ARCH_UNKNOWN 0
+#define BINARY_ARCH_X86_64  1
+#define BINARY_ARCH_I386    2
+#define BINARY_ARCH_X32     3
+
+int singularity_binary_arch(char* path);
+
+#endif /* __BINARY_H_ */


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The goal of this PR is to make containlibs work for 32 and 64 bits libraries at the same time. The use case for us is to make some old 32 bits binary only OpenGL applications work with the "--nv" option. In the current code the list of libraries is bound to `/.singularity.d/libs`, if a library is listed twice with two possible sources, it is bound only once.

With this PR, the x86_64 libraries is bound in `/.singularity.d/libs/x86_64` and i386 libraries are bound in `/.singularity.d/libs/i686`. The value of LD_LIBRARY_PATH is updated according to the used sub directories. If the architecture of a library can't be determined, it is bound to `/.singularity.d/libs` as before. This sorting only supports 'x86_64', 'i386' and 'x32', but other architecture works the same way as before and adding other architectures with multiarch should be easy.

To check for the library architecture, the PR relies on elfutils-libelf. This is added as a build dependency.


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge
