### PR TITLE
Add dev nvidia with nv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
+## [v2.4.5](https://github.com/singularityware/singularity/tree/release-2.5)
+ - Fix conflict between `--nv` and `--contain` options
+
 ## [v2.4.4](https://github.com/singularityware/singularity/tree/release-2.4)
 
  - Removed capability to handle docker layer aufs whiteout files correctly as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
+## [v2.4.4](https://github.com/singularityware/singularity/tree/release-2.4)
+ - Fix conflict between `--nv` and `--contain` options
+
 ## [v2.4.3](https://github.com/singularityware/singularity/tree/release-2.4)
 
  - Fix permission denied when binding directory located on NFS with root_squash enabled

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -146,7 +146,7 @@ while true; do
             else
                 export SINGULARITY_CONTAINLIBS
             fi
-            if NVIDIA_SMI=$(which nvidia-smi); then
+            if NVIDIA_SMI=$(which nvidia-smi >/dev/null 2>&1); then
                 if [ -n "${SINGULARITY_BINDPATH:-}" ]; then
                     SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH},${NVIDIA_SMI}"
                 else

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -123,6 +123,7 @@ while true; do
         ;;
         --nv)
             shift
+            SINGULARITY_NV=1
             export SINGULARITY_NV
             SINGULARITY_NVLIBLIST=`mktemp ${TMPDIR:-/tmp}/.singularity-nvliblist.XXXXXXXX`
             cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" > $SINGULARITY_NVLIBLIST
@@ -142,7 +143,7 @@ while true; do
             else
                 export SINGULARITY_CONTAINLIBS
             fi
-            if NVIDIA_SMI=$(which nvidia-smi >/dev/null 2>&1); then
+            if NVIDIA_SMI=$(which nvidia-smi 2>/dev/null); then
                 if [ -n "${SINGULARITY_BINDPATH:-}" ]; then
                     SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH},${NVIDIA_SMI}"
                 else

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -123,11 +123,7 @@ while true; do
         ;;
         --nv)
             shift
-            # if the --contain option is used, we will also need to bind mount
-            # whatever nvidia devices exist. $SINGULARITY_NVDEV is used in 
-            # src/lib/runtime/mounts/dev/dev.c
-            SINGULARITY_NVDEV=`ls /dev/nvidia* | tr '\n' ','`
-            export SINGULARITY_NV SINGULARITY_NVDEV
+            export SINGULARITY_NV
             SINGULARITY_NVLIBLIST=`mktemp ${TMPDIR:-/tmp}/.singularity-nvliblist.XXXXXXXX`
             cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" > $SINGULARITY_NVLIBLIST
             for i in $(ldconfig -p | grep -f "${SINGULARITY_NVLIBLIST}"); do
@@ -152,8 +148,6 @@ while true; do
                 else
                     SINGULARITY_BINDPATH="${NVIDIA_SMI}"
                 fi
-
-                # SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH},/dev/nvidia0"
                 export SINGULARITY_BINDPATH
             else
                 message WARN "Could not find the Nvidia SMI binary to bind into container\n"

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -123,6 +123,11 @@ while true; do
         ;;
         --nv)
             shift
+            # if the --contain option is used, we will also need to bind mount
+            # whatever nvidia devices exist. $SINGULARITY_NVDEV is used in 
+            # src/lib/runtime/mounts/dev/dev.c
+            SINGULARITY_NVDEV=`ls /dev/nvidia* | tr '\n' ','`
+            export SINGULARITY_NV SINGULARITY_NVDEV
             SINGULARITY_NVLIBLIST=`mktemp ${TMPDIR:-/tmp}/.singularity-nvliblist.XXXXXXXX`
             cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" > $SINGULARITY_NVLIBLIST
             for i in $(ldconfig -p | grep -f "${SINGULARITY_NVLIBLIST}"); do
@@ -147,6 +152,8 @@ while true; do
                 else
                     SINGULARITY_BINDPATH="${NVIDIA_SMI}"
                 fi
+
+                # SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH},/dev/nvidia0"
                 export SINGULARITY_BINDPATH
             else
                 message WARN "Could not find the Nvidia SMI binary to bind into container\n"

--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -119,7 +119,6 @@ int _singularity_runtime_mount_dev(void) {
 
             while ( ( dp = readdir(dir) ) != NULL ) {
                 if ( strstr(dp->d_name, "nvidia") != NULL ) {
-                    singularity_message(2, "Binding device %s\n", joinpath("/dev", dp->d_name) );
                     bind_dev(sessiondir, joinpath("/dev", dp->d_name) );
                 }
             }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Several users noted that the `--nv` option does not work in conjunction with the `--contain` option.  This is because `/dev/nvidia*` devices are not bind mounted into the container if `--contain` is used.  This PR fixes this issue by bind mounting `/dev/nvidia*` if the `--nv` option is passed along with the `--contain` option.  

I'm not sure why the commit history includes all of the other commits.  It could be because that history was inadvertently lost in the release-2.4 branch when bug fixes were backported by cherry-picking merges.  If that is the case it will actually be a good thing to add this history back into the release-2.4 branch where it belongs.

Note that this PR is slated for 2.4.4.  So it should not be merged into release-2.4 until the 2.4.3 release has been tagged.  

**This fixes or addresses the following GitHub issues:**

- Fixes https://github.com/singularityware/singularity/issues/1306

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [ ] This PR is ready for review and/or merge


Attn: @singularityware-admin
