### PR TITLE
Print error if LINTY is run and golint is not installed

### DIFF
--- a/linty.sh
+++ b/linty.sh
@@ -11,6 +11,12 @@
 # exits. If both statements are TRUE, LINTY prints out a table of lint counts
 # for the packages that are listed in its configuration.
 
+if ! which golint >/dev/null; then
+	echo "ERROR: golint not found!"
+	echo "Please install by running 'go get golang.org/x/lint/golint'"
+	exit 3
+fi
+
 # Configuration file
 linty_config=".linty.conf"
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Print error message if LINTY is run but `golint` is not installed:

```
ERROR: golint not found!
Please install by running 'go get golang.org/x/lint/golint'
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
