### PR TITLE
Fix permission denied during bind of NFS mount point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
+## [v2.4.3](https://github.com/singularityware/singularity/tree/release-2.4)
+
+ - Fix permission denied when binding directory located on NFS with root_squash enabled
 
 ## [v2.4.2](https://github.com/singularityware/singularity/tree/release-2.4)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([singularity],[2.4.2],[gmkurtzer@lbl.gov])
+AC_INIT([singularity],[2.4.2],[gmkurtzer@gmail.com])
 
 if test -z "$prefix" -o "$prefix" = "NONE" ; then
   prefix=${ac_default_prefix}

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([singularity],[2.4.1],[gmkurtzer@lbl.gov])
+AC_INIT([singularity],[2.4.2],[gmkurtzer@lbl.gov])
 
 if test -z "$prefix" -o "$prefix" = "NONE" ; then
   prefix=${ac_default_prefix}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+singularity-container (2.4.2-1) unstable; urgency=high
+
+  * This fixed an issue for support of older distributions and kernels with regards to `setns()`
+    functionality.
+  * Fixed autofs bug path (lost during merge)
+
+ -- Gregory M. Kurtzer <gmkurtzer@gmail.com>  Wed, 22 Nov 2017 12:20:27 -0700
+
 singularity-container (2.4.1-1) unstable; urgency=high
 
   * This is a bug fix point release to the 2.4 feature branch, and includes a

--- a/src/lib/image/dir/mount.c
+++ b/src/lib/image/dir/mount.c
@@ -48,13 +48,11 @@ int _singularity_image_dir_mount(struct image_object *image, char *mount_point) 
         ABORT(255);
     }
 
-    singularity_priv_escalate();
     singularity_message(DEBUG, "Mounting container directory %s->%s\n", image->path, mount_point);
     if ( singularity_mount(image->path, mount_point, NULL, MS_BIND|MS_NOSUID|MS_REC|MS_NODEV, NULL) < 0 ) {
         singularity_message(ERROR, "Could not mount container directory %s->%s: %s\n", image->path, mount_point, strerror(errno));
         return 1;
     }
-    singularity_priv_drop();
 
     return(0);
 }

--- a/src/lib/image/ext3/mount.c
+++ b/src/lib/image/ext3/mount.c
@@ -63,13 +63,11 @@ int _singularity_image_ext3_mount(struct image_object *image, char *mount_point)
 
     }
 
-    singularity_priv_escalate();
     singularity_message(VERBOSE, "Mounting '%s' to: '%s'\n", loop_dev, mount_point);
     if ( singularity_mount(loop_dev, mount_point, "ext3", opts, "errors=remount-ro") < 0 ) {
         singularity_message(ERROR, "Failed to mount ext3 image: %s\n", strerror(errno));
         ABORT(255);
     }
-    singularity_priv_drop();
 
     return(0);
 }

--- a/src/lib/image/squashfs/mount.c
+++ b/src/lib/image/squashfs/mount.c
@@ -50,13 +50,11 @@ int _singularity_image_squashfs_mount(struct image_object *image, char *mount_po
         ABORT(255);
     }
 
-    singularity_priv_escalate();
     singularity_message(VERBOSE, "Mounting squashfs image: %s -> %s\n", loop_dev, mount_point);
     if ( singularity_mount(loop_dev, mount_point, "squashfs", MS_NOSUID|MS_RDONLY|MS_NODEV, "errors=remount-ro") < 0 ) {
         singularity_message(ERROR, "Failed to mount squashfs image in (read only): %s\n", strerror(errno));
         ABORT(255);
     }
-    singularity_priv_drop();
 
     return(0);
 }

--- a/src/lib/runtime/files/file-bind.c
+++ b/src/lib/runtime/files/file-bind.c
@@ -62,21 +62,17 @@ int container_file_bind(char *source, char *dest_path) {
         return(0);
     }
 
-    singularity_priv_escalate();
     singularity_message(VERBOSE, "Binding file '%s' to '%s'\n", source, dest);
     if ( singularity_mount(source, dest, NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
-        singularity_priv_drop();
         singularity_message(ERROR, "There was an error binding %s to %s: %s\n", source, dest, strerror(errno));
         ABORT(255);
     }
     if ( singularity_priv_userns_enabled() != 1 ) {
         if ( singularity_mount(NULL, dest, NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC|MS_REMOUNT, NULL) < 0 ) {
-            singularity_priv_drop();
             singularity_message(ERROR, "There was an error remounting %s to %s: %s\n", source, dest, strerror(errno));
             ABORT(255);
         }
     }
-    singularity_priv_drop();
 
     return(0);
 }

