### PR TITLE
Stop endless 401 loop on docker hub auth pull incorrect credentials

### DIFF
--- a/libexec/python/base.py
+++ b/libexec/python/base.py
@@ -261,12 +261,14 @@ class ApiConnection(object):
             data=None,
             headers=None,
             default_headers=True,
-            return_response=False):
+            return_response=False,
+            updating_token=False):
 
         '''get will use requests to get a particular url
         :param data: a dictionary of key:value
                      items to add to the data args variable
         :param url: the url to get
+        :param updating_token: Set true if called from update_token
         :returns response: the requests response object, or stream
         '''
 
@@ -285,19 +287,23 @@ class ApiConnection(object):
                                        url=url)
 
         response = self.submit_request(request,
-                                       return_response=return_response)
+                                       return_response=return_response,
+                                       updating_token=updating_token)
 
         if return_response is True:
             return response
 
         return response.read().decode('utf-8')
 
-    def submit_request(self, request, return_response=False):
+    def submit_request(self, request, return_response=False, updating_token=False):
         '''submit_request will make the request,
         via a stream or not. If return response is True, the
         response is returned as is without further parsing.
         Given a 401 error, the update_token function is called
         to try the request again, and only then the error returned.
+
+        If updating_token is True we were called upstream from update_token, and
+        shouldn't call it again.
         '''
 
         try:
@@ -309,7 +315,7 @@ class ApiConnection(object):
             # Case 1: we have an http 401 error, and need to refresh token
             bot.debug('Http Error with code %s' % (error.code))
 
-            if error.code == 401:
+            if error.code == 401 and not updating_token:
                 self.update_token(response=error)
                 try:
                     request = self.prepare_request(request.get_full_url(),

--- a/libexec/python/docker/api.py
+++ b/libexec/python/docker/api.py
@@ -189,7 +189,8 @@ class DockerApiConnection(ApiConnection):
 
         response = self.get(self.token_url,
                             default_headers=False,
-                            headers=headers)
+                            headers=headers,
+                            updating_token=True)
 
         try:
             token = json.loads(response)["token"]
@@ -198,7 +199,7 @@ class DockerApiConnection(ApiConnection):
             self.update_headers(token)
 
         except Exception:
-            bot.error("Error getting token for repository %s, exiting."
+            bot.error("Error getting token for repository %s, please check your credentials."
                       % self.repo_name)
             sys.exit(1)
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes a bug in docker registry authentication that is present across 2.4 releases.

If incorrect `SINGULARITY_DOCKER_USERNAME/PASSWORD` credentials are set, and a user pulls from docker hub, then the code will get stuck in an endless loop, trying to get an auth token. This will end with a recursion-limit stack trace, or alternatively an HTTP 429 error if docker hub rate limits the IP address of the singularity client.

Fixes #1405 for full details, debug output, traces etc.

This is a simple fix putting in a boolean flag so that `update_token` won't be called from `submit_request`, if `update_token` was the original initiator of the request.

**This fixes or addresses the following GitHub issues:**

- Ref: Closes #1405 


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
