### PR TITLE
Use Only Maintained MongoDB Driver

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -337,15 +337,6 @@
   version = "v1.0.22"
 
 [[projects]]
-  branch = "v2"
-  name = "gopkg.in/mgo.v2"
-  packages = [
-    "bson",
-    "internal/json"
-  ]
-  revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
-
-[[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
@@ -354,6 +345,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c8359effe8d1baf378c60d7aba96883422c531ce670373eb9e6741de05701b06"
+  inputs-digest = "77190256cb81421ef7644e5b55c3a495a0dcc59cc7d361b1e26b4e73c3c480c8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/pkg/build/builder_remote.go
+++ b/src/pkg/build/builder_remote.go
@@ -18,10 +18,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
 	"github.com/singularityware/singularity/src/pkg/sylog"
-	"gopkg.in/mgo.v2/bson"
 )
 
 // RequestData contains the info necessary for submitting a build to a remote service

--- a/src/pkg/build/builder_remote_test.go
+++ b/src/pkg/build/builder_remote_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/websocket"
-	"gopkg.in/mgo.v2/bson"
 )
 
 const (


### PR DESCRIPTION
**Description of the Pull Request (PR):**

We are currently importing two versions of `mgo` according to `Gopkg.lock`:

```
[[projects]]
  branch = "master"
  name = "github.com/globalsign/mgo"
  packages = [
    "bson",
    "internal/json"
  ]
  revision = "efe0945164a7e582241f37ae8983c075f8f2e870"

...

[[projects]]
  branch = "v2"
  name = "gopkg.in/mgo.v2"
  packages = [
    "bson",
    "internal/json"
  ]
  revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
```
`github.com/globalsign/mgo` is actively maintained and recommended on the official MongoDB page, whereas `gopkg.in/mgo.v2` is _unmaintained_ (according to https://github.com/go-mgo/mgo/tree/v2). This PR fixes the imports that are causing the unmaintained `mgo` package to be brought in by `dep`.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
