### PR TITLE
Fail if NO_NEW_PRIVS is not availible on build system

### DIFF
--- a/mlocal/checks/project.chk
+++ b/mlocal/checks/project.chk
@@ -174,7 +174,7 @@ else
         exit 2;
     else
 	echo "yes"
-	config_add_def DSINGULARITY_NO_NEW_PRIVS 1
+	config_add_def SINGULARITY_NO_NEW_PRIVS 1
     fi
 fi
 /bin/rm -f ${nnp_c} /tmp/nnp_c

--- a/mlocal/checks/project.chk
+++ b/mlocal/checks/project.chk
@@ -150,13 +150,34 @@ fi
 # feature: NO_NEW_PRIVS
 ########################
 printf " checking: feature: NO_NEW_PRIVS... "
-if ! printf "#include <sys/prctl.h>\nint main() { prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0); }" | \
-   $tgtcc -x c -o /dev/null - >/dev/null 2>&1; then
+nnp_c=`mktemp -t nnp_c_XXXXXX`
+cat > $nnp_c << "EOF"
+#include <sys/prctl.h>
+#ifndef PR_SET_NO_NEW_PRIVS
+# define PR_SET_NO_NEW_PRIVS 38
+# define PR_GET_NO_NEW_PRIVS 39
+#endif
+int main() {
+  if( prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 ) { return 1; }
+  if( prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1 ) { return 1; }
+  return 0;
+}
+EOF
+if ! $tgtcc -x c -o /tmp/nnp_c ${nnp_c} >/dev/null 2>&1; then
 	echo "no"
+    echo "ERROR: Failed to compile NO_NEW_PRIVS test"
+    exit 2;
 else
+    if ! /tmp/nnp_c; then
+        echo "ERROR: Kernel does not support NO_NEW_PRIVS. Updated Kernel is required."
+        /bin/rm -f ${nnp_c} /tmp/nnp_c
+        exit 2;
+    else
 	echo "yes"
 	config_add_def DSINGULARITY_NO_NEW_PRIVS 1
+    fi
 fi
+/bin/rm -f ${nnp_c} /tmp/nnp_c
 
 ########################
 # feature: MS_SLAVE


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Update the NO_NEW_PRIVS check in `mlocal/checks/project.chk` to include the more detailed check and `#define`

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
