### PR TITLE
Prevent unmounts of the filesystem containing the image

### DIFF
--- a/src/lib/image/image.c
+++ b/src/lib/image/image.c
@@ -118,10 +118,9 @@ struct image_object singularity_image_init(char *path, int open_flags) {
         ABORT(255);
     }
 
-    if ( fcntl(image.fd, F_SETFD, FD_CLOEXEC) != 0 ) {
-        singularity_message(ERROR, "Failed to set CLOEXEC on image file descriptor\n");
-        ABORT(255);
-    }
+    // Do not CLOEXEC the image file descriptor, as we want to make sure we
+    // are holding onto it when we are running contained processes to prevent
+    // it from getting unmounted.
 
     if ( ( singularity_suid_enabled() >= 0 ) && ( singularity_priv_getuid() != 0 ) ) {
         singularity_limit_container_paths(&image);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR restores the fix in issue #714.  It was released in version 2.3.2 and promptly dropped from version 2.4, I think in this [commit](b299f704bd880c4f893e9cba336bfa8ce97f418c) as files got moved around.

The issue is that singularity does not hold open a reference to the original image outside of the container, so the filesystem holding it can be unmounted.  This particularly causes problems on autofs-mounted filesystems, as is done with cvmfs.


**This fixes or addresses the following GitHub issues:**

- Ref: None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
