### PR TITLE
Test Suite CentOS 6 support and fixes

### DIFF
--- a/.travis/centos6_setup
+++ b/.travis/centos6_setup
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+mkdir /run
+mkdir /tmp/yum-download
+yum -y --downloadonly --downloaddir /tmp/yum-download install util-linux-ng
+cd /tmp/yum-download
+rpm2cpio util-linux-ng*.rpm | cpio -idmv
+mv bin/mount /bin/mount
+

--- a/.travis/centos_run
+++ b/.travis/centos_run
@@ -17,5 +17,12 @@ SCRIPT
 cd /tmp/$DIST/singularity
 
 # mounting /run for /dev/shm (python multiprocessing)
-sudo singularity exec -w -B /run --keep-privs --allow-setuid docker://${OS_TYPE}:${OS_VERSION} /bin/bash -ex /tmp/$DIST/script
+if [ "$OS_TYPE" = "centos" -a "$OS_VERSION" = "6" ]; then
+    # No overlay on CentOS6 - must mount shm to standard location for CentOS 6
+    sudo singularity build -s sandbox/ docker://${OS_TYPE}:${OS_VERSION}
+    sudo singularity exec -w sandbox/ mkdir /run
+    sudo singularity exec -w -B /run --keep-privs --allow-setuid sandbox/ /bin/bash -ex /tmp/$DIST/script
+else
+    sudo singularity exec -w -B /run --keep-privs --allow-setuid docker://${OS_TYPE}:${OS_VERSION} /bin/bash -ex /tmp/$DIST/script
+fi
 sudo rm -rf /tmp/$DIST

--- a/.travis/centos_run
+++ b/.travis/centos_run
@@ -18,9 +18,8 @@ cd /tmp/$DIST/singularity
 
 # mounting /run for /dev/shm (python multiprocessing)
 if [ "$OS_TYPE" = "centos" -a "$OS_VERSION" = "6" ]; then
-    # No overlay on CentOS6 - must mount shm to standard location for CentOS 6
     sudo singularity build -s sandbox/ docker://${OS_TYPE}:${OS_VERSION}
