### PR TITLE
remove -larchive from LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,6 +342,8 @@ AS_IF([test "x$archive_header_found" != "xyes"],
 AC_SEARCH_LIBS([archive_read_new], [archive], [], [
 AC_MSG_ERROR([unable to find libarchive, need package libarchive-devel (libarchive-de on Debian/Ubuntu)])
 ])
+# we don't want the LIBS setting of AC_SEARCH_LIBS, override
+AC_SUBST(LIBS,"")
 
 CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector --param ssp-buffer-size=4"
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Reset $LIBS after searching for -larchive so it is only linked with docker-extract.


**This fixes or addresses the following GitHub issues:**

- #1362 doesn't directly report this problem but it is an implication of the problem reported there.


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