--- a/src/lib/runtime/files/libs/libs.c
+++ b/src/lib/runtime/files/libs/libs.c
@@ -134,14 +134,11 @@ int _singularity_runtime_files_libs(void) {
                 ABORT(255);
             }
 
-            singularity_priv_escalate();
             singularity_message(VERBOSE, "Binding file '%s' to '%s'\n", source, dest);
             if ( singularity_mount(source, dest, NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
-                    singularity_priv_drop();
                     singularity_message(ERROR, "There was an error binding %s to %s: %s\n", source, dest, strerror(errno));
                     ABORT(255);
             }
-            singularity_priv_drop();
 
             free(source);
             free(dest);
@@ -167,18 +164,12 @@ int _singularity_runtime_files_libs(void) {
             }
         }
 
-        singularity_priv_escalate();
         singularity_message(VERBOSE, "Binding libdir '%s' to '%s'\n", libdir, libdir_contained);
         if ( singularity_mount(libdir, libdir_contained, NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
-                singularity_priv_drop();
                 singularity_message(ERROR, "There was an error binding %s to %s: %s\n", libdir, libdir_contained, strerror(errno));
                 ABORT(255);
         }
-        singularity_priv_drop();
-
     }
-
-
 
     return(0);
 }

--- a/src/lib/runtime/mounts/binds/binds.c
+++ b/src/lib/runtime/mounts/binds/binds.c
@@ -131,7 +131,6 @@ int _singularity_runtime_mount_binds(void) {
             }
         }
 
-        singularity_priv_escalate();
         singularity_message(VERBOSE, "Binding '%s' to '%s/%s'\n", source, container_dir, dest);
         if ( singularity_mount(source, joinpath(container_dir, dest), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
             singularity_message(ERROR, "There was an error binding the path %s: %s\n", source, strerror(errno));
@@ -143,7 +142,6 @@ int _singularity_runtime_mount_binds(void) {
                 ABORT(255);
             }
         }
-        singularity_priv_drop();
     }
 
     return(0);

