### PR TITLE
Support docker:// and shub:// with just singularity-runtime rpm

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -103,19 +103,14 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/pull.*
 %{_libexecdir}/singularity/cli/selftest.*
 %{_libexecdir}/singularity/helpers
-%{_libexecdir}/singularity/python
 
 # Binaries
 %{_libexecdir}/singularity/bin/builddef
-%{_libexecdir}/singularity/bin/cleanupd
 %{_libexecdir}/singularity/bin/get-section
 %{_libexecdir}/singularity/bin/mount
 %{_libexecdir}/singularity/bin/image-type
 %{_libexecdir}/singularity/bin/prepheader
 %{_libexecdir}/singularity/bin/docker-extract
-
-# Directories
-%{_libexecdir}/singularity/bootstrap-scripts
 
 #SUID programs
 %attr(4755, root, root) %{_libexecdir}/singularity/bin/mount-suid
@@ -140,11 +135,14 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/test.*
 %{_libexecdir}/singularity/bin/action
 %{_libexecdir}/singularity/bin/get-configvals
+%{_libexecdir}/singularity/bin/cleanupd
 %{_libexecdir}/singularity/bin/start
 %{_libexecdir}/singularity/bin/docker-extract
+%{_libexecdir}/singularity/bootstrap-scripts
 %{_libexecdir}/singularity/functions
 %{_libexecdir}/singularity/handlers
 %{_libexecdir}/singularity/image-handler.sh
+%{_libexecdir}/singularity/python
 %dir %{_sysconfdir}/singularity
 %config(noreplace) %{_sysconfdir}/singularity/*
 %{_mandir}/man1/singularity.1*


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR moves the python and bootstrap-scripts directories and the cleanupd bin script to the singularity-runtime rpm from the singularity rpm, in order to support docker:// and shub:// URIs when running images.  The help messages say they are supported, but they don't work.  In 2.4.2, they give the error
```
ERROR  : Image path doesn't exists
```
which I addressed in PR #1317.  In the current development branch, the error message is about a missing file.  With docker:// it is
```
/usr/libexec/singularity/functions: line 256: /usr/libexec/singularity/python/import.py: No such file or directory
```
or with shub:// it is
```
/usr/libexec/singularity/handlers/image-shub.sh: line 22: /usr/libexec/singularity/python/pull.py: No such file or directory
```

**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
  Not relevant since it affects only rpm
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
