### PR TITLE
fixing issue with user custom environment not being set with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,19 +37,21 @@ secbuildimg.sh
 
 src/action
 src/action-suid
-src/start
-src/start-suid
 src/builddef
 src/cleanupd
+src/docker-extract
+src/get-configvals
+src/get-section
 src/image-type
 src/mount
 src/mount-suid
 src/sif
-src/sinit
-src/get-section
 src/sign
-src/verify
+src/sinit
+src/start
+src/start-suid
 src/stamp-h1
+src/verify
 src/include/stamp-h1
 src/.dirstamp
 src/wrapper

--- a/libexec/python/defaults.py
+++ b/libexec/python/defaults.py
@@ -126,6 +126,9 @@ TAG = "latest"
 # Container Metadata
 DOCKER_NUMBER = 10  # number to start docker files at in ENV_DIR
 DOCKER_PREFIX = "docker"
+
+# Default docker path defined in C, subtracted from Docker 10-docker.sh
+DOCKER_PATH = "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 SHUB_PREFIX = "shub"
 
 # Defaults for environment, runscript, labels

--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -11,7 +11,7 @@ import sys
 import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),  # noqa
                 os.path.pardir)))  # noqa
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) # noqa
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # noqa
 
 from sutils import (
     add_http,
@@ -181,7 +181,7 @@ def extract_env(manifest):
         lines = []
         for line in environ:
             line = re.findall("(?P<var_name>.+?)=(?P<var_value>.+)", line)
-            
+
             for x in line:
                 varname = x[0]
                 varval = x[1]
@@ -189,9 +189,9 @@ def extract_env(manifest):
                 # For PATH, subtract Docker set PATH from Singularity default
 
                 if varname == "PATH":
-                    components = varval.split(':')
-                    components = [x for x in components if x not in DOCKER_PATH]
-                    varval = "$PATH:%s" % ":".join(components)
+                    parts = varval.split(':')
+                    parts = [x for x in parts if x not in DOCKER_PATH]
+                    varval = "$PATH:%s" % ":".join(parts)
 
                 line = 'export %s="%s"' % (varname, varval.strip(':'))
                 lines.append(line)

--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -190,10 +190,10 @@ def extract_env(manifest):
 
                 if varname == "PATH":
                     components = varval.split(':')
-                    components = [x for x in components if x not in DOCKER_PATH]  
-                    varval = "$PATH:%s" % (":".join(DOCKER_PATH + components))
+                    components = [x for x in components if x not in DOCKER_PATH]
+                    varval = "$PATH:%s" % ":".join(components)
 
-                line = 'export %s="%s"' % (varname, varval)
+                line = 'export %s="%s"' % (varname, varval.strip(':'))
                 lines.append(line)
 
         environ = "\n".join(lines)

--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -167,16 +167,34 @@ def extract_env(manifest):
     '''extract the environment from the manifest, or return None.
     Used by functions env_extract_image, and env_extract_tar
     '''
+    from defaults import DOCKER_PATH
+
     environ = get_config(manifest, 'Env')
     if environ is not None:
         if not isinstance(environ, list):
             environ = [environ]
 
+        # Default PATH components to subtract Docker set PATH
+
+        DOCKER_PATH = DOCKER_PATH.split(':')
+
         lines = []
         for line in environ:
             line = re.findall("(?P<var_name>.+?)=(?P<var_value>.+)", line)
-            line = ['export %s="%s"' % (x[0], x[1]) for x in line]
-            lines = lines + line
+            
+            for x in line:
+                varname = x[0]
+                varval = x[1]
+
+                # For PATH, subtract Docker set PATH from Singularity default
+
+                if varname == "PATH":
+                    components = varval.split(':')
+                    components = [x for x in components if x not in DOCKER_PATH]  
+                    varval = "$PATH:%s" % (":".join(DOCKER_PATH + components))
+
+                line = 'export %s="%s"' % (varname, varval)
+                lines.append(line)
 
         environ = "\n".join(lines)
         bot.verbose3("Found Docker container environment!")


### PR DESCRIPTION
This pull request will address the issue that when a user specifies a custom environment variable at runtime, it is not honored. For example:

```
SINGULARITYENV_PATH=/lala singularity exec ubuntu-14.04.simg env | grep '^PATH='
PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
```
It should be the case that `/lala` is shown above, but it is not.

## The Cause of the Problem
The 10-docker.sh script is one in the environment folder that is sourced at runtime. Since Docker images typically have a PATH variable, exporting the PATH here overrides anything done by the C.

## Fix Logic
We must be able to source Docker custom environments while honoring the Singularity default path, not repeating anything twice, and also the user custom specified variables at runtime. We also don't want to overwrite the Docker environment, because it's usually relevant to the base container. To do this, we:

 - parse through the Docker Env variables, and given that we find a PATH:
   - we take the difference betweent the path set by the C and what is found in the Docker container. The path is hard coded as a string `DOCKER_PATH` in the defaults.py file.
   - we only write the variables that aren't set by singularity by default (prevents duplicates)
   - we then add $PATH to this set, and we know confidently that the Singularity C is setting this.

## Updated Example
With the fix, we run the same command and since the user defined environment is also handled by the C, we get that in addition to the custom path (note before this was wiped):

```
SINGULARITYENV_PATH=/lala singularity exec ubuntu-14.04.simg env | grep '^PATH='
PATH=/lala:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
```
This was worked on / discussed with @jmstover.  I would encourage other testing of different images that have more complicated paths, etc.

## Gitignore Update
The second fix was also adding files that are compiled and not in the .gitignore. I also put them in ABC order so the universe is returned to a state of 42 :) If there are related issues, please post here since this was alerted to me in a slack chat. Ty!

Attn: @singularityware-admin
