### PR TITLE
Typo in squashfs-tools package name (squash-tools)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ install-perms:
 all-local:
 	@echo
 	@echo "******"
-	@echo "  mksquashfs from squash-tools is required for full functionality"
+	@echo "  mksquashfs from squashfs-tools is required for full functionality"
 	@echo "******"
 	@echo
 


### PR DESCRIPTION
Just a quick PR to fix a typo in a Makefile.am message.