### PR TITLE
Make recursive chmods more efficient

### DIFF
--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -356,7 +356,7 @@ fi
 if [ "$USERID" != "0" ]; then
     # This is required as some files in a container are not readable or writable
     # by owner and thus fail to build when not root.
-    find "$SINGULARITY_ROOTFS" ! -perm -u=rw -print0|xargs -0 -r chmod u+rw
+    find "$SINGULARITY_ROOTFS" ! -type l ! -perm -u=rw -print0|xargs -0 -r chmod u+rw
 fi
 
 if [ -z "${SINGULARITY_SANDBOX:-}" ]; then

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -354,9 +354,9 @@ fi
 
 
 if [ "$USERID" != "0" ]; then
-    # This is required as some files in a container are not readable by owner and
-    # thus fail to build when not root.
-    chmod u+rw -R "$SINGULARITY_ROOTFS"
+    # This is required as some files in a container are not readable or writable
+    # by owner and thus fail to build when not root.
+    find "$SINGULARITY_ROOTFS" -type d ! -perm -u=rw -print0|xargs -0 -r chmod u+rw
 fi
 
 if [ -z "${SINGULARITY_SANDBOX:-}" ]; then

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -356,7 +356,7 @@ fi
 if [ "$USERID" != "0" ]; then
     # This is required as some files in a container are not readable or writable
     # by owner and thus fail to build when not root.
-    find "$SINGULARITY_ROOTFS" -type d ! -perm -u=rw -print0|xargs -0 -r chmod u+rw
+    find "$SINGULARITY_ROOTFS" ! -perm -u=rw -print0|xargs -0 -r chmod u+rw
 fi
 
 if [ -z "${SINGULARITY_SANDBOX:-}" ]; then

--- a/libexec/handlers/archive-cpio.sh
+++ b/libexec/handlers/archive-cpio.sh
@@ -37,7 +37,7 @@ case "$SINGULARITY_IMAGE" in
     ;;
 esac
 
-find "$CONTAINER_DIR" ! -perm -u=w -print0|xargs -0 -r chmod u+w
+find "$CONTAINER_DIR" ! -type l ! -perm -u=w -print0|xargs -0 -r chmod u+w
 
 SINGULARITY_IMAGE="$CONTAINER_DIR"
 SINGULARITY_CLEANUPDIR="$SINGULARITY_TMPDIR"

--- a/libexec/handlers/archive-cpio.sh
+++ b/libexec/handlers/archive-cpio.sh
@@ -37,7 +37,7 @@ case "$SINGULARITY_IMAGE" in
     ;;
 esac
 
-chmod -R +w "$CONTAINER_DIR"
+find "$CONTAINER_DIR" ! -perm -u=w -print0|xargs -0 -r chmod u+w
 
 SINGULARITY_IMAGE="$CONTAINER_DIR"
 SINGULARITY_CLEANUPDIR="$SINGULARITY_TMPDIR"

--- a/libexec/handlers/archive-tar.sh
+++ b/libexec/handlers/archive-tar.sh
@@ -30,7 +30,7 @@ message 1 "Opening tar archive, stand by...\n"
 # running as a user.
 tar -C "$CONTAINER_DIR" -xf "$SINGULARITY_IMAGE" 2>/dev/null
 
-chmod -R +w "$CONTAINER_DIR"
+find "$CONTAINER_DIR" ! -perm -u=w -print0|xargs -0 -r chmod u+w
 
 SINGULARITY_IMAGE="$CONTAINER_DIR"
 SINGULARITY_CLEANUPDIR="$SINGULARITY_TMPDIR"

--- a/libexec/handlers/archive-tar.sh
+++ b/libexec/handlers/archive-tar.sh
@@ -30,7 +30,7 @@ message 1 "Opening tar archive, stand by...\n"
 # running as a user.
 tar -C "$CONTAINER_DIR" -xf "$SINGULARITY_IMAGE" 2>/dev/null
 
-find "$CONTAINER_DIR" ! -perm -u=w -print0|xargs -0 -r chmod u+w
+find "$CONTAINER_DIR" ! -type l ! -perm -u=w -print0|xargs -0 -r chmod u+w
 
 SINGULARITY_IMAGE="$CONTAINER_DIR"
 SINGULARITY_CLEANUPDIR="$SINGULARITY_TMPDIR"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

I noticed that the build command when not running as root does a recursive chmod whether or not any modes need to be changed.  I looked for other places with similar code and found it in the archive-tar and archive-cpio handlers.  This PR changes the scripts to use 'find' to identify which files are the wrong permissions and only chmods those files.

**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
   I haven't done this because I don't know which release it will get into.  It is relevant to the release-2.4 branch.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
