### PR TITLE
Fix bad "doesn't exists" grammar, add more helpful error for unrecogized URIs

### DIFF
--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -61,7 +61,7 @@ struct image_object singularity_image_init(char *path, int open_flags) {
 
     real_path = realpath(path, NULL); // Flawfinder: ignore
     if ( real_path == NULL ) {
-        singularity_message(ERROR, "Image path doesn't exists\n");
+        singularity_message(ERROR, "Image path doesn't exist\n");
         ABORT(255);
     }
 

--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -52,6 +52,7 @@
 
 struct image_object singularity_image_init(char *path, int open_flags) {
     struct image_object image;
+    char *urip;
     char *real_path;
 
     if ( path == NULL ) {
@@ -59,9 +60,17 @@ struct image_object singularity_image_init(char *path, int open_flags) {
         ABORT(255);
     }
 
+    urip = strstr(path, "://");
+
+    if (urip != NULL) {
+        *(urip + 3) = '\n'
+        singularity_message(ERROR, "Image paths beginning with %s are not supported\n", path);
+        ABORT(255);
+    }
+
     real_path = realpath(path, NULL); // Flawfinder: ignore
     if ( real_path == NULL ) {
-        singularity_message(ERROR, "Image path doesn't exist\n");
+        singularity_message(ERROR, "Image path %s doesn't exist\n", path);
         ABORT(255);
     }
 

--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -63,7 +63,7 @@ struct image_object singularity_image_init(char *path, int open_flags) {
     urip = strstr(path, "://");
 
     if (urip != NULL) {
-        *(urip + 3) = '\n'
+        *(urip + 3) = '\n';
         singularity_message(ERROR, "Image paths beginning with %s are not supported\n", path);
         ABORT(255);
     }

--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -63,7 +63,7 @@ struct image_object singularity_image_init(char *path, int open_flags) {
     urip = strstr(path, "://");
 
     if (urip != NULL) {
-        *(urip + 3) = '\n';
+        *(urip + 3) = '\0';
         singularity_message(ERROR, "Image paths beginning with %s are not supported\n", path);
         ABORT(255);
     }

--- a/src/util/mount.c
+++ b/src/util/mount.c
@@ -81,7 +81,7 @@ int check_mounted(char *mountpoint) {
 
     real_mountpoint = realpath(mountpoint, NULL); // Flawfinder: ignore
     if ( real_mountpoint == NULL ) {
-        // mountpoint doesn't exists
+        // mountpoint doesn't exist
         return(retval);
     }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR removes 3 occurrences of "doesn't exists" in the singularity source code and adds a more helpful error message in image.c when some unrecognized URI is attempted.  

I started down this path by trying "docker://" on a RHEL system that had only singularity-runtime sub-rpm installed.  This doesn't completely fix the problems with that, but it's a hopefully non-controversial and simple start and helpful on its own.


**This fixes or addresses the following GitHub issues:**

- Ref: None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
