### PR TITLE
Restore shim init process for proper signal handling/child reaping

### DIFF
--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -105,6 +105,11 @@ while true; do
             SINGULARITY_UNSHARE_PID=1
             export SINGULARITY_UNSHARE_PID
         ;;
+        --noinit)
+            shift
+            SINGULARITY_NOSHIMINIT=1
+            export SINGULARITY_NOSHIMINIT
+        ;;
         -i|--ipc)
             shift
             SINGULARITY_UNSHARE_IPC=1

--- a/libexec/cli/exec.info
+++ b/libexec/cli/exec.info
@@ -33,6 +33,7 @@ EXEC OPTIONS:
     --nv                Enable experimental Nvidia support
     -o|--overlay        Use a persistent overlayFS via a writable image
     -p|--pid            Run container in a new PID namespace
+    --noinit            Do not start shim init process with --pid
     --pwd               Initial working directory for payload process inside 
                         the container
     -S|--scratch <path> Include a scratch directory within the container that 

--- a/libexec/cli/run.info
+++ b/libexec/cli/run.info
@@ -38,6 +38,7 @@ RUN OPTIONS:
     --nv                Enable experimental Nvidia support
     -o|--overlay        Use a persistent overlayFS via a writable image
     -p|--pid            Run container in a new PID namespace
+    --noinit            Do not start shim init process with --pid
     --pwd               Initial working directory for payload process inside
                         the container
     -S|--scratch <path> Include a scratch directory within the container that 

--- a/libexec/cli/shell.info
+++ b/libexec/cli/shell.info
@@ -33,7 +33,8 @@ SHELL OPTIONS:
                         only network device active)
     --nv                Enable experimental Nvidia support
     -o|--overlay        Use a persistent overlayFS via a writable image
-    -p|--pid            Run container in a new PID namespace (creates child)
+    -p|--pid            Run container in a new PID namespace
+    --noinit            Do not start shim init process with --pid
     --pwd               Initial working directory for payload process inside
                         the container
     -S|--scratch <path> Include a scratch directory within the container that

--- a/src/action.c
+++ b/src/action.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <string.h>
 #include <fcntl.h>
+#include <sys/prctl.h>
 
 #include "config.h"
 #include "util/file.h"
@@ -118,6 +119,11 @@ int main(int argc, char **argv) {
         // one more time.  This makes PID 1 a shim process and the payload
         // process PID 2 (meaning that the payload gets the "normal" signal
         // handling rules it would expect).
+
+        // Set the name of the process for ps
+        prctl(PR_SET_NAME, "shim-init", 0, 0, 0);
+        // And for ps -f
+        strncpy(argv[0], "shim-init", strlen(argv[0]));
 
         singularity_fork_run(0);
     }

--- a/src/action.c
+++ b/src/action.c
@@ -33,6 +33,7 @@
 
 #include "config.h"
 #include "util/file.h"
+#include "util/fork.h"
 #include "util/util.h"
 #include "util/daemon.h"
 #include "util/registry.h"

