### PR TITLE
Add memory filesystem type choose at configuration file level

### DIFF
--- a/etc/singularity.conf.in
+++ b/etc/singularity.conf.in
@@ -195,3 +195,11 @@ bind path = /etc/hosts
 # errors when accessed from container (typically bind mounts)
 #autofs bug path = /nfs
 #autofs bug path = /cifs-share
+
+
+# MEMORY FS TYPE: [tmpfs/ramfs]
+# DEFAULT: tmpfs
+# This feature allow to choose temporary filesystem type used by Singularity.
+# Cray CLE has issue (kernel panic) when Singularity use tmpfs, so on Cray CLE
+# it's recommended to set this value to ramfs to avoid kernel panic
+@MEMORY_FS_TYPE@ = @MEMORY_FS_TYPE_DEFAULT@

--- a/etc/singularity.conf.in
+++ b/etc/singularity.conf.in
@@ -200,6 +200,7 @@ bind path = /etc/hosts
 # MEMORY FS TYPE: [tmpfs/ramfs]
 # DEFAULT: tmpfs
 # This feature allow to choose temporary filesystem type used by Singularity.
-# Cray CLE has issue (kernel panic) when Singularity use tmpfs, so on Cray CLE
-# it's recommended to set this value to ramfs to avoid kernel panic
+# Cray CLE 5 and 6 up to CLE 6.0.UP05 there is an issue (kernel panic) when Singularity
+# use tmpfs, so on affected version it's recommended to set this value to ramfs to avoid
+# kernel panic
 @MEMORY_FS_TYPE@ = @MEMORY_FS_TYPE_DEFAULT@

--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -131,14 +131,14 @@ int _singularity_runtime_mount_dev(void) {
 
         singularity_message(DEBUG, "Mounting tmpfs for staged /dev/shm\n");
         if ( singularity_mount("/dev/shm", joinpath(devdir, "/shm"), memfs_type, MS_NOSUID, "") < 0 ) {
-            singularity_message(ERROR, "Failed to mount %s: %s\n", joinpath(devdir, "/shm"), strerror(errno));
+            singularity_message(ERROR, "Failed to mount %s/shm: %s\n", devdir, strerror(errno));
             ABORT(255);
         }
 
         if ( strcmp("tmpfs", memfs_type) != 0 ) {
             singularity_priv_escalate();
             if ( chmod(joinpath(devdir, "/shm"), S_IRWXU|S_IRWXG|S_IRWXO) < 0 ) { // Flawfinder: ignore not controllable by user
-                singularity_message(ERROR, "Failed to change permission for %s: %s\n", sessiondir, strerror(errno));
+                singularity_message(ERROR, "Failed to change permission for %s/shm: %s\n", devdir, strerror(errno));
                 ABORT(255);
             }
             singularity_priv_drop();

--- a/src/lib/runtime/mounts/hostfs/hostfs.c
+++ b/src/lib/runtime/mounts/hostfs/hostfs.c
@@ -130,7 +130,11 @@ int _singularity_runtime_mount_hostfs(void) {
             continue;
         }
         if ( strncmp(mountpoint, container_dir, strlength(container_dir, PATH_MAX)) == 0 ) {
-            singularity_message(DEBUG, "Skipping container_dir (%s) based file system: %s,%s,%s\n", container_dir, source, mountpoint, filesystem);
+            singularity_message(DEBUG, "Skipping final_dir (%s) based file system: %s,%s,%s\n", container_dir, source, mountpoint, filesystem);
+            continue;
+        }
+        if ( strcmp(mountpoint, CONTAINER_MOUNTDIR) == 0 ) {
+            singularity_message(DEBUG, "Skipping container_dir (%s) based file system: %s,%s,%s\n", CONTAINER_MOUNTDIR, source, mountpoint, filesystem);
             continue;
         }
         if ( strcmp(filesystem, "tmpfs") == 0 ) {
@@ -141,7 +145,10 @@ int _singularity_runtime_mount_hostfs(void) {
             singularity_message(DEBUG, "Skipping cgroup file system: %s,%s,%s\n", source, mountpoint, filesystem);
             continue;
         }
-
+        if ( strcmp(filesystem, "ramfs") == 0 ) {
+            singularity_message(DEBUG, "Skipping ramfs file system: %s,%s,%s\n", source, mountpoint, filesystem);
+            continue;
+        }
         singularity_message(DEBUG, "Checking if host file system is already mounted: %s\n", mountpoint);
         if ( check_mounted(mountpoint) >= 0 ) {
             singularity_message(VERBOSE, "Not mounting host FS (already mounted in container): %s\n", mountpoint);

--- a/src/lib/runtime/mounts/mounts.c
+++ b/src/lib/runtime/mounts/mounts.c
@@ -49,10 +49,10 @@ int _singularity_runtime_mounts(void) {
     int retval = 0;
 
     singularity_message(VERBOSE, "Running all mount components\n");
+    retval += _singularity_runtime_mount_dev();
+    retval += _singularity_runtime_mount_kernelfs();
     retval += _singularity_runtime_mount_hostfs();
     retval += _singularity_runtime_mount_binds();
-    retval += _singularity_runtime_mount_kernelfs();
-    retval += _singularity_runtime_mount_dev();
     retval += _singularity_runtime_mount_home();
     retval += _singularity_runtime_mount_userbinds();
     retval += _singularity_runtime_mount_tmp();

--- a/src/util/config_defaults.h.in
+++ b/src/util/config_defaults.h.in
@@ -107,4 +107,7 @@
 #define ALLOW_CONTAINER_SQUASHFS "allow container squashfs"
 #define ALLOW_CONTAINER_SQUASHFS_DEFAULT 1
 
+#define MEMORY_FS_TYPE "memory fs type"
+#define MEMORY_FS_TYPE_DEFAULT "tmpfs"
+
 #endif  // __SINGULARITY_CONFIG_DEFAULTS_H_


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fix kernel panic on Cray CLE 5 and 6, the issue is caused by Singularity using tmpfs for sessiondir, overlay and dev/shm, when container exits, kernel unmount tmpfs mount points and panic probably due to a bad reference count on tmpfs mount points when dealing with mount namespaces. This PR add a configuration file directive `memory fs type` which can take as value either `tmpfs` or `ramfs`, default is `tmpfs`.
Cray CLE seems to work well with `ramfs`, so those systems should set `memory fs type = ramfs` to work with Singularity and avoid node freezes

Things could be simpler by always using `ramfs` but it has drawbacks, ramfs mount points don't appear in `df` command and `ramfs` has no size limit, this is embarrassing especially when used with temporary overlay upper layer set by Singularity. That's why `ramfs` is optional

**This fixes or addresses the following GitHub issues:**

- Ref: #1417 #1214 #881 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin