### PR TITLE
Fix Centos7 travis build

### DIFF
--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -7,9 +7,6 @@ OS_VERSION="$1"
 # build and install
 yum install -y libtool rpm-build make yum-utils squashfs-tools libarchive-devel
 ./autogen.sh
-#yum-builddep failing on 11 May 2018 because Centos 7.5
-#   Source/repodata/repomd.xml is missing, skip for now.
-#yum-builddep -y singularity.spec
 ./configure
 make dist
 rpmbuild -ta *.tar.gz

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -7,7 +7,9 @@ OS_VERSION="$1"
 # build and install
 yum install -y libtool rpm-build make yum-utils squashfs-tools libarchive-devel
 ./autogen.sh
-yum-builddep -y singularity.spec
+#yum-builddep failing on 11 May 2018 because Centos 7.5
+#   Source/repodata/repomd.xml is missing, skip for now.
+#yum-builddep -y singularity.spec
 ./configure
 make dist
 rpmbuild -ta *.tar.gz


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Centos 7.5 has been released and as of now there are no source repositories available.  This PR skips the yum-builddep step which apparently needs the sources but is itself apparently unneeded.


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
