### PR TITLE
Define PR_(S|G)ET_NO_NEW_PRIVS ourself

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#define _GNU_SOURCE
 AC_MSG_CHECKING([for feature: NO_NEW_PRIVS])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
                                      #include <sys/prctl.h>
+                                     #ifndef PR_SET_NO_NEW_PRIVS
+                                     # define PR_SET_NO_NEW_PRIVS 38
+                                     # define PR_GET_NO_NEW_PRIVS 39
+                                     #endif
                                    ]],
                                    [[prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
                                      prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0);]])],

--- a/src/util/privilege.c
+++ b/src/util/privilege.c
@@ -29,6 +29,19 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/prctl.h>
+
+/*
+ * Some distributions have a kernel that supports PR_SET_NO_NEW_PRIVS but
+ * the userspace does not have the defines in prctl.h
+ *
+ * #define them ourself. This still fails on kernels where NO_NEW_PRIVS is
+ * not supported
+ */
+#ifndef PR_SET_NO_NEW_PRIVS
+# define PR_SET_NO_NEW_PRIVS 38
+# define PR_GET_NO_NEW_PRIVS 39
+#endif
+
 #include <pwd.h>
 #include <errno.h> 
 #include <string.h>


### PR DESCRIPTION
Some distribution kernels support the NO_NEW_PRIVS flag, but do
not have the flag defined in userspace. Define them to use them on
these distributions.

**Description of the Pull Request (PR):**

On distributions that have kernels which have PR_(S|G)ET_NO_NEW_PRIVS supported, but *not* defined in userspace (`linux/prctl.h`), define these flags. This will still fail on kernels that do not support the flags.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
