### PR TITLE
Fix Definition Reflection

### DIFF
--- a/pkg/build/definition.go
+++ b/pkg/build/definition.go
@@ -11,34 +11,34 @@ package build
 import "strings"
 
 type Definition struct {
-	Header    map[string]string
-	ImageData imageData
-	BuildData buildData
+	Header map[string]string
+	ImageData
+	BuildData
 }
 
-// imageData contains any scripts, metadata, etc... that needs to be
+// ImageData contains any scripts, metadata, etc... that needs to be
 // present in some from in the final built image
-type imageData struct {
+type ImageData struct {
 	Metadata []byte   //
 	Labels   []string //
-	imageScripts
+	ImageScripts
 }
 
-type imageScripts struct {
+type ImageScripts struct {
 	Help        string
 	Environment string
 	Runscript   string
 	Test        string
 }
 
-// buildData contains any scripts, metadata, etc... that the Builder may
+// BuildData contains any scripts, metadata, etc... that the Builder may
 // need to know only at build time to build the image
-type buildData struct {
+type BuildData struct {
 	Files map[string]string //
-	buildScripts
+	BuildScripts
 }
 
-type buildScripts struct {
+type BuildScripts struct {
 	Pre   string
 	Setup string
 	Post  string

--- a/pkg/build/definition_parser_deffile.go
+++ b/pkg/build/definition_parser_deffile.go
@@ -136,8 +136,8 @@ func doSections(s *bufio.Scanner, d *Definition, done chan error) {
 		files[key] = val
 	}
 
-	d.ImageData = imageData{
-		imageScripts: imageScripts{
+	d.ImageData = ImageData{
+		ImageScripts: ImageScripts{
 			Help:        sections["help"],
 			Environment: sections["environment"],
 			Runscript:   sections["runscript"],
@@ -145,7 +145,7 @@ func doSections(s *bufio.Scanner, d *Definition, done chan error) {
 		},
 	}
 	d.BuildData.Files = files
-	d.BuildData.buildScripts = buildScripts{
+	d.BuildData.BuildScripts = BuildScripts{
 		Pre:   sections["pre"],
 		Setup: sections["setup"],
 		Post:  sections["post"],


### PR DESCRIPTION
Libraries that use reflection aren't able to access all members of the `Definition` structure, since some of the structs inside it are not public. Make all members public.