### PR TITLE
docker-extract - Ensure we always stay within extraction target

### DIFF
--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -28,7 +28,7 @@ int apply_opaque(const char *opq_marker, char *rootfs_dir) {
     int retval = 0;
     char *token;
     char target[PATH_MAX];
-    char target_real[PATH_MAX];
+    char *target_real;
 
     token = strrchr(opq_marker, '/');
     if (token == NULL) {
@@ -47,7 +47,9 @@ int apply_opaque(const char *opq_marker, char *rootfs_dir) {
 
     if (is_dir(target) == 0) {
 
-        if(realpath(target, target_real) == NULL) {
+        target_real = realpath(target, NULL);
+
+        if(target_real == NULL) {
             singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
             ABORT(255);
         }
@@ -57,7 +59,10 @@ int apply_opaque(const char *opq_marker, char *rootfs_dir) {
         }
 
         retval = s_rmdir(target_real);
+
+        free(target_real);
     }
+
 
     return retval;
 }
@@ -73,7 +78,7 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
     char* token;
     size_t token_pos, l = 0;
     char target[PATH_MAX];
-    char target_real[PATH_MAX];
+    char *target_real;
     struct stat statbuf;
 
     token = strstr(wh_marker, ".wh.");
@@ -109,7 +114,9 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
         return 0;
     }
 
-    if(realpath(target, target_real) == NULL) {
+    target_real = realpath(target, NULL);
+
+    if(target_real == NULL) {
         singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
         ABORT(255);
     }
@@ -125,6 +132,8 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
                             target_real);
         retval = unlink(target_real);
     }
+
+    free(target_real);
 
     return retval;
 }

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -96,6 +96,10 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
     }
     l = strlen(target);
     // Add whiteout path up to .wh.
+    if (strlen(target) + strlen(token) > sizeof(target) - 1) {
+        singularity_message(ERROR, "Error with pathname too long\n");
+        ABORT(255);
+    }
     token_pos = strlen(wh_marker) - strlen(token);
     retval = snprintf(target + l, token_pos + 1, "%s", wh_marker);
     if (retval == -1 || retval >= sizeof(target) - l) {

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -47,7 +47,7 @@ int apply_opaque(const char *opq_marker, char *rootfs_dir) {
 
     if (is_dir(target) == 0) {
 
-        target_real = realpath(target, NULL);
+        target_real = realpath(target, NULL);  // Flawfinder: ignore
 
         if(target_real == NULL) {
             singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
@@ -114,7 +114,7 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
         return 0;
     }
 
-    target_real = realpath(target, NULL);
+    target_real = realpath(target, NULL);  // Flawfinder: ignore
 
     if(target_real == NULL) {
         singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -53,9 +53,10 @@ int apply_opaque(const char *opq_marker, char *rootfs_dir) {
             singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
             ABORT(255);
         }
-    
+
         if(strncmp(rootfs_dir, target_real, strlen(rootfs_dir)) != 0) {
             singularity_message(ERROR, "Attempt to whiteout outside of rootfs %s - aborting.\n", target_real);
+            ABORT(255);
         }
 
         retval = s_rmdir(target_real);
@@ -123,6 +124,7 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
  
     if(strncmp(rootfs_dir, target_real, strlen(rootfs_dir)) != 0) {
         singularity_message(ERROR, "Attempt to whiteout outside of rootfs %s - aborting.\n", target_real);
+        ABORT(255);
     }
 
     if (is_dir(target_real) == 0) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

In docker-extract.c

- Do not allow absolute paths in docker layer tars
- Do not allow escape from rootfs_dir

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
