### PR TITLE
Rebase #1387 to release-2.4 (python: strip "Authorization" header on (urllib) redirects to different domains)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
+## [v2.4.5](https://github.com/singularityware/singularity/tree/release-2.4)
+
+ - Strip authorization header on http redirect to different domain when
+   interacting with docker registries.
+
 ## [v2.4.4](https://github.com/singularityware/singularity/tree/release-2.4)
 
  - Removed capability to handle docker layer aufs whiteout files correctly as

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,3 +39,4 @@
     - Rémy Dernat <remy.dernat@umontpellier.fr>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Yaroslav Halchenko <debian@onerussian.com>
+    - Justin Riley <justin_riley@harvard.edu>

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([singularity],[2.4.4],[gmkurtzer@gmail.com])
+AC_INIT([singularity],[2.4.5],[gmkurtzer@gmail.com])
 
 if test -z "$prefix" -o "$prefix" = "NONE" ; then
   prefix=${ac_default_prefix}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+singularity-container (2.4.5-1) unstable; urgency=high
+
+  * Strip authorization header on http redirect to different domain when
+    interacting with docker registries.
+
 singularity-container (2.4.4-1) unstable; urgency=high
 
   * This is point release to correct an error with the last point release.  

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -20,12 +20,13 @@ import os
 
 try:
     from urllib.parse import urlencode, urlparse
-    from urllib.request import urlopen, Request, unquote
+    from urllib.request import Request, HTTPRedirectHandler, build_opener
     from urllib.error import HTTPError
 except ImportError:
-    from urllib import urlencode, unquote
     from urlparse import urlparse
-    from urllib2 import urlopen, Request, HTTPError
+    from urllib import urlencode
+    from urllib2 import Request, HTTPError
+    from urllib2 import HTTPRedirectHandler, build_opener
 
 
 class MultiProcess(object):
@@ -124,6 +125,31 @@ def multi_wrapper(func_args):
 
 def multi_package(func, args):
     return zip(itertools.repeat(func), args)
+
+
+class AuthRedirectHandler(HTTPRedirectHandler):
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        newreq = HTTPRedirectHandler.redirect_request(
+            self, req, fp, code, msg, headers, newurl)
+
+        if 'Authorization' not in req.headers:
+            return newreq
+
+        src = urlparse(req.get_full_url()).hostname
+        dest = urlparse(newreq.get_full_url()).hostname
+
+        if dest != src:
+            bot.debug('AuthRedirectHandler: stripping "Authorization" header '
+                      "(%s != %s)" % (dest, src))
+            del newreq.headers['Authorization']
+
+        return newreq
+
+
+def urlopen(*args, **kwargs):
+    opener = build_opener(AuthRedirectHandler())
+    return opener.open(*args, **kwargs)
 
 
 class ApiConnection(object):

--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -147,9 +147,9 @@ class AuthRedirectHandler(HTTPRedirectHandler):
         return newreq
 
 
-def urlopen(*args, **kwargs):
+def safe_urlopen(url, data=None):
     opener = build_opener(AuthRedirectHandler())
-    return opener.open(*args, **kwargs)
+    return opener.open(url, data=data)
 
 
 class ApiConnection(object):
@@ -301,7 +301,7 @@ class ApiConnection(object):
         '''
 
         try:
-            response = urlopen(request)
+            response = safe_urlopen(request)
 
         # If we have an HTTPError, try to follow the response
         except HTTPError as error:
@@ -314,7 +314,7 @@ class ApiConnection(object):
                 try:
                     request = self.prepare_request(request.get_full_url(),
                                                    headers=self.headers)
-                    response = urlopen(request)
+                    response = safe_urlopen(request)
                 except HTTPError as error:
                     bot.debug('Http Error with code %s' % (error.code))
                     return error


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR rebases #1387 to the release-2.4 branch

This is a fix from @jtriley to strip the authorization header on http redirect to a different domain when interacting with docker registries.


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
