### PR TITLE
1354 rebase - Add binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ src/sinit
 src/start
 src/start-suid
 src/docker-extract
+src/prepheader
 
 src/.deps/
 src/.libs/


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a rebase against development-2.x of #1354 

In this rebase it adds a single line to .gitignore

----

Description of the Pull Request (PR):
Couple of new binaries created recently. Add them to the .gitignore file.

