### PR TITLE
Make mksquashfs warning conditional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,11 +19,15 @@ install-perms:
 	@echo
 
 all-local:
+if !FOUND_MKSQUASHFS
 	@echo
 	@echo "******"
-	@echo "  mksquashfs from squash-tools is required for full functionality"
+	@echo "WARNING - mksquashfs was not found at configure time"
+	@echo "mksquashfs is required at runtime for full functionality"
+	@echo "Provided by distribution package squashfs-tools"
 	@echo "******"
 	@echo
+endif
 
 install-data-hook:
 	install -d -m 0755 $(DESTDIR)$(CONTAINER_MOUNTDIR)

--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,11 @@ AC_CHECK_FUNCS(setns, [
 
 AC_SUBST(SINGULARITY_DEFINES)
 
+
+AC_CHECK_PROG([mksquashfs],[mksquashfs],[yes],[no])
+AM_CONDITIONAL([FOUND_MKSQUASHFS], [test "x$mksquashfs" = xyes])
+AM_COND_IF([FOUND_MKSQUASHFS],,[AC_MSG_WARN([mksquashfs not found - needed at runtime for full build functionality])])
+
 # ---------------------------------------------------------------------
 # PYTHON
 # ---------------------------------------------------------------------


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Make the mksquashfs warning from make conditional on absence of mksquashfs at configure time.

**This fixes or addresses the following GitHub issues:**

- Ref: #1361 


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
