### PR TITLE
Use io.Reader for parsing Deffile

### DIFF
--- a/pkg/build/deffile.go
+++ b/pkg/build/deffile.go
@@ -10,8 +10,8 @@ package build
 
 import (
 	"bufio"
+	"io"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"unicode"
@@ -62,16 +62,16 @@ type Sections struct {
 	post      string
 	runscript string
 	test      string
+}
 
 // Header contains the information for what source to bootstrap from
 type header struct {
 	Lines []string
 }
 
-// DeffileFromPath reads a deffile from a given path
-// and returns a Deffile
-func DeffileFromPath(path string) (Deffile, error) {
-	lines, err := cleanUpFile(path)
+// ParseDefFile reads the contents of a deffile and returns it as a parsed Deffile
+func ParseDefFile(r io.Reader) (Deffile, error) {
+	lines, err := cleanUpFile(r)
 	if err != nil {
 		return Deffile{}, err
 	}
@@ -84,15 +84,9 @@ func DeffileFromPath(path string) (Deffile, error) {
 
 // cleanUpFile removes comments, escape characters
 // and white spaces from deffile and converts text to []string
-func cleanUpFile(path string) ([]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
+func cleanUpFile(r io.Reader) ([]string, error) {
 	var lines []string
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
 		// Trim Blank lines

--- a/pkg/build/deffile_test.go
+++ b/pkg/build/deffile_test.go
@@ -70,12 +70,18 @@ func TestCleanUpFile(t *testing.T) {
 
 		defer f.Close()
 
-		Df, err := DeffileFromPath(testFiles[k])
+		r, err := os.Open(testFiles[k])
+		if err != nil {
+			t.Error(err)
+		}
+		defer r.Close()
+
+		Df, err := ParseDefFile(r)
 		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
-		//  `Write DeffileFromPath output to file
+		// Write Deffile output to file
 		for _, k := range headerKeys {
 			v, ok := Df.Header[k]
 			if ok {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Use io.Reader for parsing Deffile instead of expecting a file path. 


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [ ] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [ ] This PR is ready for review and/or merge


Attn: @singularityware-admin
