### PR TITLE
Add checks for file/directory creation when overlay is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Adjustments to SCIF (Scientific Filesystem) integration for broader use
  - Fixed bug that did not export environment variables for apps with "-" in name
  - Fix conflict between `--nv` and `--contain` options
+ - Add checks for file/directory creation when overlay is enabled
 
 ## [v2.4.4](https://github.com/singularityware/singularity/tree/release-2.4)
 

--- a/src/lib/runtime/files/libs/libs.c
+++ b/src/lib/runtime/files/libs/libs.c
@@ -75,7 +75,7 @@ int _singularity_runtime_files_libs(void) {
         }
 
         singularity_message(DEBUG, "Creating session libdir at: %s\n", libdir);
-        if ( s_mkpath(libdir, 0755) != 0 ) {
+        if ( s_mkpath(libdir, 0755, tmpdir) != 0 ) {
             singularity_message(ERROR, "Failed creating temp lib directory at: %s\n", libdir);
             ABORT(255);
         }
@@ -150,7 +150,7 @@ int _singularity_runtime_files_libs(void) {
             char *ld_path;
             singularity_message(DEBUG, "Attempting to create contained libdir\n");
             singularity_priv_escalate();
-            if ( s_mkpath(libdir_contained, 0755) != 0 ) {
+            if ( s_mkpath(libdir_contained, 0755, container_dir) != 0 ) {
                 singularity_message(ERROR, "Failed creating directory %s :%s\n", libdir_contained, strerror(errno));
                 ABORT(255);
             }

--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -65,7 +65,7 @@ int _singularity_runtime_mount_dev(void) {
             }
 
             singularity_priv_escalate();
-            ret = s_mkpath(joinpath(container_dir, "/dev"), 0755);
+            ret = s_mkpath(joinpath(container_dir, "/dev"), 0755, container_dir);
             singularity_priv_drop();
 
             if ( ret < 0 ) {
@@ -75,13 +75,13 @@ int _singularity_runtime_mount_dev(void) {
         }
 
         singularity_message(DEBUG, "Creating temporary staged /dev\n");
-        if ( s_mkpath(devdir, 0755) != 0 ) {
+        if ( s_mkpath(devdir, 0755, NULL) != 0 ) {
             singularity_message(ERROR, "Failed creating the session device directory %s: %s\n", devdir, strerror(errno));
             ABORT(255);
         }
 
         singularity_message(DEBUG, "Creating temporary staged /dev/shm\n");
-        if ( s_mkpath(joinpath(devdir, "/shm"), 0755) != 0 ) {
+        if ( s_mkpath(joinpath(devdir, "/shm"), 0755, NULL) != 0 ) {
             singularity_message(ERROR, "Failed creating temporary /dev/shm %s: %s\n", joinpath(devdir, "/shm"), strerror(errno));
             ABORT(255);
         }
@@ -94,7 +94,7 @@ int _singularity_runtime_mount_dev(void) {
                 ABORT(255);
             }
             singularity_message(DEBUG, "Creating staged /dev/pts\n");
-            if ( s_mkpath(joinpath(devdir, "/pts"), 0755) != 0 ) {
+            if ( s_mkpath(joinpath(devdir, "/pts"), 0755, NULL) != 0 ) {
                 singularity_message(ERROR, "Failed creating /dev/pts %s: %s\n", joinpath(devdir, "/pts"), strerror(errno));
                 ABORT(255);
             }

--- a/src/lib/runtime/mounts/home/home.c
+++ b/src/lib/runtime/mounts/home/home.c
@@ -93,7 +93,7 @@ int _singularity_runtime_mount_home(void) {
     }
 
     singularity_message(DEBUG, "Creating temporary directory to stage home: %s\n", joinpath(session_dir, home_dest));
-    if ( s_mkpath(joinpath(session_dir, home_dest), 0755) < 0 ) {
+    if ( s_mkpath(joinpath(session_dir, home_dest), 0755, session_dir) < 0 ) {
         singularity_message(ERROR, "Failed creating home directory stage %s: %s\n", joinpath(session_dir, home_dest), strerror(errno));
         ABORT(255);
     }
@@ -145,7 +145,7 @@ int _singularity_runtime_mount_home(void) {
 
         singularity_priv_escalate();
         singularity_message(DEBUG, "Creating home directory within container: %s\n", joinpath(container_dir, home_dest));
-        if ( s_mkpath(joinpath(container_dir, home_dest), 0755) < 0 ) {
+        if ( s_mkpath(joinpath(container_dir, home_dest), 0755, container_dir) < 0 ) {
             singularity_message(ERROR, "Failed creating home directory in container %s: %s\n", joinpath(container_dir, home_dest), strerror(errno));
             ABORT(255);
         }

--- a/src/lib/runtime/mounts/hostfs/hostfs.c
+++ b/src/lib/runtime/mounts/hostfs/hostfs.c
@@ -151,7 +151,7 @@ int _singularity_runtime_mount_hostfs(void) {
         if ( ( is_dir(mountpoint) == 0 ) && ( is_dir(joinpath(container_dir, mountpoint)) < 0 ) ) {
             if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL ) {
                 singularity_priv_escalate();
-                if ( s_mkpath(joinpath(container_dir, mountpoint), 0755) < 0 ) {
+                if ( s_mkpath(joinpath(container_dir, mountpoint), 0755, container_dir) < 0 ) {
                     singularity_priv_drop();
                     singularity_message(WARNING, "Could not create bind point directory in container %s: %s\n", mountpoint, strerror(errno));
                     continue;

--- a/src/lib/runtime/mounts/mounts.c
+++ b/src/lib/runtime/mounts/mounts.c
@@ -54,10 +54,10 @@ int _singularity_runtime_mounts(void) {
     retval += _singularity_runtime_mount_kernelfs();
     retval += _singularity_runtime_mount_dev();
     retval += _singularity_runtime_mount_home();
-    retval += _singularity_runtime_mount_userbinds();
-    retval += _singularity_runtime_mount_tmp();
     retval += _singularity_runtime_mount_scratch();
+    retval += _singularity_runtime_mount_tmp();
     retval += _singularity_runtime_mount_cwd();
+    retval += _singularity_runtime_mount_userbinds();
 
     return(retval);
 }

--- a/src/lib/runtime/mounts/scratch/scratch.c
+++ b/src/lib/runtime/mounts/scratch/scratch.c
@@ -92,7 +92,7 @@ int _singularity_runtime_mount_scratch(void) {
         char *full_sourcedir_path = joinpath(sourcedir_path, basename(strdup(current)));
         char *full_destdir_path = joinpath(container_dir, current);
 
-        if ( s_mkpath(full_sourcedir_path, 0750) < 0 ) {
+        if ( s_mkpath(full_sourcedir_path, 0750, NULL) < 0 ) {
              singularity_message(ERROR, "Could not create scratch working directory %s: %s\n", full_sourcedir_path, strerror(errno));
              ABORT(255);
         }
@@ -101,7 +101,7 @@ int _singularity_runtime_mount_scratch(void) {
             if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL ) {
                 singularity_priv_escalate();
                 singularity_message(DEBUG, "Creating scratch directory inside container\n");
-                r = s_mkpath(full_destdir_path, 0755);
+                r = s_mkpath(full_destdir_path, 0755, container_dir);
                 singularity_priv_drop();
                 if ( r < 0 ) {
                     singularity_message(VERBOSE, "Skipping scratch directory mount, could not create dir inside container %s: %s\n", current, strerror(errno));

--- a/src/lib/runtime/mounts/tmp/tmp.c
+++ b/src/lib/runtime/mounts/tmp/tmp.c
@@ -81,7 +81,7 @@ int _singularity_runtime_mount_tmp(void) {
     }
 
     if ( check_mounted("/tmp") < 0 ) {
-        if ( s_mkpath(tmp_source, 0755) < 0 ) {
+        if ( s_mkpath(tmp_source, 0755, NULL) < 0 ) {
             singularity_message(ERROR, "Could not create source /tmp directory %s: %s\n", tmp_source, strerror(errno));
             ABORT(255);
         }
@@ -109,7 +109,7 @@ int _singularity_runtime_mount_tmp(void) {
     }
 
     if ( check_mounted("/var/tmp") < 0 ) {
-        if ( s_mkpath(vartmp_source, 0755) < 0 ) {
+        if ( s_mkpath(vartmp_source, 0755, NULL) < 0 ) {
             singularity_message(ERROR, "Could not create source /var/tmp directory %s: %s\n", vartmp_source, strerror(errno));
             ABORT(255);
         }

--- a/src/lib/runtime/overlayfs/overlayfs.c
+++ b/src/lib/runtime/overlayfs/overlayfs.c
@@ -48,6 +48,7 @@
 
 
 int _singularity_runtime_overlayfs(void) {
+    singularity_registry_set("OVERLAYFS_ENABLED", NULL);
 
     singularity_priv_escalate();
     singularity_message(DEBUG, "Creating overlay_final directory: %s\n", CONTAINER_FINALDIR);

--- a/src/lib/runtime/overlayfs/overlayfs.c
+++ b/src/lib/runtime/overlayfs/overlayfs.c
@@ -51,7 +51,7 @@ int _singularity_runtime_overlayfs(void) {
 
     singularity_priv_escalate();
     singularity_message(DEBUG, "Creating overlay_final directory: %s\n", CONTAINER_FINALDIR);
-    if ( s_mkpath(CONTAINER_FINALDIR, 0755) < 0 ) {
+    if ( s_mkpath(CONTAINER_FINALDIR, 0755, NULL) < 0 ) {
         singularity_message(ERROR, "Failed creating overlay_final directory %s: %s\n", CONTAINER_FINALDIR, strerror(errno));
         ABORT(255);
     }
@@ -143,13 +143,13 @@ int _singularity_runtime_overlayfs(void) {
 
         singularity_priv_escalate();
         singularity_message(DEBUG, "Creating upper overlay directory: %s\n", overlay_upper);
-        if ( s_mkpath(overlay_upper, 0755) < 0 ) {
+        if ( s_mkpath(overlay_upper, 0755, overlay_mount) < 0 ) {
             singularity_message(ERROR, "Failed creating upper overlay directory %s: %s\n", overlay_upper, strerror(errno));
             ABORT(255);
         }
 
         singularity_message(DEBUG, "Creating overlay work directory: %s\n", overlay_work);
-        if ( s_mkpath(overlay_work, 0755) < 0 ) {
+        if ( s_mkpath(overlay_work, 0755, overlay_mount) < 0 ) {
             singularity_message(ERROR, "Failed creating overlay work directory %s: %s\n", overlay_work, strerror(errno));
             ABORT(255);
         }

--- a/src/util/daemon.c
+++ b/src/util/daemon.c
@@ -151,7 +151,7 @@ void daemon_init_start(void) {
     
     /* Check if /var/tmp/.singularity-daemon-[UID]/ directory exists, if not create it */
     if ( is_dir(dirname(daemon_file_dir)) == -1 ) {
-        s_mkpath(daemon_file_dir, 0755);
+        s_mkpath(daemon_file_dir, 0755, NULL);
     }
     
     /* Attempt to open lock on daemon file */

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -39,7 +39,7 @@ int is_suid(char *path);
 int is_owner(char *path, uid_t uid);
 int is_blk(char *path);
 int is_chr(char *path);
-int s_mkpath(char *dir, mode_t mode);
+int s_mkpath(char *dir, mode_t mode, char *base);
 int s_rmdir(char *dir);
 int copy_file(char * source, char * dest);
 char *filecat(char *path);

--- a/src/util/mount.c
+++ b/src/util/mount.c
@@ -13,6 +13,7 @@
  * 
 */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -23,6 +24,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <libgen.h>
 
 #include "config.h"
 #include "util/file.h"
@@ -37,11 +39,41 @@ int singularity_mount(const char *source, const char *target,
                       const void *data) {
     int ret;
     int mount_errno;
-
     uid_t fsuid = 0;
+    char dest[PATH_MAX];
+    char *realdest;
+    int target_fd = open(target, O_RDONLY);
+
+    if ( target_fd < 0 ) {
+        singularity_message(ERROR, "Target %s doesn't exist\n", target);
+        ABORT(255);
+    }
+
+    if ( snprintf(dest, PATH_MAX-1, "/proc/self/fd/%d", target_fd) < 0 ) {
+        singularity_message(ERROR, "Failed to determine path for target file descriptor\n");
+        ABORT(255);
+    }
 
     if ( ( mountflags & MS_BIND ) ) {
         fsuid = singularity_priv_getuid();
+    }
+
+    realdest = realpath(dest, NULL); // Flawfinder: ignore
+    if ( realdest == NULL ) {
+        singularity_message(ERROR, "Failed to get real path of %s %s\n", target, dest);
+        ABORT(255);
+    }
+
+    if ( (mountflags & MS_PRIVATE) == 0 && (mountflags & MS_SLAVE) == 0 ) {
+        if ( strncmp(realdest, CONTAINER_MOUNTDIR, strlen(CONTAINER_MOUNTDIR)) != 0 &&
+             strncmp(realdest, CONTAINER_FINALDIR, strlen(CONTAINER_FINALDIR)) != 0 &&
+             strncmp(realdest, CONTAINER_OVERLAY, strlen(CONTAINER_OVERLAY)) != 0 &&
+             strncmp(realdest, SESSIONDIR, strlen(SESSIONDIR)) != 0 ) {
+            singularity_message(VERBOSE, "Ignored, try to mount %s outside of container %s\n", target, realdest);
+            free(realdest);
+            close(target_fd);
+            return(0);
+        }
     }
 
     /* don't modify user groups */
@@ -53,8 +85,12 @@ int singularity_mount(const char *source, const char *target,
         /* NFS root_squash option set uid 0 to nobody, force use of real user ID */
         setfsuid(fsuid);
     }
-    ret = mount(source, target, filesystemtype, mountflags, data);
+
+    ret = mount(source, dest, filesystemtype, mountflags, data);
     mount_errno = errno;
+
+    close(target_fd);
+    free(realdest);
 
     if ( singularity_priv_userns_enabled() == 0 && seteuid(singularity_priv_getuid()) < 0 ) {
         singularity_message(ERROR, "Failed to drop privileges: %s\n", strerror(errno));


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Nested binds can create unattended files/directories :

- Add check in check_mounted to avoid /proc/mounts bind override
- Detect nested binds and skip file/directory creation by warning user
- A base path argument was added in s_mkpath to check if created directory are within base path
- Minor fix for singularity_mount to save/restore errno on mount syscall

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
