### PR TITLE
Remove some dependencies to Singularity main source tree  on Slurm plugin 

### DIFF
--- a/src/lib/runtime/Makefile.am
+++ b/src/lib/runtime/Makefile.am
@@ -11,7 +11,7 @@ distincludedir = $(includedir)/singularity
 
 noinst_LTLIBRARIES = libinternal.la
 libinternal_la_LIBADD = ns/libinternal.la mounts/libinternal.la files/libinternal.la enter/libinternal.la overlayfs/libinternal.la environment/libinternal.la autofs/libinternal.la
-libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c ../../util/setns.c ../../util/mount.c
+libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c ../../util/setns.c ../../util/mount.c ../../util/cleanupd.c
 libinternal_la_CFLAGS = $(AM_CFLAGS) # This fixes duplicate sources in library and progs
 
 distinclude_HEADERS = runtime.h

--- a/src/lib/runtime/Makefile.am
+++ b/src/lib/runtime/Makefile.am
@@ -11,7 +11,7 @@ distincludedir = $(includedir)/singularity
 
 noinst_LTLIBRARIES = libinternal.la
 libinternal_la_LIBADD = ns/libinternal.la mounts/libinternal.la files/libinternal.la enter/libinternal.la overlayfs/libinternal.la environment/libinternal.la autofs/libinternal.la
-libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c ../../util/setns.c ../../util/mount.c ../../util/cleanupd.c
+libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c ../../util/setns.c ../../util/mount.c ../../util/cleanupd.c ../../util/sessiondir.c
 libinternal_la_CFLAGS = $(AM_CFLAGS) # This fixes duplicate sources in library and progs
 
 distinclude_HEADERS = runtime.h

--- a/src/lib/runtime/Makefile.am
+++ b/src/lib/runtime/Makefile.am
@@ -11,7 +11,7 @@ distincludedir = $(includedir)/singularity
 
 noinst_LTLIBRARIES = libinternal.la
 libinternal_la_LIBADD = ns/libinternal.la mounts/libinternal.la files/libinternal.la enter/libinternal.la overlayfs/libinternal.la environment/libinternal.la autofs/libinternal.la
-libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c ../../util/setns.c ../../util/mount.c ../../util/cleanupd.c ../../util/sessiondir.c
+libinternal_la_SOURCES = runtime.c ../../util/fork.c ../../util/registry.c ../../util/message.c ../../util/config_parser.c ../../util/privilege.c ../../util/util.c ../../util/file.c ../../util/setns.c ../../util/mount.c ../../util/cleanupd.c ../../util/sessiondir.c ../../action-lib/ready.c
 libinternal_la_CFLAGS = $(AM_CFLAGS) # This fixes duplicate sources in library and progs
 
 distinclude_HEADERS = runtime.h

--- a/src/slurm/Makefile.am
+++ b/src/slurm/Makefile.am
@@ -5,7 +5,7 @@ plugindir = $(libdir)/slurm
 
 if WITH_SLURM
 plugin_LTLIBRARIES = singularity_spank.la
-singularity_spank_la_SOURCES = singularity.c ../util/sessiondir.c ../action-lib/ready.c ../util/cleanupd.c
+singularity_spank_la_SOURCES = singularity.c
 singularity_spank_la_LIBADD = ../lib/image/libsingularity-image.la ../lib/runtime/libsingularity-runtime.la
 singularity_spank_la_LDFLAGS = -module -no-undefined -avoid-version -export-symbols-regex '^slurm_spank_|^plugin_'
 endif


### PR DESCRIPTION
Remove some dependencies to Singularity main source tree from src/slurm/Makefile.am.

I think that it will help to maintain the Slurm plugin as a subproject on GitHub as mentioned in #895  .
It is needed to fix Slurm plugin to make the plugin work yet, however we can make  the plugin development separated from main development by this fix to a extent.
**This fixes or addresses the following GitHub issues:**

- Ref: #1231


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
