### PR TITLE
Use double quotes for log messages written to syslog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
+## v2.5.x
+
+ - Use double quotes for log messages written to syslog
+
 ## [v2.5.0](https://github.com/singularityware/singularity/releases/tag/2.5.0-rc1) (2018-04-04)
 
 ### Security related fixes

--- a/src/action.c
+++ b/src/action.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
 
     fd_cleanup(&close_fd);
 
-    singularity_message(LOG, "USER=%s, IMAGE='%s', COMMAND='%s'\n", singularity_priv_getuser(), singularity_image_name(&image), singularity_registry_get("COMMAND"));
+    singularity_message(LOG, "USER=\"%s\", IMAGE=\"%s\", COMMAND=\"%s\"\n", singularity_priv_getuser(), singularity_image_name(&image), singularity_registry_get("COMMAND"));
 
     if ( command == NULL ) {
         singularity_message(INFO, "No action command verb was given, invoking 'shell'\n");

--- a/src/slurm/singularity.c
+++ b/src/slurm/singularity.c
@@ -231,7 +231,7 @@ static int setup_container(spank_t spank)
     envar_set("SINGULARITY_SHELL", singularity_registry_get("SHELL"), 1);
 
     command = singularity_registry_get("COMMAND");
-    singularity_message(LOG, "USER=%s, IMAGE='%s', COMMAND='%s'\n", singularity_priv_getuser(), singularity_image_name(&image), singularity_registry_get("COMMAND"));
+    singularity_message(LOG, "USER=\"%s\", IMAGE=\"%s\", COMMAND=\"%s\"\n", singularity_priv_getuser(), singularity_image_name(&image), singularity_registry_get("COMMAND"));
 
     // At this point, the current process is in the runtime container environment.
     // Return control flow back to SLURM: when execv is invoked, it'll be done from


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This change will help tools like Splunk parse the key=value where single quotes are added to value but double quotes are not.

Example of new message output from running `make test`

```
Mar 27 09:09:04 build-el7 Singularity: action-suid (U=20821,P=32716)> USER="tdockendorf", IMAGE="container.img", COMMAND="exec"
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
