### PR TITLE
Fix debootstrap issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - python-pip
       - squashfs-tools
       - libarchive-dev
+      - debootstrap
 
 env:
   global:

--- a/src/lib/image/dir/mount.c
+++ b/src/lib/image/dir/mount.c
@@ -43,11 +43,15 @@
 
 
 int _singularity_image_dir_mount(struct image_object *image, char *mount_point) {
-    int mntflags = MS_BIND | MS_NOSUID | MS_REC | MS_NODEV;
+    int mntflags = MS_BIND | MS_NOSUID | MS_REC;
 
     if ( strcmp(image->path, "/") == 0 ) {
         singularity_message(ERROR, "Naughty naughty naughty...\n");
         ABORT(255);
+    }
+
+    if ( singularity_priv_getuid() != 0 ) {
+        mntflags |= MS_NODEV;
     }
 
     singularity_message(DEBUG, "Mounting container directory %s->%s\n", image->path, mount_point);

--- a/tests/20-build.sh
+++ b/tests/20-build.sh
@@ -42,6 +42,20 @@ stest 0 singularity exec \"$CONTAINER\" test -L /singularity"
 stest 0 sudo singularity build "$CONTAINER" "../examples/busybox/Singularity"
 container_check
 
+# from debootstrap example to squashfs
+if which debootstrap > /dev/null 2>&1; then
+    sudo rm "$CONTAINER"
+    stest 0 sudo singularity build "$CONTAINER" "../examples/debian/Singularity"
+    container_check
+fi
+
+# from yum to squashfs
+if which yum > /dev/null 2>&1; then
+    sudo rm "$CONTAINER"
+    stest 0 sudo singularity build "$CONTAINER" "../examples/centos/Singularity"
+    container_check
+fi
+
 # from definition file to sandbox
 sudo rm "$CONTAINER"
 stest 0 sudo singularity build --sandbox "$CONTAINER" "../examples/busybox/Singularity"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

A change introduce in 2.5.0 release has changed mount behaviour for directory image impacting build from definition file using debootstrap. Since build from definition files are done by root user, the mount flag MS_NODEV is not enforced for root to fix debootstrap error.

**This fixes or addresses the following GitHub issues:**

- fixes #1498 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
