### PR TITLE
 update_token: make scope,service params optional

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@
     - Jason Stover <jason.stover@gmail.com>
     - Jeff Kriske <jekriske@gmail.com>
     - Josef Hrabal <josef.hrabal@vsb.cz>
+    - Justin Riley <justin_riley@harvard.edu>
     - Maciej Sieczka <msieczka@sieczka.org>
     - Mark Egan-Fuller <markeganfuller@googlemail.com>
     - Nathan Lin <nathan.lin@yale.edu>
@@ -41,4 +42,3 @@
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
     - Yaroslav Halchenko <debian@onerussian.com>
-    - Justin Riley <justin_riley@harvard.edu>

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -26,7 +26,7 @@ import math
 import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
                                 os.path.pardir)))  # noqa
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) # noqa
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # noqa
 
 from base import ApiConnection
 

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -528,3 +528,21 @@ def write_singularity_infos(base_dir,
                                  extension)
     write_file(output_file, content)
     return output_file
+
+
+def parse_bearer_challenge(challenge):
+    '''
+    Parses a bearer challenge from a 'Www-Authenticate' header into a
+    dictionary of params. Supports realm, service, and scope bearer params
+    appearing in any order and assumes param values are double quoted.
+    '''
+    param_re = '((?:realm|service|scope)=".+?")'
+    regexp = '^Bearer\s+{param},?{param}?,?{param}?'.format(param=param_re)
+    match = re.match(regexp, challenge)
+    params = {}
+    if match:
+        for group in match.groups():
+            if group:
+                param, value = group.split('=', 1)
+                params[param] = value.strip('"')
+    return params

--- a/libexec/python/tests/test_core.py
+++ b/libexec/python/tests/test_core.py
@@ -667,6 +667,35 @@ class TestUtils(TestCase):
             written_content = filey.read()
         self.assertEqual(content, written_content)
 
+    def test_bearer_challenge_parsing(self):
+        '''
+        test_bearer_challenge_parsing will test the parse_bearer_challenge
+        function
+        '''
+        from sutils import parse_bearer_challenge
+
+        realm = "https://some-registry.io/auth"
+        service = "some-service"
+        scope = "some-scope"
+
+        cases = (
+            [("realm", realm), ("service", service), ("scope", scope)],
+            [("service", service), ("scope", scope), ("realm", realm)],
+            [("scope", scope), ("realm", realm), ("service", service)],
+            [("scope", scope), ("realm", realm)],
+            [("realm", realm), ("service", service)],
+            [("scope", scope), ("service", service)],
+            [("service", service)],
+            [("scope", scope)],
+            [("realm", realm)],
+        )
+
+        for case in cases:
+            challenge = 'Bearer %s' % ','.join(
+                ['%s="%s"' % (k, v) for k, v in case]
+            )
+            self.assertEqual(parse_bearer_challenge(challenge), dict(case))
+
 
 # Supporting Test Functions
 def create_test_tar(tmpdir, compressed=True):


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR updates the `Www-Authenticate` challenge parsing code in the `update_token` function in the python docker client to make `service` and `scope` params optional. These params are then conditionally used when building the token URL based on whether they were present in the auth challenge. The `realm` parameter is still required as that's the endpoint used for auth.

Not all private docker registries provide `scope` and `service` params in the auth challenge. For example, NVIDIA's private registry, `nvcr.io`, returns only the bearer `realm` as part of their proxy authentication flow and this is supported by the native docker client.

**This fixes or addresses the following GitHub issues:**

- Ref: https://github.com/singularityware/singularity/issues/1159#issuecomment-347593106
- Ref: singularityware/singularity#1184 (proxy auth flow piece)
- Ref: singularityware/singularity#1383 (proxy auth flow piece)

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
