### PR TITLE
Add tagging and other support for singularity pull

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,6 +120,15 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/globalsign/mgo"
+  packages = [
+    "bson",
+    "internal/json"
+  ]
+  revision = "efe0945164a7e582241f37ae8983c075f8f2e870"
+
+[[projects]]
+  branch = "master"
   name = "github.com/golang/glog"
   packages = ["."]
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
@@ -351,6 +360,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8e2c4da71c4abfc0303f3072d27bce241b7aa2f856b2753f0b46660e8c7da8ce"
+  inputs-digest = "7df4c18f4790707ad1bc6d19cbe1c3377e38959d49082429b5833b517641d72a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/cmd/singularity/cli/pull.go
+++ b/src/cmd/singularity/cli/pull.go
@@ -23,9 +23,13 @@ func init() {
 }
 
 var pullCmd = &cobra.Command{
-	Use:  "pull myimage.sif library://user/collection/container:tag",
-	Args: cobra.ExactArgs(2),
+	Use:  "pull [myimage.sif] library://user/collection/container[:tag]",
+	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
-		libexec.PullImage(args[0], args[1], PullLibraryURI)
+		if len(args) == 2 {
+			libexec.PullImage(args[0], args[1], PullLibraryURI)
+			return
+		}
+		libexec.PullImage("", args[0], PullLibraryURI)
 	},
 }

--- a/src/cmd/singularity/cli/pull.go
+++ b/src/cmd/singularity/cli/pull.go
@@ -18,18 +18,19 @@ var (
 
 func init() {
 	pullCmd.Flags().StringVar(&PullLibraryURI, "libraryuri", "http://localhost:5150", "")
+	pullCmd.Flags().BoolVarP(&Force, "force", "F", false, "overwrite an image file if it exists")
 	singularityCmd.AddCommand(pullCmd)
 
 }
 
 var pullCmd = &cobra.Command{
-	Use:  "pull [myimage.sif] library://user/collection/container[:tag]",
+	Use:  "pull [options] [myimage.sif] library://user/collection/container[:tag]",
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 2 {
-			libexec.PullImage(args[0], args[1], PullLibraryURI)
+			libexec.PullImage(args[0], args[1], PullLibraryURI, Force)
 			return
 		}
-		libexec.PullImage("", args[0], PullLibraryURI)
+		libexec.PullImage("", args[0], PullLibraryURI, Force)
 	},
 }

--- a/src/cmd/singularity/cli/pull.go
+++ b/src/cmd/singularity/cli/pull.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	// PullLibraryURI holds the base URI to a Sylabs library API instance
 	PullLibraryURI string
 )
 

--- a/src/cmd/singularity/cli/push.go
+++ b/src/cmd/singularity/cli/push.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var pushCmd = &cobra.Command{
-	Use:  "push myimage.sif library://user/collection/container:tag",
+	Use:  "push myimage.sif library://user/collection/container[:tag[,tag]...]",
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		libexec.PushImage(args[0], args[1], PushLibraryURI)

--- a/src/cmd/singularity/cli/push.go
+++ b/src/cmd/singularity/cli/push.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	// PushLibraryURI holds the base URI to a Sylabs library API instance
 	PushLibraryURI string
 )
 

--- a/src/pkg/libexec/pull.go
+++ b/src/pkg/libexec/pull.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 
 	"github.com/singularityware/singularity/src/pkg/library/client"
-	"log"
+	"github.com/singularityware/singularity/src/pkg/sylog"
 )
 
 // PullImage is the function that is responsible for pulling an image from a Sylabs library. This will
@@ -20,6 +20,6 @@ func PullImage(image string, library string, libraryURL string) {
 	fmt.Printf("Pulling image: \"%s\" from library: \"%s\"\n", image, library)
 	err := client.DownloadImage(image, library, libraryURL)
 	if err != nil {
-		log.Fatalf("[ERROR] %s", err.Error())
+		sylog.Fatalf("%v\n", err)
 	}
 }

--- a/src/pkg/libexec/pull.go
+++ b/src/pkg/libexec/pull.go
@@ -8,8 +8,6 @@
 package libexec
 
 import (
-	"fmt"
-
 	"github.com/singularityware/singularity/src/pkg/library/client"
 	"github.com/singularityware/singularity/src/pkg/sylog"
 )
