### PR TITLE
Add delay in cleanupd before removing runtime directory (against dev branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
-## [v2.4.3](https://github.com/singularityware/singularity/tree/release-2.4)
-
- - Fix permission denied when binding directory located on NFS with root_squash enabled
-
 ## [v3.0](https://github.com/singularityware/singularity/tree/development)
 
 ### Implemented enhancements
@@ -39,6 +35,11 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Put /usr/local/{bin,sbin} in front of the default PATH
  - Fixed bug that did not export environment variables for apps with "-" in name
  
+## [v2.4.3](https://github.com/singularityware/singularity/tree/release-2.4)
+
+ - Fix permission denied when binding directory located on NFS with root_squash enabled
+ - Fix race condition between container exit and cleanupd while removing runtime directory
+
 ## [v2.4.2](https://github.com/singularityware/singularity/tree/release-2.4)
 
  - This fixed an issue for support of older distributions and kernels with regards to `setns()`

--- a/src/cleanupd.c
+++ b/src/cleanupd.c
@@ -78,6 +78,8 @@ int main(int argc, char **argv) {
     singularity_message(DEBUG, "Waiting for exclusive flock() on trigger file descriptor: %d\n", trigger_fd);
     if ( flock(trigger_fd, LOCK_EX) == 0 ) {
         singularity_message(VERBOSE, "Cleaning directory: %s\n", cleanup_dir);
+        /* remove directory after 50ms delay (issue #1255) */
+        usleep(50000);
         if ( s_rmdir(cleanup_dir) < 0 ) {
             unlink(trigger);
             singularity_message(ERROR, "Could not remove directory %s: %s\n", cleanup_dir, strerror(errno));


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix race condition between container exit and cleanupd while removing runtime directory

**This fixes or addresses the following GitHub issues:**

- Ref: #1255


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
