### PR TITLE
free strdupped temporary variable in joinpath

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -191,6 +191,8 @@ char *joinpath(const char * path1, const char * path2_in) {
         ABORT(255);
     }
 
+    free(tmp_path1);
+
     return(ret);
 }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

I noticed a strdup() in joinpath() that was not getting freed and not needed after the function returns.  This adds the free().


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
