### PR TITLE
Better check for systems where NO_NEW_PRIVS are partially backported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
    added SINGULARITYENV_PREPEND_PATH and SINGULARITYENV_APPEND_PATH for users
    wanting to prepend or append to the container PATH at runtime
  - Fix for check_mounted() to check parent directories #1436
+ - Added better checks for systems were NO_NEW_PRIVS is only partially 
+   backported
 
 ## [v2.4.6-rc1](https://github.com/singularityware/singularity/releases/tag/2.4.6-rc1) (2018-04-04)
 

--- a/configure.ac
+++ b/configure.ac
@@ -150,11 +150,15 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#define _GNU_SOURCE
                   )
 
 AC_MSG_CHECKING([for feature: NO_NEW_PRIVS])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+AC_RUN_IFELSE([AC_LANG_PROGRAM([[
                                      #include <sys/prctl.h>
                                    ]],
-                                   [[prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
-                                     prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0);]])],
+                                   [[if ( prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+                                       return 1;
+                                   }
+                                   if ( prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1) {
+                                       return 1;
+                                   }]])],
                       [
                           AC_MSG_RESULT([yes])
                           SINGULARITY_DEFINES="$SINGULARITY_DEFINES -DSINGULARITY_NO_NEW_PRIVS"
@@ -162,7 +166,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
                           AC_MSG_RESULT([no])
                       ]
                   )
-
 
 AC_MSG_CHECKING([for feature: MS_SLAVE])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[


### PR DESCRIPTION
**Description of the Pull Request (PR):**

On some very specific versions of RHEL, the `NO_NEW_PRIVS` feature was only partially backported.  So the `PR_SET_NO_NEW_PRIVS` and `PR_GET_NO_NEW_PRIVS` are available for use by `prctl.h`, but once you actually try to use them you get an error.  The current `configure.ac` just checks for the presence of these arguments, but doesn't check whether they actually work or not.  If you use Singularity on a RHEL system with a half-way patch, you will end up with a non-working binary.  With these changes, `configure.ac` will check that the `NO_NEW_PRIVS` arguments actually work without returning errors and will set runtime variables accordingly.

Tested on a system with the following configuration.
```
[vagrant@localhost singularity]$ cat /etc/issue
CentOS release 6.5 (Final)
Kernel \r on an \m

[vagrant@localhost singularity]$ uname -a
Linux localhost.localdomain 2.6.32-431.el6.x86_64 #1 SMP Fri Nov 22 03:15:09 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
[vagrant@localhost singularity]$
```  
The issue is discussed in the Google Group here.

https://groups.google.com/a/lbl.gov/forum/#!searchin/singularity/PR_SET_NO_NEW_PRIVS%7Csort:date/singularity/S2WaCngE7M8/CMCSGT48DQAJ

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
