### PR TITLE
Fix getting Arch keyword from definition file

### DIFF
--- a/libexec/bootstrap-scripts/deffile-driver-debootstrap.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-debootstrap.sh
@@ -46,6 +46,7 @@ if ! DEBOOTSTRAP_PATH=`singularity_which debootstrap`; then
     exit 1
 fi
 
+ARCH="${SINGULARITY_DEFFILE_ARCH:-}"
 if [ -n "${ARCH:-}" ]; then
     ARCH=`echo ${ARCH:-} | sed -e 's/\s//g'`
 else


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix an oversight to take Arch keyword from deboostrap bootstrap method.
Changelog not updated -> dev branch

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
