### PR TITLE
Remove Lint from Runtime Packages

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -16,7 +16,6 @@ github.com/singularityware/singularity/src/pkg/workflows
 github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config
 github.com/singularityware/singularity/src/runtime/startup
-github.com/singularityware/singularity/src/runtime/workflows
 github.com/singularityware/singularity/src/runtime/workflows/rpc
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc

--- a/.linty.conf
+++ b/.linty.conf
@@ -20,5 +20,4 @@ github.com/singularityware/singularity/src/runtime/workflows
 github.com/singularityware/singularity/src/runtime/workflows/rpc
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc
-github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server

--- a/.linty.conf
+++ b/.linty.conf
@@ -16,4 +16,3 @@ github.com/singularityware/singularity/src/pkg/workflows
 github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config
 github.com/singularityware/singularity/src/runtime/startup
-github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc

--- a/.linty.conf
+++ b/.linty.conf
@@ -19,7 +19,6 @@ github.com/singularityware/singularity/src/runtime/startup
 github.com/singularityware/singularity/src/runtime/workflows
 github.com/singularityware/singularity/src/runtime/workflows/rpc
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity
-github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server

--- a/.linty.conf
+++ b/.linty.conf
@@ -16,5 +16,4 @@ github.com/singularityware/singularity/src/pkg/workflows
 github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config
 github.com/singularityware/singularity/src/runtime/startup
-github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc

--- a/.linty.conf
+++ b/.linty.conf
@@ -16,6 +16,5 @@ github.com/singularityware/singularity/src/pkg/workflows
 github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config
 github.com/singularityware/singularity/src/runtime/startup
-github.com/singularityware/singularity/src/runtime/workflows/rpc
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc

--- a/.linty.conf
+++ b/.linty.conf
@@ -20,4 +20,3 @@ github.com/singularityware/singularity/src/runtime/workflows
 github.com/singularityware/singularity/src/runtime/workflows/rpc
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity
 github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc
-github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server

--- a/.linty.conf
+++ b/.linty.conf
@@ -15,4 +15,3 @@ github.com/singularityware/singularity/src/pkg/util/loop
 github.com/singularityware/singularity/src/pkg/workflows
 github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config
-github.com/singularityware/singularity/src/runtime/startup

--- a/src/runtime/startup/rpc.go
+++ b/src/runtime/startup/rpc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/singularityware/singularity/src/runtime/workflows/rpc"
 )
 
