### PR TITLE
Remount sandbox to correctly apply mount options

### DIFF
--- a/src/lib/image/dir/mount.c
+++ b/src/lib/image/dir/mount.c
@@ -43,6 +43,7 @@
 
 
 int _singularity_image_dir_mount(struct image_object *image, char *mount_point) {
+    int mntflags = MS_BIND | MS_NOSUID | MS_REC | MS_NODEV;
 
     if ( strcmp(image->path, "/") == 0 ) {
         singularity_message(ERROR, "Naughty naughty naughty...\n");
@@ -50,9 +51,19 @@ int _singularity_image_dir_mount(struct image_object *image, char *mount_point) 
     }
 
     singularity_message(DEBUG, "Mounting container directory %s->%s\n", image->path, mount_point);
-    if ( singularity_mount(image->path, mount_point, NULL, MS_BIND|MS_NOSUID|MS_REC|MS_NODEV, NULL) < 0 ) {
+    if ( singularity_mount(image->path, mount_point, NULL, mntflags, NULL) < 0 ) {
         singularity_message(ERROR, "Could not mount container directory %s->%s: %s\n", image->path, mount_point, strerror(errno));
         return 1;
+    }
+
+    if ( singularity_priv_userns_enabled() != 1 ) {
+        if ( image->writable == 0 ) {
+            mntflags |= MS_RDONLY;
+        }
+        if ( singularity_mount(NULL, mount_point, NULL, MS_REMOUNT | mntflags, NULL) < 0 ) {
+            singularity_message(ERROR, "Could not mount container directory %s->%s: %s\n", image->path, mount_point, strerror(errno));
+            return 1;
+        }
     }
 
     return(0);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Backport from development branch. Directory mount are not remounted, so mount options are not correctly applied for sandbox container.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
