### PR TITLE
Fix cgo path when building outside of makeit.

### DIFF
--- a/src/pkg/sif/sifcore.go
+++ b/src/pkg/sif/sifcore.go
@@ -7,7 +7,8 @@
 */
 package sif
 
-// #cgo LDFLAGS: -lruntime -luuid
+// #cgo CFLAGS: -I../../runtime/c/lib
+// #cgo LDFLAGS: -L../../../builddir/lib -lruntime -luuid
 /*
 #include <sys/types.h>
 #include <stdio.h>

--- a/src/runtime/startup/scontainer/scontainer.go
+++ b/src/runtime/startup/scontainer/scontainer.go
@@ -11,7 +11,8 @@ package main
 /*
 #include "startup/cgo_scontainer.c"
 */
-// #cgo LDFLAGS: -lruntime -luuid
+// #cgo CFLAGS: -I../../c -I../../c/lib
+// #cgo LDFLAGS: -L../../../../builddir/lib/ -lruntime -luuid
 import "C"
 
 import (

--- a/src/runtime/workflows/workflows/singularity/create.go
+++ b/src/runtime/workflows/workflows/singularity/create.go
@@ -5,8 +5,8 @@ package runtime
 #include "image/image.h"
 #include "util/config_parser.h"
 */
-// #cgo CFLAGS: -I../c
-// #cgo LDFLAGS: -lruntime -luuid
+// #cgo CFLAGS: -I../../../c/lib
+// #cgo LDFLAGS: -L../../../../../builddir/lib -lruntime -luuid
 import "C"
 
 import (


### PR DESCRIPTION
This will allow tools such as "go vet -all ./..., go fmt ./..., golint ./..." to run an any other tools that are not initiated via the 'makeit' build system.

Caveat but default, the buildtree path needs to be "./builddir" as
generated by makeit defaults for this to work.