+// RPCServer serves runtime engine requests
 //export RPCServer
 func RPCServer(socket C.int, sruntime *C.char) {
 	runtime := C.GoString(sruntime)

--- a/src/runtime/startup/scontainer.go
+++ b/src/runtime/startup/scontainer.go
@@ -35,9 +35,10 @@ func bool2int(b bool) uint8 {
 	return 0
 }
 
+// SContainer performs container startup
 //export SContainer
-func SContainer(stage C.int, socket C.int, rpc_socket C.int, sruntime *C.char, config *C.struct_cConfig, jsonC *C.char) {
-	rpcfd := rpc_socket
+func SContainer(stage C.int, socket C.int, rpcSocket C.int, sruntime *C.char, config *C.struct_cConfig, jsonC *C.char) {
+	rpcfd := rpcSocket
 
 	cconf := config
 

--- a/src/runtime/startup/smaster.go
+++ b/src/runtime/startup/smaster.go
@@ -59,6 +59,7 @@ func handleChild(pid int, child chan os.Signal, engine *runtime.RuntimeEngine) {
 	}
 }
 
+// SMaster initializes a runtime engine and runs it
 //export SMaster
 func SMaster(socket C.int, sruntime *C.char, config *C.struct_cConfig, jsonC *C.char) {
 	var wg sync.WaitGroup

--- a/src/runtime/workflows/rpc/server.go
+++ b/src/runtime/workflows/rpc/server.go
@@ -1,22 +1,24 @@
 package rpc
 
 import (
-	singularityConfig "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config"
-	singularityRpcServer "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server"
 	"net"
 	"net/rpc"
+
+	singularityConfig "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config"
+	singularityRpcServer "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server"
 )
 
 var rpcServerMethods map[string]interface{}
 
 // Register RPC server methods for runtime engine
-func registerRuntimeRpcServerMethods(methods interface{}, name string) {
+func registerRuntimeRPCServerMethods(methods interface{}, name string) {
 	if rpcServerMethods == nil {
 		rpcServerMethods = make(map[string]interface{})
 	}
 	rpcServerMethods[name] = methods
 }
 
+// ServeRuntimeEngineRequests services runtime engine requests
 func ServeRuntimeEngineRequests(name string, conn net.Conn) {
 	methods := rpcServerMethods[name]
 	rpc.RegisterName(name, methods)
@@ -26,5 +28,5 @@ func ServeRuntimeEngineRequests(name string, conn net.Conn) {
 func init() {
 	// register singularity RPC methods
 	methods := new(singularityRpcServer.Methods)
-	registerRuntimeRpcServerMethods(methods, singularityConfig.Name)
+	registerRuntimeRPCServerMethods(methods, singularityConfig.Name)
 }

--- a/src/runtime/workflows/workflows.go
+++ b/src/runtime/workflows/workflows.go
@@ -11,7 +11,7 @@ import (
 
 var engines map[string]*runtime.RuntimeEngine
 
-// Instanciate a runtime engine based on json configuration
+// NewRuntimeEngine instantiates a runtime engine based on JSON configuration
 func NewRuntimeEngine(name string, jsonConfig []byte) (*runtime.RuntimeEngine, error) {
 	var engine *runtime.RuntimeEngine
 

--- a/src/runtime/workflows/workflows.go
+++ b/src/runtime/workflows/workflows.go
@@ -40,6 +40,6 @@ func registerRuntimeEngine(engine *runtime.RuntimeEngine, name string) {
 
 func init() {
 	// initialize singularity engine
-	e := &singularity.RuntimeEngine{}
+	e := &singularity.Engine{}
 	registerRuntimeEngine(&runtime.RuntimeEngine{Runtime: e}, singularityConfig.Name)
 }

--- a/src/runtime/workflows/workflows/singularity/check.go
+++ b/src/runtime/workflows/workflows/singularity/check.go
@@ -1,5 +1,6 @@
 package runtime
 
-func (c *RuntimeEngine) CheckConfig() error {
+// CheckConfig checks the runtime engine config
+func (c *Engine) CheckConfig() error {
 	return nil
 }

--- a/src/runtime/workflows/workflows/singularity/cleanup.go
+++ b/src/runtime/workflows/workflows/singularity/cleanup.go
@@ -1,5 +1,6 @@
 package runtime
 
-func (c *RuntimeEngine) CleanupContainer() error {
+// CleanupContainer cleans up the container
+func (c *Engine) CleanupContainer() error {
 	return nil
 }

--- a/src/runtime/workflows/workflows/singularity/config/config.go
+++ b/src/runtime/workflows/workflows/singularity/config/config.go
@@ -7,8 +7,10 @@ import (
 	oci "github.com/singularityware/singularity/src/pkg/workflows/oci/config"
 )
 
+// Name is the name of the runtime.
 const Name = "singularity"
 
+// Configuration describes the runtime configuration.
 type Configuration struct {
 	AllowSetuid             bool     `default:"yes" authorized:"yes,no" directive:"allow setuid"`
 	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
@@ -40,16 +42,19 @@ type Configuration struct {
 	AllowUserCapabilities   bool     `default:"no" authorized:"yes,no" directive:"allow user capabilities"`
 }
 
+// RuntimeEngineSpec is the specification of the runtime engine.
 type RuntimeEngineSpec struct {
 	TestField string `json:"testfield"`
 }
 
+// RuntimeEngineConfig is the configuration of the runtime engine.
 type RuntimeEngineConfig struct {
 	config.RuntimeConfig
 	RuntimeEngineSpec RuntimeEngineSpec `json:"runtimeConfig"`
 	FileConfig        *Configuration
 }
 
+// NewSingularityConfig returns a new Singularity configuration.
 func NewSingularityConfig(containerID string) (*oci.RuntimeOciConfig, *RuntimeEngineConfig) {
 	c := &Configuration{}
 	if err := config.Parser("/usr/local/etc/singularity/singularity.conf", c); err != nil {
@@ -63,9 +68,4 @@ func NewSingularityConfig(containerID string) (*oci.RuntimeOciConfig, *RuntimeEn
 	runtimecfg.RuntimeSpec.RuntimeEngineSpec = &runtimecfg.RuntimeEngineSpec
 	oci.DefaultRuntimeOciConfig(&cfg.OciConfig)
 	return &cfg.OciConfig, runtimecfg
-}
-
-func (c *RuntimeEngineConfig) Test() {
-	fmt.Println("Testfield:", c.RuntimeEngineSpec.TestField, "ociVersion:", c.RuntimeOciSpec.Version)
-	c.RuntimeEngineSpec.TestField = "testfield"
 }

--- a/src/runtime/workflows/workflows/singularity/create.go
+++ b/src/runtime/workflows/workflows/singularity/create.go
@@ -30,7 +30,7 @@ func (engine *RuntimeEngine) CreateContainer(rpcConn net.Conn) error {
 		return fmt.Errorf("engineName configuration doesn't match runtime name")
 	}
 
-	rpcOps := &client.Rpc{
+	rpcOps := &client.RPC{
 		Client: rpc.NewClient(rpcConn),
 		Name:   engine.RuntimeSpec.RuntimeName,
 	}

--- a/src/runtime/workflows/workflows/singularity/create.go
+++ b/src/runtime/workflows/workflows/singularity/create.go
@@ -25,7 +25,8 @@ import (
 	"github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client"
 )
 
-func (engine *RuntimeEngine) CreateContainer(rpcConn net.Conn) error {
+// CreateContainer creates a container
+func (engine *Engine) CreateContainer(rpcConn net.Conn) error {
 	if engine.RuntimeSpec.RuntimeName != runtimeconfig.Name {
 		return fmt.Errorf("engineName configuration doesn't match runtime name")
 	}

--- a/src/runtime/workflows/workflows/singularity/monitor.go
+++ b/src/runtime/workflows/workflows/singularity/monitor.go
@@ -1,5 +1,6 @@
 package runtime
 
-func (c *RuntimeEngine) MonitorContainer() error {
+// MonitorContainer monitors a container
+func (c *Engine) MonitorContainer() error {
 	return nil
 }

--- a/src/runtime/workflows/workflows/singularity/process.go
+++ b/src/runtime/workflows/workflows/singularity/process.go
@@ -6,12 +6,14 @@ import (
 	"syscall"
 )
 
-func (engine *RuntimeEngine) PrestartProcess() error {
+// PrestartProcess runs pre-start tasks
+func (engine *Engine) PrestartProcess() error {
 	/* seccomp setup goes here */
 	return nil
 }
 
-func (engine *RuntimeEngine) StartProcess() error {
+// StartProcess starts the process
+func (engine *Engine) StartProcess() error {
 	os.Setenv("PS1", "shell> ")
 	os.Chdir("/")
 	args := engine.OciConfig.RuntimeOciSpec.Process.Args

--- a/src/runtime/workflows/workflows/singularity/rpc/args.go
+++ b/src/runtime/workflows/workflows/singularity/rpc/args.go
@@ -10,16 +10,19 @@ package rpc
 
 import "github.com/singularityware/singularity/src/pkg/util/loop"
 
+// MkdirArgs defines the arguments to mkdir
 type MkdirArgs struct {
 	Path string
 }
 
+// LoopArgs defines the arguments to create a loop device
 type LoopArgs struct {
 	Image string
 	Mode  int
 	Info  loop.LoopInfo64
 }
 
+// MountArgs defines the arguments to mount
 type MountArgs struct {
 	Source     string
 	Target     string
@@ -28,6 +31,7 @@ type MountArgs struct {
 	Data       string
 }
 
+// ChrootArgs defines the arguments to chroot
 type ChrootArgs struct {
 	Root string
 }

--- a/src/runtime/workflows/workflows/singularity/rpc/client/client.go
+++ b/src/runtime/workflows/workflows/singularity/rpc/client/client.go
@@ -15,12 +15,14 @@ import (
 	args "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc"
 )
 
-type Rpc struct {
+// RPC holds the state necessary for remote procedure calls
+type RPC struct {
 	Client *rpc.Client
 	Name   string
 }
 
-func (t *Rpc) Mount(source string, target string, filesystem string, flags uintptr, data string) (int, error) {
+// Mount calls tme mount RPC using the supplied arguments
+func (t *RPC) Mount(source string, target string, filesystem string, flags uintptr, data string) (int, error) {
 	arguments := &args.MountArgs{
 		Source:     source,
 		Target:     target,
@@ -33,7 +35,8 @@ func (t *Rpc) Mount(source string, target string, filesystem string, flags uintp
 	return reply, err
 }
 
-func (t *Rpc) Mkdir(path string) (int, error) {
+// Mkdir calls the mkdir RPC using the supplied arguments
+func (t *RPC) Mkdir(path string) (int, error) {
 	arguments := &args.MkdirArgs{
 		Path: path,
 	}
@@ -42,7 +45,8 @@ func (t *Rpc) Mkdir(path string) (int, error) {
 	return reply, err
 }
 
-func (t *Rpc) Chroot(root string) (int, error) {
+// Chroot calls the chroot RPC using the supplied arguments
+func (t *RPC) Chroot(root string) (int, error) {
 	arguments := &args.ChrootArgs{
 		Root: root,
 	}
@@ -51,7 +55,8 @@ func (t *Rpc) Chroot(root string) (int, error) {
 	return reply, err
 }
 
-func (t *Rpc) LoopDevice(image string, mode int, info loop.LoopInfo64) (int, error) {
+// LoopDevice calls the loop device RPC using the supplied arguments
+func (t *RPC) LoopDevice(image string, mode int, info loop.LoopInfo64) (int, error) {
 	arguments := &args.LoopArgs{
 		Image: image,
 		Mode:  mode,

--- a/src/runtime/workflows/workflows/singularity/rpc/server/server.go
+++ b/src/runtime/workflows/workflows/singularity/rpc/server/server.go
@@ -17,17 +17,21 @@ import (
 	args "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc"
 )
 
+// Methods is a receiver type
 type Methods int
 
+// Mount performs a mount with the specified arguments
 func (t *Methods) Mount(arguments *args.MountArgs, reply *int) error {
 	return syscall.Mount(arguments.Source, arguments.Target, arguments.Filesystem, arguments.Mountflags, arguments.Data)
 }
 
+// Mkdir performs a mkdir with the specified arguments
 func (t *Methods) Mkdir(arguments *args.MkdirArgs, reply *int) error {
 	fmt.Println("Mkdir requested")
 	return nil
 }
 
+// Chroot performs a chroot with the specified arguments
 func (t *Methods) Chroot(arguments *args.ChrootArgs, reply *int) error {
 	if err := syscall.Chdir(arguments.Root); err != nil {
 		return fmt.Errorf("Failed to change directory to %s", arguments.Root)
@@ -55,6 +59,7 @@ func (t *Methods) Chroot(arguments *args.ChrootArgs, reply *int) error {
 	return nil
 }
 
+// LoopDevice attaches a loop device with the specified arguments
 func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) error {
 	loopdev := new(loop.LoopDevice)
 

--- a/src/runtime/workflows/workflows/singularity/runtime.go
+++ b/src/runtime/workflows/workflows/singularity/runtime.go
@@ -6,11 +6,13 @@ import (
 	singularityConfig "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config"
 )
 
-type RuntimeEngine struct {
+// Engine describes a runtime engine
+type Engine struct {
 	singularityConfig.RuntimeEngineConfig
 }
 
-func (e *RuntimeEngine) InitConfig() *config.RuntimeConfig {
+// InitConfig initializes a runtime configuration
+func (e *Engine) InitConfig() *config.RuntimeConfig {
 	if e.FileConfig == nil {
 		e.FileConfig = &singularityConfig.Configuration{}
 		if err := config.Parser("/usr/local/etc/singularity/singularity.conf", e.FileConfig); err != nil {
@@ -22,6 +24,7 @@ func (e *RuntimeEngine) InitConfig() *config.RuntimeConfig {
 	return cfg
 }
 
-func (e *RuntimeEngine) IsRunAsInstance() bool {
+// IsRunAsInstance returns true if the runtime engine was run as an instance
+func (e *Engine) IsRunAsInstance() bool {
 	return false
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Removing 38 pieces of lint from the various runtime packages:

```
$ golint github.com/singularityware/singularity/src/runtime/...
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/startup/rpc.go:21:1: comment on exported function RPCServer should be of the form "RPCServer ..."
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/startup/scontainer.go:38:1: comment on exported function SContainer should be of the form "SContainer ..."
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/startup/scontainer.go:39:44: don't use underscores in Go names; func parameter rpc_socket should be rpcSocket
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/startup/smaster.go:62:1: comment on exported function SMaster should be of the form "SMaster ..."
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows.go:14:1: comment on exported function NewRuntimeEngine should be of the form "NewRuntimeEngine ..."
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/rpc/server.go:13:6: func registerRuntimeRpcServerMethods should be registerRuntimeRPCServerMethods
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/rpc/server.go:20:1: exported function ServeRuntimeEngineRequests should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/check.go:3:1: exported method RuntimeEngine.CheckConfig should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/cleanup.go:3:1: exported method RuntimeEngine.CleanupContainer should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/create.go:28:1: exported method RuntimeEngine.CreateContainer should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/monitor.go:3:1: exported method RuntimeEngine.MonitorContainer should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/process.go:9:1: exported method RuntimeEngine.PrestartProcess should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/process.go:14:1: exported method RuntimeEngine.StartProcess should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/runtime.go:9:6: exported type RuntimeEngine should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/runtime.go:9:6: type name will be used as runtime.RuntimeEngine by other packages, and that stutters; consider calling this Engine
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/runtime.go:13:1: exported method RuntimeEngine.InitConfig should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/runtime.go:25:1: exported method RuntimeEngine.IsRunAsInstance should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config/config.go:10:7: exported const Name should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config/config.go:12:6: exported type Configuration should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config/config.go:43:6: exported type RuntimeEngineSpec should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config/config.go:47:6: exported type RuntimeEngineConfig should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config/config.go:53:1: exported function NewSingularityConfig should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config/config.go:68:1: exported method RuntimeEngineConfig.Test should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/args.go:13:6: exported type MkdirArgs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/args.go:17:6: exported type LoopArgs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/args.go:23:6: exported type MountArgs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/args.go:31:6: exported type ChrootArgs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client/client.go:18:6: exported type Rpc should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client/client.go:18:6: type Rpc should be RPC
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client/client.go:23:1: exported method Rpc.Mount should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client/client.go:36:1: exported method Rpc.Mkdir should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client/client.go:45:1: exported method Rpc.Chroot should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/client/client.go:54:1: exported method Rpc.LoopDevice should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server/server.go:20:6: exported type Methods should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server/server.go:22:1: exported method Methods.Mount should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server/server.go:26:1: exported method Methods.Mkdir should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server/server.go:31:1: exported method Methods.Chroot should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/rpc/server/server.go:58:1: exported method Methods.LoopDevice should have comment or be unexported
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin