### PR TITLE
Fix push/pull related package deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -274,12 +274,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/syndtr/gocapability"
-  packages = ["capability"]
-  revision = "33e07d32887e1e06b7c025f27ce52f62c7990bc0"
-
-[[projects]]
-  branch = "master"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
   revision = "4e3ac2762d5f479393488629ee9370b50873b3a6"
@@ -340,6 +334,15 @@
   version = "v1.0.22"
 
 [[projects]]
+  branch = "v2"
+  name = "gopkg.in/mgo.v2"
+  packages = [
+    "bson",
+    "internal/json"
+  ]
+  revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+
+[[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
@@ -348,6 +351,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "73d99a2cf326eb9294396f7d9018fdb71c29b3caa8b978a0b86daa26d829a2de"
+  inputs-digest = "8607bcf437ba2d692698568fb2a46eb20331e6e108e7ac11dade49213fea463b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/library/client/pull.go
+++ b/pkg/library/client/pull.go
@@ -9,7 +9,7 @@ import (
 
 	"log"
 
-	"github.com/cheggaaa/pb"
+	"gopkg.in/cheggaaa/pb.v1"
 )
 
 func DownloadImage(filePath string, libraryRef string, libraryURL string) error {

--- a/pkg/library/client/push.go
+++ b/pkg/library/client/push.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/cheggaaa/pb"
+	"gopkg.in/cheggaaa/pb.v1"
 	"gopkg.in/mgo.v2/bson"
 )
 


### PR DESCRIPTION
Install of the pb dep for the library push / pull was broken recently if taking it from GitHub, due to v2 work there. Switch to the versioned pb package source via gopkg.in to track v1 without introducing hard constraint.