### PR TITLE
Move sign command out of the runtime package

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -106,6 +106,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/mount.*
 %{_libexecdir}/singularity/cli/pull.*
 %{_libexecdir}/singularity/cli/selftest.*
+%{_libexecdir}/singularity/cli/sign.*
 %{_libexecdir}/singularity/helpers
 %{_libexecdir}/singularity/python
 
@@ -141,7 +142,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/shell.*
 %{_libexecdir}/singularity/cli/test.*
 %{_libexecdir}/singularity/cli/capability.*
-%{_libexecdir}/singularity/cli/sign.*
 %{_libexecdir}/singularity/cli/verify.*
 %{_libexecdir}/singularity/cli/siflist.*
 %{_libexecdir}/singularity/bin/action


### PR DESCRIPTION
**Description of the Pull Request (PR):**

3 new CONTAINER MANAGEMENT COMMANDS have shown up in the development branch in the singularity-runtime rpm.  I'm not sure if siflist and verify are needed at runtime, but surely sign isn't.  This PR moves the sign command from the runtime subrpm to the main singularity rpm.


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
  This only affects the development branch so no CHANGELOG entry is needed.
- [ ] I have tested this PR locally with a `make test`
  This only affects the rpm so make test isn't relevant.
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
