### PR TITLE
fix two new lines introduced by d3e6131

### DIFF
--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -63,22 +63,22 @@ var buildCmd = &cobra.Command{
 			// URI passed as arg[1]
 			def, err = build.NewDefinitionFromURI(args[1])
 			if err != nil {
-				sylog.Fatalf("unable to parse URI %s: %v", args[1], err)
+				sylog.Fatalf("unable to parse URI %s: %v\n", args[1], err)
 			}
 		} else if !ok && err == nil {
 			// Non-URI passed as arg[1]
 			defFile, err := os.Open(args[1])
 			if err != nil {
-				sylog.Fatalf("unable to open file %s: %v", args[1], err)
+				sylog.Fatalf("unable to open file %s: %v\n", args[1], err)
 			}
 			defer defFile.Close()
 
 			def, err = build.ParseDefinitionFile(defFile)
 			if err != nil {
-				sylog.Fatalf("failed to parse definition file %s: %v", args[1], err)
+				sylog.Fatalf("failed to parse definition file %s: %v\n", args[1], err)
 			}
 		} else {
-			sylog.Fatalf("unable to parse %s: %v", args[1], err)
+			sylog.Fatalf("unable to parse %s: %v\n", args[1], err)
 		}
 
 		if Remote {
@@ -86,12 +86,12 @@ var buildCmd = &cobra.Command{
 		} else {
 			b, err = build.NewSifBuilder(args[0], def)
 			if err != nil {
-				sylog.Fatalf("failed to create SifBuilder object: %v", err)
+				sylog.Fatalf("failed to create SifBuilder object: %v\n", err)
 			}
 		}
 
 		if err := b.Build(context.TODO()); err != nil {
-			sylog.Fatalf("failed to build image: %v", err)
+			sylog.Fatalf("failed to build image: %v\n", err)
 		}
 	},
 	TraverseChildren: true,

--- a/src/pkg/build/builder_remote.go
+++ b/src/pkg/build/builder_remote.go
@@ -85,7 +85,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 	rd, err := rb.doBuildRequest(ctx, rb.Definition, rb.IsDetached)
 	if err != nil {
 		err = errors.Wrap(err, "failed to post request to remote build service")
-		sylog.Warningf("%v", err)
+		sylog.Warningf("%v\n", err)
 		return
 	}
 
@@ -94,7 +94,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 		err = rb.streamOutput(ctx, rd.WSURL)
 		if err != nil {
 			err = errors.Wrap(err, "failed to stream output from remote build service")
-			sylog.Warningf("%v", err)
+			sylog.Warningf("%v\n", err)
 			return
 		}
 	}
@@ -103,7 +103,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 	rd, err = rb.doStatusRequest(ctx, rd.ID)
 	if err != nil {
 		err = errors.Wrap(err, "failed to get status from remote build service")
-		sylog.Warningf("%v", err)
+		sylog.Warningf("%v\n", err)
 		return
 	}
 

--- a/src/pkg/build/definition_parser_deffile.go
+++ b/src/pkg/build/definition_parser_deffile.go
@@ -193,11 +193,11 @@ func ParseDefinitionFile(r io.Reader) (d Definition, err error) {
 	}
 
 	if err = doHeader(s.Text(), &d); err != nil {
-		sylog.Warningf("failed to parse DefFile header: %v", err)
+		sylog.Warningf("failed to parse DefFile header: %v\n", err)
 		return
 	}
 	if err = doSections(s, &d); err != nil {
-		sylog.Warningf("failed to parse DefFile sections: %v", err)
+		sylog.Warningf("failed to parse DefFile sections: %v\n", err)
 	}
 
 	return

--- a/src/pkg/sylog/sylog.go
+++ b/src/pkg/sylog/sylog.go
@@ -111,7 +111,7 @@ func writef(level messageLevel, format string, a ...interface{}) {
 	prefix := fmt.Sprintf("%s%-8s%s%-19s%-30s", messageColor, level, colorReset, uidStr, funcName)
 	message := fmt.Sprintf(format, a...)
 
-	fmt.Printf("%s%s\n", prefix, message)
+	fmt.Printf("%s%s", prefix, message)
 }
 
 // Fatalf is equivalent to a call to Errorf followed by os.Exit(255). Code that


### PR DESCRIPTION
After PR d3e6131
> @bauerm97 : If we are adding newlines to each log statement, then you should have gone through and deleted all the newline characters that are on the current logging statements. We’ll now have a bunch of log messages which output two new lines.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
