### PR TITLE
move image handlers to runtime

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -102,9 +102,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/mount.*
 %{_libexecdir}/singularity/cli/pull.*
 %{_libexecdir}/singularity/cli/selftest.*
-%{_libexecdir}/singularity/handlers
 %{_libexecdir}/singularity/helpers
-%{_libexecdir}/singularity/image-handler.sh
 %{_libexecdir}/singularity/python
 
 # Binaries
@@ -146,6 +144,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/bin/wrapper
 %{_libexecdir}/singularity/functions
 %{_libexecdir}/singularity/capabilities
+%{_libexecdir}/singularity/handlers
+%{_libexecdir}/singularity/image-handler.sh
 %dir %{_sysconfdir}/singularity
 %config(noreplace) %{_sysconfdir}/singularity/*
 %dir %{_sysconfdir}/singularity/capabilities


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Move image-handler.sh and the image handlers to the singularity-runtime rpm.


**This fixes or addresses the following GitHub issues:**

- Ref: #1227


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
  Not relevant because this is an rpm only fix.
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
