### PR TITLE
dd status=none unknown

### DIFF
--- a/libexec/cli/image.create.exec
+++ b/libexec/cli/image.create.exec
@@ -96,8 +96,13 @@ if [ -f "$SINGULARITY_IMAGE" ]; then
     fi
 fi
 
+DDSTATUS="none"
+if dd --help | grep -q 'status=noxfer'; then
+    DDSTATUS="noxfer"
+fi
+
 message 1 "Creating empty ${SINGULARITY_IMAGESIZE:-768}MiB image file: $SINGULARITY_IMAGE\n"
-if ! dd if=/dev/zero of="$SINGULARITY_IMAGE" bs=1M count=${SINGULARITY_IMAGESIZE:-768} status=none; then
+if ! dd if=/dev/zero of="$SINGULARITY_IMAGE" bs=1M count=${SINGULARITY_IMAGESIZE:-768} status=${DDSTATUS}; then
     message ERROR "Failed creating image!\n"
     exit 1
 fi

--- a/libexec/cli/image.expand.exec
+++ b/libexec/cli/image.expand.exec
@@ -101,8 +101,13 @@ if ! touch "$SINGULARITY_IMAGE" >/dev/null 2>&1; then
     ABORT 255
 fi
 
+DDSTATUS="none"
+if dd --help | grep -q 'status=noxfer'; then
+    DDSTATUS="noxfer"
+fi
+
 message 1 "Expanding image by ${SINGULARITY_IMAGESIZE:-768}MB\n"
-if ! dd if=/dev/zero bs=1M count=${SINGULARITY_IMAGESIZE:-768} status=none >> "$SINGULARITY_IMAGE"; then
+if ! dd if=/dev/zero bs=1M count=${SINGULARITY_IMAGESIZE:-768} status=${DDSTATUS} >> "$SINGULARITY_IMAGE"; then
     message ERROR "Failed expanding image!\n"
     exit 1
 fi


### PR DESCRIPTION
Hack to work around older dd binaries where `status=LEVEL` is not
known. To my knowledge, these are all `status=noxfer`

**Description of the Pull Request (PR):**

The `status=LEVEL` option isn't known in older dd binaries. Check the `--help` output for what is
shown, and use `noxfer` if appropriate. Otherwise use `none`


**This fixes or addresses the following GitHub issues:**

- Ref: #1333 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