-    sudo singularity exec -w sandbox/ mkdir /run
+    sudo singularity exec -w  --keep-privs --allow-setuid sandbox/ /tmp/$DIST/singularity/.travis/centos6_setup
     sudo singularity exec -w -B /run --keep-privs --allow-setuid sandbox/ /bin/bash -ex /tmp/$DIST/script
 else
     sudo singularity exec -w -B /run --keep-privs --allow-setuid docker://${OS_TYPE}:${OS_VERSION} /bin/bash -ex /tmp/$DIST/script

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -14,14 +14,13 @@ rpmbuild -ta *.tar.gz
 rpm -iv ~/rpmbuild/RPMS/*/*.rpm
 
 if [ "$OS_VERSION" = 6 ]; then
-    echo "the test suite has not yet been ported to centos6 python, skipping."
-    exit
+    echo "the python tests have not yet been ported to centos6 python, and will be skipped."
+else
+    # Install python 3 and pylint
+    yum install -y epel-release
+    yum install -y python34 python34-pip python34-setuptools docker
+    yum install -y pylint
 fi
-
-# Install python 3 and pylint
-yum install -y epel-release
-yum install -y python34 python34-pip python34-setuptools docker
-yum install -y pylint
 
 # run the test suite
 yum install -y libtool sudo which e2fsprogs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - --nv can be made default with all action commands in singularity.conf
  - --nv can be controlled by env vars `$SINGULARITY_NV` and `$SINGULARITY_NV_OFF`
  - Adjustments to SCIF (Scientific Filesystem) integration for broader use
+ - Test suite runs on CentOS 6, except python tests
 
 ### Security related fixes
  - Add capability support and secure build #934

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -27,18 +27,25 @@ test_init "Checking Python unit tests"
 cd ../libexec/python
 
 if which python2 >/dev/null 2>&1; then
-    stest 0 python2 -m unittest tests.test_json
-    stest 0 python2 -m unittest tests.test_helpers
-    stest 0 python2 -m unittest tests.test_base
-    stest 0 python2 -m unittest tests.test_core
-    stest 0 python2 -m unittest tests.test_docker_import
-    stest 0 python2 -m unittest tests.test_docker_api
-    stest 0 python2 -m unittest tests.test_docker_tasks
-    stest 0 python2 -m unittest tests.test_shub_pull
-    stest 0 python2 -m unittest tests.test_shub_api
-    stest 0 python2 -m unittest tests.test_custom_cache
-    stest 0 python2 -m unittest tests.test_default_cache
-    stest 0 python2 -m unittest tests.test_disable_cache
+   
+    PY_BELOW_27=`python -c 'import sys; print("%i" % (sys.hexversion<0x02070000))'`
+
+    if [ "$PY_BELOW_27" = "1" ]; then
+        echo "Skipping python2 tests: requires python >=2.7"
+    else
+        stest 0 python2 -m unittest tests.test_json
+        stest 0 python2 -m unittest tests.test_helpers
+        stest 0 python2 -m unittest tests.test_base
+        stest 0 python2 -m unittest tests.test_core
+        stest 0 python2 -m unittest tests.test_docker_import
+        stest 0 python2 -m unittest tests.test_docker_api
+        stest 0 python2 -m unittest tests.test_docker_tasks
+        stest 0 python2 -m unittest tests.test_shub_pull
+        stest 0 python2 -m unittest tests.test_shub_api
+        stest 0 python2 -m unittest tests.test_custom_cache
+        stest 0 python2 -m unittest tests.test_default_cache
+        stest 0 python2 -m unittest tests.test_disable_cache
+    fi
 else
     echo "Skipping python2 tests: not installed"
 fi

--- a/tests/21-build_docker.sh
+++ b/tests/21-build_docker.sh
@@ -31,6 +31,8 @@ test_init "Docker bootstrap tests"
 CONTAINER="$SINGULARITY_TESTDIR/container.img"
 DEFFILE="$SINGULARITY_TESTDIR/example.def"
 
+KERNEL_MAJOR=$(uname -r | cut -f1 -d.)
+
 # Make sure the examples/docker/Singularity is pointing to busybox:latest (nobody mess with the examples! LOL)
 stest 0 grep busybox:latest ../examples/docker/Singularity
 
@@ -47,10 +49,14 @@ stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
 stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
-stest 0 sed -i -e 's@centos:latest@dock0/arch:latest@' "$DEFFILE"
-stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
-stest 0 singularity exec "$CONTAINER" true
-stest 1 singularity exec "$CONTAINER" false
+if [ "$KERNEL_MAJOR" = "2" ]; then
+    echo "Skipping Arch Linux tests - requires host with >=3.x kernel"
+else
+    stest 0 sed -i -e 's@centos:latest@dock0/arch:latest@' "$DEFFILE"
+    stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
+    stest 0 singularity exec "$CONTAINER" true
+    stest 1 singularity exec "$CONTAINER" false
+fi
 
 stest 0 sudo singularity build -F "$CONTAINER" docker://busybox
 stest 0 singularity exec "$CONTAINER" true

--- a/tests/32-action_options.sh
+++ b/tests/32-action_options.sh
@@ -54,7 +54,7 @@ stest 0 mkdir -p "$TESTDIR"
 stest 0 touch "$TESTDIR/testfile"
 stest 0 singularity exec --home "$TESTDIR" "$CONTAINER" test -f "$TESTDIR/testfile"
 stest 0 singularity exec --home "$TESTDIR:/home" "$CONTAINER" test -f "/home/testfile"
-if [ -n "${SINGULARITY_OVERLAY_FS:-}" ]; then
+if [  "$SINGULARITY_OVERLAY_FS" = "1" ]; then
     stest 0 singularity exec --contain --home "$TESTDIR:/blah" "$CONTAINER" test -f "/blah/testfile"
 fi
 stest 0 sh -c "echo 'cd; test -f testfile' | singularity exec --home '$TESTDIR' '$CONTAINER' /bin/sh"

--- a/tests/35-userbinds.sh
+++ b/tests/35-userbinds.sh
@@ -33,9 +33,9 @@ CONTAINER="$SINGULARITY_TESTDIR/container.img"
 stest 0 sudo singularity build "$CONTAINER" "../examples/busybox/Singularity"
 
 stest 0 touch /tmp/hello_world_test
-stest 0 singularity exec -B /tmp:/opt "$CONTAINER" test -f /opt/hello_world_test
+stest 0 singularity exec -B /tmp:/var/tmp "$CONTAINER" test -f /var/tmp/hello_world_test
 
-if [ -n "$SINGULARITY_OVERLAY_FS" ]; then
+if [ "$SINGULARITY_OVERLAY_FS" = "1" ]; then
     stest 0 singularity exec -B /tmp:/nonexistent "$CONTAINER" test -f /nonexistent/hello_world_test
 fi
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Support CentOS 6 for `make test` and travis rpmbuild tests. This is important now that we have integration of libs such as libarchive (used by docker-extract) that are quite different in older versions.

Changes:

- Let travis run test suite on CentOS 6
- Skip only python tests where python <2.7 (CentOS 6 has 2.6 and test code is not compatible)
- Skip arch linux container test if we are on a 2 series kernel (will get kernel too old on CentOS 6)
- Fix `SINGULARITY_OVERLAY_FS` check - this variable is always defined, 0 or 1 - so check for that, not `-n`
- Fix busybox non-overlay user bind test - `/opt` doesn't actually exist in the busybox container, so we have to user bind somewhere else to check functionality without overlay. Use `/var/tmp` which is available and empty.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin