### PR TITLE
Call fd_cleanup after container setup

### DIFF
--- a/src/lib/runtime/files/passwd/passwd.c
+++ b/src/lib/runtime/files/passwd/passwd.c
@@ -72,6 +72,11 @@ int _singularity_runtime_files_passwd(void) {
         ABORT(255);
     }
 
+    if ( pwent == NULL ) {
+        singularity_message(ERROR, "Failed to obtain user identity information\n");
+        ABORT(255);
+    }
+
     singularity_message(DEBUG, "Checking configuration option: 'config passwd'\n");
     if ( singularity_config_get_bool(CONFIG_PASSWD) <= 0 ) {
         singularity_message(VERBOSE, "Skipping bind of the host's /etc/passwd\n");

--- a/src/mount.c
+++ b/src/mount.c
@@ -49,8 +49,6 @@
 int main(int argc, char **argv) {
     struct image_object image;
 
-    fd_cleanup();
-
     singularity_config_init(joinpath(SYSCONFDIR, "/singularity/singularity.conf"));
 
     singularity_priv_init();

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -443,8 +443,8 @@ struct tempfile *make_logfile(char *label) {
     return(tf);
 }
 
-// close all file descriptors pointing to a directory or a socket
-void fd_cleanup(void) {
+// iter on /proc/self/fd and call close_fd callback to determine file descriptors to close
+void fd_cleanup(int (*close_fd)(int fd, struct stat *st)) {
     int fd_proc;
     DIR *dir;
     struct dirent *dirent;
@@ -474,7 +474,7 @@ void fd_cleanup(void) {
         if ( fd == fd_proc || fstat(fd, &st) < 0 ) {
             continue;
         }
-        if ( S_ISDIR(st.st_mode) || S_ISSOCK(st.st_mode) ) {
+        if ( close_fd(fd, &st) ) {
             close(fd);
         }
     }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <linux/limits.h>
 
 #include "util/message.h"
@@ -59,7 +60,7 @@ char *random_string(int length);
 void free_tempfile(struct tempfile *tf);
 struct tempfile *make_tempfile(void);
 struct tempfile *make_logfile(char *label);
-void fd_cleanup(void);
+void fd_cleanup(int (*close_fd)(int fd, struct stat *));
 
 // Given a const char * string containing a base-10 integer,
 // try to convert to an C integer.


### PR DESCRIPTION
**Description of the Pull Request (PR):**

fd_cleanup closes socket early in code and can break identity services like SSSD.
This fix call fd_cleanup later after all functions finished to request user identity.

fd_cleanup take a callback function as argument to call a custom function which return 1 if file descriptor must be closed and 0 if not. With callback function src/start.c can call fd_cleanup and avoid long loop like reported by user here since actual code use sysconf to get max number of file descriptor : https://github.com/singularityware/singularity/issues/1447#issuecomment-380832392


**This fixes or addresses the following GitHub issues:**

- Ref: #1489 #1447 

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
