### PR TITLE
Force write perms for docker builds as user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 ### Bug Fixes
  - Put /usr/local/{bin,sbin} in front of the default PATH
  - Fixed bug that did not export environment variables for apps with "-" in name
- 
+ - Fix non-root build from docker containers with non-writable file/dir permissions
+
 ## [v2.4.2](https://github.com/singularityware/singularity/tree/release-2.4)
 
  - This fixed an issue for support of older distributions and kernels with regards to `setns()`

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -258,10 +258,17 @@ int extract_tar(const char *tarfile, const char *rootfs_dir) {
 
         // Issue 977 - Force write perms needed for user builds
         if(getuid() != 0) {
+          #if ARCHIVE_VERSION_NUMBER <= 3000000
+            perms = archive_entry_mode(entry);
+            if( (perms & S_IWUSR) != S_IWUSR) {
+               archive_entry_set_mode(entry, perms | S_IWUSR);
+            }
+          #else
             perms = archive_entry_perm(entry);
             if( (perms & S_IWUSR) != S_IWUSR) {
                archive_entry_set_perm(entry, perms | S_IWUSR);
             }
+          #endif
         }
 
         r = archive_write_header(ext, entry);

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -258,17 +258,17 @@ int extract_tar(const char *tarfile, const char *rootfs_dir) {
 
         // Issue 977 - Force write perms needed for user builds
         if(getuid() != 0) {
-          #if ARCHIVE_VERSION_NUMBER <= 3000000
+#if ARCHIVE_VERSION_NUMBER <= 3000000
             perms = archive_entry_mode(entry);
             if( (perms & S_IWUSR) != S_IWUSR) {
-               archive_entry_set_mode(entry, perms | S_IWUSR);
+                archive_entry_set_mode(entry, perms | S_IWUSR);
             }
-          #else
+#else
             perms = archive_entry_perm(entry);
             if( (perms & S_IWUSR) != S_IWUSR) {
-               archive_entry_set_perm(entry, perms | S_IWUSR);
+                archive_entry_set_perm(entry, perms | S_IWUSR);
             }
-          #endif
+#endif
         }
 
         r = archive_write_header(ext, entry);

--- a/tests/21-build_docker.sh
+++ b/tests/21-build_docker.sh
@@ -66,6 +66,11 @@ stest 0 singularity exec "$CONTAINER" ls /test/whiteout-dir/file2 /test/whiteout
 stest 1 singularity exec "$CONTAINER" ls /test/whiteout-dir/file1 /test/whiteout-file/file1
 stest 1 singularity exec "$CONTAINER" ls /test/*/.wh*
 
+# Check force permissions for user builds #977
+stest 0 singularity build -F "$CONTAINER" docker://dctrud/docker-singularity-userperms
+stest 0 singularity exec "$CONTAINER" ls /testdir/
+stest 1 singularity exec "$CONTAINER" ls /testdir/testfile
+
 if singularity_which docker >/dev/null 2>&1; then
 # make sure local test does not exist, ignore errors
 sudo docker kill registry >/dev/null 2>&1


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Some docker layer .tar.gz files contain files or dirs that, when extracted, have -r-r-r permissions (no write for the owner). When building a singularity image as a user, we can't manipulate these dirs/files during extraction of later layers, and the build will fail.

#977 has examples from multiple users including:

```
singularity pull docker://jakirkham/centos_conda
singularity -vv build es_test.img docker://docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.3
```

This patch force the perms of extracted files to include user write, if we are not running as root.

In conjunction with the previous whiteout fixes this allows the cases above to work as expected.


**This fixes or addresses the following GitHub issues:**

- Ref: #977 


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
