### PR TITLE
docker-extract - fix retval bug and locale warnings

### DIFF
--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -135,13 +135,15 @@ int apply_whiteouts(char *tarfile, char *rootfs_dir) {
             singularity_message(DEBUG, "Opaque Marker %s\n", pathname);
             errcode = apply_opaque(pathname, rootfs_dir);
             if (errcode != 0) {
-                break;
+                singularity_message(ERROR, "Error applying opaque marker from docker layer.\n");
+                ABORT(255);
             }
         } else if (strstr(pathname, "/.wh.")) {
             singularity_message(DEBUG, "Whiteout Marker %s\n", pathname);
             errcode = apply_whiteout(pathname, rootfs_dir);
             if (errcode != 0) {
-                break;
+                singularity_message(ERROR, "Error applying whiteout marker from docker layer.\n");
+                ABORT(255);
             }
         }
     }

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -8,6 +8,7 @@
 #include <sys/file.h>
 #include <sys/param.h>
 #include <sys/stat.h>
+#include <locale.h>
 #include <archive.h>
 #include <archive_entry.h>
 
@@ -299,6 +300,15 @@ int main(int argc, char **argv) {
     int retval = 0;
     char *rootfs_dir = singularity_registry_get("ROOTFS");
     char *tarfile = NULL;
+
+    // Set UTF8 locale so that libarchive doesn't produce warnings for UTF8
+    // names - en_US.UTF-8 is most likely to be available
+    if( setlocale(LC_ALL, "en_US.UTF-8") == NULL ) {
+        // Fall back to C.UTF-8 for super-minimal debian and musl based distros
+        if (setlocale(LC_ALL, "C.UTF-8") == NULL ) {
+            singularity_message(WARNING, "Could not set a UTF8 locale, layer extraction may produce warnings\n");
+        }
+    }
 
     if (argc != 2) {
         singularity_message(ERROR, "Provide a single docker tar file to extract\n");

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -40,8 +40,11 @@ int apply_opaque(const char *opq_marker, char *rootfs_dir) {
         ABORT(255);
     }
 
+    // Target may not exist - that's ok
+    retval = 0;
+
     if (is_dir(buf) == 0) {
-        s_rmdir(buf);
+        retval = s_rmdir(buf);
     }
 
     return retval;
@@ -86,6 +89,9 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
         singularity_message(ERROR, "Error with pathname too long\n");
         ABORT(255);
     }
+
+    // Target may not exist - that's ok
+    retval = 0;
 
     if (is_dir(buf) == 0) {
         retval = s_rmdir(buf);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

2 fixes for the libexec/docker-extract executable

1. BUG Fix - Fix retval handling bug - in some multi-stage build docker containers a whiteout marker may be present in next layer, but the whiteout target does not exist in extraction dir. docker-extract was exiting with error here, as retval contained a prior non-zero value from snprintf return code. Fix by resetting retval to 0 after string handling so that if marker present, but target missing we don't abort. This bug was observed with `nvidia/digits:5.0`

2. Fix for issue #1260 - libarchive tries to use UTF8 header filenames if present in archive. If running in non-UTF8 locale it will drop to using binary filenames and extract OK, but raises warnings. Singularity forces C locale by default for libexec runs. To silence warnings setlocale to en_US.UTF-8 (most commonly available UTF8 locale), or C.UTF-8 (available in some minimal debian installs / musl distros when en_US.UTF-8 is not available). Fixes warnings observed with `singularity pull docker://brainlife/freesurfer:latest`


**This fixes or addresses the following GitHub issues:**

- Ref: #1260 


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware] (https://www.github.com/singularityware/singularityware.github.io) documentation base. - _Covered by previous PR_
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin @GodloveD 
