### PR TITLE
Fix compilation and execution on Pi aarch64

### DIFF
--- a/core/lib/sif/sif.c
+++ b/core/lib/sif/sif.c
@@ -111,7 +111,8 @@ sif_validate(Sifinfo *info)
 		currarch = SIF_ARCH_386;
 	else if(!strncmp(name.machine, "arm", 3) && sizeof(void *) == 4)
 		currarch = SIF_ARCH_ARM;
-	else if(!strncmp(name.machine, "arm", 3) && sizeof(void *) == 8)
+	else if( (!strncmp(name.machine, "arm", 3) && sizeof(void *) == 8) ||
+		!strncmp(name.machine, "aarch64", 7) )
 		currarch = SIF_ARCH_AARCH64;
 	else{
 		siferrno = SIF_EUARCH;

--- a/core/lib/sif/sif.c
+++ b/core/lib/sif/sif.c
@@ -111,8 +111,7 @@ sif_validate(Sifinfo *info)
 		currarch = SIF_ARCH_386;
 	else if(!strncmp(name.machine, "arm", 3) && sizeof(void *) == 4)
 		currarch = SIF_ARCH_ARM;
-	else if( (!strncmp(name.machine, "arm", 3) && sizeof(void *) == 8) ||
-		!strncmp(name.machine, "aarch64", 7) )
+	else if(!strncmp(name.machine, "aarch64", 7))
 		currarch = SIF_ARCH_AARCH64;
 	else{
 		siferrno = SIF_EUARCH;

--- a/core/mlocal/checks/basechecks.chk
+++ b/core/mlocal/checks/basechecks.chk
@@ -175,6 +175,10 @@ if echo | $hstcc -E -dM - | grep -qs -e __amd64 -e __amd64__ -e __x86_64 \
 	-e __x86_64__; then
 	tgt_arch=x86_64
 fi
+if echo | $hstcc -E -dM - | grep -qs -e __aarch64 -e __aarch64__ -e __arm64 \
+	-e __arm64__; then
+	tgt_arch=arm64
+fi
 if [ "$tgt_arch" != "" ]; then
 	echo $tgt_arch
 else
@@ -196,6 +200,11 @@ if echo | $hstcc -E -dM - | grep -qs -e __amd64 -e __amd64__ -e __x86_64 \
 	-e __x86_64__; then
 	wordsize=64
 fi
+if echo | $hstcc -E -dM - | grep -qs -e __aarch64 -e __aarch64__ -e __arm64 \
+	-e __arm64__; then
+	wordsize=64
+fi
+
 if [ "$wordsize" != "" ]; then
 	echo $wordsize
 else

--- a/core/mlocal/checks/basechecks.chk
+++ b/core/mlocal/checks/basechecks.chk
@@ -177,7 +177,7 @@ if echo | $hstcc -E -dM - | grep -qs -e __amd64 -e __amd64__ -e __x86_64 \
 fi
 if echo | $hstcc -E -dM - | grep -qs -e __aarch64 -e __aarch64__ -e __arm64 \
 	-e __arm64__; then
-	tgt_arch=arm64
+	tgt_arch=aarch64
 fi
 if [ "$tgt_arch" != "" ]; then
 	echo $tgt_arch


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Quick fixes for some architecture detection on compilation and execution so that the 3.0 tree is able to run on a RaspberryPi 3B with Pi64 linux install. This can now work...

```
singularity build pi_alpine.sif docker://aarch64/alpine
singularity -d exec pi_alpine.sif cat /etc/lsb-release
```


