### PR TITLE
Use PATH_MAX for filename size in struct

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -379,6 +379,12 @@ void free_tempfile(struct tempfile *tf) {
 struct tempfile *make_tempfile(void) {
    int fd;
    struct tempfile *tf;
+   char *tmpdir = singularity_registry_get("TMPDIR");
+
+   printf("TMPDIR is: %s\n", tmpdir);
+   if (tmpdir == NULL) {
+       tmpdir = "/tmp";
+   }
 
    tf = malloc(sizeof(struct tempfile));
    if (tf == NULL) {
@@ -386,7 +392,7 @@ struct tempfile *make_tempfile(void) {
        ABORT(255);
    }
 
-   strncpy(tf->filename, "/tmp/vb.XXXXXXXXXX", sizeof(tf->filename) - 1);
+   snprintf(tf->filename, sizeof(tf->filename) - 1, "%s/vb.XXXXXXXXXX", tmpdir);
    tf->filename[sizeof(tf->filename) - 1] = '\0';
    if ((fd = mkstemp(tf->filename)) == -1 || (tf->fp = fdopen(fd, "w+")) == NULL) {
        if (fd != -1) {
@@ -405,6 +411,11 @@ struct tempfile *make_logfile(char *label) {
 
     char *daemon = singularity_registry_get("DAEMON_NAME");
     char *image = basename(singularity_registry_get("IMAGE"));
+    char *tmpdir = singularity_registry_get("TMPDIR");
+
+    if (tmpdir == NULL) {
+        tmpdir = "/tmp";
+    }
         
     tf = malloc(sizeof(struct tempfile));
     if (tf == NULL) {
@@ -412,7 +423,7 @@ struct tempfile *make_logfile(char *label) {
         ABORT(255);
     }    
 
-    if ( snprintf(tf->filename, sizeof(tf->filename) - 1, "/tmp/%s.%s.%s.XXXXXX", image, daemon, label) > sizeof(tf->filename) - 1 ) {
+    if ( snprintf(tf->filename, sizeof(tf->filename) - 1, "%s/%s.%s.%s.XXXXXX", tmpdir, image, daemon, label) > sizeof(tf->filename) - 1 ) {
         singularity_message(ERROR, "Label string too long\n");
         ABORT(255);
     }

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -381,7 +381,6 @@ struct tempfile *make_tempfile(void) {
    struct tempfile *tf;
    char *tmpdir = singularity_registry_get("TMPDIR");
 
-   printf("TMPDIR is: %s\n", tmpdir);
    if (tmpdir == NULL) {
        tmpdir = "/tmp";
    }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <linux/limits.h>
 
 #include "util/message.h"
 
@@ -37,7 +38,7 @@
 struct tempfile {
     FILE *fp;
     int fd;
-    char filename[64];
+    char filename[PATH_MAX];
 };
 
 char *envar_get(char *name, char *allowed, int len);


### PR DESCRIPTION
**Description of the Pull Request (PR):**
Use `PATH_MAX` for filename size in struct

Also, do not use a hard coded `/tmp`. Use `SINGULARITY_TMPDIR` if set,
and fall back to `/tmp` if not.

**This fixes or addresses the following GitHub issues:**

- Ref: #1185 

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
