### PR TITLE
Explicitly set umask to 0022 at the beginning of execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
    added SINGULARITYENV_PREPEND_PATH and SINGULARITYENV_APPEND_PATH for users
    wanting to prepend or append to the container PATH at runtime
  - Fix for check_mounted() to check parent directories #1436
+ - Reset umask to 0002 at start to corrrect several errors 
 
 ## [v2.4.6-rc1](https://github.com/singularityware/singularity/releases/tag/2.4.6-rc1) (2018-04-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
    added SINGULARITYENV_PREPEND_PATH and SINGULARITYENV_APPEND_PATH for users
    wanting to prepend or append to the container PATH at runtime
  - Fix for check_mounted() to check parent directories #1436
- - Reset umask to 0002 at start to corrrect several errors 
+ - Reset umask to 0022 at start to corrrect several errors 
 
 ## [v2.4.6-rc1](https://github.com/singularityware/singularity/releases/tag/2.4.6-rc1) (2018-04-04)
 

--- a/bin/singularity.in
+++ b/bin/singularity.in
@@ -23,7 +23,7 @@
 # 
 
 # Relax restrictive umasks that can cause several problems
-umask 0002
+umask 0022
 
 prefix="@prefix@"
 exec_prefix="@exec_prefix@"

--- a/bin/singularity.in
+++ b/bin/singularity.in
@@ -22,6 +22,8 @@
 # 
 # 
 
+# Relax restrictive umasks that can cause several problems
+umask 0002
 
 prefix="@prefix@"
 exec_prefix="@exec_prefix@"

--- a/etc/init
+++ b/etc/init
@@ -32,8 +32,11 @@ fi
 # Provide a sane starting path within the container (unfortunately the same 
 # var name is recycled from above for legacy reasons)
 SINGULARITYENV_PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+export SINGULARITYENV_PATH 
 
 # Don't save the shell's HISTFILE
 SINGULARITYENV_HISTFILE=""
+export SINGULARITYENV_HISTFILE
 
-export SINGULARITYENV_PATH SINGULARITYENV_HISTFILE
+# Relax restrictive umasks that can cause several problems 
+umask 0002

--- a/etc/init
+++ b/etc/init
@@ -37,6 +37,3 @@ export SINGULARITYENV_PATH
 # Don't save the shell's HISTFILE
 SINGULARITYENV_HISTFILE=""
 export SINGULARITYENV_HISTFILE
-
-# Relax restrictive umasks that can cause several problems 
-umask 0002


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is perhaps not the most elegant solution, but restrictive umasks have caused several problems.  


**This fixes or addresses the following GitHub issues:**

- fixes #1465 
- fixes #1460
- fixes #1079 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
