### PR TITLE
use cobra pointers

### DIFF
--- a/internal/pkg/cli/build.go
+++ b/internal/pkg/cli/build.go
@@ -1,48 +1,44 @@
 /*
-  Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018, Sylabs, Inc. All rights reserved.
 
-  This software is licensed under a 3-clause BSD license.  Please
-  consult LICENSE file distributed with the sources of this project regarding
-  your rights to use or distribute this software.
+This software is licensed under a 3-clause BSD license.  Please
+consult LICENSE file distributed with the sources of this project regarding
+your rights to use or distribute this software.
 */
+
 package cli
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-
-	"github.com/singularityware/singularity/pkg/build"
 	"github.com/spf13/cobra"
+)
+
+// Build cmd local vars
+var (
+	sandbox  bool
+	writable bool
+	remote   bool
+	force    bool
+	noTest   bool
+	section  string
 )
 
 // buildCmd represents the build command
 var buildCmd = &cobra.Command{
 	Use: "build",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("build called")
 
-		if cmd.Flags().Lookup("deffile") != nil {
-			str, _ := cmd.Flags().GetString("deffile")
-
-			file, _ := os.Open(str)
-			d, _ := build.ParseDefinitionFile(file)
-
-			f, _ := ioutil.TempFile("/tmp/", "Singularity-Definition-")
-			d.WriteDefinitionFile(f)
-		}
 	},
 }
 
 func init() {
 	singularityCmd.AddCommand(buildCmd)
 
-	buildCmd.PersistentFlags().String("sandbox", "s", "")
-	buildCmd.PersistentFlags().String("writable", "w", "")
-	buildCmd.PersistentFlags().String("force", "f", "")
-	buildCmd.PersistentFlags().String("notest", "T", "")
-	buildCmd.PersistentFlags().String("section", "s", "")
-	buildCmd.PersistentFlags().String("deffile", "d", "")
+	buildCmd.PersistentFlags().BoolVarP(&sandbox, "sandbox", "s", false, "")
+	buildCmd.PersistentFlags().BoolVarP(&remote, "remote", "r", false, "")
+	buildCmd.PersistentFlags().BoolVarP(&writable, "writable", "w", false, "")
+	buildCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "")
+	buildCmd.PersistentFlags().BoolVarP(&noTest, "notest", "T", false, "")
+	buildCmd.PersistentFlags().StringVarP(&section, "section", "s", "post", "")
 
 	buildCmd.SetHelpTemplate(`
 	The build command compiles a container per a recipe (definition file) or based
@@ -217,7 +213,6 @@ func init() {
 		
 	http://singularity.lbl.gov/
 `)
-
 	buildCmd.SetUsageTemplate(`
 USAGE: singularity [...] build [build options...] <container path> <deffile path>
     `)

--- a/internal/pkg/cli/singularity.go
+++ b/internal/pkg/cli/singularity.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
 This software is licensed under a 3-clause BSD license.  Please
 consult LICENSE file distributed with the sources of this project regarding
 your rights to use or distribute this software.
@@ -10,6 +11,14 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+)
+
+// Global variables for singularity CLI
+var (
+	debug   bool
+	silent  bool
+	verbose bool
+	quiet   bool
 )
 
 // singularity is the base command when called without any subcommands
@@ -26,14 +35,12 @@ func Execute() {
 	}
 }
 
-var verbose bool
-
 func init() {
 
-	singularityCmd.PersistentFlags().BoolP("debug", "d", false, "")
-	singularityCmd.PersistentFlags().BoolP("silent", "s", false, "")
-	singularityCmd.PersistentFlags().BoolP("quiet", "q", false, "")
-	singularityCmd.PersistentFlags().BoolP("verbose", "v", false, "")
+	singularityCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "")
+	singularityCmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "")
+	singularityCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "")
+	singularityCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "")
 
 	singularityCmd.SetHelpTemplate(`
 USAGE: singularity [global options...] <command> [command options...] ...


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The idea is to have a global data struct on which parse the flags , for now is a var array, but we might want to build a GobalFlags or some data struct in the future (next PR) 
```go
// Global variables for singularity CLI
var (
	debug   bool
	silent  bool
	verbose bool
	quiet   bool
)
```

```go
singularityCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "")
	singularityCmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "")
	singularityCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "")
	singularityCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "")
```

now this variables can be used directly with out using cobra. 

Attn: @singularityware-admin
