### PR TITLE
Change path to binary in setup.sh

### DIFF
--- a/runtime/setup.sh
+++ b/runtime/setup.sh
@@ -8,6 +8,7 @@
 #
 
 export GOPATH=$(go env GOPATH)
+export BINPATH=$GOPATH/src/github.com/singularityware/singularity/core/buildtree
 go build -ldflags="-s -w" -o ../build/scontainer go/scontainer.go
 go build -ldflags="-s -w" -buildmode=c-shared -o ../build/librpc.so go/rpc.go
 go build -ldflags="-s -w" -o ../build/smaster go/smaster.go
@@ -23,9 +24,9 @@ cp ../build/librpc.so /tmp/
 sudo chown root:root /tmp/wrapper-suid && sudo chmod 4755 /tmp/wrapper-suid
 
 if [ ! -e "/tmp/testing.simg" ]; then
-    singularity pull --name testing.simg shub://GodloveD/busybox
+    "${BINPATH}"/singularity pull --name testing.simg shub://GodloveD/busybox
     mv testing.simg /tmp/
 fi
 if [ ! -e "/tmp/testing" ]; then
-    singularity build --sandbox /tmp/testing docker://alpine
+    "${BINPATH}"/singularity build --sandbox /tmp/testing docker://alpine
 fi


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The path to the `singularity` binary is not correct in the current version of `setup.sh`.  This points it to the right place.  Don't know if this is the best way to do it or if there is a more flexible way without hardcoding.   

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
