### PR TITLE
First version of working SIF building completely within Singularity 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ singularity-*.tar.gz
 *.m4
 *.pyc
 
+vendor/
+trash.lock
 Makefile
 Makefile.in
 autom4te.cache/

--- a/build_demo.sh
+++ b/build_demo.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd core && ./mconfig -b builddir
+make -C builddir && cp builddir/sif ../build
+
+cd ../ && go build -o build/singularity cmd/cli/cli.go

--- a/internal/pkg/cli/build.go
+++ b/internal/pkg/cli/build.go
@@ -10,6 +10,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/singularityware/singularity/pkg/build"
@@ -72,7 +73,9 @@ var buildCmd = &cobra.Command{
 			doRemoteBuild(args[0], args[1])
 		} else {
 			if ok, err := build.IsValidURI(args[1]); ok && err == nil {
-				b, err := build.NewCachedBuilder(args[0], args[1])
+				u := strings.SplitN(args[1], "://", 2)
+				fmt.Println(u)
+				b, err := build.NewSifBuilderFromURI(args[0], args[1])
 				if err != nil {
 					glog.Errorf("Image build system encountered an error: %s\n", err)
 					return

--- a/internal/pkg/cli/build.go
+++ b/internal/pkg/cli/build.go
@@ -71,13 +71,15 @@ var buildCmd = &cobra.Command{
 		if Remote {
 			doRemoteBuild(args[0], args[1])
 		} else {
-			if build.IsValidURI(args[1]) {
+			if ok, err := build.IsValidURI(args[1]); ok && err == nil {
 				b, err := build.NewCachedBuilder(args[0], args[1])
 				if err != nil {
 					glog.Errorf("Image build system encountered an error: %s\n", err)
 					return
 				}
 				b.Build()
+			} else {
+				glog.Fatalf("%s", err)
 			}
 		}
 

--- a/pkg/build/builder_cached.go
+++ b/pkg/build/builder_cached.go
@@ -16,15 +16,14 @@ import (
 // CachedBuilder is the object that satisfies the Builder interface which is in charge
 // of quickly builder an image from a URI (i.e. docker://, shub://, etc...)
 type CachedBuilder struct {
-	P         Provisioner
-	imagePath string
-	Image     image.Image
+	P     Provisioner
+	Image *image.Sandbox
 }
 
-func NewCachedBuilder(image string, uri string) (c *CachedBuilder, err error) {
-	fmt.Printf("Building a cached image (%s) from source (%s)\n", image, uri)
+func NewCachedBuilder(path string, uri string) (c *CachedBuilder, err error) {
+	fmt.Printf("Building a cached image (%s) from source (%s)\n", path, uri)
 	c = &CachedBuilder{
-		imagePath: image,
+		Image: image.SandboxFromPath(path),
 	}
 
 	c.P, err = NewProvisionerFromURI(uri)
@@ -36,5 +35,5 @@ func NewCachedBuilder(image string, uri string) (c *CachedBuilder, err error) {
 }
 
 func (c *CachedBuilder) Build() {
-	c.P.Provision(c.imagePath)
+	c.P.Provision(c.Image)
 }

--- a/pkg/build/builder_legacy.go
+++ b/pkg/build/builder_legacy.go
@@ -1,5 +1,6 @@
 /*
   Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE file distributed with the sources of this project regarding
   your rights to use or distribute this software.

--- a/pkg/build/builder_remote.go
+++ b/pkg/build/builder_remote.go
@@ -9,6 +9,7 @@ package build
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -119,7 +120,7 @@ func (b *RemoteBuilder) Build() {
 				glog.Infoln("read:", err)
 				return
 			}
-			glog.Infof("recv: %s", message)
+			fmt.Printf("%s\n", message)
 		}
 	}()
 

--- a/pkg/build/builder_sif.go
+++ b/pkg/build/builder_sif.go
@@ -8,9 +8,7 @@
 package build
 
 import (
-	"fmt"
 	"path"
-	"strings"
 
 	"github.com/singularityware/singularity/pkg/image"
 )
@@ -23,9 +21,9 @@ type SifBuilder struct {
 	tmpfs *image.Sandbox
 }
 
+/*
 func NewSifBuilderFromURI(imagePath string, uri string) (b *SifBuilder, err error) {
 	u := strings.SplitN(uri, "://", 2)
-	fmt.Println(u)
 	d := Definition{
 		Header: map[string]string{
 			"bootstrap": u[0],
@@ -33,9 +31,9 @@ func NewSifBuilderFromURI(imagePath string, uri string) (b *SifBuilder, err erro
 		},
 	}
 
-	fmt.Println(d.Header["bootstrap"])
 	return NewSifBuilder(imagePath, d)
 }
+*/
 
 func NewSifBuilder(imagePath string, d Definition) (b *SifBuilder, err error) {
 	b = &SifBuilder{
@@ -49,25 +47,15 @@ func NewSifBuilder(imagePath string, d Definition) (b *SifBuilder, err error) {
 	}
 
 	uri := d.Header["bootstrap"] + "://" + d.Header["from"]
-	fmt.Println(uri)
 	b.p, err = NewProvisionerFromURI(uri)
-	if err != nil {
-		fmt.Println("big fucking error", err)
-	}
 
-	return b, nil
+	return b, err
 }
 
 func (b *SifBuilder) Build() {
-	fmt.Println(b.tmpfs.Rootfs())
-	fmt.Println(b.tmpfs)
-	fmt.Println("before provision")
 	b.p.Provision(b.tmpfs)
-	fmt.Println("After b.p.Provision()")
 	img, err := image.SIFFromSandbox(b.tmpfs, b.path)
-	fmt.Println("After SIFFromSandbox")
 	if err != nil {
-		fmt.Println(err)
 		return
 	}
 

--- a/pkg/build/builder_sif.go
+++ b/pkg/build/builder_sif.go
@@ -1,0 +1,46 @@
+/*
+  Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
+  This software is licensed under a 3-clause BSD license.  Please
+  consult LICENSE file distributed with the sources of this project regarding
+  your rights to use or distribute this software.
+*/
+package build
+
+import (
+	"path"
+
+	"github.com/singularityware/singularity/pkg/image"
+)
+
+type SifBuilder struct {
+	Definition
+	path string
+
+	tmpfs *image.Sandbox
+}
+
+func NewSifBuilder(d Definition, p string) (b *SifBuilder, err error) {
+	b = &SifBuilder{
+		Definition: d,
+	}
+
+	b.tmpfs, err = image.TempSandbox(path.Base(p) + "-")
+	if err != nil {
+		return b, err
+	}
+
+	return b, nil
+}
+
+func (b *SifBuilder) Build() {
+
+}
+
+func (b *SifBuilder) createSifFile() (err error) {
+	return nil
+}
+
+func (b *SifBuilder) mksquashfs() (err error) {
+	return nil
+}

--- a/pkg/build/builder_sif.go
+++ b/pkg/build/builder_sif.go
@@ -39,7 +39,7 @@ func NewSifBuilder(imagePath string, d Definition) (b *SifBuilder, err error) {
 	b = &SifBuilder{
 		Definition: d,
 		path:       imagePath,
-		Out:        io.MultiReader(r, er),
+		Out:        io.MultiReader(er, r),
 		outWrite:   w,
 		errWrite:   ew,
 		outRead:    r,
@@ -67,9 +67,9 @@ func (b *SifBuilder) Build() {
 	defer func() {
 		os.Stdout = oldstdout
 		os.Stderr = oldstderr
-		b.outRead.Close()
+		//b.outRead.Close()
 		b.outWrite.Close()
-		b.errRead.Close()
+		//b.errRead.Close()
 		b.errWrite.Close()
 	}()
 

--- a/pkg/build/definition.go
+++ b/pkg/build/definition.go
@@ -61,8 +61,6 @@ var validSections = map[string]bool{
 var validHeaders = map[string]bool{
 	"bootstrap":  true,
 	"from":       true,
-	"registry":   true,
-	"namespace":  true,
 	"includecmd": true,
 	"mirrorurl":  true,
 	"osversion":  true,

--- a/pkg/build/definition.go
+++ b/pkg/build/definition.go
@@ -8,6 +8,8 @@
 
 package build
 
+import "strings"
+
 type Definition struct {
 	Header    map[string]string
 	ImageData imageData
@@ -40,6 +42,19 @@ type buildScripts struct {
 	Pre   string
 	Setup string
 	Post  string
+}
+
+func NewDefinitionFromURI(uri string) (d Definition, err error) {
+	u := strings.SplitN(uri, "://", 2)
+
+	d = Definition{
+		Header: map[string]string{
+			"bootstrap": u[0],
+			"from":      u[1],
+		},
+	}
+
+	return d, nil
 }
 
 // validSections just contains a list of all the valid sections a definition file

--- a/pkg/build/provisioner.go
+++ b/pkg/build/provisioner.go
@@ -23,12 +23,9 @@ var validProvisioners = map[string]bool{
 // a remote image source (e.g. singularity run docker://..., singularity build image.sif docker://...)
 func NewProvisionerFromURI(uri string) (p Provisioner, err error) {
 	u := strings.SplitN(uri, ":", 2)
-	fmt.Printf("uri: %s\n", uri)
-	fmt.Printf("u[0]: %s; u[1]: %s\n", u[0], u[1])
 
 	switch u[0] {
 	case "docker":
-		fmt.Println("Returning docker provisioner")
 		return NewDockerProvisioner(u[1])
 	//case "shub":
 	//	return NewSHubProvisioner()

--- a/pkg/build/provisioner.go
+++ b/pkg/build/provisioner.go
@@ -23,12 +23,15 @@ var validProvisioners = map[string]bool{
 // a remote image source (e.g. singularity run docker://..., singularity build image.sif docker://...)
 func NewProvisionerFromURI(uri string) (p Provisioner, err error) {
 	u := strings.SplitN(uri, ":", 2)
+	fmt.Printf("uri: %s\n", uri)
+	fmt.Printf("u[0]: %s; u[1]: %s\n", u[0], u[1])
 
 	switch u[0] {
 	case "docker":
+		fmt.Println("Returning docker provisioner")
 		return NewDockerProvisioner(u[1])
-	case "shub":
-		return NewSHubProvisioner()
+	//case "shub":
+	//	return NewSHubProvisioner()
 	default:
 		return nil, fmt.Errorf("Provisioner \"%s\" not supported", u[0])
 	}
@@ -52,17 +55,19 @@ func IsValidURI(uri string) (valid bool, err error) {
 // source into a chroot tree on disk. All necessary input (URL, etc...) should be
 // set up when we're creating the specific data structure.
 type Provisioner interface {
-	Provision(i *image.Sandbox)
+	Provision(i *image.Sandbox) (err error)
 }
 
+/*
 // ===== SHub =====
-func NewSHubProvisioner() (s *SHubProvisioner, err error) {
+func NewSHubProvisioner() (s SHubProvisioner, err error) {
 	return &SHubProvisioner{}, nil
 }
 
 type SHubProvisioner struct {
 }
 
-func (s *SHubProvisioner) Provision(i *image.Sandbox) {
-
+func (s *SHubProvisioner) Provision(i image.Sandbox) (err error) {
+	return nil
 }
+*/

--- a/pkg/build/provisioner.go
+++ b/pkg/build/provisioner.go
@@ -9,65 +9,60 @@ package build
 
 import (
 	"fmt"
-	"net/url"
+	"strings"
+
+	"github.com/singularityware/singularity/pkg/image"
 )
+
+var validProvisioners = map[string]bool{
+	"docker": true,
+	"shub":   true,
+}
 
 // NewProvisionerFromURI is used for providing a provisioner for any command that accepts
 // a remote image source (e.g. singularity run docker://..., singularity build image.sif docker://...)
 func NewProvisionerFromURI(uri string) (p Provisioner, err error) {
-	u, err := url.ParseRequestURI(uri)
+	u := strings.SplitN(uri, ":", 2)
 
-	if u.Scheme == "" {
-		return nil, err
-	}
-
-	switch u.Scheme {
+	switch u[0] {
 	case "docker":
-		return NewDockerProvisioner(), nil
+		return NewDockerProvisioner(u[1])
 	case "shub":
-		return NewSHubProvisioner(), nil
+		return NewSHubProvisioner()
 	default:
-		return nil, fmt.Errorf("Provisioner \"%s\" not supported", u.Scheme)
+		return nil, fmt.Errorf("Provisioner \"%s\" not supported", u[0])
 	}
 }
 
-func IsValidURI(uri string) bool {
-	_, err := url.ParseRequestURI(uri)
+func IsValidURI(uri string) (valid bool, err error) {
+	u := strings.SplitN(uri, ":", 2)
 
-	if err != nil {
-		return false
-	} else {
-		return true
+	if len(u) != 2 {
+		return false, nil
 	}
+
+	if _, ok := validProvisioners[u[0]]; ok {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("Invaled image URI: %s", uri)
 }
 
 // Provisioner is the interface used to represent how we convert any image
 // source into a chroot tree on disk. All necessary input (URL, etc...) should be
 // set up when we're creating the specific data structure.
 type Provisioner interface {
-	Provision(path string)
-}
-
-// ===== Docker =====
-func NewDockerProvisioner() (d *DockerProvisioner) {
-	return &DockerProvisioner{}
-}
-
-type DockerProvisioner struct {
-}
-
-func (d *DockerProvisioner) Provision(path string) {
-
+	Provision(i *image.Sandbox)
 }
 
 // ===== SHub =====
-func NewSHubProvisioner() (s *SHubProvisioner) {
-	return &SHubProvisioner{}
+func NewSHubProvisioner() (s *SHubProvisioner, err error) {
+	return &SHubProvisioner{}, nil
 }
 
 type SHubProvisioner struct {
 }
 
-func (s *SHubProvisioner) Provision(path string) {
+func (s *SHubProvisioner) Provision(i *image.Sandbox) {
 
 }

--- a/pkg/build/provisioner_docker.go
+++ b/pkg/build/provisioner_docker.go
@@ -10,6 +10,7 @@ package build
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -62,10 +63,11 @@ type DockerProvisioner struct {
 	policyCtx *signature.PolicyContext
 }
 
-func (p *DockerProvisioner) Provision(i *image.Sandbox) {
+func (p *DockerProvisioner) Provision(i *image.Sandbox) (err error) {
+	fmt.Println("provision start")
 	defer os.RemoveAll(p.tmpfs)
 
-	err := p.fetch(i)
+	err = p.fetch(i)
 	if err != nil {
 		return
 	}
@@ -95,6 +97,9 @@ func (p *DockerProvisioner) Provision(i *image.Sandbox) {
 		return
 	}
 
+	fmt.Println("provision ret")
+
+	return nil
 }
 
 func (p *DockerProvisioner) fetch(i *image.Sandbox) (err error) {

--- a/pkg/build/provisioner_docker.go
+++ b/pkg/build/provisioner_docker.go
@@ -10,7 +10,6 @@ package build
 import (
 	"archive/tar"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -64,7 +63,6 @@ type DockerProvisioner struct {
 }
 
 func (p *DockerProvisioner) Provision(i *image.Sandbox) (err error) {
-	fmt.Println("provision start")
 	defer os.RemoveAll(p.tmpfs)
 
 	err = p.fetch(i)
@@ -96,8 +94,6 @@ func (p *DockerProvisioner) Provision(i *image.Sandbox) (err error) {
 	if err != nil {
 		return
 	}
-
-	fmt.Println("provision ret")
 
 	return nil
 }

--- a/pkg/build/provisioner_docker.go
+++ b/pkg/build/provisioner_docker.go
@@ -1,0 +1,281 @@
+/*
+  Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
+  This software is licensed under a 3-clause BSD license.  Please
+  consult LICENSE file distributed with the sources of this project regarding
+  your rights to use or distribute this software.
+*/
+package build
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/image/copy"
+	"github.com/containers/image/docker"
+	oci "github.com/containers/image/oci/layout"
+	"github.com/containers/image/signature"
+	"github.com/containers/image/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	imagetools "github.com/opencontainers/image-tools/image"
+	"github.com/singularityware/singularity/pkg/image"
+)
+
+// ===== Docker =====
+func NewDockerProvisioner(src string) (p *DockerProvisioner, err error) {
+	p = &DockerProvisioner{}
+
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	p.policyCtx, err = signature.NewPolicyContext(policy)
+	if err != nil {
+		return &DockerProvisioner{}, err
+	}
+
+	p.srcRef, err = docker.ParseReference(src)
+	if err != nil {
+		return &DockerProvisioner{}, err
+	}
+
+	p.tmpfs, err = ioutil.TempDir("", "temp-oci-")
+	if err != nil {
+		return &DockerProvisioner{}, err
+	}
+
+	p.tmpfsRef, err = oci.ParseReference(p.tmpfs + ":" + "tmp")
+	if err != nil {
+		return &DockerProvisioner{}, err
+	}
+
+	return p, nil
+}
+
+type DockerProvisioner struct {
+	src       string
+	srcRef    types.ImageReference
+	tmpfs     string
+	tmpfsRef  types.ImageReference
+	policyCtx *signature.PolicyContext
+}
+
+func (p *DockerProvisioner) Provision(i *image.Sandbox) {
+	defer os.RemoveAll(p.tmpfs)
+
+	err := p.fetch(i)
+	if err != nil {
+		return
+	}
+
+	imgConfig, err := p.getConfig()
+	if err != nil {
+		return
+	}
+
+	err = p.unpackTmpfs(i)
+	if err != nil {
+		return
+	}
+
+	err = p.insertBaseEnv(i)
+	if err != nil {
+		return
+	}
+
+	err = p.insertRunScript(i, imgConfig)
+	if err != nil {
+		return
+	}
+
+	err = p.insertEnv(i, imgConfig)
+	if err != nil {
+		return
+	}
+
+}
+
+func (p *DockerProvisioner) fetch(i *image.Sandbox) (err error) {
+	err = copy.Image(p.policyCtx, p.tmpfsRef, p.srcRef, &copy.Options{
+		ReportWriter: os.Stderr,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *DockerProvisioner) getConfig() (imgspecv1.ImageConfig, error) {
+	img, err := p.tmpfsRef.NewImage(nil)
+	if err != nil {
+		return imgspecv1.ImageConfig{}, err
+	}
+	defer img.Close()
+
+	imgSpec, err := img.OCIConfig()
+	if err != nil {
+		return imgspecv1.ImageConfig{}, err
+	}
+
+	return imgSpec.Config, nil
+}
+
+func (p *DockerProvisioner) unpackTmpfs(i *image.Sandbox) (err error) {
+	refs := []string{"name=tmp"}
+	err = imagetools.UnpackLayout(p.tmpfs, i.Rootfs(), "amd64", refs)
+	return err
+}
+
+func (p *DockerProvisioner) insertBaseEnv(i *image.Sandbox) (err error) {
+	f, err := os.Open("environment.tar")
+	if err != nil {
+		return
+	}
+
+	defer f.Close()
+
+	err = Untar(i.Rootfs(), f)
+
+	return nil
+}
+
+func (p *DockerProvisioner) insertRunScript(i *image.Sandbox, ociConfig imgspecv1.ImageConfig) (err error) {
+	f, err := os.Create(i.Rootfs() + "/.singularity.d/runscript")
+	if err != nil {
+		return
+	}
+
+	defer f.Close()
+
+	_, err = f.WriteString("#!/bin/sh\n")
+	if err != nil {
+		return
+	}
+
+	_, err = f.WriteString(strings.Join(ociConfig.Entrypoint, " "))
+	if err != nil {
+		return
+	}
+
+	_, err = f.WriteString(" ")
+	if err != nil {
+		return
+	}
+
+	_, err = f.WriteString(strings.Join(ociConfig.Cmd, " "))
+	if err != nil {
+		return
+	}
+
+	_, err = f.WriteString("\n")
+	if err != nil {
+		return
+	}
+
+	f.Sync()
+
+	err = os.Chmod(i.Rootfs()+"/.singularity.d/runscript", 0755)
+	if err != nil {
+		return
+	}
+
+	return nil
+}
+
+func (p *DockerProvisioner) insertEnv(i *image.Sandbox, ociConfig imgspecv1.ImageConfig) (err error) {
+	f, err := os.Create(i.Rootfs() + "/.singularity.d/env/10-docker2singularity.sh")
+	if err != nil {
+		return
+	}
+
+	defer f.Close()
+
+	_, err = f.WriteString("#!/bin/sh\n")
+	if err != nil {
+		return
+	}
+
+	for _, element := range ociConfig.Env {
+		_, err = f.WriteString("export " + element + "\n")
+		if err != nil {
+			return
+		}
+
+	}
+
+	f.Sync()
+
+	err = os.Chmod(i.Rootfs()+"/.singularity.d/env/10-docker2singularity.sh", 0755)
+	if err != nil {
+		return
+	}
+
+	return nil
+}
+
+//
+// Untar takes a destination path and a reader; a tar reader loops over the tarfile
+// creating the file structure at 'dst' along the way, and writing any files
+func Untar(dst string, r io.Reader) error {
+	gzr, err := gzip.NewReader(r)
+	defer gzr.Close()
+	if err != nil {
+		return err
+	}
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		// if no more files are found return
+		case err == io.EOF:
+			return nil
+
+		// return any other error
+		case err != nil:
+			return err
+
+		// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// the target location where the dir/file should be created
+		target := filepath.Join(dst, header.Name)
+
+		// the following switch could also be done using fi.Mode(), not sure if there
+		// a benefit of using one vs. the other.
+		// fi := header.FileInfo()
+
+		// check the file type
+		switch header.Typeflag {
+
+		// if its a dir and it doesn't exist create it
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+
+		// if it's a file create it
+		case tar.TypeReg:
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			// copy over contents
+			if _, err := io.Copy(f, tr); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/pkg/image/sandbox.go
+++ b/pkg/image/sandbox.go
@@ -9,6 +9,8 @@
 package image
 
 import (
+	"io/ioutil"
+
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -16,9 +18,22 @@ type Sandbox struct {
 	rootfs string
 }
 
+func TempSandbox(name string) (i *Sandbox, err error) {
+	i = &Sandbox{}
+
+	i.rootfs, err = ioutil.TempDir("", name)
+	if err != nil {
+		return i, err
+	}
+
+	return i, nil
+}
+
 // SandboxFromPath returns a sandbox object of the directory located at path
 func SandboxFromPath(path string) *Sandbox {
-	return &Sandbox{}
+	return &Sandbox{
+		rootfs: path,
+	}
 }
 
 /* RuntimeImage Interface Methods */

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -9,16 +9,62 @@
 package image
 
 import (
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/golang/glog"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type SIF struct {
+	path string
 }
 
 // SIFFromSandbox converts the sandbox, s, to a SIF file
-func SIFFromSandbox(s *Sandbox) *SIF {
-	return &SIF{}
+func SIFFromSandbox(sandbox *Sandbox, imagePath string) (*SIF, error) {
+	mksquashfs, err := exec.LookPath("mksquashfs")
+	if err != nil {
+		glog.Error("mksquashfs is not installed on this system")
+		return nil, err
+	}
+
+	f, err := ioutil.TempFile("", "squashfs-")
+	squashfsPath := f.Name() + ".img"
+	f.Close()
+	os.Remove(squashfsPath)
+	mksquashfsCmd := exec.Command(mksquashfs, sandbox.Rootfs(), squashfsPath, "-noappend", "-all-root")
+	fmt.Println("sandbox rootfs:", sandbox.Rootfs(), "sqfs:", squashfsPath)
+	out, err := mksquashfsCmd.Output()
+
+	fmt.Println("MKSQUASHFS:")
+	fmt.Println(string(out))
+
+	if err != nil {
+		return nil, err
+	}
+
+	sif, err := exec.LookPath("sif")
+	if err != nil {
+		glog.Error("sif is not installed on this system")
+		return nil, err
+	}
+
+	fmt.Println("sif:", sif, "sqfs:", squashfsPath, "image path:", imagePath)
+	sifCmd := exec.Command(sif, "create", "-P", squashfsPath, "-f", "\"SQUASHFS\"", "-p", "\"SYSTEM\"", "-c", "\"LINUX\"", imagePath)
+	out, err = sifCmd.CombinedOutput()
+
+	fmt.Println("SIF:")
+	fmt.Println(string(out))
+	fmt.Println(err)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SIF{path: imagePath}, nil
+
 }
 
 // SIFFromPath returns a SIF object of the file located at path
@@ -35,7 +81,7 @@ func (i *SIF) Root() *specs.Root {
 }
 
 func (i *SIF) Rootfs() string {
-	return ""
+	return i.path
 }
 
 // isSIF checks the "magic" of the given file and

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -9,7 +9,6 @@
 package image
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -35,13 +34,9 @@ func SIFFromSandbox(sandbox *Sandbox, imagePath string) (*SIF, error) {
 	squashfsPath := f.Name() + ".img"
 	f.Close()
 	os.Remove(squashfsPath)
+
 	mksquashfsCmd := exec.Command(mksquashfs, sandbox.Rootfs(), squashfsPath, "-noappend", "-all-root")
-	fmt.Println("sandbox rootfs:", sandbox.Rootfs(), "sqfs:", squashfsPath)
-	out, err := mksquashfsCmd.Output()
-
-	fmt.Println("MKSQUASHFS:")
-	fmt.Println(string(out))
-
+	_, err = mksquashfsCmd.Output()
 	if err != nil {
 		return nil, err
 	}
@@ -52,13 +47,8 @@ func SIFFromSandbox(sandbox *Sandbox, imagePath string) (*SIF, error) {
 		return nil, err
 	}
 
-	fmt.Println("sif:", sif, "sqfs:", squashfsPath, "image path:", imagePath)
-	sifCmd := exec.Command(sif, "create", "-P", squashfsPath, "-f", "\"SQUASHFS\"", "-p", "\"SYSTEM\"", "-c", "\"LINUX\"", imagePath)
-	out, err = sifCmd.CombinedOutput()
-
-	fmt.Println("SIF:")
-	fmt.Println(string(out))
-	fmt.Println(err)
+	sifCmd := exec.Command(sif, "create", "-P", squashfsPath, "-f", "SQUASHFS", "-p", "SYSTEM", "-c", "LINUX", imagePath)
+	_, err = sifCmd.CombinedOutput()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -9,6 +9,7 @@
 package image
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -36,10 +37,12 @@ func SIFFromSandbox(sandbox *Sandbox, imagePath string) (*SIF, error) {
 	os.Remove(squashfsPath)
 
 	mksquashfsCmd := exec.Command(mksquashfs, sandbox.Rootfs(), squashfsPath, "-noappend", "-all-root")
-	_, err = mksquashfsCmd.Output()
+	mksfsout, err := mksquashfsCmd.CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println(string(mksfsout))
 
 	sif, err := exec.LookPath("sif")
 	if err != nil {
@@ -48,10 +51,12 @@ func SIFFromSandbox(sandbox *Sandbox, imagePath string) (*SIF, error) {
 	}
 
 	sifCmd := exec.Command(sif, "create", "-P", squashfsPath, "-f", "SQUASHFS", "-p", "SYSTEM", "-c", "LINUX", imagePath)
-	_, err = sifCmd.CombinedOutput()
+	sifout, err := sifCmd.CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println(string(sifout))
 
 	return &SIF{path: imagePath}, nil
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,0 +1,17 @@
+github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
+github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
+github.com/docker/docker 30eb4d8cdc422b023d5f11f29a82ecb73554183b
+github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
+github.com/docker/libtrust aabc10ec26b754e797f9028f4589c5b7bd90dc20
+github.com/ghodss/yaml 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
+github.com/mtrmac/gpgme b2432428689ca58c2b8e8dea9449d3295cf96fc9
+github.com/opencontainers/image-tools master
+github.com/pkg/errors 248dadf4e9068a0b3e79f02ed0a610d935de5302
+github.com/sirupsen/logrus v1.0.0
+github.com/mattn/go-runewidth 14207d285c6c197daabb5c9793d63e7af9ab2d50
+golang.org/x/crypto 453249f01cfeb54c3d549ddb75ff152ca243f9d8
+golang.org/x/net 6b27048ae5e6ad1ef927e72e437531493de612fe
+gopkg.in/yaml.v2 a3f3340b5840cee44f372bddb5880fcbc419b46a
+gopkg.in/cheggaaa/pb.v1 d7e6ca3010b6f084d8056847f55d7f572f180678
+
+


### PR DESCRIPTION
**Description of the Pull Request (PR):**

After slaving away all day, we can now build a SIF *directly* from Singularity 3.0. This is a huge milestone for the progress towards a 3.0 version, as people can now see the entire end-to-end image building process. Run `build_demo.sh` (just builds the sif binary and the cli binary), make sure to put `build/sif` binary into your path, and run `singularity build image_name.sif docker://something` or `singularity build image_name.sif path/to/deffile`. Yes it only works on docker sources right now ;)


Attn: @singularityware-admin
