### PR TITLE
Add message to top level Makefile.am about mksquashfs and Makefile cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,13 @@ install-perms:
 	@echo "install-perms is no longer required"
 	@echo
 
+all-local:
+	@echo
+	@echo "******"
+	@echo "  mksquashfs from squash-tools is required for full functionality"
+	@echo "******"
+	@echo
+
 install-data-hook:
 	install -d -m 0755 $(DESTDIR)$(CONTAINER_MOUNTDIR)
 	install -d -m 0755 $(DESTDIR)$(CONTAINER_FINALDIR)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = bin etc libexec man src
 
-MAINTAINERCLEANFILES = Makefile.in aclocal.m4 configure ltmain.sh depcomp install-sh missing config.* *.m4 singularity-*.tar.gz singularity-*.rpm m4/* test.sh secbuildimg.sh
+MAINTAINERCLEANFILES = Makefile.in aclocal.m4 configure ltmain.sh compile depcomp install-sh missing config.* *.m4 singularity-*.tar.gz singularity-*.rpm m4/* test.sh secbuildimg.sh
 DISTCLEANFILES = Makefile test.sh secbuildimg.sh
 CLEANFILES = 
 EXTRA_DIST = singularity.spec autogen.sh examples debian CONTRIBUTORS.md CONTRIBUTING.md COPYRIGHT.md INSTALL.md LICENSE-LBNL.md LICENSE.md README.md tests

--- a/configure.ac
+++ b/configure.ac
@@ -315,6 +315,14 @@ else
 
 fi
 
+# ---------------------------------------------------------------------
+# MKSQUASHFS
+# ---------------------------------------------------------------------
+AC_CHECK_PROG(MKSQUASHFS_CHECK,mksquashfs,yes)
+if test x"$MKSQUASHFS_CHECK" != "xyes" ; then
+    AC_MSG_ERROR([mksquashfs is required.])
+fi
+
 AC_MSG_CHECKING([--with-slurm])
 AC_ARG_WITH([slurm],
             AS_HELP_STRING([--with-slurm], [This feature will no longer be part of Singularity proper]),

--- a/configure.ac
+++ b/configure.ac
@@ -320,7 +320,7 @@ fi
 # ---------------------------------------------------------------------
 AC_CHECK_PROG(MKSQUASHFS_CHECK,mksquashfs,yes)
 if test x"$MKSQUASHFS_CHECK" != "xyes" ; then
-    AC_MSG_ERROR([mksquashfs is required.])
+    AC_MSG_ERROR([Unable to find mksquashfs, need package squashfs-tools.])
 fi
 
 AC_MSG_CHECKING([--with-slurm])

--- a/configure.ac
+++ b/configure.ac
@@ -315,14 +315,6 @@ else
 
 fi
 
-# ---------------------------------------------------------------------
-# MKSQUASHFS
-# ---------------------------------------------------------------------
-AC_CHECK_PROG(MKSQUASHFS_CHECK,mksquashfs,yes)
-if test x"$MKSQUASHFS_CHECK" != "xyes" ; then
-    AC_MSG_ERROR([Unable to find mksquashfs, need package squashfs-tools.])
-fi
-
 AC_MSG_CHECKING([--with-slurm])
 AC_ARG_WITH([slurm],
             AS_HELP_STRING([--with-slurm], [This feature will no longer be part of Singularity proper]),

--- a/libexec/python/Makefile.am
+++ b/libexec/python/Makefile.am
@@ -6,4 +6,7 @@ scriptlibexecdir = $(libexecdir)/singularity/python
 dist_scriptlibexec_DATA = defaults.py __init__.py message.py shell.py sutils.py base.py templates.py
 dist_scriptlibexec_SCRIPTS = import.py pull.py size.py
 
-MAINTAINERCLEANFILES = Makefile.in
+MAINTAINERCLEANFILES = Makefile.in *.pyc
+DISTCLEANFILES = Makefile *.pyc
+CLEANFILES = *.pyc
+

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,1 +1,3 @@
+MAINTAINERCLEANFILES = Makefile.in
+
 dist_man_MANS = singularity.1

--- a/src/lib/image/Makefile.am
+++ b/src/lib/image/Makefile.am
@@ -26,10 +26,12 @@ libsingularity_image_la_CFLAGS = $(AM_CFLAGS)
 # These are kludges so they don't remove the $(DEPDIR) in ../../util/ otherwise
 # the clean will fail when other Makefile tries to remove those directories
 distclean: distclean-recursive
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f Makefile
 
 maintainer-clean: maintainer-clean-recursive
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f Makefile
 

--- a/src/lib/image/Makefile.am
+++ b/src/lib/image/Makefile.am
@@ -28,10 +28,10 @@ libsingularity_image_la_CFLAGS = $(AM_CFLAGS)
 distclean: distclean-recursive
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f Makefile
+	-rm -f $(DISTCLEANFILES) $(CLEANFILES)
 
 maintainer-clean: maintainer-clean-recursive
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f Makefile
+	-rm -f $(MAINTAINERCLEANFILES) $(DISTCLEANFILES) $(CLEANFILES)
 

--- a/src/lib/runtime/Makefile.am
+++ b/src/lib/runtime/Makefile.am
@@ -28,10 +28,12 @@ EXTRA_DIST =
 # These are kludges so they don't remove the $(DEPDIR) in ../../util/ otherwise
 # the clean will fail when other Makefile tries to remove those directories
 distclean: distclean-recursive
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f $(DISTCLEANFILES)
 
 maintainer-clean: maintainer-clean-recursive
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f $(MAINTAINERCLEANFILES)
 

--- a/src/lib/runtime/Makefile.am
+++ b/src/lib/runtime/Makefile.am
@@ -29,9 +29,9 @@ EXTRA_DIST =
 # the clean will fail when other Makefile tries to remove those directories
 distclean: distclean-recursive
 	-rm ./$(DEPDIR)
-	-rm -f Makefile
+	-rm -f $(DISTCLEANFILES)
 
 maintainer-clean: maintainer-clean-recursive
 	-rm ./$(DEPDIR)
-	-rm -f Makefile
+	-rm -f $(MAINTAINERCLEANFILES)
 

--- a/src/lib/runtime/Makefile.am
+++ b/src/lib/runtime/Makefile.am
@@ -30,10 +30,10 @@ EXTRA_DIST =
 distclean: distclean-recursive
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f $(DISTCLEANFILES)
+	-rm -f $(DISTCLEANFILES) $(CLEANFILES)
 
 maintainer-clean: maintainer-clean-recursive
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f $(MAINTAINERCLEANFILES)
+	-rm -f $(MAINTAINERCLEANFILES) $(DISTCLEANFILES) $(CLEANFILES)
 

--- a/src/lib/runtime/ns/Makefile.am
+++ b/src/lib/runtime/ns/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS = mnt pid ipc net uts user
 
 CLEANFILES = core.* *~ *.la
-DISTCLEANFILES = Makefile 
+DISTCLEANFILES = Makefile
 MAINTAINERCLEANFILES = Makefile.in
 
 AM_CFLAGS = -Wall -fpie

--- a/src/lib/runtime/ns/Makefile.am
+++ b/src/lib/runtime/ns/Makefile.am
@@ -1,8 +1,8 @@
 SUBDIRS = mnt pid ipc net uts user
 
-MAINTAINERCLEANFILES = Makefile.in 
-DISTCLEANFILES = Makefile
 CLEANFILES = core.* *~ *.la
+DISTCLEANFILES = Makefile 
+MAINTAINERCLEANFILES = Makefile.in
 
 AM_CFLAGS = -Wall -fpie
 AM_LDFLAGS = -pie
@@ -21,10 +21,10 @@ EXTRA_DIST = ns.h
 distclean: distclean-recursive
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f $(DISTCLEANFILES)
+	-rm -f $(DISTCLEANFILES) $(CLEANFILES)
 
 maintainer-clean: maintainer-clean-recursive
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f $(MAINTAINERCLEANFILES)
+	-rm -f $(MAINTAINERCLEANFILES) $(DISTCLEANFILES) $(CLEANFILES)
 

--- a/src/lib/runtime/ns/Makefile.am
+++ b/src/lib/runtime/ns/Makefile.am
@@ -19,10 +19,12 @@ EXTRA_DIST = ns.h
 # These are kludges so they don't remove the $(DEPDIR) in ../../util/ otherwise
 # the clean will fail when other Makefile tries to remove those directories
 distclean: distclean-recursive
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f $(DISTCLEANFILES)
 
 maintainer-clean: maintainer-clean-recursive
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f $(MAINTAINERCLEANFILES)
 

--- a/src/lib/runtime/ns/Makefile.am
+++ b/src/lib/runtime/ns/Makefile.am
@@ -15,3 +15,14 @@ libinternal_la_LIBADD = mnt/libinternal.la pid/libinternal.la ipc/libinternal.la
 libinternal_la_SOURCES = ns.c ../../../util/daemon.c
 
 EXTRA_DIST = ns.h
+
+# These are kludges so they don't remove the $(DEPDIR) in ../../util/ otherwise
+# the clean will fail when other Makefile tries to remove those directories
+distclean: distclean-recursive
+	-rm ./$(DEPDIR)
+	-rm -f $(DISTCLEANFILES)
+
+maintainer-clean: maintainer-clean-recursive
+	-rm ./$(DEPDIR)
+	-rm -f $(MAINTAINERCLEANFILES)
+

--- a/src/lib/signing/Makefile.am
+++ b/src/lib/signing/Makefile.am
@@ -21,10 +21,10 @@ libsingularity_signing_la_CFLAGS = $(AM_CFLAGS)
 
 # These are kludges so they don't remove the $(DEPDIR) in ../../util/ otherwise
 # the clean will fail when other Makefile tries to remove those directories
-distclean: distclean-recursive
+distclean:
 	-rm ./$(DEPDIR)
-	-rm -f Makefile
+	-rm -f $(DISTCLEANFILES)
 
-maintainer-clean: maintainer-clean-recursive
+maintainer-clean:
 	-rm ./$(DEPDIR)
-	-rm -f Makefile
+	-rm -f $(MAINTAINERCLEANFILES)

--- a/src/lib/signing/Makefile.am
+++ b/src/lib/signing/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in config.h config.h.in
 DISTCLEANFILES = Makefile
-CLEANFILES = core.* *~ *.la
+CLEANFILES = core.* *~ *.la *.o *.lo
 AM_CFLAGS = -Wall -fpie -fPIC
 AM_LDFLAGS = -pie
 AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATEDIR=\"$(localstatedir)\" -DLIBEXECDIR=\"$(libexecdir)\" $(SINGULARITY_DEFINES)
@@ -24,9 +24,9 @@ libsingularity_signing_la_CFLAGS = $(AM_CFLAGS)
 distclean:
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f $(DISTCLEANFILES)
+	-rm -f $(DISTCLEANFILES) $(CLEANFILES)
 
 maintainer-clean:
 	-rm -rf ./$(DEPDIR)
 	-rm -rf ./.libs
-	-rm -f $(MAINTAINERCLEANFILES)
+	-rm -f $(MAINTAINERCLEANFILES) $(DISTCLEANFILES) $(CLEANFILES)

--- a/src/lib/signing/Makefile.am
+++ b/src/lib/signing/Makefile.am
@@ -22,9 +22,11 @@ libsingularity_signing_la_CFLAGS = $(AM_CFLAGS)
 # These are kludges so they don't remove the $(DEPDIR) in ../../util/ otherwise
 # the clean will fail when other Makefile tries to remove those directories
 distclean:
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f $(DISTCLEANFILES)
 
 maintainer-clean:
-	-rm ./$(DEPDIR)
+	-rm -rf ./$(DEPDIR)
+	-rm -rf ./.libs
 	-rm -f $(MAINTAINERCLEANFILES)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

mksquashfs is a install requirement in the .spec file. After `make` is ran, output a message saying mksquashfs is required.

General cleanup of Makefiles and to resolve issue #1206

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin
