### PR TITLE
Mksquashfs opts

### DIFF
--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -386,7 +386,7 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
         if [ -n "${MKSQASHFS_LVL_OPTS:-}" ]; then
             COMP="-comp $MKSQASHFS_LVL_OPTS" 
         else
-            COMP="-comp lzo"
+            COMP=""
         fi
         if ! mksquashfs "$SINGULARITY_ROOTFS/" "$SINGULARITY_CONTAINER_OUTPUT" -noappend $OPTS $COMP > /dev/null; then
             message ERROR "Failed squashing image, left template directory at: $SINGULARITY_ROOTFS\n"

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -76,6 +76,7 @@ while true; do
             shift
         ;;
         --comp)
+            shift
             MKSQASHFS_LVL_OPTS="$1"
             shift
         ;;
@@ -382,7 +383,7 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
         else
             OPTS=""
         fi
-        if [ -n "${MKSQASHFS_LVL_OPTS:-}"]; then
+        if [ -n "${MKSQASHFS_LVL_OPTS:-}" ]; then
             COMP="-comp $MKSQASHFS_LVL_OPTS" 
         else
             COMP=""

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -386,7 +386,7 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
         if [ -n "${MKSQASHFS_LVL_OPTS:-}" ]; then
             COMP="-comp $MKSQASHFS_LVL_OPTS" 
         else
-            COMP=""
+            COMP="-comp lzo"
         fi
         if ! mksquashfs "$SINGULARITY_ROOTFS/" "$SINGULARITY_CONTAINER_OUTPUT" -noappend $OPTS $COMP > /dev/null; then
             message ERROR "Failed squashing image, left template directory at: $SINGULARITY_ROOTFS\n"

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -75,6 +75,10 @@ while true; do
             SINGULARITY_SANDBOX=1
             shift
         ;;
+        --comp)
+            MKSQASHFS_LVL_OPTS="$1"
+            shift
+        ;;
         -w|--writable)
             if [ "$USERID" != "0" ]; then
                 message ERROR "Writable images must be created as root\n"
@@ -378,7 +382,12 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
         else
             OPTS=""
         fi
-        if ! mksquashfs "$SINGULARITY_ROOTFS/" "$SINGULARITY_CONTAINER_OUTPUT" -noappend $OPTS > /dev/null; then
+        if [ -n "${MKSQASHFS_LVL_OPTS:-}"]; then
+            COMP="-comp $MKSQASHFS_LVL_OPTS" 
+        else
+            COMP=""
+        fi
+        if ! mksquashfs "$SINGULARITY_ROOTFS/" "$SINGULARITY_CONTAINER_OUTPUT" -noappend $OPTS $COMP > /dev/null; then
             message ERROR "Failed squashing image, left template directory at: $SINGULARITY_ROOTFS\n"
             exit 1
         fi

--- a/libexec/cli/build.info
+++ b/libexec/cli/build.info
@@ -48,7 +48,7 @@ BUILD OPTIONS:
     -T|--notest     Bootstrap without running tests in %test section
     -s|--section    Only run a given section within the recipe file (setup,
                     post, files, environment, test, labels, none)
-    -comp <comp>    select squashfs Compressors 
+    --comp <comp>   select squashfs Compressors 
                     available:
                         gzip (default)
                         lzma

--- a/libexec/cli/build.info
+++ b/libexec/cli/build.info
@@ -52,7 +52,7 @@ BUILD OPTIONS:
                     available:
                         gzip 
                         lzma
-                        lzo (default)
+                        lzo 
                         xz
 
 

--- a/libexec/cli/build.info
+++ b/libexec/cli/build.info
@@ -50,9 +50,9 @@ BUILD OPTIONS:
                     post, files, environment, test, labels, none)
     --comp <comp>   select squashfs Compressors 
                     available:
-                        gzip (default)
+                        gzip 
                         lzma
-                        lzo
+                        lzo (default)
                         xz
 
 

--- a/libexec/cli/build.info
+++ b/libexec/cli/build.info
@@ -48,6 +48,12 @@ BUILD OPTIONS:
     -T|--notest     Bootstrap without running tests in %test section
     -s|--section    Only run a given section within the recipe file (setup,
                     post, files, environment, test, labels, none)
+    -comp <comp>    select squashfs Compressors 
+                    available:
+                        gzip (default)
+                        lzma
+                        lzo
+                        xz
 
 
 CHECKS OPTIONS:


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Enable users to choose comp at build time

```
--comp <comp>    select squashfs Compressors 
                    available:
                        gzip (default)
                        lzma
                        lzo
                        xz
```

example for lzo

```
sudo singularity build --comp lzo lzo_comp.img testdef
```

Comp differences:

```bash
-rwxr-xr-x.  1 root    root     36M Apr 12 15:45 default_comp.img
-rwxr-xr-x.  1 root    root     39M Apr 12 15:41 lzo_comp.img
-rwxr-xr-x.  1 root    root     30M Apr 12 15:41 xz_comp.img
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware/singularity-admin 