### PR TITLE
SCIF allow for "." in app names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ secbuildimg.sh
 
 src/action
 src/action-suid
+src/docker-extract
+src/get-configvals
 src/start
 src/start-suid
 src/builddef

--- a/libexec/bootstrap-scripts/deffile-sections.sh
+++ b/libexec/bootstrap-scripts/deffile-sections.sh
@@ -373,7 +373,9 @@ for app in ${SINGULARITY_ROOTFS}/scif/apps/*; do
     if [ -d "$app" ]; then
 
         app="${app##*/}"
-        appvar=(`echo $app | sed -e "s/-/_/g"`)
+
+        # Replace all - or . with an underscore
+        appvar=(`echo $app | sed -e "s/-/_/g" | sed -e "s/[.]/_/g"`)
         appbase="${SINGULARITY_ROOTFS}/scif/apps/$app"
         appmeta="${appbase}/scif"
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a quick PR to close #1237 for a bug found by @Saford91 to allow for a user to define a SCIF app with a period (.) without breaking the environment. I also added two compiled filed to the gitignore that were missing.

Before the fix, interacting with a SCIF app looks like this:

```
./apps apps
/.singularity.d/actions/run: 1: /.singularity.d/env/94-appsbase.sh: SCIF_APPDATA_name.v1.0=/scif/data/name.v1.0: not found
/.singularity.d/actions/run: 2: /.singularity.d/env/94-appsbase.sh: SCIF_APPMETA_name.v1.0=/scif/apps/name.v1.0/scif: not found
/.singularity.d/actions/run: 3: /.singularity.d/env/94-appsbase.sh: SCIF_APPROOT_name.v1.0=/scif/apps/name.v1.0: not found
/.singularity.d/actions/run: 4: /.singularity.d/env/94-appsbase.sh: SCIF_APPBIN_name.v1.0=/scif/apps/name.v1.0/bin: not found
/.singularity.d/actions/run: 5: /.singularity.d/env/94-appsbase.sh: SCIF_APPLIB_name.v1.0=/scif/apps/name.v1.0/lib: not found
/.singularity.d/actions/run: 6: export: SCIF_APPDATA_name.v1.0: bad variable name
```
Ruhroh! The reason is the same that we cannot have a `-` in an environment variable. Now, usage is fixed with a simple adjustment to sed:

```
# Build
sudo singularity build versions.simg Singularity

...

Finished processing dependencies for scif==0.0.71

# Install the recipe with lots of bad characters in the name
+ /opt/conda/bin/scif install /recipe.scif
Installing base at /scif
+ apprun     FOO.BAR
+ appenv     FOO.BAR
+ apprun     name.v3.0
+ appenv     name.v3.0
+ apprun     name.v2.0
+ appenv     name.v2.0
+ apprun     name.v1.0
+ appenv     name.v1.0
+ apphelp     name.v1.0
Adding runscript
Finalizing Singularity container
Calculating final size for metadata...
Skipping checks
Building Singularity FS image...
Building Singularity SIF container image...
Singularity container built: versions.simg
Cleaning up...
```
Now we want to run the image to see if we get the SCIF entry point...
```
./versions.simg 

Scientific Filesystem [v0.0.71]
usage: scif [-h] [--debug] [--quiet] [--writable]
            {version,pyshell,shell,preview,help,install,inspect,run,apps,dump,exec}
            ...

scientific filesystem tools

optional arguments:
  -h, --help            show this help message and exit
  --debug               use verbose logging to debug.
  --quiet               suppress print output
  --writable, -w        for relevant commands, if writable SCIF is needed

actions:
  actions for Scientific Filesystem

  {version,pyshell,shell,preview,help,install,inspect,run,apps,dump,exec}
                        scif actions
    version             show software version
    pyshell             Interactive python shell to scientific filesystem
    shell               shell to interact with scientific filesystem
    preview             preview changes to a filesytem
    help                look at help for an app, if it exists.
    install             install a recipe on the filesystem
    inspect             inspect an attribute for a scif installation
    run                 entrypoint to run a scientific filesystem
    apps                list apps installed
    dump                dump recipe
    exec                execute a command to a scientific filesystem
```

And the apps listing?

```
$ ./versions.simg  apps
   FOO.BAR
 name.v1.0
 name.v2.0
 name.v3.0
```

And run it!
```
$ ./versions.simg run FOO.BAR
[FOO.BAR] executing /bin/bash /scif/apps/FOO.BAR/scif/runscript
BAR
```
Quietly...
```
./versions.simg --quiet run FOO.BAR
BAR
```

The full huzzah (and the same image built with Docker from the same file!!) [is here](https://github.com/vsoch/scif/issues/35#issuecomment-360910949) for those interested. Let me know if you have any questions, I hope I didn't mess something up because this PR is so tiny, haha.

Attn: @singularityware/singularity-maintainers 