@@ -17,7 +15,6 @@ import (
 // PullImage is the function that is responsible for pulling an image from a Sylabs library. This will
 // eventually be integrated with the build system as a builder, but for now this is the palce to put it
 func PullImage(image string, library string, libraryURL string) {
-	fmt.Printf("Pulling image: \"%s\" from library: \"%s\"\n", image, library)
 	err := client.DownloadImage(image, library, libraryURL)
 	if err != nil {
 		sylog.Fatalf("%v\n", err)

--- a/src/pkg/libexec/pull.go
+++ b/src/pkg/libexec/pull.go
@@ -14,8 +14,8 @@ import (
 
 // PullImage is the function that is responsible for pulling an image from a Sylabs library. This will
 // eventually be integrated with the build system as a builder, but for now this is the palce to put it
-func PullImage(image string, library string, libraryURL string) {
-	err := client.DownloadImage(image, library, libraryURL)
+func PullImage(image string, library string, libraryURL string, Force bool) {
+	err := client.DownloadImage(image, library, libraryURL, Force)
 	if err != nil {
 		sylog.Fatalf("%v\n", err)
 	}

--- a/src/pkg/libexec/push.go
+++ b/src/pkg/libexec/push.go
@@ -8,14 +8,11 @@
 package libexec
 
 import (
-	"fmt"
-
 	"github.com/singularityware/singularity/src/pkg/library/client"
 	"github.com/singularityware/singularity/src/pkg/sylog"
 )
 
 func PushImage(image string, library string, libraryURL string) {
-	fmt.Printf("Pushing image: \"%s\" to library: \"%s\"\n", image, library)
 	err := client.UploadImage(image, library, libraryURL)
 	if err != nil {
 		sylog.Fatalf("%v\n", err)

--- a/src/pkg/libexec/push.go
+++ b/src/pkg/libexec/push.go
@@ -11,13 +11,13 @@ import (
 	"fmt"
 
 	"github.com/singularityware/singularity/src/pkg/library/client"
-	"log"
+	"github.com/singularityware/singularity/src/pkg/sylog"
 )
 
 func PushImage(image string, library string, libraryURL string) {
 	fmt.Printf("Pushing image: \"%s\" to library: \"%s\"\n", image, library)
 	err := client.UploadImage(image, library, libraryURL)
 	if err != nil {
-		log.Fatalf("[ERROR] %s", err.Error())
+		sylog.Fatalf("%v\n", err)
 	}
 }

--- a/src/pkg/library/client/models.go
+++ b/src/pkg/library/client/models.go
@@ -1,5 +1,9 @@
 /*
   Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
+  This software is licensed under a 3-clause BSD license.  Please
+  consult LICENSE file distributed with the sources of this project regarding
+  your rights to use or distribute this software.
 */
 
 package client
@@ -8,44 +12,35 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/mgo.v2/bson"
+	"github.com/globalsign/mgo/bson"
 )
+
+// LibraryModels lists names of valid models in the database
+var LibraryModels = []string{"Entity", "Collection", "Container", "Image", "Blob"}
 
 // ModelManager - Generic interface for models which must have a bson ObjectID
 type ModelManager interface {
 	GetID() bson.ObjectId
-	setID(id bson.ObjectId) bson.ObjectId
+	SetID(id bson.ObjectId) bson.ObjectId
 	IsDeleted() bool
 	GetCreated() (auditUser string, auditTime time.Time)
 	GetUpdated() (auditUser string, auditTime time.Time)
 	GetDeleted() (auditUser string, auditTime time.Time)
-	setCreated(auditUser string, auditTime ...time.Time)
-	setUpdated(auditUser string, auditTime ...time.Time)
-	setDeleted(auditUser string, auditTime ...time.Time)
+	SetCreated(auditUser string, auditTime ...time.Time)
+	SetUpdated(auditUser string, auditTime ...time.Time)
+	SetDeleted(auditUser string, auditTime ...time.Time)
 }
 
 // BaseModel - has an ID, soft deletion marker, and Audit struct
 type BaseModel struct {
 	ModelManager `bson:",omitempty" json:",omitempty"`
-	ID           bson.ObjectId `bson:"_id" json:"id"`
-	Deleted      bool          `bson:"IsDeleted" json:"IsDeleted"`
-	CreatedBy    string        `bson:"CreatedBy" json:"CreatedBy"`
-	CreatedAt    time.Time     `bson:"CreatedAt" json:"CreatedAt"`
-	UpdatedBy    string        `bson:"UpdatedBy,omitempty" json:"UpdatedBy,omitempty"`
-	UpdatedAt    time.Time     `bson:"UpdatedAt,omitempty" json:"UpdatedAt,omitempty"`
-	DeletedBy    string        `bson:"DeletedBy,omitempty" json:"DeletedBy,omitempty"`
-	DeletedAt    time.Time     `bson:"DeletedAt,omitempty" json:"DeletedAt,omitempty"`
-}
-
-// GetID - Convenience method to get model ID if working with an interface
-func (m BaseModel) GetID() bson.ObjectId {
-	return m.ID
-}
-
-// SetID - Convenience method to set model ID if working with an interface
-func (m *BaseModel) setID(id bson.ObjectId) bson.ObjectId {
-	m.ID = id
-	return m.ID
+	Deleted      bool      `bson:"IsDeleted" json:"IsDeleted"`
+	CreatedBy    string    `bson:"CreatedBy" json:"CreatedBy"`
+	CreatedAt    time.Time `bson:"CreatedAt" json:"CreatedAt"`
+	UpdatedBy    string    `bson:"UpdatedBy,omitempty" json:"UpdatedBy,omitempty"`
+	UpdatedAt    time.Time `bson:"UpdatedAt,omitempty" json:"UpdatedAt,omitempty"`
+	DeletedBy    string    `bson:"DeletedBy,omitempty" json:"DeletedBy,omitempty"`
+	DeletedAt    time.Time `bson:"DeletedAt,omitempty" json:"DeletedAt,omitempty"`
 }
 
 // IsDeleted - Convenience method to check soft deletion state if working with
@@ -72,29 +67,35 @@ func (m BaseModel) GetDeleted() (auditUser string, auditTime time.Time) {
 	return m.DeletedBy, m.DeletedAt
 }
 
-func (m *BaseModel) setCreated(auditUser string, auditTime ...time.Time) {
+// SetCreated - Convenience method to set creation stamps if working with an
+// interface
+func (m *BaseModel) SetCreated(auditUser string, auditTime ...time.Time) {
 	if len(auditTime) > 0 {
 		m.CreatedAt = auditTime[0]
 	} else {
-		m.CreatedAt = time.Now()
+		m.CreatedAt = BsonUTCNow()
 	}
 	m.CreatedBy = auditUser
 }
 
-func (m *BaseModel) setUpdated(auditUser string, auditTime ...time.Time) {
+// SetUpdated - Convenience method to set update stamps if working with an
+// interface
+func (m *BaseModel) SetUpdated(auditUser string, auditTime ...time.Time) {
 	if len(auditTime) > 0 {
 		m.UpdatedAt = auditTime[0]
 	} else {
-		m.UpdatedAt = time.Now()
+		m.UpdatedAt = BsonUTCNow()
 	}
 	m.UpdatedBy = auditUser
 }
 
-func (m *BaseModel) setDeleted(auditUser string, auditTime ...time.Time) {
+// SetDeleted - Convenience method to set deletino stamps if working with an
+// interface
+func (m *BaseModel) SetDeleted(auditUser string, auditTime ...time.Time) {
 	if len(auditTime) > 0 {
 		m.DeletedAt = auditTime[0]
 	} else {
-		m.DeletedAt = time.Now()
+		m.DeletedAt = BsonUTCNow()
 	}
 	m.DeletedBy = auditUser
 	m.Deleted = true
@@ -107,14 +108,26 @@ var _ ModelManager = (*BaseModel)(nil)
 // for a user or group
 type Entity struct {
 	BaseModel
+	ID          bson.ObjectId   `bson:"_id" json:"id"`
 	Name        string          `bson:"name" json:"name"`
 	Description string          `bson:"description" json:"description"`
-	Collections []bson.ObjectId `bson:"collections,omitempty" json:"collections,omitempty"`
+	Collections []bson.ObjectId `bson:"collections" json:"collections"`
+}
+
+// GetID - Convenience method to get model ID if working with an interface
+func (e Entity) GetID() bson.ObjectId {
+	return e.ID
+}
+
+// SetID - Convenience method to set model ID if working with an interface
+func (e *Entity) SetID(id bson.ObjectId) bson.ObjectId {
+	e.ID = id
+	return e.ID
 }
 
 // AddCollection - Associate a collection with an Entity
 func (e *Entity) AddCollection(collectionID bson.ObjectId) ([]bson.ObjectId, error) {
-	if idInSlice(collectionID, e.Collections) {
+	if IDInSlice(collectionID, e.Collections) {
 		return e.Collections, fmt.Errorf("Collection %s is already a member of entity %s", collectionID.Hex(), e.ID.Hex())
 	}
 	e.Collections = append(e.Collections, collectionID)
@@ -123,53 +136,90 @@ func (e *Entity) AddCollection(collectionID bson.ObjectId) ([]bson.ObjectId, err
 
 // RemoveCollection - Dissociate a collection from an Entity
 func (e *Entity) RemoveCollection(collectionID bson.ObjectId) ([]bson.ObjectId, error) {
-	if !idInSlice(collectionID, e.Collections) {
+	if !IDInSlice(collectionID, e.Collections) {
 		return e.Collections, fmt.Errorf("Collection %s is not a member of entity %s", collectionID.Hex(), e.ID.Hex())
 	}
-	e.Collections = sliceWithoutID(e.Collections, collectionID)
+	e.Collections = SliceWithoutID(e.Collections, collectionID)
 	return e.Collections, nil
 }
 
 // Collection - Second level in the library, holds a collection of containers
 type Collection struct {
 	BaseModel
+	ID          bson.ObjectId   `bson:"_id" json:"id"`
 	Name        string          `bson:"name" json:"name"`
 	Description string          `bson:"description" json:"description"`
 	Entity      bson.ObjectId   `bson:"entity" json:"entity"`
-	Containers  []bson.ObjectId `bson:"containers,omitempty" json:"containers,omitempty"`
+	Containers  []bson.ObjectId `bson:"containers" json:"containers"`
+}
+
+// GetID - Convenience method to get model ID if working with an interface
+func (c Collection) GetID() bson.ObjectId {
+	return c.ID
+}
+
+// SetID - Convenience method to set model ID if working with an interface
+func (c *Collection) SetID(id bson.ObjectId) bson.ObjectId {
+	c.ID = id
+	return c.ID
 }
 
 // AddContainer - Associate a container with a collection
 func (c *Collection) AddContainer(containerID bson.ObjectId) ([]bson.ObjectId, error) {
-	if idInSlice(containerID, c.Containers) {
-		return c.Containers, fmt.Errorf("Collection %s is already a member of entity %s", containerID.Hex(), c.ID.Hex())
+	if IDInSlice(containerID, c.Containers) {
+		return c.Containers, fmt.Errorf("Container %s is already a member of entity %s", containerID.Hex(), c.ID.Hex())
 	}
 	c.Containers = append(c.Containers, containerID)
 	return c.Containers, nil
 }
 
 // RemoveContainer - Dissociate a container from an Collection
-func (c *Collection) RemoveCollection(containerID bson.ObjectId) ([]bson.ObjectId, error) {
-	if idInSlice(containerID, c.Containers) {
-		return c.Containers, fmt.Errorf("Collection %s is already a member of entity %s", containerID.Hex(), c.ID.Hex())
+func (c *Collection) RemoveContainer(containerID bson.ObjectId) ([]bson.ObjectId, error) {
+	if !IDInSlice(containerID, c.Containers) {
+		return c.Containers, fmt.Errorf("Collection %s is not a member of entity %s", containerID.Hex(), c.ID.Hex())
 	}
-	c.Containers = sliceWithoutID(c.Containers, containerID)
+	c.Containers = SliceWithoutID(c.Containers, containerID)
 	return c.Containers, nil
+}
+
+// GetEntity returns the parent entity for this collection
+func (c *Collection) GetEntity() (entity *Entity, err error) {
+	mm, err := Get("Entity", c.Entity.Hex())
+	if err != nil {
+		return nil, err
+	}
+	if mm == nil {
+		return nil, fmt.Errorf("No such entity: %s", c.Entity.Hex())
+	}
+	return mm.(*Entity), err
 }
 
 // Container - Third level of library. Inside a collection, holds images for
 // a particular container
 type Container struct {
 	BaseModel
-	Name        string          `bson:"name" json:"name"`
-	Description string          `bson:"description" json:"description"`
-	Collection  bson.ObjectId   `bson:"collection" json:"collection"`
-	Images      []bson.ObjectId `son:"images,omitempty" json:"images,omitempty"`
+	ID          bson.ObjectId            `bson:"_id" json:"id"`
+	Name        string                   `bson:"name" json:"name"`
+	Description string                   `bson:"description" json:"description"`
+	Collection  bson.ObjectId            `bson:"collection" json:"collection"`
+	Images      []bson.ObjectId          `bson:"images" json:"images"`
+	ImageTags   map[string]bson.ObjectId `bson:"imageTags" json:"imageTags"`
+}
+
+// GetID - Convenience method to get model ID if working with an interface
+func (c Container) GetID() bson.ObjectId {
+	return c.ID
+}
+
+// SetID - Convenience method to set model ID if working with an interface
+func (c *Container) SetID(id bson.ObjectId) bson.ObjectId {
+	c.ID = id
+	return c.ID
 }
 
 // AddImage - Associate an image with a container
 func (c *Container) AddImage(imageID bson.ObjectId) ([]bson.ObjectId, error) {
-	if idInSlice(imageID, c.Images) {
+	if IDInSlice(imageID, c.Images) {
 		return c.Images, fmt.Errorf("Image %s is already a member of container %s", imageID.Hex(), c.ID.Hex())
 	}
 	c.Images = append(c.Images, imageID)
@@ -178,61 +228,144 @@ func (c *Container) AddImage(imageID bson.ObjectId) ([]bson.ObjectId, error) {
 
 // RemoveImage - Dissociate an image from a container
 func (c *Container) RemoveImage(imageID bson.ObjectId) ([]bson.ObjectId, error) {
-	if idInSlice(imageID, c.Images) {
-		return c.Images, fmt.Errorf("Image %s is already a member of container %s", imageID.Hex(), c.ID.Hex())
+	if !IDInSlice(imageID, c.Images) {
+		return c.Images, fmt.Errorf("Image %s is not a member of container %s", imageID.Hex(), c.ID.Hex())
 	}
-	c.Images = sliceWithoutID(c.Images, imageID)
+	c.Images = SliceWithoutID(c.Images, imageID)
 	return c.Images, nil
+}
+
+// GetCollection returns the parent collection for this container
+func (c *Container) GetCollection() (collection *Collection, err error) {
+	mm, err := Get("Collection", c.Collection.Hex())
+	if err != nil {
+		return nil, err
+	}
+	if mm == nil {
+		return nil, fmt.Errorf("No such collection: %s", c.Collection.Hex())
+	}
+	return mm.(*Collection), err
+}
+
+// GetImageTag gets the image ID associated with a provided tag
+func (c *Container) GetImageTag(tag string) (imgID bson.ObjectId, err error) {
+	if !IsTag(tag) {
+		return "", fmt.Errorf("Not a valid tag: %s", tag)
+	}
+	if c.ImageTags == nil {
+		return "", fmt.Errorf("No tags exist on container %s", c.ID.Hex())
+	}
+	imgID, ok := c.ImageTags[tag]
+	if !ok {
+		return "", fmt.Errorf("Tag %s does not exist on container %s", tag, c.ID.Hex())
+	}
+	return imgID, nil
+}
+
+// SetImageTag adds or sets a tag to point to a particular image
+func (c *Container) SetImageTag(tag string, imgID bson.ObjectId) error {
+	if !IsTag(tag) {
+		return fmt.Errorf("Not a valid tag: %s", tag)
+	}
+	if !IDInSlice(imgID, c.Images) {
+		return fmt.Errorf("Image %s is not associated with container %s", imgID.Hex(), c.ID.Hex())
+	}
+	if c.ImageTags == nil {
+		c.ImageTags = map[string]bson.ObjectId{}
+	}
+	c.ImageTags[tag] = imgID
+	return nil
+}
+
+// DeleteImageTag removes an image tag
+func (c *Container) DeleteImageTag(tag string) error {
+	if !IsTag(tag) {
+		return fmt.Errorf("Not a valid tag: %s", tag)
+	}
+	_, ok := c.ImageTags[tag]
+	if c.ImageTags == nil {
+		return fmt.Errorf("No tags exist on container %s", c.ID.Hex())
+	}
+	if !ok {
+		return fmt.Errorf("Tag %s does not exist on container %s", tag, c.ID.Hex())
+	}
+	delete(c.ImageTags, tag)
+	return nil
 }
 
 // Image - Represents a Singularity image held by the library for a particular
 // Container
 type Image struct {
 	BaseModel
-	Name        string        `bson:"name" json:"name"`
+	ID          bson.ObjectId `bson:"_id" json:"id"`
+	Hash        string        `bson:"hash" json:"hash"`
 	Description string        `bson:"description" json:"description"`
 	Container   bson.ObjectId `bson:"container" json:"container"`
-	Blob        bson.ObjectId `bson:"blob" json:"blob"`
-	Tags        []string      `bson:"tags" json:"tags"`
+	Blob        bson.ObjectId `bson:"blob,omitempty" json:"blob,omitempty"`
+	Size        int64         `bson:"size" json:"size"`
 }
 
-// Blob - Binary data object (e.g. container image file) stored in a backend
+// GetID - Convenience method to get model ID if working with an interface
+func (img Image) GetID() bson.ObjectId {
+	return img.ID
+}
+
+// SetID - Convenience method to set model ID if working with an interface
+func (img *Image) SetID(id bson.ObjectId) bson.ObjectId {
+	img.ID = id
+	return img.ID
+}
+
+// GetContainer returns the parent container for this image
+func (img *Image) GetContainer() (container *Container, err error) {
+	mm, err := Get("Container", img.Container.Hex())
+	if err != nil {
+		return nil, err
+	}
+	if mm == nil {
+		return nil, fmt.Errorf("No such container: %s", img.Container.Hex())
+	}
+	return mm.(*Container), err
+}
+
+// GetBlob returns the child Blob for this image
+func (img *Image) GetBlob() (blob *Blob, err error) {
+	mm, err := Get("Blob", img.Blob.Hex())
+	if err != nil {
+		return nil, err
+	}
+	if mm == nil {
+		return nil, fmt.Errorf("No such blob: %s", img.Blob.Hex())
+	}
+	return mm.(*Blob), err
+}
+
+// Blob - Binary data object (e.g. container image file) stored in a Backend
 // Uses object store bucket/key semantics
 type Blob struct {
 	BaseModel
-	Bucket      string `bson:"bucket" json:"bucket"`
-	Key         string `bson:"key" json:"key"`
-	Size        int64  `bson:"size" json:"size"`
-	ContentHash string `bson:"contentHash" json:"contentHash"`
-	Status      string `bson:"status" json:"status"`
+	ID          bson.ObjectId `bson:"_id" json:"id"`
+	Bucket      string        `bson:"bucket" json:"bucket"`
+	Key         string        `bson:"key" json:"key"`
+	Size        int64         `bson:"size" json:"size"`
+	ContentHash string        `bson:"contentHash" json:"contentHash"`
+	Status      string        `bson:"status" json:"status"`
 }
 
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+// GetID - Convenience method to get model ID if working with an interface
+func (b Blob) GetID() bson.ObjectId {
+	return b.ID
 }
 
-func idInSlice(a bson.ObjectId, list []bson.ObjectId) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+// SetID - Convenience method to set model ID if working with an interface
+func (b *Blob) SetID(id bson.ObjectId) bson.ObjectId {
+	b.ID = id
+	return b.ID
 }
 
-func sliceWithoutID(list []bson.ObjectId, a bson.ObjectId) []bson.ObjectId {
-
-	var newList []bson.ObjectId
-
-	for _, b := range list {
-		if b != a {
-			newList = append(newList, b)
-		}
-	}
-	return newList
+// ImageTag - A simple mapping from a string to bson ID. Not stored in the DB
+// but used by API calls setting tags
+type ImageTag struct {
+	Tag     string
+	ImageID bson.ObjectId
 }

--- a/src/pkg/library/client/models.go
+++ b/src/pkg/library/client/models.go
@@ -182,18 +182,6 @@ func (c *Collection) RemoveContainer(containerID bson.ObjectId) ([]bson.ObjectId
 	return c.Containers, nil
 }
 
-// GetEntity returns the parent entity for this collection
-func (c *Collection) GetEntity() (entity *Entity, err error) {
-	mm, err := Get("Entity", c.Entity.Hex())
-	if err != nil {
-		return nil, err
-	}
-	if mm == nil {
-		return nil, fmt.Errorf("No such entity: %s", c.Entity.Hex())
-	}
-	return mm.(*Entity), err
-}
-
 // Container - Third level of library. Inside a collection, holds images for
 // a particular container
 type Container struct {
@@ -233,18 +221,6 @@ func (c *Container) RemoveImage(imageID bson.ObjectId) ([]bson.ObjectId, error) 
 	}
 	c.Images = SliceWithoutID(c.Images, imageID)
 	return c.Images, nil
-}
-
-// GetCollection returns the parent collection for this container
-func (c *Container) GetCollection() (collection *Collection, err error) {
-	mm, err := Get("Collection", c.Collection.Hex())
-	if err != nil {
-		return nil, err
-	}
-	if mm == nil {
-		return nil, fmt.Errorf("No such collection: %s", c.Collection.Hex())
-	}
-	return mm.(*Collection), err
 }
 
 // GetImageTag gets the image ID associated with a provided tag
@@ -314,30 +290,6 @@ func (img Image) GetID() bson.ObjectId {
 func (img *Image) SetID(id bson.ObjectId) bson.ObjectId {
 	img.ID = id
 	return img.ID
-}
-
-// GetContainer returns the parent container for this image
-func (img *Image) GetContainer() (container *Container, err error) {
-	mm, err := Get("Container", img.Container.Hex())
-	if err != nil {
-		return nil, err
-	}
-	if mm == nil {
-		return nil, fmt.Errorf("No such container: %s", img.Container.Hex())
-	}
-	return mm.(*Container), err
-}
-
-// GetBlob returns the child Blob for this image
-func (img *Image) GetBlob() (blob *Blob, err error) {
-	mm, err := Get("Blob", img.Blob.Hex())
-	if err != nil {
-		return nil, err
-	}
-	if mm == nil {
-		return nil, fmt.Errorf("No such blob: %s", img.Blob.Hex())
-	}
-	return mm.(*Blob), err
 }
 
 // Blob - Binary data object (e.g. container image file) stored in a Backend

--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -19,6 +19,8 @@ import (
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
+// DownloadImage will retrieve an image from the Container Library,
+// saving it into the specified file
 func DownloadImage(filePath string, libraryRef string, libraryURL string, Force bool) error {
 
 	if !isLibraryPullRef(libraryRef) {

--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -15,26 +15,27 @@ import (
 	"os"
 	"strings"
 
-	"log"
-
+	"github.com/singularityware/singularity/src/pkg/sylog"
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
 func DownloadImage(filePath string, libraryRef string, libraryURL string) error {
 
 	if !isLibraryPullRef(libraryRef) {
-		log.Fatalf("Not a valid library reference: %s", libraryRef)
+		return fmt.Errorf("Not a valid library reference: %s", libraryRef)
 	}
 
 	url := libraryURL + "/v1/imagefile/" + strings.TrimPrefix(libraryRef, "library://")
 
-	fmt.Println(url)
+	sylog.Debugf("Pulling from URL: %s\n", url)
 
 	out, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
+
+	sylog.Debugf("Created output file: %s\n", filePath)
 
 	res, err := http.Get(url)
 	if err != nil {
@@ -55,6 +56,8 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string) error 
 			jRes.Error.Code, jRes.Error.Status, jRes.Error.Message)
 	}
 
+	sylog.Debugf("OK response received, beginning body download\n", filePath)
+
 	bodySize := res.ContentLength
 	bar := pb.New(int(bodySize)).SetUnits(pb.U_BYTES)
 	bar.ShowTimeLeft = true
@@ -72,7 +75,7 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string) error 
 
 	bar.Finish()
 
-	log.Printf("Download Complete!")
+	sylog.Debugf("Download complete\n")
 
 	return nil
 

--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -25,6 +25,12 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string) error 
 		return fmt.Errorf("Not a valid library reference: %s", libraryRef)
 	}
 
+	if filePath == "" {
+		_, _, container, tags := parseLibraryRef(libraryRef)
+		filePath = fmt.Sprintf("%s_%s.sif", container, tags[0])
+		sylog.Infof("Download filename not provided. Downloading to: %s\n", filePath)
+	}
+
 	url := libraryURL + "/v1/imagefile/" + strings.TrimPrefix(libraryRef, "library://")
 
 	sylog.Debugf("Pulling from URL: %s\n", url)

--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -1,3 +1,11 @@
+/*
+  Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
+  This software is licensed under a 3-clause BSD license.  Please
+  consult LICENSE file distributed with the sources of this project regarding
+  your rights to use or distribute this software.
+*/
+
 package client
 
 import (

--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -22,7 +22,7 @@ import (
 
 func DownloadImage(filePath string, libraryRef string, libraryURL string) error {
 
-	if !isLibraryRef(libraryRef) {
+	if !isLibraryPullRef(libraryRef) {
 		log.Fatalf("Not a valid library reference: %s", libraryRef)
 	}
 

--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -19,7 +19,7 @@ import (
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
-func DownloadImage(filePath string, libraryRef string, libraryURL string) error {
+func DownloadImage(filePath string, libraryRef string, libraryURL string, Force bool) error {
 
 	if !isLibraryPullRef(libraryRef) {
 		return fmt.Errorf("Not a valid library reference: %s", libraryRef)
@@ -35,7 +35,14 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string) error 
 
 	sylog.Debugf("Pulling from URL: %s\n", url)
 
-	out, err := os.Create(filePath)
+	if !Force {
+		if _, err := os.Stat(filePath); err == nil {
+			return fmt.Errorf("image file already exists - will not overwrite")
+		}
+	}
+
+	// Perms are 777 *prior* to umask
+	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 777)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/library/client/push.go
+++ b/src/pkg/library/client/push.go
@@ -18,8 +18,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/globalsign/mgo/bson"
 	"gopkg.in/cheggaaa/pb.v1"
-	"gopkg.in/mgo.v2/bson"
 )
 
 var baseURL string

--- a/src/pkg/library/client/push.go
+++ b/src/pkg/library/client/push.go
@@ -1,3 +1,11 @@
+/*
+  Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
+  This software is licensed under a 3-clause BSD license.  Please
+  consult LICENSE file distributed with the sources of this project regarding
+  your rights to use or distribute this software.
+*/
+
 package client
 
 import (

--- a/src/pkg/library/client/push.go
+++ b/src/pkg/library/client/push.go
@@ -25,6 +25,7 @@ import (
 
 var baseURL string
 
+// UploadImage will push a specified image up to the Container Library,
 func UploadImage(filePath string, libraryRef string, libraryURL string) error {
 
 	baseURL = libraryURL
@@ -289,8 +290,7 @@ func postFile(filePath string, imageID string) error {
 	w := multipart.NewWriter(&b)
 	f, err := os.Open(filePath)
 	if err != nil {
-		fmt.Errorf("Could not open the image file to upload: %v", err)
-		return err
+		return fmt.Errorf("Could not open the image file to upload: %v", err)
 	}
 	fi, _ := f.Stat()
 	fileSize := fi.Size()
@@ -299,12 +299,10 @@ func postFile(filePath string, imageID string) error {
 
 	fw, err := w.CreateFormFile("imagefile", filePath)
 	if err != nil {
-		fmt.Errorf("Could not prepare the image file upload: %v", err)
-		return err
+		return fmt.Errorf("Could not prepare the image file upload: %v", err)
 	}
 	if _, err = io.Copy(fw, f); err != nil {
-		fmt.Errorf("Could not prepare the image file upload: %v", err)
-		return err
+		return fmt.Errorf("Could not prepare the image file upload: %v", err)
 	}
 
 	w.Close()

--- a/src/pkg/library/client/util.go
+++ b/src/pkg/library/client/util.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -151,4 +154,29 @@ func PrettyPrint(v interface{}) {
 // BsonUTCNow returns a time.Time in UTC, with the precision supported by BSON
 func BsonUTCNow() time.Time {
 	return bson.Now().UTC()
+}
+
+// ImageHash returns the appropriate hash for a provided image file
+//   e.g. sif.<uuid> or sha256.<sha256>
+func ImageHash(filePath string) (result string, err error) {
+	// Currently using sha256 always
+	// TODO - use sif uuid for sif files!
+	return sha256sum(filePath)
+}
+
+// SHA256Sum computes the sha256sum of a file
+func sha256sum(filePath string) (result string, err error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
+
+	return "sha256." + hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/src/pkg/library/client/util.go
+++ b/src/pkg/library/client/util.go
@@ -32,7 +32,7 @@ type JSONResponse struct {
 }
 
 func isLibraryRef(libraryRef string) bool {
-	match, _ := regexp.MatchString("^(library://)?([a-z0-9]+(?:[._-][a-z0-9]+)*/){2}([a-z0-9]+(?:[._-][a-z0-9]+)*)(:[a-z0-9]+(?:[._-][a-z0-9]+)*)?$", libraryRef)
+	match, _ := regexp.MatchString("^(library://)?([a-z0-9]+(?:[._-][a-z0-9]+)*/){2}([a-z0-9]+(?:[._-][a-z0-9]+)*)(:[a-z0-9]+(?:[,._-][a-z0-9]+)*)?$", libraryRef)
 	return match
 }
 
@@ -71,7 +71,7 @@ func IsTag(tag string) bool {
 	return match
 }
 
-func parseLibraryRef(libraryRef string) (entity string, collection string, container string, image string) {
+func parseLibraryRef(libraryRef string) (entity string, collection string, container string, tags []string) {
 
 	libraryRef = strings.TrimPrefix(libraryRef, "library://")
 
@@ -80,12 +80,17 @@ func parseLibraryRef(libraryRef string) (entity string, collection string, conta
 	entity = refParts[0]
 	collection = refParts[1]
 	container = refParts[2]
-	image = "latest"
+
+	// Default tag is latest
+	tags = []string{"latest"}
 
 	if strings.Contains(container, ":") {
 		imageParts := strings.Split(container, ":")
 		container = imageParts[0]
-		image = imageParts[1]
+		tags = []string{imageParts[1]}
+		if strings.Contains(tags[0], ",") {
+			tags = strings.Split(tags[0], ",")
+		}
 	}
 
 	return

--- a/src/pkg/library/client/util.go
+++ b/src/pkg/library/client/util.go
@@ -5,10 +5,14 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"time"
 
 	"bytes"
 	"fmt"
 	"net/http"
+
+	"github.com/golang/glog"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // JSONError - Struct for standard error returns over REST API
@@ -26,6 +30,41 @@ type JSONResponse struct {
 
 func isLibraryRef(libraryRef string) bool {
 	match, _ := regexp.MatchString("^(library://)?([a-z0-9]+(?:[._-][a-z0-9]+)*/){2}([a-z0-9]+(?:[._-][a-z0-9]+)*)(:[a-z0-9]+(?:[._-][a-z0-9]+)*)?$", libraryRef)
+	return match
+}
+
+// IsRefPart returns true if the provided string is valid as a component of a
+// library URI (i.e. a valid entity, collection etc. name)
+func IsRefPart(refPart string) bool {
+	match, err := regexp.MatchString("^[a-z0-9]+(?:[._-][a-z0-9]+)*$", refPart)
+	if err != nil {
+		glog.Errorf("Error in regex matching: %v", err)
+		return false
+	}
+	return match
+}
+
+// IsImageHash returns true if the provided string is valid as a unique hash
+// for an image
+func IsImageHash(refPart string) bool {
+	// Legacy images will be sent with hash sha256.[a-f0-9]{64}
+	// SIF images will be sent with hash sif.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+	//  which is the unique SIF UUID
+	match, err := regexp.MatchString("^(sha256\\.[a-f0-9]{64})|(sif\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", refPart)
+	if err != nil {
+		glog.Errorf("Error in regex matching: %v", err)
+		return false
+	}
+	return match
+}
+
+// IsTag returns true if the provided string is valid as a tag
+func IsTag(tag string) bool {
+	match, err := regexp.MatchString("^[a-z0-9]+(?:[._-][a-z0-9]+)*$", tag)
+	if err != nil {
+		glog.Errorf("Error in regex matching: %v", err)
+		return false
+	}
 	return match
 }
 
@@ -68,4 +107,48 @@ func ParseErrorResponse(res *http.Response) (jRes JSONResponse) {
 	jRes.Error.Status = http.StatusText(res.StatusCode)
 	jRes.Error.Message = s
 	return jRes
+}
+
+// IDInSlice returns true if ID is present in the slice
+func IDInSlice(a bson.ObjectId, list []bson.ObjectId) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// SliceWithoutID returns slice with specified ID removed
+func SliceWithoutID(list []bson.ObjectId, a bson.ObjectId) []bson.ObjectId {
+
+	var newList []bson.ObjectId
+
+	for _, b := range list {
+		if b != a {
+			newList = append(newList, b)
+		}
+	}
+	return newList
+}
+
+// StringInSlice returns true if string is present in the slice
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// PrettyPrint - Debug helper, print nice json for any interface
+func PrettyPrint(v interface{}) {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	println(string(b))
+}
+
+// BsonUTCNow returns a time.Time in UTC, with the precision supported by BSON
+func BsonUTCNow() time.Time {
+	return bson.Now().UTC()
 }

--- a/src/pkg/library/client/util.go
+++ b/src/pkg/library/client/util.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/globalsign/mgo/bson"
 	"github.com/golang/glog"
-	"gopkg.in/mgo.v2/bson"
 )
 
 // JSONError - Struct for standard error returns over REST API

--- a/src/pkg/library/client/util.go
+++ b/src/pkg/library/client/util.go
@@ -31,7 +31,13 @@ type JSONResponse struct {
 	Error JSONError   `json:"error,omitempty"`
 }
 
-func isLibraryRef(libraryRef string) bool {
+func isLibraryPullRef(libraryRef string) bool {
+	match, _ := regexp.MatchString("^(library://)?([a-z0-9]+(?:[._-][a-z0-9]+)*/){2}([a-z0-9]+(?:[._-][a-z0-9]+)*)(:[a-z0-9]+(?:[._-][a-z0-9]+)*)?$", libraryRef)
+	return match
+}
+
+func isLibraryPushRef(libraryRef string) bool {
+	// For push we allow specifying multiple tags, delimited with ,
 	match, _ := regexp.MatchString("^(library://)?([a-z0-9]+(?:[._-][a-z0-9]+)*/){2}([a-z0-9]+(?:[._-][a-z0-9]+)*)(:[a-z0-9]+(?:[,._-][a-z0-9]+)*)?$", libraryRef)
 	return match
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds CLI support for tagging in the Container library.

You can push an image with:
- no tag (will default to tagging with 'latest'
    `singularity push myimage.sif library://dave/test/alpine`
- a single tag
   `singularity push myimage.sif library://dave/test/alpine:demo1`
- multiple tags
  `singularity push myimage.sif library://dave/test/alpine:demo1,latest,meoww`

Images can be pulled with a named tag, or their id (currently in `sha256.<sha256>` format, but native `sif.<uuid>` to be added later)

Also:
- now uses sylog for log messages
- pull won't overwrite existing image file unless `--force/-F` specified
- can pull without specifying an image name - it'll use a default `<container>_<tag>.sif` format


