### PR TITLE
Fix suse openssl package name in spec file

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -37,10 +37,11 @@ BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 BuildRequires: python
 BuildRequires: libuuid-devel
 BuildRequires: libarchive-devel
-BuildRequires: openssl-devel
 %if "%{_target_vendor}" == "suse"
+BuildRequires: libopenssl-devel
 Requires: squashfs
 %else
+BuildRequires: openssl-devel
 Requires: squashfs-tools
 %endif
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The development package for openssl is named `libopenssl-devel` on suse distributions (Leap and Tumbleweed).


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
