### PR TITLE
Fix tar magic number check

### DIFF
--- a/libexec/functions
+++ b/libexec/functions
@@ -467,8 +467,9 @@ is_tar() {
 # check if a file looks like, walks like,... oh you get the idea
     FILE2CHECK=$1
     TARMAGIC="7573746172202000" # "ustar  \x00"
+    PAX_TARMAGIC="7573746172003030" # "ustar.00"; dot denotes \x00 (NULL)
 
-    zcat_compat "$FILE2CHECK" | head -c 320 | od -A n -t x1 -w320 | tr -d ' ' | grep -q "$TARMAGIC"
+    zcat_compat "$FILE2CHECK" | head -c 320 | od -A n -t x1 -w320 | tr -d ' ' | grep -q -e "$TARMAGIC" -e "$PAX_TARMAGIC"
     RETVAL=$?
     return $RETVAL
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The current `is_tar` function for the cli is flawed in that it does not
check for both possible tar magic numbers.

TARMAGIC stays as the OLDGNU_MAGIC define from GNU tar:

```
ustar  \x00
```

The new PAX_TARMAGIC is the concatenation of the TMAGIC and TVERSION defines
in GNU tar (the dot denotes \x00):

```
ustar.00
```

See https://www.gnu.org/software/tar/manual/html_node/Standard.html for
reference.

**This fixes or addresses the following GitHub issues:**

- Ref: None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
