### PR TITLE
Clean up ROOTFS handling in docker build / extraction

### DIFF
--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -194,6 +194,10 @@ fi
 # if the container exists, build into it (or delete it if -F was passed)
 if [ -e "$SINGULARITY_CONTAINER_OUTPUT" ]; then
     if eval is_image "${SINGULARITY_CONTAINER_OUTPUT}"; then
+        if [ "$SINGULARITY_CONTAINER_OUTPUT" = "/" ]; then
+            message ERROR "Not building a container into the host root / !\n"
+            ABORT 255
+        fi
         if [ -z "${SINGULARITY_FORCE:-}" ]; then
             message 1 "Building into existing container: $SINGULARITY_CONTAINER_OUTPUT\n"
             SINGULARITY_BTSTRP_2EXISTING=1

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -432,5 +432,7 @@ int main(int argc, char **argv) {
         ABORT(255);
     }
 
+    free(rootfs_realpath);
+
     return (retval);
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

1. In docker-extract use realpath to canonicalize ROOTFS so that it resolves duplicate '//' etc. that can result from user setting SINGULARITY_TMPDIR. This fixes an issue observed in #1476.

```
export SINGULARITY_TMPDIR=/tmp/sing/
singularity build -d dave.simg docker://alpine
...
DEBUG   [U=1000,P=6929]    main()                                    ROOTFS /tmp/sing//.singularity-build.KL2vWt canonicalized to /tmp/sing/.singularity-build.KL2vWt
...
```


2. Make docker-extract refuse to extract into '/'  - we should never hit this as the shell scripts calling it should never have SINGULARITY_ROOTFS as '/' but it's a good check that we can test directly:

```
/usr/local/libexec/singularity/bin/docker-extract ~/.singularity/docker/sha256\:ff3a5c916c92643ff77519ffa742d3ec61b7f591b6b7504599d95a4a41134e28.tar.gz 
DEBUG   [U=1000,P=6954]    message_init()                            SINGULARITY_MESSAGELEVEL undefined, setting level 5 (debug)
VERBOSE [U=1000,P=6954]    singularity_registry_init()               Initializing Singularity Registry
VERBOSE [U=1000,P=6954]    singularity_registry_set()                Adding value to registry: 'ROOTFS' = '/'
DEBUG   [U=1000,P=6954]    singularity_registry_set()                Returning singularity_registry_set(ROOTFS, /) = 0
VERBOSE [U=1000,P=6954]    singularity_registry_set()                Adding value to registry: 'TMPDIR' = '/tmp/sing/'
DEBUG   [U=1000,P=6954]    singularity_registry_set()                Returning singularity_registry_set(TMPDIR, /tmp/sing/) = 0
DEBUG   [U=1000,P=6954]    singularity_registry_get()                Returning value from registry: 'ROOTFS' = '/'
DEBUG   [U=1000,P=6954]    main()                                    ROOTFS / canonicalized to /
ERROR   [U=1000,P=6954]    main()                                    Refusing to extract into host root / - aborting.
ABORT   [U=1000,P=6954]    main()                                    Retval = 255


```

3. Modify the `build.exec` to prevent trying to build into '/' as a sandbox. This could do bad things ahead of `docker-extract` as there can be an `rm -rf` of existing content if forced - plus it will try to extract the base `environment.tar` using `tar` to `/` before getting to the docker layer extraction portion

```
$ singularity build -s / docker://alpine
WARNING: Building sandbox as non-root may result in wrong file permissions
ERROR: Not building a container into the host root / !
ABORT: Aborting with RETVAL=255
```


**This fixes or addresses the following GitHub issues:**

- Ref: Part of #1476 (SINGULARITY_TMPDIR with trailing slash)


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
