### PR TITLE
Add LINTY

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -1,0 +1,25 @@
+# This is the LINTY configuration, which is a list of packages that contain
+# lint. Once a package is free of lint, it must be removed from this list.
+github.com/singularityware/singularity/src/cmd/sbuild
+github.com/singularityware/singularity/src/cmd/singularity/cli
+github.com/singularityware/singularity/src/pkg/build
+github.com/singularityware/singularity/src/pkg/buildcfg
+github.com/singularityware/singularity/src/pkg/buildcfg/confgen
+github.com/singularityware/singularity/src/pkg/capability
+github.com/singularityware/singularity/src/pkg/image
+github.com/singularityware/singularity/src/pkg/libexec
+github.com/singularityware/singularity/src/pkg/sif
+github.com/singularityware/singularity/src/pkg/sypgp
+github.com/singularityware/singularity/src/pkg/util/capabilities
+github.com/singularityware/singularity/src/pkg/util/loop
+github.com/singularityware/singularity/src/pkg/workflows
+github.com/singularityware/singularity/src/pkg/workflows/config
+github.com/singularityware/singularity/src/pkg/workflows/oci/config
+github.com/singularityware/singularity/src/runtime/startup
+github.com/singularityware/singularity/src/runtime/workflows
+github.com/singularityware/singularity/src/runtime/workflows/rpc
+github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity
+github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config
+github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc
+github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client
+github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
 
 before_install:
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - go get -u golang.org/x/lint/golint
   - export PATH="${GOPATH}/bin:${PATH}"
   - dep ensure -vendor-only
 

--- a/linty.sh
+++ b/linty.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# De-linting is a time-consuming process. The aim of LINTY is to support an
+# iterative process to clear out lint. It uses a configuration file which lists
+# packages that currently contain lint, and ensures that:
+#
+#  - packages listed in the configuration are removed once they are free of lint
+#  - packages not listed in the configuration continue to be free of lint
+#
+# If either of the above statements is FALSE, LINTY prints out a warning and
+# exits. If both statements are TRUE, LINTY prints out a table of lint counts
+# for the packages that are listed in its configuration.
+
+# Configuration file
+linty_config=".linty.conf"
+
+# Temporary table file
+tmp_file=$(mktemp /tmp/linty.XXXXXX)
+
+for pkg in `go list ./...`; do
+	# Check package for lint
+	lint=$(golint -set_exit_status ${pkg} 2>/dev/null)
+	has_lint=$?
+
+	# Check if the package is expected to have lint
+	if grep -Fxq $pkg ".linty.conf"; then
+		if [ "$has_lint" -eq 1 ]; then
+			# Still has lint...
+			lint_count=$(echo "$lint" | wc -l)
+			printf " %5s | %s\n" "$lint_count" "$pkg" >> "$tmp_file"
+		else
+			# Lint free!
+			echo "ERROR: package $pkg contains NO lint, but is listed in the LINTY config."
+			echo "Please remove it from '$linty_config'!"
+			rm $tmp_file
+			exit 1
+		fi
+	else
+		if [ "$has_lint" -eq 1 ]; then
+			# New lint...
+			echo "$lint"
+			echo ""
+			echo "ERROR: package $pkg contains NEW lint. Please address the issues listed above!"
+			rm $tmp_file
+			exit 2
+		fi
+	fi
+done
+
+# Sort results by count
+sort -nr $tmp_file -o $tmp_file
+
+# Print results table
+echo "================================  L I N T Y   W A L L   O F   S H A M E  ================================"
+echo ""
+echo " Count | Name of Linty Package"
+echo "-------+-------------------------------------------------------------------------------------------------"
+cat $tmp_file
+echo ""
+echo "Help LINTY fight the good fight, golint today!"
+
+# Remove temporary file
+rm $tmp_file

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -172,6 +172,10 @@ test:
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && go vet -all ./...
 	@echo "       PASS"
+	@echo " TEST LINTY"
+	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
+		cd $(SOURCEDIR) && ./linty.sh
+	@echo "       PASS"
 	@echo " TEST go test ./..."
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && go test -cover -race -timeout 60s ./...


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add a helper script called LINTY that will help us iteratively reduce lint in the 3.0 Golang source code, and run the script in our Travis CI.

LINTY uses a configuration that contains the list of packages that currently contain lint. If lint is found in a package that is not listed, an error is printed to the screen. If no lint is found in a package that is listed, the user is prompted to remove it from the LINTY configuration. In this way, the number of packages that contain lint should not increase over time (and, hopefully, will decrease!)

If and when the source tree is lint-free, LINTY can be removed and we can switch to running `golint` directly.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin