### PR TITLE
Minor fixup for bind points with broken links

### DIFF
--- a/src/util/mount.c
+++ b/src/util/mount.c
@@ -113,14 +113,15 @@ int check_proc_mount(char *mount, char *real_mountpoint) {
         if ( is_link(tmp_test_path) == 0 ) {
             char *linktarget = realpath(tmp_test_path, NULL); // Flawfinder: ignore
             if ( linktarget == NULL ) {
-                singularity_message(ERROR, "Could not identify the source of contained link: %s\n", test_mountpoint);
-                ABORT(255);
-            }
-            full_test_path = joinpath(CONTAINER_FINALDIR, linktarget);
-            singularity_message(DEBUG, "Parent directory is a link, resolved: %s->%s\n", tmp_test_path, full_test_path);
-            if ( strcmp(linktarget, "/") == 0 ) {
-                singularity_message(DEBUG, "Link is pointing to /, not allowed: %s\n", test_mountpoint);
+                singularity_message(WARNING, "Skipping bind point within container (broken link): %s\n", test_mountpoint);
                 retval = 1;
+            } else {
+                full_test_path = joinpath(CONTAINER_FINALDIR, linktarget);
+                singularity_message(DEBUG, "Parent directory is a link, resolved: %s->%s\n", tmp_test_path, full_test_path);
+                if ( strcmp(linktarget, "/") == 0 ) {
+                    singularity_message(WARNING, "Skipping bind point within container (link is pointing to /): %s\n", test_mountpoint);
+                    retval = 1;
+                }
             }
             free(linktarget);
         } else {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes bug when the bind target within a container is a broken link:

```
singularity exec   container.img /bin/bash
ERROR  : Could not identify the source of contained link: /etc/localtime
ABORT  : Retval = 255
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
