### PR TITLE
1184 rebase - add support for proxy auth flow and secured S3-backed registries

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@
     - Jason Stover <jason.stover@gmail.com>
     - Jeff Kriske <jekriske@gmail.com>
     - Josef Hrabal <josef.hrabal@vsb.cz>
+    - Justin Riley <justin_riley@harvard.edu>
     - Maciej Sieczka <msieczka@sieczka.org>
     - Mark Egan-Fuller <markeganfuller@googlemail.com>
     - Nathan Lin <nathan.lin@yale.edu>

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -128,7 +128,7 @@ def multi_package(func, args):
     return zip(itertools.repeat(func), args)
 
 
-def _strip_auth_presigned_s3(req, auth_query_params=['Signature',
+def _strip_auth_presigned_s3(req, auth_query_params=['AWSAccessKeyId',
                                                      'X-Amz-Algorithm']):
     """
     Handles stripping authorization headers from requests to pre-signed S3
@@ -139,17 +139,10 @@ def _strip_auth_presigned_s3(req, auth_query_params=['Signature',
         return req
 
     parts = urlparse(req.get_full_url())
-    host = parts.netloc
     query_dict = parse_qs(parts.query)
-    is_s3_url = 's3' in host and host.endswith('.amazonaws.com')
 
-    if not is_s3_url:
-        return req
-
-    for q in auth_query_params:
-        if q in query_dict:
-            del req.headers['Authorization']
-            break
+    if any(q in query_dict for q in auth_query_params):
+        del req.headers['Authorization']
 
     return req
 

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -388,6 +388,7 @@ class ApiConnection(object):
             msg = "Error downloading %s. " % (url)
             msg += "Do you have permission to write to %s?" % (download_folder)
             bot.error(msg)
+            bot.exception(msg)
             try:
                 os.remove(tmp_file)
             except Exception:

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -163,7 +163,9 @@ class DockerApiConnection(ApiConnection):
                 sys.exit(1)
 
             challenge = response.headers["Www-Authenticate"]
-            regexp = '^Bearer\s+realm="(.+?)"(?:,service="(.+?)")?(?:,scope="(.+?)")?'
+            regexp = '^Bearer\s+realm="(.+?)"'
+            regexp += '(?:,service="(.+?)")?'
+            regexp += '(?:,scope="(.+?)")?'
             match = re.match(regexp, challenge)
 
             if not match:

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -142,7 +142,7 @@ class DockerApiConnection(ApiConnection):
         self.registry = image['registry']
         self.update_token()
 
-    def update_token(self, response=None, auth=None):
+    def update_token(self, response=None, auth=None, expires_in=9000):
         '''update_token uses HTTP basic authentication to get a token for
         Docker registry API V2 operations. We get here if a 401 is
         returned for a request.
@@ -163,7 +163,7 @@ class DockerApiConnection(ApiConnection):
                 sys.exit(1)
 
             challenge = response.headers["Www-Authenticate"]
-            regexp = '^Bearer\s+realm="(.+)",service="(.+)",scope="(.+)",?'
+            regexp = '^Bearer\s+realm="(.+?)"(?:,service="(.+?)")?(?:,scope="(.+?)")?'
             match = re.match(regexp, challenge)
 
             if not match:
@@ -171,11 +171,17 @@ class DockerApiConnection(ApiConnection):
                 sys.exit(1)
 
             realm = match.group(1)
-            service = match.group(2)
-            scope = match.group(3).split(',')[0]
+            service = match.group(2) or ''
+            scope = (match.group(3) or '').split(',')[0]
 
-            self.token_url = ("%s?service=%s&expires_in=9000&scope=%s"
-                              % (realm, service, scope))
+            token_url_params = ['expires_in=%s' % expires_in]
+
+            if service:
+                token_url_params.append('service=%s' % service)
+            if scope:
+                token_url_params.append('scope=%s' % scope)
+
+            self.token_url = "%s?%s" % (realm, '&'.join(token_url_params))
 
         headers = dict()
 

--- a/libexec/python/message.py
+++ b/libexec/python/message.py
@@ -55,6 +55,7 @@ perform publicly and display publicly, and to permit other to do so.
 
 import os
 import sys
+import traceback
 
 ABRT = -4
 ERROR = -3
@@ -265,6 +266,10 @@ class SingularityMessage:
         self.emit(VERBOSE3, message, 'VERBOSE3')
 
     def debug(self, message):
+        self.emit(DEBUG, message, 'DEBUG')
+
+    def exception(self, message):
+        message = '%s\n%s' % (message, traceback.format_exc())
         self.emit(DEBUG, message, 'DEBUG')
 
     def is_quiet(self):


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a rebase of #1184 from @jtriley  against development-2.x

Original PR has 1 'accept' review at present. Cherry picked cleanly except CONTRIBUTORS.md

-----
Description of the Pull Request (PR):

NVIDIA cloud's private docker registry flow is slightly different than the flow used in singularity's python docker registry API and is supported by the official docker client. In addition to a slightly different flow, NVIDIA cloud's private docker registry is also backed by a secured S3 bucket which singularity currently doesn't handle properly. This PR fixes both of these issues and allows converting images from NVIDIA cloud's private docker registry into singularity images.

With the proxy auth challenge only the realm is returned and the only requirement is to auth against that realm URL (see singularityware/singularity#1159 for more details). To address this the challenge parsing regex and code has been updated to handle any combination of realm, service, and scope (as long as that order is maintained) and builds the token URL accordingly. NOTE: to be fully robust in our challenge parsing we'd need to use something like https://github.com/alexsdutton/www-authenticate but for now this is likely close enough for most docker registry use cases.

Once you get past the auth challenge parsing and token URL generation issue the next hurdle is that fetching layers involves a redirect to pre-signed S3 urls. Currently when this happens the auth credentials are passed along with the request which causes an InvalidArgument error about using more than one auth mechanism due to the pre-signed URL already containing an X-Amz-Algorithm query param and singularity additionally providing the Authorization: header with the bearer token (see singularityware/singularity#1159 for more details). This PR employs an HTTPHandler and HTTPSHandler with urllib to intercept all requests, inspect the URL for a pre-signed S3 URL, and if present strips any Authorization: header from the request. This should fix things for any private registry using a secured S3-backend - not just NVIDIA's.

This approach ensures that we're only stripping the Authorization: header in the case of S3-backed docker registries that use pre-signed S3 URLS where this is known be an issue (e.g. NVIDIA's private registry: nvcr.io). In all other cases the previous behavior should be preserved.

This fixes or addresses the following GitHub issues:

Ref: #1159, #1183
Checkoff for all PRs:

 I have read the Guidelines for Contributing, and this PR conforms to the stated requirements.
 I have added changes to the CHANGELOG and documentation updates to the singularityware documentation base.
 I have tested this PR locally with a make test
 This PR is NOT against the project's master branch
 I have added myself as a contributor to the contributors's file
 This PR is ready for review and/or merge
Attn: @singularityware-admin
