### PR TITLE
Fix mount invalid argument and restrictive directory binds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - python-pip
       - squashfs-tools
       - libarchive-dev
+      - debootstrap
 
 env:
   global:

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#define _GNU_SOURCE
 AC_MSG_CHECKING([for feature: NO_NEW_PRIVS])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
                                      #include <sys/prctl.h>
+                                     #ifndef PR_SET_NO_NEW_PRIVS
+                                     # define PR_SET_NO_NEW_PRIVS 38
+                                     # define PR_GET_NO_NEW_PRIVS 39
+                                     #endif
                                    ]],
                                    [[prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
                                      prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0);]])],

--- a/src/lib/image/dir/mount.c
+++ b/src/lib/image/dir/mount.c
@@ -43,11 +43,15 @@
 
 
 int _singularity_image_dir_mount(struct image_object *image, char *mount_point) {
-    int mntflags = MS_BIND | MS_NOSUID | MS_REC | MS_NODEV;
+    int mntflags = MS_BIND | MS_NOSUID | MS_REC;
 
     if ( strcmp(image->path, "/") == 0 ) {
         singularity_message(ERROR, "Naughty naughty naughty...\n");
         ABORT(255);
+    }
+
+    if ( singularity_priv_getuid() != 0 ) {
+        mntflags |= MS_NODEV;
     }
 
     singularity_message(DEBUG, "Mounting container directory %s->%s\n", image->path, mount_point);

--- a/src/lib/runtime/files/libs/libs.c
+++ b/src/lib/runtime/files/libs/libs.c
@@ -70,7 +70,7 @@ int _singularity_runtime_files_libs(void) {
         }
 
         singularity_message(DEBUG, "Creating session libdir at: %s\n", libdir);
-        if ( container_mkpath(libdir, 0755) != 0 ) {
+        if ( container_mkpath_nopriv(libdir, 0755) != 0 ) {
             singularity_message(ERROR, "Failed creating temp lib directory at: %s\n", libdir);
             ABORT(255);
         }
@@ -125,7 +125,7 @@ int _singularity_runtime_files_libs(void) {
 
             singularity_message(DEBUG, "Binding library source here: %s -> %s\n", source, dest);
 
-            if ( fileput(dest, "") != 0 ) {
+            if ( fileput_nopriv(dest, "") != 0 ) {
                 singularity_message(ERROR, "Failed creating file at %s: %s\n", dest, strerror(errno));
                 ABORT(255);
             }
@@ -144,12 +144,10 @@ int _singularity_runtime_files_libs(void) {
         if ( is_dir(libdir_contained) != 0 ) {
             char *ld_path;
             singularity_message(DEBUG, "Attempting to create contained libdir\n");
-            singularity_priv_escalate();
-            if ( container_mkpath(libdir_contained, 0755) != 0 ) {
+            if ( container_mkpath_priv(libdir_contained, 0755) != 0 ) {
                 singularity_message(ERROR, "Failed creating directory %s :%s\n", libdir_contained, strerror(errno));
                 ABORT(255);
             }
-            singularity_priv_drop();
             ld_path = envar_path("LD_LIBRARY_PATH");
             if ( ld_path == NULL ) {
                 singularity_message(DEBUG, "Setting LD_LIBRARY_PATH to '/.singularity.d/libs'\n");

--- a/src/lib/runtime/files/passwd/passwd.c
+++ b/src/lib/runtime/files/passwd/passwd.c
@@ -72,6 +72,11 @@ int _singularity_runtime_files_passwd(void) {
         ABORT(255);
     }
 
+    if ( pwent == NULL ) {
+        singularity_message(ERROR, "Failed to obtain user identity information\n");
+        ABORT(255);
+    }
+
     singularity_message(DEBUG, "Checking configuration option: 'config passwd'\n");
     if ( singularity_config_get_bool(CONFIG_PASSWD) <= 0 ) {
         singularity_message(VERBOSE, "Skipping bind of the host's /etc/passwd\n");

--- a/src/lib/runtime/mounts/binds/binds.c
+++ b/src/lib/runtime/mounts/binds/binds.c
@@ -89,23 +89,18 @@ int _singularity_runtime_mount_binds(void) {
                 singularity_message(DEBUG, "Checking base directory for file %s ('%s')\n", dest, basedir);
                 if ( is_dir(basedir) != 0 ) {
                     singularity_message(DEBUG, "Creating base directory for file bind\n");
-                    singularity_priv_escalate();
-                    if ( container_mkpath(basedir, 0755) != 0 ) {
+                    if ( container_mkpath_priv(basedir, 0755) != 0 ) {
                         singularity_message(ERROR, "Failed creating base directory to bind file: %s\n", dest);
                         ABORT(255);
                     }
-                    singularity_priv_drop();
                 }
 
                 free(basedir);
 
-                singularity_priv_escalate();
                 singularity_message(VERBOSE3, "Creating bind file on overlay file system: %s\n", dest);
-                if ( fileput(joinpath(container_dir, dest), "") != 0 ) {
-                    singularity_priv_drop();
+                if ( fileput_priv(joinpath(container_dir, dest), "") != 0 ) {
                     continue;
                 }
-                singularity_priv_drop();
                 singularity_message(DEBUG, "Created bind file: %s\n", dest);
             } else {
                 singularity_message(WARNING, "Non existent bind point (file) in container: '%s'\n", dest);
@@ -113,14 +108,11 @@ int _singularity_runtime_mount_binds(void) {
             }
         } else if ( ( is_dir(source) == 0 ) && ( is_dir(joinpath(container_dir, dest)) < 0 ) ) {
             if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL ) {
-                singularity_priv_escalate();
                 singularity_message(VERBOSE3, "Creating bind directory on overlay file system: %s\n", dest);
-                if ( container_mkpath(joinpath(container_dir, dest), 0755) < 0 ) {
-                    singularity_priv_drop();
+                if ( container_mkpath_priv(joinpath(container_dir, dest), 0755) < 0 ) {
                     singularity_message(WARNING, "Could not create bind point directory in container %s: %s\n", dest, strerror(errno));
                     continue;
                 }
-                singularity_priv_drop();
             } else {
                 singularity_message(WARNING, "Non existent bind point (directory) in container: '%s'\n", dest);
                 continue;

--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -64,9 +64,7 @@ int _singularity_runtime_mount_dev(void) {
                 return(-1);
             }
 
-            singularity_priv_escalate();
-            ret = container_mkpath(joinpath(container_dir, "/dev"), 0755);
-            singularity_priv_drop();
+            ret = container_mkpath_priv(joinpath(container_dir, "/dev"), 0755);
 
             if ( ret < 0 ) {
                 singularity_message(ERROR, "Could not create /dev inside container\n");
@@ -75,13 +73,13 @@ int _singularity_runtime_mount_dev(void) {
         }
 
         singularity_message(DEBUG, "Creating temporary staged /dev\n");
-        if ( container_mkpath(devdir, 0755) != 0 ) {
+        if ( container_mkpath_nopriv(devdir, 0755) != 0 ) {
             singularity_message(ERROR, "Failed creating the session device directory %s: %s\n", devdir, strerror(errno));
             ABORT(255);
         }
 
         singularity_message(DEBUG, "Creating temporary staged /dev/shm\n");
-        if ( container_mkpath(joinpath(devdir, "/shm"), 0755) != 0 ) {
+        if ( container_mkpath_nopriv(joinpath(devdir, "/shm"), 0755) != 0 ) {
             singularity_message(ERROR, "Failed creating temporary /dev/shm %s: %s\n", joinpath(devdir, "/shm"), strerror(errno));
             ABORT(255);
         }
@@ -94,7 +92,7 @@ int _singularity_runtime_mount_dev(void) {
                 ABORT(255);
             }
             singularity_message(DEBUG, "Creating staged /dev/pts\n");
-            if ( container_mkpath(joinpath(devdir, "/pts"), 0755) != 0 ) {
+            if ( container_mkpath_nopriv(joinpath(devdir, "/pts"), 0755) != 0 ) {
                 singularity_message(ERROR, "Failed creating /dev/pts %s: %s\n", joinpath(devdir, "/pts"), strerror(errno));
                 ABORT(255);
             }
@@ -226,9 +224,7 @@ static int bind_dev(char *tmpdir, char *dev) {
             int ret;
             singularity_message(VERBOSE2, "Creating bind point within container: %s\n", dev);
 
-            singularity_priv_escalate();
-            ret = fileput(path, "");
-            singularity_priv_drop();
+            ret = fileput_priv(path, "");
 
             if ( ret < 0 ) {
                 singularity_message(WARNING, "Can not create %s: %s\n", dev, strerror(errno));

--- a/src/lib/runtime/mounts/home/home.c
+++ b/src/lib/runtime/mounts/home/home.c
@@ -89,7 +89,7 @@ int _singularity_runtime_mount_home(void) {
     }
 
     singularity_message(DEBUG, "Creating temporary directory to stage home: %s\n", joinpath(session_dir, home_dest));
-    if ( container_mkpath(joinpath(session_dir, home_dest), 0755) < 0 ) {
+    if ( container_mkpath_nopriv(joinpath(session_dir, home_dest), 0755) < 0 ) {
         singularity_message(ERROR, "Failed creating home directory stage %s: %s\n", joinpath(session_dir, home_dest), strerror(errno));
         ABORT(255);
     }
@@ -139,13 +139,11 @@ int _singularity_runtime_mount_home(void) {
     } else {
         singularity_message(DEBUG, "Staging home directory\n");
 
-        singularity_priv_escalate();
         singularity_message(DEBUG, "Creating home directory within container: %s\n", joinpath(container_dir, home_dest));
-        if ( container_mkpath(joinpath(container_dir, home_dest), 0755) < 0 ) {
+        if ( container_mkpath_priv(joinpath(container_dir, home_dest), 0755) < 0 ) {
             singularity_message(ERROR, "Failed creating home directory in container %s: %s\n", joinpath(container_dir, home_dest), strerror(errno));
             ABORT(255);
         }
-        singularity_priv_drop();
 
         singularity_message(VERBOSE, "Mounting staged home directory to container: %s -> %s\n", joinpath(session_dir, home_dest), joinpath(container_dir, home_dest));
         if ( singularity_mount(joinpath(session_dir, home_dest), joinpath(container_dir, home_dest), NULL, MS_BIND | MS_NOSUID | MS_NODEV | MS_REC, NULL) < 0 ) {

--- a/src/lib/runtime/mounts/hostfs/hostfs.c
+++ b/src/lib/runtime/mounts/hostfs/hostfs.c
@@ -150,13 +150,10 @@ int _singularity_runtime_mount_hostfs(void) {
 
         if ( ( is_dir(mountpoint) == 0 ) && ( is_dir(joinpath(container_dir, mountpoint)) < 0 ) ) {
             if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL ) {
-                singularity_priv_escalate();
-                if ( container_mkpath(joinpath(container_dir, mountpoint), 0755) < 0 ) {
-                    singularity_priv_drop();
+                if ( container_mkpath_priv(joinpath(container_dir, mountpoint), 0755) < 0 ) {
                     singularity_message(WARNING, "Could not create bind point directory in container %s: %s\n", mountpoint, strerror(errno));
                     continue;
                 }
-                singularity_priv_drop();
             } else {
                 singularity_message(WARNING, "Non existent 'bind point' directory in container: '%s'\n", mountpoint);
                 continue;

--- a/src/lib/runtime/mounts/scratch/scratch.c
+++ b/src/lib/runtime/mounts/scratch/scratch.c
@@ -93,17 +93,15 @@ int _singularity_runtime_mount_scratch(void) {
             ABORT(255);
         }
 
-        if ( container_mkpath(full_sourcedir_path, 0750) < 0 ) {
+        if ( container_mkpath_nopriv(full_sourcedir_path, 0750) < 0 ) {
              singularity_message(ERROR, "Could not create scratch working directory %s: %s\n", full_sourcedir_path, strerror(errno));
              ABORT(255);
         }
 
         if ( is_dir(full_destdir_path) != 0 ) {
             if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL ) {
-                singularity_priv_escalate();
                 singularity_message(DEBUG, "Creating scratch directory inside container\n");
-                r = container_mkpath(full_destdir_path, 0755);
-                singularity_priv_drop();
+                r = container_mkpath_priv(full_destdir_path, 0755);
                 if ( r < 0 ) {
                     singularity_message(VERBOSE, "Skipping scratch directory mount, could not create dir inside container %s: %s\n", current, strerror(errno));
                     current = strtok_r(NULL, ",", &outside_token);

--- a/src/lib/runtime/mounts/userbinds/userbinds.c
+++ b/src/lib/runtime/mounts/userbinds/userbinds.c
@@ -100,23 +100,18 @@ int _singularity_runtime_mount_userbinds(void) {
                     char *dir = dirname(strdup(dest));
                     if ( is_dir(joinpath(container_dir, dir)) < 0 ) {
                         singularity_message(VERBOSE3, "Creating bind directory on overlay file system: %s\n", dest);
-                        if ( container_mkpath(joinpath(container_dir, dir), 0755) < 0 ) {
-                            singularity_priv_escalate();
+                        if ( container_mkpath_nopriv(joinpath(container_dir, dir), 0755) < 0 ) {
                             singularity_message(VERBOSE3, "Retrying with privileges to create bind directory on overlay file system: %s\n", dest);
-                            if ( container_mkpath(joinpath(container_dir, dir), 0755) < 0 ) {
+                            if ( container_mkpath_priv(joinpath(container_dir, dir), 0755) < 0 ) {
                                 singularity_message(ERROR, "Could not create basedir for file bind %s: %s\n", dest, strerror(errno));
                                 continue;
                             }
-                            singularity_priv_drop();
                         }
                     }
-                    singularity_priv_escalate();
                     singularity_message(VERBOSE3, "Creating bind file on overlay file system: %s\n", dest);
-                    if ( fileput(joinpath(container_dir, dest), "") != 0 ) {
-                        singularity_priv_drop();
+                    if ( fileput_priv(joinpath(container_dir, dest), "") != 0 ) {
                         continue;
                     }
-                    singularity_priv_drop();
                     singularity_message(DEBUG, "Created bind file: %s\n", dest);
                 } else {
                     singularity_message(WARNING, "Skipping user bind, non existent bind point (file) in container: '%s'\n", dest);
@@ -125,15 +120,12 @@ int _singularity_runtime_mount_userbinds(void) {
             } else if ( ( is_dir(source) == 0 ) && ( is_dir(joinpath(container_dir, dest)) < 0 ) ) {
                 if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL ) {
                     singularity_message(VERBOSE3, "Creating bind directory on overlay file system: %s\n", dest);
-                    if ( container_mkpath(joinpath(container_dir, dest), 0755) < 0 ) {
-                        singularity_priv_escalate();
+                    if ( container_mkpath_nopriv(joinpath(container_dir, dest), 0755) < 0 ) {
                         singularity_message(VERBOSE3, "Retrying with privileges to create bind directory on overlay file system: %s\n", dest);
-                        if ( container_mkpath(joinpath(container_dir, dest), 0755) < 0 ) {
-                            singularity_priv_drop();
+                        if ( container_mkpath_priv(joinpath(container_dir, dest), 0755) < 0 ) {
                             singularity_message(WARNING, "Skipping user bind, could not create bind point %s: %s\n", dest, strerror(errno));
                             continue;
                         }
-                        singularity_priv_drop();
                     }
                 } else {
                     singularity_message(WARNING, "Skipping user bind, non existent bind point (directory) in container: '%s'\n", dest);

--- a/src/lib/runtime/overlayfs/overlayfs.c
+++ b/src/lib/runtime/overlayfs/overlayfs.c
@@ -146,19 +146,17 @@ int _singularity_runtime_overlayfs(void) {
 
         container_statdir_update(0);
 
-        singularity_priv_escalate();
         singularity_message(DEBUG, "Creating upper overlay directory: %s\n", overlay_upper);
-        if ( container_mkpath(overlay_upper, 0755) < 0 ) {
+        if ( container_mkpath_priv(overlay_upper, 0755) < 0 ) {
             singularity_message(ERROR, "Failed creating upper overlay directory %s: %s\n", overlay_upper, strerror(errno));
             ABORT(255);
         }
 
         singularity_message(DEBUG, "Creating overlay work directory: %s\n", overlay_work);
-        if ( container_mkpath(overlay_work, 0755) < 0 ) {
+        if ( container_mkpath_priv(overlay_work, 0755) < 0 ) {
             singularity_message(ERROR, "Failed creating overlay work directory %s: %s\n", overlay_work, strerror(errno));
             ABORT(255);
         }
-        singularity_priv_drop();
 
         singularity_message(VERBOSE, "Mounting overlay with options: %s\n", overlay_options);
         int result = singularity_mount("OverlayFS", overlay_final, "overlay", MS_NOSUID | MS_NODEV, overlay_options);

--- a/src/mount.c
+++ b/src/mount.c
@@ -49,8 +49,6 @@
 int main(int argc, char **argv) {
     struct image_object image;
 
-    fd_cleanup();
-
     singularity_config_init(joinpath(SYSCONFDIR, "/singularity/singularity.conf"));
 
     singularity_priv_init();

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -41,11 +41,13 @@ int is_owner(char *path, uid_t uid);
 int is_blk(char *path);
 int is_chr(char *path);
 int s_mkpath(char *dir, mode_t mode);
-int container_mkpath(char *dir, mode_t mode);
+int container_mkpath_nopriv(char *dir, mode_t mode);
+int container_mkpath_priv(char *dir, mode_t mode);
 int s_rmdir(char *dir);
 int copy_file(char * source, char * dest);
 char *filecat(char *path);
-int fileput(char *path, char *string);
+int fileput_nopriv(char *path, char *string);
+int fileput_priv(char *path, char *string);
 int filelock(const char *const filepath, int *const fdptr);
 char *basedir(char *dir);
 

--- a/src/util/mount.c
+++ b/src/util/mount.c
@@ -77,39 +77,20 @@ int singularity_mount(const char *source, const char *target,
     int ret;
     int mount_errno;
     uid_t fsuid = 0;
-    char dest[PATH_MAX];
-    char *realdest, *realtarget;
-    int target_fd = -1;
+    char *realdest;
     static struct resolved_container_path container_path;
-
-    resolve_container_path(&container_path);
-
-    if ( ( mountflags & MS_REMOUNT ) == 0 ) {
-        target_fd = open(target, O_RDONLY);
-
-        if ( target_fd < 0 ) {
-            singularity_message(ERROR, "Target %s doesn't exist\n", target);
-            ABORT(255);
-        }
-
-        if ( snprintf(dest, PATH_MAX-1, "/proc/self/fd/%d", target_fd) < 0 ) {
-            singularity_message(ERROR, "Failed to determine path for target file descriptor\n");
-            ABORT(255);
-        }
-        realtarget = dest;
-    } else {
-        realtarget = (char *)target;
-    }
 
     if ( ( mountflags & MS_BIND ) ) {
         fsuid = singularity_priv_getuid();
     }
 
-    realdest = realpath(realtarget, NULL); // Flawfinder: ignore
+    realdest = realpath(target, NULL); // Flawfinder: ignore
     if ( realdest == NULL ) {
-        singularity_message(ERROR, "Failed to get real path of %s %s\n", target, dest);
+        singularity_message(ERROR, "Failed to get real path of %s\n", target);
         ABORT(255);
     }
+
+    resolve_container_path(&container_path);
 
     if ( (mountflags & MS_PRIVATE) == 0 && (mountflags & MS_SLAVE) == 0 ) {
         if ( strncmp(realdest, container_path.mountdir, strlen(container_path.mountdir)) != 0 &&
@@ -118,9 +99,6 @@ int singularity_mount(const char *source, const char *target,
              strncmp(realdest, container_path.session, strlen(container_path.session)) != 0 ) {
             singularity_message(VERBOSE, "Ignored, try to mount %s outside of container %s\n", target, realdest);
             free(realdest);
-            if ( target_fd >= 0 ) {
-                close(target_fd);
-            }
             return(0);
         }
     }
@@ -135,12 +113,9 @@ int singularity_mount(const char *source, const char *target,
         setfsuid(fsuid);
     }
 
-    ret = mount(source, realtarget, filesystemtype, mountflags, data);
+    ret = mount(source, realdest, filesystemtype, mountflags, data);
     mount_errno = errno;
 
-    if ( target_fd >= 0 ) {
-        close(target_fd);
-    }
     free(realdest);
 
     if ( singularity_priv_userns_enabled() == 0 && seteuid(singularity_priv_getuid()) < 0 ) {

--- a/src/util/privilege.c
+++ b/src/util/privilege.c
@@ -29,6 +29,19 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/prctl.h>
+
+/*
+ * Some distributions have a kernel that supports PR_SET_NO_NEW_PRIVS but
+ * the userspace does not have the defines in prctl.h
+ *
+ * #define them ourself. This still fails on kernels where NO_NEW_PRIVS is
+ * not supported
+ */
+#ifndef PR_SET_NO_NEW_PRIVS
+# define PR_SET_NO_NEW_PRIVS 38
+# define PR_GET_NO_NEW_PRIVS 39
+#endif
+
 #include <pwd.h>
 #include <errno.h> 
 #include <string.h>

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -443,8 +443,8 @@ struct tempfile *make_logfile(char *label) {
     return(tf);
 }
 
-// close all file descriptors pointing to a directory or a socket
-void fd_cleanup(void) {
+// iter on /proc/self/fd and call close_fd callback to determine file descriptors to close
+void fd_cleanup(int (*close_fd)(int fd, struct stat *st)) {
     int fd_proc;
     DIR *dir;
     struct dirent *dirent;
@@ -474,7 +474,7 @@ void fd_cleanup(void) {
         if ( fd == fd_proc || fstat(fd, &st) < 0 ) {
             continue;
         }
-        if ( S_ISDIR(st.st_mode) || S_ISSOCK(st.st_mode) ) {
+        if ( close_fd(fd, &st) ) {
             close(fd);
         }
     }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <linux/limits.h>
 
 #include "util/message.h"
@@ -59,7 +60,7 @@ char *random_string(int length);
 void free_tempfile(struct tempfile *tf);
 struct tempfile *make_tempfile(void);
 struct tempfile *make_logfile(char *label);
-void fd_cleanup(void);
+void fd_cleanup(int (*close_fd)(int fd, struct stat *));
 
 // Given a const char * string containing a base-10 integer,
 // try to convert to an C integer.

--- a/tests/20-build.sh
+++ b/tests/20-build.sh
@@ -42,6 +42,20 @@ stest 0 singularity exec \"$CONTAINER\" test -L /singularity"
 stest 0 sudo singularity build "$CONTAINER" "../examples/busybox/Singularity"
 container_check
 
+# from debootstrap example to squashfs
+if which debootstrap > /dev/null 2>&1; then
+    sudo rm "$CONTAINER"
+    stest 0 sudo singularity build "$CONTAINER" "../examples/debian/Singularity"
+    container_check
+fi
+
+# from yum to squashfs
+if which yum > /dev/null 2>&1; then
+    sudo rm "$CONTAINER"
+    stest 0 sudo singularity build "$CONTAINER" "../examples/centos/Singularity"
+    container_check
+fi
+
 # from definition file to sandbox
 sudo rm "$CONTAINER"
 stest 0 sudo singularity build --sandbox "$CONTAINER" "../examples/busybox/Singularity"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR remove `open` call from singularity_mount.
`open` was used to get path from `/proc/self/fd/x` and obtain a "trusted" path, but a kernel bug on CentOS 7.2.1511 in overlay code give a wrong path relative to overlay mountpoint and singularity always fail.
Another issue was to open directories or file with restrictive permissions since the code is executed unprivileged, `open` fail.

**This fixes or addresses the following GitHub issues:**

- Ref: #1524 #1518 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
