### PR TITLE
allow --home to still work with "mount home = no"

### DIFF
--- a/src/lib/runtime/mounts/home/home.c
+++ b/src/lib/runtime/mounts/home/home.c
@@ -50,11 +50,6 @@ int _singularity_runtime_mount_home(void) {
     char *container_dir = CONTAINER_FINALDIR;
 
 
-    if ( singularity_config_get_bool(MOUNT_HOME) <= 0 ) {
-        singularity_message(VERBOSE, "Skipping home dir mounting (per config)\n");
-        return(0);
-    }
-
     singularity_message(DEBUG, "Checking that home directry is configured: %s\n", home_dest);
     if ( home_dest == NULL ) {
         singularity_message(ERROR, "Could not obtain user's home directory\n");
@@ -68,7 +63,11 @@ int _singularity_runtime_mount_home(void) {
             singularity_message(ERROR, "Not mounting user requested home: User bind control is disallowed\n");
             ABORT(255);
         }
+    } else if ( singularity_config_get_bool(MOUNT_HOME) <= 0 ) {
+        singularity_message(VERBOSE, "Skipping home dir mounting (per config)\n");
+        return(0);
     }
+
 
     singularity_message(DEBUG, "Checking ownership of home directory source: %s\n", home_source);
     if ( is_owner(home_source, singularity_priv_getuid()) != 0 ) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This allows the --home command line option to still work even when "mount home = no" is set in singularity.conf.  The comments in singularity.conf don't say anything about this option disabling setting the home directory on the command line, so although this changes functionality, it fixes a bug in the currently documented behavior.

This affects all versions of singularity that I know about, but it was particularly noticed with 2.4.6 because before that some of my users had specified both --bind and --home for the same mapping.  With 2.4.6 the duplication was rejected, so the users removed the --bind, and then ran into one site that had set mount home = no, where the --home was silently ignored.

**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
