### PR TITLE
Fix/appcommand indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 ### Bug Fixes
  - Put /usr/local/{bin,sbin} in front of the default PATH
  - Fixed bug that did not export environment variables for apps with "-" in name
+ - Fixed stripping whitespaces and empty new lines for the app commands
  
 ## [v2.4.3](https://github.com/singularityware/singularity/tree/release-2.4)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,3 +43,4 @@
     - David Trudgian <david.trudgian@utsouthwestern.edu>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Diana Langenbach <dcl@dcl.sh>
+    - Rafal Gumienny <rafal.gumienny@gmail.com>

--- a/libexec/bootstrap-scripts/functions
+++ b/libexec/bootstrap-scripts/functions
@@ -71,6 +71,7 @@ singularity_section_get() {
 
 get_section() {
 
+    IFS=""
     SECTION="$1"
     RECIPE="$2"
     FOUND="no"
@@ -101,10 +102,7 @@ get_section() {
             else
                 # We already found it, still in section
                 if [[ "$FOUND" == "yes" ]]; then
-                    if [ ! -z "${line}" ]; then
-                        echo $line
-                    fi 
-
+                    echo $line
                 fi            
             fi
         fi

--- a/libexec/bootstrap-scripts/functions
+++ b/libexec/bootstrap-scripts/functions
@@ -70,13 +70,12 @@ singularity_section_get() {
 
 
 get_section() {
-
-    IFS=""
+ 
     SECTION="$1"
     RECIPE="$2"
     FOUND="no"
 
-    while read -r line
+    while IFS="" read -r line
     do
 
  


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The commands starting with the %app* strip all white spaces and empty new lines when they are copied to the corresponding files. This is unintended behavior eg. the help section (%apphelp) might look unreadable. Additionally, the %runscript section does not require to strip the spaces. This fix also will cause the empty file to be created if the empty command is specified. This is an expected behavior IMHO.

**This fixes or addresses the following GitHub issues:**

- Ref: #1391 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.

- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
