### PR TITLE
Accept io.Reader in ParseDefinitionFile

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@
     - Vanessa Sochat <vsochat@stanford.edu>
     - Yannick Cote <yhcote@gmail.com>
     - Eduardo Arango <carlos.arango.gutierrez@correounivalle.edu.co>
+    - Adam Hughes <stickmanica@gmail.com>
 
 #Contributors:
 

--- a/pkg/build/definition_parser_deffile.go
+++ b/pkg/build/definition_parser_deffile.go
@@ -12,8 +12,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"unicode"
@@ -206,11 +206,22 @@ func doHeader(r io.Reader) (header map[string]string, err error) {
 	return
 }
 
-func ParseDefinitionFile(f *os.File) (Definition, error) {
-	header, err := doHeader(f)
+// ParseDefinitionFile parses the contents of a DefFile into a Definition
+func ParseDefinitionFile(r io.Reader) (Definition, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return Definition{}, err
+	}
 
-	f.Seek(0, 0)
-	sections, err := doSections(f)
+	header, err := doHeader(bytes.NewReader(b))
+	if err != nil {
+		return Definition{}, err
+	}
+
+	sections, err := doSections(bytes.NewReader(b))
+	if err != nil {
+		return Definition{}, err
+	}
 
 	def := Definition{
 		Header: header,
@@ -231,7 +242,7 @@ func ParseDefinitionFile(f *os.File) (Definition, error) {
 		},
 	}
 
-	return def, err
+	return def, nil
 }
 
 func writeSectionIfExists(w io.Writer, ident string, s string) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

`ParseDefinitionFile()` should take an `io.Reader` rather than `os.File` to be more general.


**This fixes or addresses the following GitHub issues:**

-  N/A


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