--- a/src/lib/runtime/mounts/cwd/cwd.c
+++ b/src/lib/runtime/mounts/cwd/cwd.c
@@ -133,12 +133,10 @@ int _singularity_runtime_mount_cwd(void) {
 #endif  
 
     singularity_message(VERBOSE, "Binding '%s' to '%s/%s'\n", cwd_path, container_dir, cwd_path);
-    singularity_priv_escalate();
     r = singularity_mount(cwd_path, joinpath(container_dir, cwd_path), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL);
     if ( singularity_priv_userns_enabled() != 1 ) {
         r = singularity_mount(NULL, joinpath(container_dir, cwd_path), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC|MS_REMOUNT, NULL);
     }
-    singularity_priv_drop();
     if ( r < 0 ) {
         singularity_message(WARNING, "Could not bind CWD to container %s: %s\n", cwd_path, strerror(errno));
     }

--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -102,7 +102,6 @@ int _singularity_runtime_mount_dev(void) {
         bind_dev(sessiondir, "/dev/random");
         bind_dev(sessiondir, "/dev/urandom");
 
-        singularity_priv_escalate();
         singularity_message(DEBUG, "Mounting tmpfs for staged /dev/shm\n");
         if ( singularity_mount("/dev/shm", joinpath(devdir, "/shm"), "tmpfs", MS_NOSUID, "") < 0 ) {
             singularity_message(ERROR, "Failed to mount %s: %s\n", joinpath(devdir, "/shm"), strerror(errno));
@@ -163,13 +162,11 @@ int _singularity_runtime_mount_dev(void) {
 
         singularity_message(DEBUG, "Mounting minimal staged /dev into container\n");
         if ( singularity_mount(devdir, joinpath(container_dir, "/dev"), NULL, MS_BIND|MS_REC, NULL) < 0 ) {
-            singularity_priv_drop();
             singularity_message(WARNING, "Could not stage dev tree: '%s' -> '%s': %s\n", devdir, joinpath(container_dir, "/dev"), strerror(errno));
             free(sessiondir);
             free(devdir);
             return(-1);
         }
-        singularity_priv_drop();
 
         free(sessiondir);
         free(devdir);
@@ -180,13 +177,11 @@ int _singularity_runtime_mount_dev(void) {
     singularity_message(DEBUG, "Checking configuration file for 'mount dev'\n");
     if ( singularity_config_get_bool_char(MOUNT_DEV) > 0 ) {
         if ( is_dir(joinpath(container_dir, "/dev")) == 0 ) {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE, "Bind mounting /dev\n");
                 if ( singularity_mount("/dev", joinpath(container_dir, "/dev"), NULL, MS_BIND|MS_NOSUID|MS_REC, NULL) < 0 ) {
                     singularity_message(ERROR, "Could not bind mount container's /dev: %s\n", strerror(errno));
                     ABORT(255);
                 }
-                singularity_priv_drop();
         } else {
             singularity_message(WARNING, "Not mounting /dev, container has no bind directory\n");
         }
@@ -221,15 +216,12 @@ static int bind_dev(char *tmpdir, char *dev) {
         return(-1);
     }
 
-    singularity_priv_escalate();
     singularity_message(DEBUG, "Mounting device %s at %s\n", dev, path);
     if ( singularity_mount(dev, path, NULL, MS_BIND, NULL) < 0 ) {
-        singularity_priv_drop();
         singularity_message(WARNING, "Could not mount %s: %s\n", dev, strerror(errno));
         free(path);
         return(-1);
     }
-    singularity_priv_drop();
 
     free(path);
 

--- a/src/lib/runtime/mounts/home/home.c
+++ b/src/lib/runtime/mounts/home/home.c
@@ -99,7 +99,6 @@ int _singularity_runtime_mount_home(void) {
 
     singularity_message(DEBUG, "Checking if SINGULARITY_CONTAIN is set\n");
     if ( ( singularity_registry_get("CONTAIN") == NULL ) || ( singularity_registry_get("HOME") != NULL ) ) {
-        singularity_priv_escalate();
         singularity_message(VERBOSE, "Mounting home directory source into session directory: %s -> %s\n", home_source, joinpath(session_dir, home_dest));
         if ( singularity_mount(home_source, joinpath(session_dir, home_dest), NULL, MS_BIND | MS_NOSUID | MS_NODEV | MS_REC, NULL) < 0 ) {
             singularity_message(ERROR, "Failed to mount home directory %s -> %s: %s\n", home_source, joinpath(session_dir, home_dest), strerror(errno));
@@ -111,7 +110,6 @@ int _singularity_runtime_mount_home(void) {
                 ABORT(255);
             }
         }
-        singularity_priv_drop();
     } else {
         singularity_message(VERBOSE, "Using sessiondir for home directory\n");
     }
@@ -134,13 +132,11 @@ int _singularity_runtime_mount_home(void) {
             ABORT(255);
         }
 
-        singularity_priv_escalate();
         singularity_message(VERBOSE, "Mounting staged home directory base to container's base dir: %s -> %s\n", joinpath(session_dir, homedir_base), joinpath(container_dir, homedir_base));
         if ( singularity_mount(joinpath(session_dir, homedir_base), joinpath(container_dir, homedir_base), NULL, MS_BIND | MS_NOSUID | MS_NODEV | MS_REC, NULL) < 0 ) {
             singularity_message(ERROR, "Failed to mount staged home base: %s -> %s: %s\n", joinpath(session_dir, homedir_base), joinpath(container_dir, homedir_base), strerror(errno));
             ABORT(255);
         }
-        singularity_priv_drop();
 
         free(homedir_base);
     } else {
@@ -152,14 +148,13 @@ int _singularity_runtime_mount_home(void) {
             singularity_message(ERROR, "Failed creating home directory in container %s: %s\n", joinpath(container_dir, home_dest), strerror(errno));
             ABORT(255);
         }
+        singularity_priv_drop();
 
         singularity_message(VERBOSE, "Mounting staged home directory to container: %s -> %s\n", joinpath(session_dir, home_dest), joinpath(container_dir, home_dest));
         if ( singularity_mount(joinpath(session_dir, home_dest), joinpath(container_dir, home_dest), NULL, MS_BIND | MS_NOSUID | MS_NODEV | MS_REC, NULL) < 0 ) {
             singularity_message(ERROR, "Failed to mount staged home base: %s -> %s: %s\n", joinpath(session_dir, home_dest), joinpath(container_dir, home_dest), strerror(errno));
             ABORT(255);
         }
-        singularity_priv_drop();
-
     }
 
     envar_set("HOME", home_dest, 1);

--- a/src/lib/runtime/mounts/hostfs/hostfs.c
+++ b/src/lib/runtime/mounts/hostfs/hostfs.c
@@ -163,7 +163,6 @@ int _singularity_runtime_mount_hostfs(void) {
         }
 
 
-        singularity_priv_escalate();
         singularity_message(VERBOSE, "Binding '%s'(%s) to '%s/%s'\n", mountpoint, filesystem, container_dir, mountpoint);
         if ( singularity_mount(mountpoint, joinpath(container_dir, mountpoint), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
             singularity_message(ERROR, "There was an error binding the path %s: %s\n", mountpoint, strerror(errno));
@@ -175,7 +174,6 @@ int _singularity_runtime_mount_hostfs(void) {
                 ABORT(255);
             }
         }
-        singularity_priv_drop();
 
     }
 

--- a/src/lib/runtime/mounts/kernelfs/kernelfs.c
+++ b/src/lib/runtime/mounts/kernelfs/kernelfs.c
@@ -50,21 +50,17 @@ int _singularity_runtime_mount_kernelfs(void) {
     if ( singularity_config_get_bool(MOUNT_PROC) > 0 ) {
         if ( is_dir(joinpath(container_dir, "/proc")) == 0 ) {
             if ( singularity_registry_get("PIDNS_ENABLED") == NULL ) {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE, "Bind-mounting host /proc\n");
                 if ( singularity_mount("/proc", joinpath(container_dir, "/proc"), NULL, MS_BIND | MS_NOSUID | MS_REC, NULL) < 0 ) {
                     singularity_message(ERROR, "Could not bind-mount host /proc into container: %s\n", strerror(errno));
                     ABORT(255);
                 }
-                singularity_priv_drop();
             } else {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE, "Mounting new procfs\n");
                 if ( singularity_mount("proc", joinpath(container_dir, "/proc"), "proc", MS_NOSUID, NULL) < 0 ) {
                     singularity_message(ERROR, "Could not mount new procfs into container: %s\n", strerror(errno));
                     ABORT(255);
                 }
-                singularity_priv_drop();
             }
         } else {
             singularity_message(WARNING, "Not mounting /proc, container has no bind directory\n");
@@ -79,21 +75,17 @@ int _singularity_runtime_mount_kernelfs(void) {
     if ( singularity_config_get_bool(MOUNT_SYS) > 0 ) {
         if ( is_dir(joinpath(container_dir, "/sys")) == 0 ) {
             if ( singularity_priv_userns_enabled() == 1 ) {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE, "Mounting /sys\n");
                 if ( singularity_mount("/sys", joinpath(container_dir, "/sys"), NULL, MS_BIND | MS_NOSUID | MS_REC, NULL) < 0 ) {
                     singularity_message(ERROR, "Could not mount /sys into container: %s\n", strerror(errno));
                     ABORT(255);
                 }
-                singularity_priv_drop();
             } else {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE, "Mounting /sys\n");
                 if ( singularity_mount("sysfs", joinpath(container_dir, "/sys"), "sysfs", MS_NOSUID, NULL) < 0 ) {
                     singularity_message(ERROR, "Could not mount /sys into container: %s\n", strerror(errno));
                     ABORT(255);
                 }
-                singularity_priv_drop();
             }
         } else {
             singularity_message(WARNING, "Not mounting /sys, container has no bind directory\n");

--- a/src/lib/runtime/mounts/scratch/scratch.c
+++ b/src/lib/runtime/mounts/scratch/scratch.c
@@ -114,13 +114,11 @@ int _singularity_runtime_mount_scratch(void) {
             }
         }
 
-        singularity_priv_escalate();
         singularity_message(VERBOSE, "Binding '%s' to '%s/%s'\n", full_sourcedir_path, container_dir, current);
         r = singularity_mount(full_sourcedir_path, joinpath(container_dir, current), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL);
         if ( singularity_priv_userns_enabled() != 1 ) {
             r += singularity_mount(NULL, joinpath(container_dir, current), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC|MS_REMOUNT, NULL);
         }
-        singularity_priv_drop();
         if ( r < 0 ) {
             singularity_message(WARNING, "Could not bind scratch directory into container %s: %s\n", full_sourcedir_path, strerror(errno));
             ABORT(255);

--- a/src/lib/runtime/mounts/tmp/tmp.c
+++ b/src/lib/runtime/mounts/tmp/tmp.c
@@ -86,7 +86,6 @@ int _singularity_runtime_mount_tmp(void) {
         }
         if ( is_dir(tmp_source) == 0 ) {
             if ( is_dir(joinpath(container_dir, "/tmp")) == 0 ) {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE, "Mounting directory: /tmp\n");
                 if ( singularity_mount(tmp_source, joinpath(container_dir, "/tmp"), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
                     singularity_message(ERROR, "Failed to mount %s -> /tmp: %s\n", tmp_source, strerror(errno));
@@ -98,7 +97,6 @@ int _singularity_runtime_mount_tmp(void) {
                         ABORT(255);
                     }
                 }
-                singularity_priv_drop();
             } else {
                 singularity_message(VERBOSE, "Could not mount container's /tmp directory: does not exist\n");
             }
@@ -116,7 +114,6 @@ int _singularity_runtime_mount_tmp(void) {
         }
         if ( is_dir(vartmp_source) == 0 ) {
             if ( is_dir(joinpath(container_dir, "/var/tmp")) == 0 ) {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE, "Mounting directory: /var/tmp\n");
                 if ( singularity_mount(vartmp_source, joinpath(container_dir, "/var/tmp"), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
                     singularity_message(ERROR, "Failed to mount %s -> /var/tmp: %s\n", vartmp_source, strerror(errno));
@@ -128,7 +125,6 @@ int _singularity_runtime_mount_tmp(void) {
                         ABORT(255);
                     }
                 }
-                singularity_priv_drop();
             } else {
                 singularity_message(VERBOSE, "Could not mount container's /var/tmp directory: does not exist\n");
             }

--- a/src/lib/runtime/mounts/userbinds/userbinds.c
+++ b/src/lib/runtime/mounts/userbinds/userbinds.c
@@ -150,7 +150,6 @@ int _singularity_runtime_mount_userbinds(void) {
                 }
             }
 
-            singularity_priv_escalate();
             singularity_message(VERBOSE, "Binding '%s' to '%s/%s'\n", source, container_dir, dest);
             if ( singularity_mount(source, joinpath(container_dir, dest), NULL, MS_BIND|MS_NOSUID|MS_NODEV|MS_REC, NULL) < 0 ) {
                 singularity_message(ERROR, "There was an error binding the path %s: %s\n", source, strerror(errno));
@@ -178,8 +177,6 @@ int _singularity_runtime_mount_userbinds(void) {
                     }
                 }
             }
-            singularity_priv_drop();
-
         }
 
         singularity_message(DEBUG, "Unsetting environment variable 'SINGULARITY_BINDPATH'\n");

--- a/src/lib/runtime/ns/mnt/mnt.c
+++ b/src/lib/runtime/ns/mnt/mnt.c
@@ -64,6 +64,7 @@ int _singularity_runtime_ns_mnt(void) {
         singularity_message(ERROR, "Could not virtualize mount namespace: %s\n", strerror(errno));
         ABORT(255);
     }
+    singularity_priv_drop();
 
     // Privatize the mount namespaces
     //
@@ -87,7 +88,6 @@ int _singularity_runtime_ns_mnt(void) {
     }
 #endif
 
-    singularity_priv_drop();
     enabled = 0;
     return(0);
 }

--- a/src/lib/runtime/overlayfs/overlayfs.c
+++ b/src/lib/runtime/overlayfs/overlayfs.c
@@ -121,13 +121,11 @@ int _singularity_runtime_overlayfs(void) {
                 size = strdup("size=1m");
             }
 
-            singularity_priv_escalate();
             singularity_message(DEBUG, "Mounting overlay tmpfs: %s\n", overlay_mount);
             if ( singularity_mount("tmpfs", overlay_mount, "tmpfs", MS_NOSUID | MS_NODEV, size) < 0 ){
                 singularity_message(ERROR, "Failed to mount overlay tmpfs %s: %s\n", overlay_mount, strerror(errno));
                 ABORT(255);
             }
-            singularity_priv_drop();
 
             free(size);
         }
@@ -181,13 +179,11 @@ int _singularity_runtime_overlayfs(void) {
 
 
     // If we got here, assume we are not overlaying, so we must bind to final directory
-    singularity_priv_escalate();
     singularity_message(DEBUG, "Binding container directory to final home %s->%s\n", CONTAINER_MOUNTDIR, CONTAINER_FINALDIR);
     if ( singularity_mount(CONTAINER_MOUNTDIR, CONTAINER_FINALDIR, NULL, MS_BIND|MS_NOSUID|MS_REC|MS_NODEV, NULL) < 0 ) {
         singularity_message(ERROR, "Could not bind mount container to final home %s->%s: %s\n", CONTAINER_MOUNTDIR, CONTAINER_FINALDIR, strerror(errno));
         return 1;
     }
-    singularity_priv_drop();
 
     return(0);
 }

--- a/src/lib/runtime/overlayfs/overlayfs.c
+++ b/src/lib/runtime/overlayfs/overlayfs.c
@@ -152,6 +152,7 @@ int _singularity_runtime_overlayfs(void) {
             singularity_message(ERROR, "Failed creating overlay work directory %s: %s\n", overlay_work, strerror(errno));
             ABORT(255);
         }
+        singularity_priv_drop();
 
         singularity_message(VERBOSE, "Mounting overlay with options: %s\n", overlay_options);
         int result = singularity_mount("OverlayFS", overlay_final, "overlay", MS_NOSUID | MS_NODEV, overlay_options);
@@ -159,13 +160,15 @@ int _singularity_runtime_overlayfs(void) {
             if ( (errno == EPERM) || ( try_overlay && ( errno == ENODEV ) ) ) {
                 singularity_message(VERBOSE, "Singularity overlay mount did not work (%s), continuing without it\n", strerror(errno));
                 singularity_message(DEBUG, "Unmounting overlay tmpfs: %s\n", overlay_mount);
+
+                singularity_priv_escalate();
                 umount(overlay_mount);
+                singularity_priv_drop();
             } else {
                 singularity_message(ERROR, "Could not mount Singularity overlay: %s\n", strerror(errno));
                 ABORT(255); 
             }
         }
-        singularity_priv_drop();
 
         free(overlay_upper);
         free(overlay_work);

--- a/src/util/mount.c
+++ b/src/util/mount.c
@@ -35,7 +35,19 @@ int singularity_mount(const char *source, const char *target,
                       const char *filesystemtype, unsigned long mountflags,
                       const void *data) {
     if ( ( mountflags & MS_BIND ) ) {
+        struct stat stbuf;
+
         setfsuid(singularity_priv_getuid());
+
+        if ( source ) {
+            if ( stat(source, &stbuf) < 0 ) {
+                singularity_message(ERROR, "Can't stat %s directory: %s\n", source, strerror(errno));
+                ABORT(255);
+            }
+            if ( singularity_priv_has_gid(stbuf.st_gid) ) {
+                setfsgid(stbuf.st_gid);
+            }
+        }
     }
     return mount(source, target, filesystemtype, mountflags, data);
 }

--- a/src/util/sessiondir.c
+++ b/src/util/sessiondir.c
@@ -89,13 +89,11 @@ int singularity_sessiondir(void) {
         ABORT(255);
     }
 
-    singularity_priv_escalate();
     singularity_message(DEBUG, "Mounting sessiondir tmpfs: %s\n", sessiondir);
     if ( singularity_mount("tmpfs", sessiondir, "tmpfs", MS_NOSUID, sessiondir_size_str) < 0 ){
         singularity_message(ERROR, "Failed to mount sessiondir tmpfs %s: %s\n", sessiondir, strerror(errno));
         ABORT(255);
     }
-    singularity_priv_drop();
 
     singularity_registry_set("SESSIONDIR", sessiondir);
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix permission denied error while binding NFS mount point when root_squash enabled. Both uid and gid are set to corresponding NFS directory owner

**This fixes or addresses the following GitHub issues:**

- Ref: #1205 #1249 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
