### PR TITLE
Fix compatibility with non-GNU tar

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,4 +42,5 @@
     - Thomas Hamel <hmlth@t-hamel.fr>
     - David Trudgian <david.trudgian@utsouthwestern.edu>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
+    - Diana Langenbach <dcl@dcl.sh>
 

--- a/libexec/bootstrap-scripts/deffile-driver-localimage.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-localimage.sh
@@ -48,7 +48,7 @@ umask 0002
 
 message 1 "Exporting contents of ${FROM} to ${SINGULARITY_IMAGE}\n"
 
-${SINGULARITY_bindir}/singularity image.export "${FROM}" | tar xBf - -C "${SINGULARITY_ROOTFS}"
+${SINGULARITY_bindir}/singularity image.export "${FROM}" | tar xf - -C "${SINGULARITY_ROOTFS}"
 if [ $? != 0 ]; then
     message ERROR "Failed to export contents of ${FROM} to ${SINGULARITY_ROOTFS}\n"
     ABORT 255

--- a/libexec/bootstrap-scripts/deffile-driver-shub.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-shub.sh
@@ -86,7 +86,7 @@ message 1 "Exporting contents of ${SINGULARITY_CONTAINER} to ${SINGULARITY_IMAGE
 SINGULARITY_CONTAINER=`cat $SINGULARITY_CONTENTS`
 rm -r $SINGULARITY_CONTENTS
 
-${SINGULARITY_bindir}/singularity image.export "${SINGULARITY_CONTAINER}" | tar xBf - -C "${SINGULARITY_ROOTFS}"
+${SINGULARITY_bindir}/singularity image.export "${SINGULARITY_CONTAINER}" | tar xf - -C "${SINGULARITY_ROOTFS}"
 if [ $? != 0 ]; then
     message ERROR "Failed to export contents of ${SINGULARITY_CONTAINER} to ${SINGULARITY_ROOTFS}\n"
     rm $SINGULARITY_CONTAINER

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -271,7 +271,7 @@ case $SINGULARITY_BUILDDEF in
         export SINGULARITY_CONTAINER SINGULARITY_CONTENTS
         eval_abort "$SINGULARITY_libexecdir/singularity/python/import.py"
         message 1 "Importing: base Singularity environment\n"
-        zcat "$SINGULARITY_libexecdir/singularity/bootstrap-scripts/environment.tar" | tar xBf - -C "${SINGULARITY_ROOTFS}" || exit $?
+        zcat "$SINGULARITY_libexecdir/singularity/bootstrap-scripts/environment.tar" | tar xf - -C "${SINGULARITY_ROOTFS}" || exit $?
 
         for i in `cat "$SINGULARITY_CONTENTS"`; do
             name=`basename "$i"`
@@ -320,7 +320,7 @@ if [ -f "${SINGULARITY_BUILDDEF:-}" ]; then
     elif eval is_image "${SINGULARITY_BUILDDEF}"; then
         message 1 "Building from local FS image: $SINGULARITY_BUILDDEF\n"
         nonroot_build_warning
-        if ! eval "${SINGULARITY_bindir}"/singularity image.export "${SINGULARITY_BUILDDEF}" 2>/dev/null | tar xBf - -C "${SINGULARITY_ROOTFS}" >/dev/null 2>&1; then
+        if ! eval "${SINGULARITY_bindir}"/singularity image.export "${SINGULARITY_BUILDDEF}" 2>/dev/null | tar xf - -C "${SINGULARITY_ROOTFS}" >/dev/null 2>&1; then
             message ERROR "Failed to export contents of ${SINGULARITY_BUILDDEF} to ${SINGULARITY_ROOTFS}\n"
             ABORT 255
         fi
@@ -332,7 +332,7 @@ if [ -f "${SINGULARITY_BUILDDEF:-}" ]; then
             exit 1
         fi
         if [ -n "${SINGULARITY_BTSTRP_2EXISTING:-}" ]; then # we are bootstrapping to an existing image and need to populate the rootfs
-            if ! eval "${SINGULARITY_bindir}"/singularity image.export "${SINGULARITY_CONTAINER_OUTPUT}" | tar xBf - -C "${SINGULARITY_ROOTFS}"; then
+            if ! eval "${SINGULARITY_bindir}"/singularity image.export "${SINGULARITY_CONTAINER_OUTPUT}" | tar xf - -C "${SINGULARITY_ROOTFS}"; then
                 message ERROR "Failed to export contents of ${SINGULARITY_BUILDDEF} to ${SINGULARITY_ROOTFS}\n"
                 ABORT 255
             fi


### PR DESCRIPTION
**Fix compatibility with non-GNU tar**

Currently, several `tar` commands in the singularity cli use the `-B` option, a GNU extension. This breaks on host systems with non-GNU tar. Removing this option resolves the issue, without changing the behavior of GNU tar -- all instances of this option are used when reading from stdin, which will [cause GNU tar to automatically enable this option](https://www.gnu.org/software/tar/manual/tar.html#SEC73).


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
