### PR TITLE
SCIF revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 ## [v3.0](https://github.com/singularityware/singularity/tree/development)
 
  - Adjustments to SCIF (Scientific Filesystem) integration for broader use
+ - Fixed bug that did not export environment variables for apps with "-" in name
  - Feature sif sign #1143
  - Add capability support and secure build #934
  - Boot/start instance #1032

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 ## [v3.0](https://github.com/singularityware/singularity/tree/development)
 
+ - Adjustments to SCIF (Scientific Filesystem) integration for broader use
  - Feature sif sign #1143
  - Add capability support and secure build #934
  - Boot/start instance #1032

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -3,7 +3,8 @@
 The Scientific Filesystem is well suited for Singularity containers to allow you
 to build a container that has multiple entrypoints, along with modular environments,
 libraries, and executables. Here we will review the basic building and using of a
-Singularity container that implements SCIF.
+Singularity container that implements SCIF. For more quick start tutorials, see
+the [official documentation for SCIF](https://vsoch.github.io/scif/).
 
 Build your image
 
@@ -39,6 +40,7 @@ to a better world, I am moved to lead a different life.
 Inspect an app
 
 ```
+ singularity inspect --app fortune cowsay.img 
 {
     "SCIF_APPNAME": "fortune",
     "SCIF_APPSIZE": "1MB"

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -1,15 +1,20 @@
 # Singularity SCI-F Apps
 
+The Scientific Filesystem is well suited for Singularity containers to allow you
+to build a container that has multiple entrypoints, along with modular environments,
+libraries, and executables. Here we will review the basic building and using of a
+Singularity container that implements SCIF.
+
 Build your image
 
 ```
-sudo singularity build cowsay.img Singularity.cowsay 
+sudo singularity build cowsay.simg Singularity.cowsay 
 ```
 
 What apps are installed?
 
 ```
-singularity apps cowsay.img
+singularity apps cowsay.simg
 cowsay
 fortune
 lolcat
@@ -18,23 +23,24 @@ lolcat
 Ask for help for a specific app!
 
 ```
-singularity help --app fortune cowsay.img
+singularity help --app fortune cowsay.simg
 fortune is the best app
 ```
 
 Run a particular app
 
 ```
-singularity run --app fortune cowsay.img
+singularity run --app fortune cowsay.simg
+When I reflect upon the number of disagreeable people who I know who have gone
+to a better world, I am moved to lead a different life.
+		-- Mark Twain, "Pudd'nhead Wilson's Calendar"
 ```
 
 Inspect an app
 
 ```
- singularity inspect --app fortune cowsay.img 
 {
-    "SINGULARITY_APP_NAME": "fortune",
-    "SINGULARITY_APP_SIZE": "1MB"
+    "SCIF_APPNAME": "fortune",
+    "SCIF_APPSIZE": "1MB"
 }
 ```
-

--- a/libexec/bootstrap-scripts/deffile-sections.sh
+++ b/libexec/bootstrap-scripts/deffile-sections.sh
@@ -349,8 +349,8 @@ if [ -z "${SINGULARITY_BUILDSECTION:-}" -o "${SINGULARITY_BUILDSECTION:-}" == "a
         for APPNAME in "${APPNAMES[@]}"; do
             message 1 "Installing ${APPNAME}\n"
             APPBASE="$SINGULARITY_ROOTFS/scif/apps/${APPNAME}"
-            SINGULARITY_APPROOT="/scif/apps/${APPNAME}"
-            export SINGULARITY_APPROOT
+            SCIF_APPROOT="/scif/apps/${APPNAME}"
+            export SCIF_APPROOT
             singularity_app_init "${APPNAME}" "${SINGULARITY_ROOTFS}"
             singularity_app_save "${APPNAME}" "$SINGULARITY_BUILDDEF" "${APPBASE}/scif/Singularity"
             singularity_app_install_get "${APPNAME}" "$SINGULARITY_BUILDDEF" | chroot "$SINGULARITY_ROOTFS" /bin/sh -xe || ABORT 255

--- a/libexec/bootstrap-scripts/deffile-sections.sh
+++ b/libexec/bootstrap-scripts/deffile-sections.sh
@@ -325,7 +325,7 @@ fi
 
 
 ### APPLABELS
-if [ -z "${SINGULARITY_BUILDSECTION:-}" -o "${SINGULARITY_BUILDSECTION:-}" == "appfiles" ]; then
+if [ -z "${SINGULARITY_BUILDSECTION:-}" -o "${SINGULARITY_BUILDSECTION:-}" == "applabels" ]; then
     if singularity_section_exists "applabels" "$SINGULARITY_BUILDDEF"; then
         APPNAMES=(`singularity_section_args "applabels" "$SINGULARITY_BUILDDEF"`)
 
@@ -373,34 +373,34 @@ for app in ${SINGULARITY_ROOTFS}/scif/apps/*; do
     if [ -d "$app" ]; then
 
         app="${app##*/}"
-        app=(`echo $app | sed -e "s/-/_/g"`)
+        appvar=(`echo $app | sed -e "s/-/_/g"`)
         appbase="${SINGULARITY_ROOTFS}/scif/apps/$app"
         appmeta="${appbase}/scif"
 
         # Export data, root, metadata, labels, environment
-        echo "SCIF_APPDATA_$app=/scif/data/$app" >> "${APPGLOBAL}"
-        echo "SCIF_APPMETA_$app=/scif/apps/$app/scif" >> "${APPGLOBAL}"
-        echo "SCIF_APPROOT_$app=/scif/apps/$app" >> "${APPGLOBAL}"
-        echo "SCIF_APPBIN_$app=/scif/apps/$app/bin" >> "${APPGLOBAL}"
-        echo "SCIF_APPLIB_$app=/scif/apps/$app/lib" >> "${APPGLOBAL}"
-        echo "export SCIF_APPDATA_$app SCIF_APPROOT_$app SCIF_APPMETA_$app SCIF_APPBIN_$app SCIF_APPLIB_$app"  >> "${APPGLOBAL}"
+        echo "SCIF_APPDATA_$appvar=/scif/data/$app" >> "${APPGLOBAL}"
+        echo "SCIF_APPMETA_$appvar=/scif/apps/$app/scif" >> "${APPGLOBAL}"
+        echo "SCIF_APPROOT_$appvar=/scif/apps/$app" >> "${APPGLOBAL}"
+        echo "SCIF_APPBIN_$appvar=/scif/apps/$app/bin" >> "${APPGLOBAL}"
+        echo "SCIF_APPLIB_$appvar=/scif/apps/$app/lib" >> "${APPGLOBAL}"
+        echo "export SCIF_APPDATA_$appvar SCIF_APPROOT_$appvar SCIF_APPMETA_$appvar SCIF_APPBIN_$appvar SCIF_APPLIB_$appvar"  >> "${APPGLOBAL}"
 
         # Environment
         if [ -e "${appmeta}/env/90-environment.sh" ]; then
-            echo  "SCIF_APPENV_${app}=/scif/apps/$app/scif/env/90-environment.sh" >> "${APPGLOBAL}"
-            echo  "export SCIF_APPENV_${app}" >> "${APPGLOBAL}"
+            echo  "SCIF_APPENV_${appvar}=/scif/apps/$app/scif/env/90-environment.sh" >> "${APPGLOBAL}"
+            echo  "export SCIF_APPENV_${appvar}" >> "${APPGLOBAL}"
         fi
 
         # Labels
         if [ -e "${appmeta}/labels.json" ]; then
-            echo  "SCIF_APPLABELS_${app}=/scif/apps/$app/scif/labels.json" >> "${APPGLOBAL}"
-            echo  "export SCIF_APPLABELS_${app}" >> "${APPGLOBAL}"
+            echo  "SCIF_APPLABELS_${appvar}=/scif/apps/$app/scif/labels.json" >> "${APPGLOBAL}"
+            echo  "export SCIF_APPLABELS_${appvar}" >> "${APPGLOBAL}"
         fi
 
         # Runscript
         if [ -e "${appmeta}/runscript" ]; then
-            echo  "SCIF_APPRUN_${app}=/scif/apps/$app/scif/runscript" >> "${APPGLOBAL}"
-            echo  "export SCIF_APPRUN_${app}" >> "${APPGLOBAL}"
+            echo  "SCIF_APPRUN_${appvar}=/scif/apps/$app/scif/runscript" >> "${APPGLOBAL}"
+            echo  "export SCIF_APPRUN_${appvar}" >> "${APPGLOBAL}"
         fi
     fi
 done

--- a/libexec/bootstrap-scripts/deffile-sections.sh
+++ b/libexec/bootstrap-scripts/deffile-sections.sh
@@ -302,8 +302,8 @@ if [ -z "${SINGULARITY_BUILDSECTION:-}" -o "${SINGULARITY_BUILDSECTION:-}" == "a
             # Make sure we have metadata
             APPBASE="$SINGULARITY_ROOTFS/scif/apps/${APPNAME}"
             APPFOLDER_SIZE=$(singularity_calculate_size "${APPBASE}")
-            $ADD_LABEL --key "SINGULARITY_APP_SIZE" --value "${APPFOLDER_SIZE}MB" --file "$APPBASE/scif/labels.json"
-            $ADD_LABEL --key "SINGULARITY_APP_NAME" --value "${APPNAME}" --file "${APPBASE}/scif/labels.json"
+            $ADD_LABEL --key "SCIF_APPSIZE" --value "${APPFOLDER_SIZE}MB" --file "$APPBASE/scif/labels.json"
+            $ADD_LABEL --key "SCIF_APPNAME" --value "${APPNAME}" --file "${APPBASE}/scif/labels.json"
 
         done
     fi
@@ -356,8 +356,8 @@ if [ -z "${SINGULARITY_BUILDSECTION:-}" -o "${SINGULARITY_BUILDSECTION:-}" == "a
             singularity_app_install_get "${APPNAME}" "$SINGULARITY_BUILDDEF" | chroot "$SINGULARITY_ROOTFS" /bin/sh -xe || ABORT 255
 
             APPFOLDER_SIZE=$(singularity_calculate_size "${APPBASE}")
-            $ADD_LABEL --key "SINGULARITY_APP_SIZE" --value "${APPFOLDER_SIZE}MB" --file "$APPBASE/scif/labels.json" --quiet -f
-            $ADD_LABEL --key "SINGULARITY_APP_NAME" --value "${APPNAME}" --file "${APPBASE}/scif/labels.json" --quiet -f
+            $ADD_LABEL --key "SCIF_APPSIZE" --value "${APPFOLDER_SIZE}MB" --file "$APPBASE/scif/labels.json" --quiet -f
+            $ADD_LABEL --key "SCIF_APPNAME" --value "${APPNAME}" --file "${APPBASE}/scif/labels.json" --quiet -f
 
         done
     fi
@@ -378,29 +378,29 @@ for app in ${SINGULARITY_ROOTFS}/scif/apps/*; do
         appmeta="${appbase}/scif"
 
         # Export data, root, metadata, labels, environment
-        echo "APPDATA_$app=/scif/data/$app" >> "${APPGLOBAL}"
-        echo "APPMETA_$app=/scif/apps/$app/scif" >> "${APPGLOBAL}"
-        echo "APPROOT_$app=/scif/apps/$app" >> "${APPGLOBAL}"
-        echo "APPBIN_$app=/scif/apps/$app/bin" >> "${APPGLOBAL}"
-        echo "APPLIB_$app=/scif/apps/$app/lib" >> "${APPGLOBAL}"
-        echo "export APPDATA_$app APPROOT_$app APPMETA_$app APPBIN_$app APPLIB_$app"  >> "${APPGLOBAL}"
+        echo "SCIF_APPDATA_$app=/scif/data/$app" >> "${APPGLOBAL}"
+        echo "SCIF_APPMETA_$app=/scif/apps/$app/scif" >> "${APPGLOBAL}"
+        echo "SCIF_APPROOT_$app=/scif/apps/$app" >> "${APPGLOBAL}"
+        echo "SCIF_APPBIN_$app=/scif/apps/$app/bin" >> "${APPGLOBAL}"
+        echo "SCIF_APPLIB_$app=/scif/apps/$app/lib" >> "${APPGLOBAL}"
+        echo "export SCIF_APPDATA_$app SCIF_APPROOT_$app SCIF_APPMETA_$app SCIF_APPBIN_$app SCIF_APPLIB_$app"  >> "${APPGLOBAL}"
 
         # Environment
         if [ -e "${appmeta}/env/90-environment.sh" ]; then
-            echo  "APPENV_${app}=/scif/apps/$app/scif/env/90-environment.sh" >> "${APPGLOBAL}"
-            echo  "export APPENV_${app}" >> "${APPGLOBAL}"
+            echo  "SCIF_APPENV_${app}=/scif/apps/$app/scif/env/90-environment.sh" >> "${APPGLOBAL}"
+            echo  "export SCIF_APPENV_${app}" >> "${APPGLOBAL}"
         fi
 
         # Labels
         if [ -e "${appmeta}/labels.json" ]; then
-            echo  "APPLABELS_${app}=/scif/apps/$app/scif/labels.json" >> "${APPGLOBAL}"
-            echo  "export APPLABELS_${app}" >> "${APPGLOBAL}"
+            echo  "SCIF_APPLABELS_${app}=/scif/apps/$app/scif/labels.json" >> "${APPGLOBAL}"
+            echo  "export SCIF_APPLABELS_${app}" >> "${APPGLOBAL}"
         fi
 
         # Runscript
         if [ -e "${appmeta}/runscript" ]; then
-            echo  "APPRUN_${app}=/scif/apps/$app/scif/runscript" >> "${APPGLOBAL}"
-            echo  "export APPRUN_${app}" >> "${APPGLOBAL}"
+            echo  "SCIF_APPRUN_${app}=/scif/apps/$app/scif/runscript" >> "${APPGLOBAL}"
+            echo  "export SCIF_APPRUN_${app}" >> "${APPGLOBAL}"
         fi
     fi
 done

--- a/libexec/bootstrap-scripts/environment/95-apps.sh
+++ b/libexec/bootstrap-scripts/environment/95-apps.sh
@@ -18,9 +18,9 @@ if test -n "${SINGULARITY_APPNAME:-}"; then
     export SINGULARITY_APPNAME
 
     if test -d "/scif/apps/${SINGULARITY_APPNAME:-}/"; then
-        SINGULARITY_APPS="/scif/apps"
-        SINGULARITY_APPROOT="/scif/apps/${SINGULARITY_APPNAME:-}"
-        export SINGULARITY_APPROOT SINGULARITY_APPS
+        SCIF_APPS="/scif/apps"
+        SCIF_APPROOT="/scif/apps/${SINGULARITY_APPNAME:-}"
+        export SCIF_APPROOT SCIF_APPS
         PATH="/scif/apps/${SINGULARITY_APPNAME:-}:$PATH"
 
         # Automatically add application bin to path

--- a/libexec/bootstrap-scripts/functions
+++ b/libexec/bootstrap-scripts/functions
@@ -198,14 +198,14 @@ singularity_app_init() {
 
     # App specific variables should be exposed at run, shell, exec
     echo "
-    SINGULARITY_APPNAME=$APPNAME
-    SINGULARITY_APPROOT=\"/scif/apps/${APPNAME}\"
-    SINGULARITY_APPMETA=\"/scif/apps/${APPNAME}/scif\"
-    SINGULARITY_DATA=\"/scif/data\"
-    SINGULARITY_APPDATA=\"/scif/data/${APPNAME}\"
-    SINGULARITY_APPINPUT=\"/scif/data/${APPNAME}/input\"
-    SINGULARITY_APPOUTPUT=\"/scif/data/${APPNAME}/output\"
-    export SINGULARITY_APPDATA SINGULARITY_APPNAME SINGULARITY_APPROOT SINGULARITY_APPMETA SINGULARITY_APPINPUT SINGULARITY_APPOUTPUT SINGULARITY_DATA
+    SCIF_APPNAME=$APPNAME
+    SCIF_APPROOT=\"/scif/apps/${APPNAME}\"
+    SCIF_APPMETA=\"/scif/apps/${APPNAME}/scif\"
+    SCIF_DATA=\"/scif/data\"
+    SCIF_APPDATA=\"/scif/data/${APPNAME}\"
+    SCIF_APPINPUT=\"/scif/data/${APPNAME}/input\"
+    SCIF_APPOUTPUT=\"/scif/data/${APPNAME}/output\"
+    export SCIF_APPDATA SCIF_APPNAME SCIF_APPROOT SCIF_APPMETA SCIF_APPINPUT SCIF_APPOUTPUT SCIF_DATA
     " > "${APPMETA}/env/01-base.sh"
 
 }

--- a/libexec/cli/apps.info
+++ b/libexec/cli/apps.info
@@ -24,20 +24,20 @@ for all apps regardless of the active:
 
 ACTIVE APP ENVIRONMENT:
 
-    SINGULARITY_APPNAME     the name of the application
-    SINGULARITY_APPROOT     the application base (/scif/apps/<app>)
-    SINGULARITY_APPMETA     the application metadata folder
-    SINGULARITY_APPDATA     the data base folder for active app
-        SINGULARITY_APPINPUT    expected input folder within data base folder
-        SINGULARITY_APPOUTPUT   the output data folder within data base folder
+    SCIF_APPNAME     the name of the application
+    SCIF_APPROOT     the application base (/scif/apps/<app>)
+    SCIF_APPMETA     the application metadata folder
+    SCIF_APPDATA     the data base folder for active app
+        SCIF_APPINPUT    expected input folder within data base folder
+        SCIF_APPOUTPUT   the output data folder within data base folder
 
 
 GLOBAL APP ENVIRONMENT:
     
-    SINGULARITY_DATA        scif defined data base for all apps (/scif/data)
-    SINGULARITY_APPS        scif defined install bases for all apps (/scif/apps)
-    APPROOT_<app>           root for application <app>
-    APPDATA_<app>           data root for application <app>
+    SCIF_DATA        scif defined data base for all apps (/scif/data)
+    SCIF_APPS        scif defined install bases for all apps (/scif/apps)
+    SCIF_APPROOT_<app>    root for application <app>
+    SCIF_APPDATA_<app>    data root for application <app>
 
 
 For additional help, please visit our public documentation pages which are


### PR DESCRIPTION
**Description of the Pull Request (PR):**

In order to make the Scientific Filesystem more general, the naming of variables should also be a part of the standard, consistent with a "SCIF" namespace that Singularity then implements. Thankfully the organization itself (and it's logic) is already agnostic to containers, but the variables needed some work! This PR is a simple fix to rename the current `SINGULARITY_` namespace of variables to start with `_SCIF`. I will demonstrate some uses in the next section.

**This fixes or addresses the following GitHub issues:**

- Ref: #1236 #1237

## Examples

### Inspect
Inspection of a container with context of an app still returns the app specific labels, but with different names of course:

```
singularity inspect --app hub sregistry.simg 
{
    "SCIF_APPNAME": "hub",
    "SCIF_APPSIZE": "1MB"
}
```

### Runtime Environment
When we run the container in context of an app, we see that the running app (top section of variables) reveals a global/general variable to indicate the active app, and the others are still available (for apps to communicate with one another). Note that I re-ordered this list to show this distinction.

```
 singularity exec --app hub sregistry.simg env | grep SCIF

# Here are variables for active app (hub)
SCIF_APPDATA=/scif/data/hub
SCIF_APPROOT=/scif/apps/hub
SCIF_APPNAME=hub
SCIF_APPMETA=/scif/apps/hub/scif
SCIF_APPINPUT=/scif/data/hub/input
SCIF_APPOUTPUT=/scif/data/hub/output

# These refer to SCIF, globally
SCIF_DATA=/scif/data
SCIF_APPS=/scif/apps

# And specific for all apps, for internal reference
SCIF_APPDATA_google_drive=/scif/data/google-drive
SCIF_APPRUN_google_drive=/scif/apps/google-drive/scif/runscript
SCIF_APPROOT_google_drive=/scif/apps/google-drive
SCIF_APPLIB_google_drive=/scif/apps/google-drive/lib
SCIF_APPMETA_google_drive=/scif/apps/google-drive/scif
SCIF_APPBIN_google_drive=/scif/apps/google-drive/bin
SCIF_APPENV_google_drive=/scif/apps/google-drive/scif/env/90-environment.sh
SCIF_APPLABELS_google_drive=/scif/apps/google-drive/scif/labels.json

SCIF_APPLABELS_registry=/scif/apps/registry/scif/labels.json
SCIF_APPDATA_registry=/scif/data/registry
SCIF_APPRUN_registry=/scif/apps/registry/scif/runscript
SCIF_APPROOT_registry=/scif/apps/registry
SCIF_APPLIB_registry=/scif/apps/registry/lib
SCIF_APPMETA_registry=/scif/apps/registry/scif
SCIF_APPBIN_registry=/scif/apps/registry/bin
SCIF_APPENV_registry=/scif/apps/registry/scif/env/90-environment.sh

SCIF_APPENV_google_storage=/scif/apps/google-storage/scif/env/90-environment.sh
SCIF_APPLABELS_google_storage=/scif/apps/google-storage/scif/labels.json
SCIF_APPDATA_google_storage=/scif/data/google-storage
SCIF_APPRUN_google_storage=/scif/apps/google-storage/scif/runscript
SCIF_APPROOT_google_storage=/scif/apps/google-storage
SCIF_APPLIB_google_storage=/scif/apps/google-storage/lib
SCIF_APPMETA_google_storage=/scif/apps/google-storage/scif
SCIF_APPBIN_google_storage=/scif/apps/google-storage/bin

SCIF_APPENV_hub=/scif/apps/hub/scif/env/90-environment.sh
SCIF_APPLABELS_hub=/scif/apps/hub/scif/labels.json
SCIF_APPDATA_hub=/scif/data/hub
SCIF_APPRUN_hub=/scif/apps/hub/scif/runscript
SCIF_APPROOT_hub=/scif/apps/hub
SCIF_APPLIB_hub=/scif/apps/hub/lib
SCIF_APPMETA_hub=/scif/apps/hub/scif
SCIF_APPBIN_hub=/scif/apps/hub/bin
```

And here shows running the container in context of an app is still good to "activate" it, in this case it sets up the container to serve a google-drive client (shell):

```
 singularity run --app google-drive sregistry.simg shell
[client|google-drive] [database|sqlite:////home/vanessa/.singularity/sregistry.db]
[folder][sregistry]
Python 3.6.2 |Anaconda, Inc.| (default, Sep 22 2017, 02:03:08) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> 
```

To move forward with SCIF I'm going to (I think) simplify it down to a list of these variables and then different functions to produce recipe files (for example, for Singularity) along with taking an already existing filesystem and spitting out those variables. This is relevant directly to Singularity per say (meaning that it's unlikely we will need additional development of SCIF here), but since there are a lot of good use cases, and integration directly empowers many scientists to build these containers. For example, having SCIF for the sregistry container client is awesome!

Would love any feedback or discussion on SCIF that might come with this PR. Thanks everyone!

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
