### PR TITLE
Fixed typo in image.import example

### DIFF
--- a/libexec/cli/image.import.info
+++ b/libexec/cli/image.import.info
@@ -14,7 +14,7 @@ IMPORT OPTIONS:
 EXAMPLES:
 
     $ singularity image.import /tmp/Debian.img < /tmp/Debian.tar
-    $ gzip -9 > Debian.tar.gz | singularity image.import /tmp/Debian.img
+    $ gzip -dc Debian.tar.gz | singularity image.import /tmp/Debian.img
     $ tar -cvf - -C data_dir/ . | singularity image.import /tmp/data.img
 
 For additional help, please visit our public documentation pages which are


### PR DESCRIPTION
Fixed typo in image.import example

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin