### PR TITLE
Pull --debug fix on docker:// URI

### DIFF
--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -141,7 +141,7 @@ case "$SINGULARITY_CONTAINER" in
             message WARNING "Container will be sized appropriately for Docker image.\n"
         fi
 
-         if [ -f "$SINGULARITY_IMAGE" ]; then
+        if [ -f "$SINGULARITY_IMAGE" ]; then
             if [ -n "${OVERWRITE:-}" ]; then
                 message 2 "Removing existing file\n"
                 rm -f "$SINGULARITY_IMAGE"
@@ -151,8 +151,13 @@ case "$SINGULARITY_CONTAINER" in
             fi
         fi
 
-         if [ -x "${SINGULARITY_bindir}/singularity" ]; then
-             ${SINGULARITY_bindir}/singularity build ${SINGULARITY_IMAGE} ${SINGULARITY_CONTAINER}
+        DBGFLAG=""
+        if [ "x${SINGULARITY_MESSAGELEVEL}" == "x5" ]; then
+            DBGFLAG="-d"
+        fi
+
+        if [ -x "${SINGULARITY_bindir}/singularity" ]; then
+             ${SINGULARITY_bindir}/singularity ${DBGFLAG} build ${SINGULARITY_IMAGE} ${SINGULARITY_CONTAINER}
              RETVAL=$?
          else
              message ERROR "Could not locate the Singularity binary: $SINGULARITY_home/singularity\n"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

When we `pull` from a `docker://` URI, we aren't passing the debug flag if it was used. Check `SINGULARITY_MESSAGELEVEL`, and if `5` (debug), pass the `-d` flag to the `singularity build`


**This fixes or addresses the following GitHub issues:**

- Ref: #1555 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
