### PR TITLE
fix is_deffile assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Put /usr/local/{bin,sbin} in front of the default PATH
  - Adjustments to SCIF (Scientific Filesystem) integration for broader use
  - Fixed bug that did not export environment variables for apps with "-" in name
+ - Removed overeager check for known invalid recipe file extension
 
 ## [v2.4.4](https://github.com/singularityware/singularity/tree/release-2.4)
 

--- a/libexec/functions
+++ b/libexec/functions
@@ -396,30 +396,12 @@ nonroot_build_warning() {
 is_deffile() {
 # check if a file looks like, walks like, and quacks like a def file
     FILE2CHECK=$1
-    
-    # first make a guess based on naming convention
-    case ${FILE2CHECK:-} in
-        *.img)
-            return 1
-            ;;
-        *.tar*)
-            return 1
-            ;;
-        *.def)
-            return 0
-            ;;
-        Singularity) 
-            return 0
-            ;;
-        *)
-            ;;
-        esac
 
-    # name is ambiguous.  is it a text file with def file words in it?
+    # is it a text file with def file words in it?
     if ! `file $FILE2CHECK | grep -q "ASCII\|Unicode"`; then
         return 1
     fi
-        
+
     grep -qiE "^bootstrap:|^%setup|^%post|^%test|^%labels|^%files|^%runscript|^%environment" "$FILE2CHECK"
     RETVAL=$?
 


### PR DESCRIPTION
I just created a recipe called `Singularity.tardis` (the name of our cluster) and it failed to build.
As it turns out this is because the file matches `*.tar*` and `is_deffile()` assumes that it's a tar archive. I think the whole test/guess for known file names can be safely removed.

Note that i ticked the box "I have tested this PR", but it didn't finish. It seems the test is broken in my environment - I waited 18h for the stage `+ python2 -m unittest tests.test_docker_import ` to complete.

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