--- a/src/action.c
+++ b/src/action.c
@@ -108,7 +108,8 @@ int main(int argc, char **argv) {
     singularity_priv_drop_perm();
 
     if ( singularity_registry_get("DAEMON_JOIN") == NULL  &&
-         singularity_registry_get("PIDNS_ENABLED") != NULL ) {
+         singularity_registry_get("PIDNS_ENABLED") != NULL &&
+         singularity_registry_get("NOSHIMINIT") == NULL ) {
 
         // At this point, we are now PID 1; when we later exec the payload,
         // it will also be PID 1.  Unfortunately, PID 1 in Linux has special
@@ -117,6 +118,7 @@ int main(int argc, char **argv) {
         // one more time.  This makes PID 1 a shim process and the payload
         // process PID 2 (meaning that the payload gets the "normal" signal
         // handling rules it would expect).
+
         singularity_fork_run(0);
     }
 

--- a/src/lib/runtime/ns/pid/pid.c
+++ b/src/lib/runtime/ns/pid/pid.c
@@ -69,6 +69,15 @@ int _singularity_runtime_ns_pid(void) {
         singularity_fork_daemonize(CLONE_NEWPID);
     } else {
         singularity_fork_run(CLONE_NEWPID);
+
+        // At this point, we are now PID 1; when we later exec the payload,
+        // it will also be PID 1.  Unfortunately, PID 1 in Linux has special
+        // signal handling rules (the _only_ signal that will terminate the
+        // process is SIGKILL; all other signals are ignored).  Hence, we fork
+        // one more time.  This makes PID 1 a shim process and the payload
+        // process PID 2 (meaning that the payload gets the "normal" signal
+        // handling rules it would expect).
+        singularity_fork_run(0);
     }
 
     singularity_registry_set("PIDNS_ENABLED", "1");

--- a/src/lib/runtime/ns/pid/pid.c
+++ b/src/lib/runtime/ns/pid/pid.c
@@ -69,15 +69,6 @@ int _singularity_runtime_ns_pid(void) {
         singularity_fork_daemonize(CLONE_NEWPID);
     } else {
         singularity_fork_run(CLONE_NEWPID);
-
-        // At this point, we are now PID 1; when we later exec the payload,
-        // it will also be PID 1.  Unfortunately, PID 1 in Linux has special
-        // signal handling rules (the _only_ signal that will terminate the
-        // process is SIGKILL; all other signals are ignored).  Hence, we fork
-        // one more time.  This makes PID 1 a shim process and the payload
-        // process PID 2 (meaning that the payload gets the "normal" signal
-        // handling rules it would expect).
-        singularity_fork_run(0);
     }
 
     singularity_registry_set("PIDNS_ENABLED", "1");

--- a/src/start.c
+++ b/src/start.c
@@ -81,6 +81,7 @@ int main(int argc, char **argv) {
     singularity_runtime_autofs();
 
     singularity_registry_set("UNSHARE_PID", "1");
+    singularity_registry_set("NOSHIMINIT", "1");
     singularity_registry_set("UNSHARE_IPC", "1");
 
     singularity_cleanupd();

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -381,8 +381,8 @@ pid_t singularity_fork(unsigned int flags) {
         fds[1].events = POLLIN;
         fds[1].revents = 0;
 
-        /* Drop privs if we're SUID */
-        if ( singularity_priv_is_suid() == 0 ) {
+        /* Drop privs if we're SUID and haven't dropped permanently */
+        if ( singularity_suid_enabled() && !singularity_priv_dropped_perm() ) {
             singularity_message(DEBUG, "Dropping permissions\n");
             singularity_priv_drop();
         }

--- a/src/util/fork.c
+++ b/src/util/fork.c
@@ -38,6 +38,7 @@
 
 #include "util/privilege.h"
 #include "util/message.h"
+#include "util/suid.h"
 #include "util/util.h"
 
 int signal_rpipe = -1;

--- a/src/util/privilege.c
+++ b/src/util/privilege.c
@@ -75,6 +75,7 @@ static struct PRIV_INFO {
     char *username;
     int dropped_groups;
     int target_mode;  // Set to 1 if we are running in "target mode" (admin specifies UID/GID)
+    int dropped_perm;
 } uinfo;
 
 
@@ -451,9 +452,15 @@ void singularity_priv_drop_perm(void) {
     // Prevent the following processes to increase privileges
     singularity_priv_check_nonewprivs(); 
 
+    uinfo.dropped_perm = 1;
+
     singularity_message(DEBUG, "Finished dropping privileges\n");
 }
 
+
+int singularity_priv_dropped_perm(void) {
+    return uinfo.dropped_perm;
+}
 
 int singularity_priv_userns_enabled(void) {
     return uinfo.userns_ready;

--- a/src/util/privilege.h
+++ b/src/util/privilege.h
@@ -30,6 +30,7 @@
     void singularity_priv_escalate(void);
     void singularity_priv_drop(void);
     void singularity_priv_drop_perm(void);
+    int singularity_priv_dropped_perm(void);
     uid_t singularity_priv_getuid(void);
     gid_t singularity_priv_getgid(void);
     const gid_t *singularity_priv_getgids();


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR restores the "shim" init process inside of singularity containers that are not started with the instance start/stop command.  This is necessary for proper signal handling and reaping of zombie child processes.  The init process (PID 1) is treated specially, ignoring signals by default, and it is assigned all child processes when their parents die.  This feature was added by @bbockelm in PR #383, released in singularity version 2.3, and removed with very little explanation between releases 2.3 & 2.3.1 by @gmkurtzer in commit 2d2ab63f9942965336f91519750e4309bcd18de6.  The description of the commit was "Don't run a second fork until we support start/stop" which doesn't seem very relevant to me, and anyway instance start & stop is now supported and this behavior was not restored for cases where images are started without instance start & stop.

Please also review #384 because it isn't clear to me that it was fully addressed.  #394 said it addressed it partially.


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
