### PR TITLE
reorder mounts

### DIFF
--- a/src/lib/runtime/mounts/mounts.c
+++ b/src/lib/runtime/mounts/mounts.c
@@ -54,10 +54,10 @@ int _singularity_runtime_mounts(void) {
     retval += _singularity_runtime_mount_kernelfs();
     retval += _singularity_runtime_mount_dev();
     retval += _singularity_runtime_mount_home();
-    retval += _singularity_runtime_mount_userbinds();
-    retval += _singularity_runtime_mount_tmp();
     retval += _singularity_runtime_mount_scratch();
+    retval += _singularity_runtime_mount_tmp();
     retval += _singularity_runtime_mount_cwd();
+    retval += _singularity_runtime_mount_userbinds();
 
     return(retval);
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Change the order that mounts are done.  In particular, make sure that scratch is done before user binds.  This is a subset of pr #1424.


**This fixes or addresses the following GitHub issues:**

- 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
