### PR TITLE
Correct ENTRYPOINT + CMD behaviour - 3.0

### DIFF
--- a/pkg/build/provisioner_docker.go
+++ b/pkg/build/provisioner_docker.go
@@ -163,22 +163,55 @@ func (p *DockerProvisioner) insertRunScript(i *image.Sandbox, ociConfig imgspecv
 		return
 	}
 
-	_, err = f.WriteString(strings.Join(ociConfig.Entrypoint, " "))
-	if err != nil {
-		return
+	if len(ociConfig.Entrypoint) > 0 {
+		_, err = f.WriteString("OCI_ENTRYPOINT=\"" + strings.Join(ociConfig.Entrypoint, " ") + "\"\n")
+		if err != nil {
+			return
+		}
+	} else {
+		_, err = f.WriteString("OCI_ENTRYPOINT=\"\"\n")
+		if err != nil {
+			return
+		}
 	}
 
-	_, err = f.WriteString(" ")
-	if err != nil {
-		return
+	if len(ociConfig.Cmd) > 0 {
+		_, err = f.WriteString("OCI_CMD=\"" + strings.Join(ociConfig.Cmd, " ") + "\"\n")
+		if err != nil {
+			return
+		}
+	} else {
+		_, err = f.WriteString("OCI_CMD=\"\"\n")
+		if err != nil {
+			return
+		}
 	}
 
-	_, err = f.WriteString(strings.Join(ociConfig.Cmd, " "))
-	if err != nil {
-		return
-	}
+	_, err = f.WriteString(`# ENTRYPOINT only - run entrypoint plus args
+if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
+    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
+fi
 
-	_, err = f.WriteString("\n")
+# CMD only - run CMD or override with args
+if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
+    if [ $# -gt 0 ]; then
+        SINGULARITY_OCI_RUN="$@"
+    else
+        SINGULARITY_OCI_RUN="${OCI_CMD}"
+    fi
+fi
+
+# ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
+# override with user provided args
+if [ $# -gt 0 ]; then
+    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
+else
+    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
+fi
+
+exec $SINGULARITY_OCI_RUN
+
+`)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Singularity 2.x does not implement correct docker/oci handling of ENTRYPOINT and CMD. It only uses one of these, with an option to set a preference, and does not follow the correct behaviour for overriding CMD or using ENTRYPOINT with CMD as default arguments.

Per OCI spec at https://github.com/opencontainers/image-spec/blob/master/config.md which is nicely explained at https://www.ctl.io/developers/blog/post/dockerfile-entrypoint-vs-cmd behaviour should be as follows:

- If only ENTRYPOINT is set, that is the command to run, and user-supplied arguments in the run command line are appended.

```
ENTRYPOINT="ping"

singularity run myimage.sif => ping
singularity run myimage.sif localhost => ping localhost
```

- If only CMD is set, then run that if there are no user-supplied arugments. If the user supplied arguments in the run command line they completely override CMD.

```
CMD="ping localhost"

singularity run myimage.sif => ping localhost
singularity run myimage.sif hostname => hostname
```

- If ENTRYPOINT and CMD are set, ENTRYPOINT is the command that is run. CMD provides default arguments that can be overridden by the user.

```
ENTRYPOINT="ping"
CMD="localhost"

singularity run myimage.sif => ping localhost
singularity run myimage.sif example.com => ping example.com
```

In Singularity, the ability to override ENTRYPOINT is given by the `singularity exec` command.

This PR implements the OCI spec behavior above. This is a change that will modify Singularity behavior, but I believe it is important given we are working toward OCI compliance, and to reduce the issues faced with differences in behaviour between Singularity and Docker when running Docker containers.

