### PR TITLE
add comment to bind path option about being ignored with --contain

### DIFF
--- a/etc/singularity.conf.in
+++ b/etc/singularity.conf.in
@@ -113,6 +113,7 @@
 # the container. The file or directory must exist within the container on
 # which to attach to. you can specify a different source and destination
 # path (respectively) with a colon; otherwise source and dest are the same.
+# NOTE: these are ignored if singularity is invoked with --contain.
 #bind path = /etc/singularity/default-nsswitch.conf:/etc/nsswitch.conf
 #bind path = /opt
 #bind path = /scratch


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This adds a comment to the singularity.conf "bind path" documentation comment that the paths are ignored if singularity is invoked with --contain, which is what the [code](https://github.com/singularityware/singularity/blob/master/src/lib/runtime/mounts/binds/binds.c#L49) does and was a surprise to  us.


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
