### PR TITLE
Fixes use of --pwd with --contain

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,3 +36,4 @@
     - Yaroslav Halchenko <debian@onerussian.com>
     - Josef Hrabal <josef.hrabal@vsb.cz>
     - Daniele Tamino <daniele.tamino@gmail.com>
+    - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>

--- a/src/action.c
+++ b/src/action.c
@@ -101,7 +101,13 @@ int main(int argc, char **argv) {
     
     singularity_priv_drop_perm();
 
-    if ( singularity_registry_get("CONTAIN") != NULL ) {
+    if ( ( target_pwd = singularity_registry_get("TARGET_PWD") ) != NULL ) {
+        singularity_message(DEBUG, "Attempting to chdir to TARGET_PWD: %s\n", target_pwd);
+        if ( chdir(target_pwd) != 0 ) {
+            singularity_message(ERROR, "Could not change directory to: %s\n", target_pwd);
+            ABORT(255);
+        }
+    } else if ( singularity_registry_get("CONTAIN") != NULL ) {
         singularity_message(DEBUG, "Attempting to chdir to home: %s\n", singularity_priv_home());
         if ( chdir(singularity_priv_home()) != 0 ) {
             singularity_message(WARNING, "Could not chdir to home: %s\n", singularity_priv_home());
@@ -109,12 +115,6 @@ int main(int argc, char **argv) {
                 singularity_message(ERROR, "Could not change directory within container.\n");
                 ABORT(255);
             }
-        }
-    } else if ( ( target_pwd = singularity_registry_get("TARGET_PWD") ) != NULL ) {
-        singularity_message(DEBUG, "Attempting to chdir to TARGET_PWD: %s\n", target_pwd);
-        if ( chdir(target_pwd) != 0 ) {
-            singularity_message(ERROR, "Could not change directory to: %s\n", target_pwd);
-            ABORT(255);
         }
     } else if ( pwd != NULL ) {
         singularity_message(DEBUG, "Attempting to chdir to CWD: %s\n", pwd);


### PR DESCRIPTION
As reported in #1208 when `--contain` is specified the --pwd option is not honored. This patch fixes the problem.

**Description of the Pull Request (PR):**

The solution adopted in the patch is simple. I simply moved the if branch that checkes if a target path is specified by the user as first. With this change if `--pwd` is specified the user requested path is set if `--contain` is present in the command line the path is set to the user home and if no either option is present the folder is set to the current directory.

**This fixes or addresses the following GitHub issues:**

- Ref: #1208 

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
