### PR TITLE
Close file descriptors pointing to a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Put /usr/local/{bin,sbin} in front of the default PATH
  - Add capability to support all tar compression formats #1155
  - Handle docker layer aufs whiteout files correctly (requires libarchive).
+ - Close file descriptors pointing to a directory #1305
 
 ### Bug Fixes
  - Put /usr/local/{bin,sbin} in front of the default PATH

--- a/src/action.c
+++ b/src/action.c
@@ -55,6 +55,8 @@ int main(int argc, char **argv) {
     char *target_pwd = NULL;
     char *command = NULL;
 
+    fd_cleanup();
+
     singularity_config_init();
 
     singularity_suid_init();

--- a/src/mount.c
+++ b/src/mount.c
@@ -48,6 +48,8 @@
 int main(int argc, char **argv) {
     struct image_object image;
 
+    fd_cleanup();
+
     singularity_config_init();
 
     singularity_suid_init();

--- a/src/start.c
+++ b/src/start.c
@@ -58,6 +58,8 @@ int main(int argc, char **argv) {
     siginfo_t siginfo;
     struct stat filestat;
 
+    fd_cleanup();
+
     singularity_config_init();
 
     singularity_suid_init();

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -45,6 +45,7 @@
 
 #include "config.h"
 #include "util/util.h"
+#include "util/file.h"
 #include "util/message.h"
 #include "util/privilege.h"
 #include "util/registry.h"
@@ -456,7 +457,6 @@ struct tempfile *make_logfile(char *label) {
 
 // close all file descriptors pointing to a directory
 void fd_cleanup(void) {
-    struct stat st;
     char *fd_path = (char *)malloc(128);
     int i;
 
@@ -472,12 +472,10 @@ void fd_cleanup(void) {
         length = snprintf(fd_path, 127, "/proc/self/fd/%d", i);
         fd_path[length] = '\0';
 
-        if ( stat(fd_path, &st) < 0 ) {
+        if ( is_dir(fd_path) < 0 ) {
             continue;
         }
-        if ( S_ISDIR(st.st_mode) ) {
-            close(i);
-        }
+        close(i);
     }
 
     free(fd_path);

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -457,7 +457,7 @@ struct tempfile *make_logfile(char *label) {
 
 // close all file descriptors pointing to a directory
 void fd_cleanup(void) {
-    char *fd_path = (char *)malloc(128);
+    char *fd_path = (char *)malloc(PATH_MAX);
     int i;
 
     singularity_message(DEBUG, "Cleanup file descriptor table\n");
@@ -469,7 +469,14 @@ void fd_cleanup(void) {
 
     for ( i = 0; i <= sysconf(_SC_OPEN_MAX); i++ ) {
         int length;
-        length = snprintf(fd_path, 127, "/proc/self/fd/%d", i);
+        length = snprintf(fd_path, PATH_MAX-1, "/proc/self/fd/%d", i);
+        if ( length < 0 ) {
+            singularity_message(ERROR, "Failed to determine file descriptor path\n");
+            ABORT(255);
+        }
+        if ( length > PATH_MAX-1 ) {
+            length = PATH_MAX-1;
+        }
         fd_path[length] = '\0';
 
         if ( is_dir(fd_path) < 0 ) {

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -58,6 +58,7 @@ void munmap_file(void *map, size_t size);
 void free_tempfile(struct tempfile *tf);
 struct tempfile *make_tempfile(void);
 struct tempfile *make_logfile(char *label);
+void fd_cleanup(void);
 
 // Given a const char * string containing a base-10 integer,
 // try to convert to an C integer.


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Singularity doesn't cleanup file descriptor table during runtime. This is especially important with file descriptor pointing to directory, because that could break container isolation with some scenarios

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
