### PR TITLE
Remove Confgen Lint

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -2,7 +2,6 @@
 # lint. Once a package is free of lint, it must be removed from this list.
 github.com/singularityware/singularity/src/cmd/singularity/cli
 github.com/singularityware/singularity/src/pkg/build
-github.com/singularityware/singularity/src/pkg/buildcfg/confgen
 github.com/singularityware/singularity/src/pkg/image
 github.com/singularityware/singularity/src/pkg/libexec
 github.com/singularityware/singularity/src/pkg/sif

--- a/src/pkg/buildcfg/confgen/gen.go
+++ b/src/pkg/buildcfg/confgen/gen.go
@@ -15,7 +15,7 @@ import (
 	"text/template"
 )
 
-func ParseLine(s string) (d Define) {
+func parseLine(s string) (d Define) {
 	d = Define{
 		Words: strings.Fields(s),
 	}
@@ -23,10 +23,12 @@ func ParseLine(s string) (d Define) {
 	return
 }
 
+// Define is a struct that contains one line of configuration words.
 type Define struct {
 	Words []string
 }
 
+// WriteLine writes a line of configuration.
 func (d Define) WriteLine() (s string) {
 	s = "const " + d.Words[1] + " = " + d.Words[2]
 
@@ -63,7 +65,7 @@ func main() {
 	header := []Define{}
 	s := bufio.NewScanner(bytes.NewReader(inFile))
 	for s.Scan() {
-		header = append(header, ParseLine(s.Text()))
+		header = append(header, parseLine(s.Text()))
 	}
 
 	confgenTemplate.Execute(outFile, header)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove lint from package `src/pkg/buildcfg/confgen`:

```
src/pkg/buildcfg/confgen/gen.go:18:1: exported function ParseLine should have comment or be unexported
src/pkg/buildcfg/confgen/gen.go:26:6: exported type Define should have comment or be unexported
src/pkg/buildcfg/confgen/gen.go:30:1: exported method Define.WriteLine should have comment or be unexported
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin