### PR TITLE
move get-configvals to runtime subrpm

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -108,7 +108,6 @@ rm -rf $RPM_BUILD_ROOT
 # Binaries
 %{_libexecdir}/singularity/bin/builddef
 %{_libexecdir}/singularity/bin/cleanupd
-%{_libexecdir}/singularity/bin/get-configvals
 %{_libexecdir}/singularity/bin/get-section
 %{_libexecdir}/singularity/bin/mount
 %{_libexecdir}/singularity/bin/image-type
@@ -140,6 +139,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/shell.*
 %{_libexecdir}/singularity/cli/test.*
 %{_libexecdir}/singularity/bin/action
+%{_libexecdir}/singularity/bin/get-configvals
 %{_libexecdir}/singularity/bin/start
 %{_libexecdir}/singularity/bin/docker-extract
 %{_libexecdir}/singularity/functions


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This moves get-configvals, introduced in #1082, to the runtime subrpm.  Otherwise if only singularity-runtime rpm is installed, doing something like a singularity exec causes these errors:
```
/usr/libexec/singularity/cli/action_argparser.sh: line 212: /usr/libexec/singularity/bin/get-configvals: No such file or directory
/usr/libexec/singularity/cli/action_argparser.sh: line 212: [: ==: unary operator expected
```

**This fixes or addresses the following GitHub issues:**

- Ref: None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
  Not needed because this fixes an unreleased bug.
- [ ] I have tested this PR locally with a `make test` 
   Not appropriate because it only affects rpms
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
