### PR TITLE
add environment containing to --containall help

### DIFF
--- a/libexec/cli/exec.info
+++ b/libexec/cli/exec.info
@@ -20,7 +20,8 @@ EXEC OPTIONS:
                         default). This option can be called multiple times.
     -c|--contain        Use minimal /dev and empty other directories (e.g. /tmp
                         and $HOME) instead of sharing filesystems on your host
-    -C|--containall     Contain not only file systems, but also PID and IPC 
+    -C|--containall     Contain not only file systems, but also PID, IPC, and
+                        environment
     -e|--cleanenv       Clean environment before running container
     -H|--home <spec>    A home directory specification.  spec can either be a
                         src path or src:dest pair.  src is the source path

--- a/libexec/cli/run.info
+++ b/libexec/cli/run.info
@@ -25,7 +25,8 @@ RUN OPTIONS:
                         default). This option can be called multiple times.
     -c|--contain        Use minimal /dev and empty other directories (e.g. /tmp
                         and $HOME) instead of sharing filesystems on your host
-    -C|--containall     Contain not only file systems, but also PID and IPC
+    -C|--containall     Contain not only file systems, but also PID, IPC, and
+                        environment
     -e|--cleanenv       Clean environment before running container
     -H|--home <spec>    A home directory specification.  spec can either be a
                         src path or src:dest pair.  src is the source path

--- a/libexec/cli/shell.info
+++ b/libexec/cli/shell.info
@@ -19,7 +19,8 @@ SHELL OPTIONS:
                         default). This option can be called multiple times.
     -c|--contain        Use minimal /dev and empty other directories (e.g. /tmp
                         and $HOME) instead of sharing filesystems on your host
-    -C|--containall     Contain not only file systems, but also PID and IPC
+    -C|--containall     Contain not only file systems, but also PID, IPC, and
+                        environment
     -e|--cleanenv       Clean environment before running container
     -H|--home <spec>    A home directory specification.  spec can either be a
                         src path or src:dest pair.  src is the source path


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes the --containall help to also include that it contains the environment as the [code](https://github.com/singularityware/singularity/blob/master/libexec/cli/action_argparser.sh#L94) clearly does.


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
