### PR TITLE
Remove Lint from Loop Package

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -4,7 +4,6 @@ github.com/singularityware/singularity/src/cmd/singularity/cli
 github.com/singularityware/singularity/src/pkg/image
 github.com/singularityware/singularity/src/pkg/libexec
 github.com/singularityware/singularity/src/pkg/sif
-github.com/singularityware/singularity/src/pkg/util/loop
 github.com/singularityware/singularity/src/pkg/workflows
 github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config

--- a/src/pkg/util/loop/header.go
+++ b/src/pkg/util/loop/header.go
@@ -5,12 +5,16 @@
 
 package loop
 
+// Loop device flags values
 const (
 	FlagsReadOnly  = 1
 	FlagsAutoClear = 4
 	FlagsPartScan  = 8
 	FlagsDirectIO  = 16
+)
 
+// Loop device encryption types
+const (
 	CryptNone      = 0
 	CryptXor       = 1
 	CryptDes       = 2
@@ -22,7 +26,10 @@ const (
 	CryptSkipJack  = 10
 	CryptCryptoAPI = 18
 	CryptMax       = 20
+)
 
+// Loop device IOCTL commands
+const (
 	CmdSetFd       = 0x4C00
 	CmdClrFd       = 0x4C01
 	CmdSetStatus   = 0x4C02
@@ -34,7 +41,8 @@ const (
 	CmdSetDirectIO = 0x4C08
 )
 
-type LoopInfo64 struct {
+// Info64 contains information about a loop device.
+type Info64 struct {
 	Device         uint64
 	Inode          uint64
 	Rdevice        uint64

--- a/src/pkg/util/loop/loop.go
+++ b/src/pkg/util/loop/loop.go
@@ -14,14 +14,16 @@ import (
 	"unsafe"
 )
 
+// MaxLoopDevices is the maxiumum number of loop devices that are supported
 const MaxLoopDevices = 256
 
-type LoopDevice struct {
+// Device describes a loop device
+type Device struct {
 	file *os.File
 }
 
-// Find a free loop device, open it and store file descriptor
-func (loop *LoopDevice) Attach(image string, mode int, number *int) error {
+// Attach finds a free loop device, opens it, and stores file descriptor
+func (loop *Device) Attach(image string, mode int, number *int) error {
 	var path string
 
 	runtime.LockOSThread()
@@ -69,8 +71,8 @@ func (loop *LoopDevice) Attach(image string, mode int, number *int) error {
 	return errors.New("No loop devices available")
 }
 
-// Set info status about image
-func (loop *LoopDevice) SetStatus(info *LoopInfo64) error {
+// SetStatus sets info status about image
+func (loop *Device) SetStatus(info *Info64) error {
 	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, loop.file.Fd(), CmdSetStatus64, uintptr(unsafe.Pointer(info)))
 	if err != 0 {
 		return fmt.Errorf("Failed to set loop flags on loop device: %s", syscall.Errno(err))

--- a/src/runtime/workflows/workflows/singularity/create.go
+++ b/src/runtime/workflows/workflows/singularity/create.go
@@ -67,7 +67,7 @@ func (engine *Engine) CreateContainer(rpcConn net.Conn) error {
 
 	imageObject := C.singularity_image_init(C.CString(rootfs), 0)
 
-	info := new(loop.LoopInfo64)
+	info := new(loop.Info64)
 	mountType := ""
 
 	switch C.singularity_image_type(&imageObject) {

--- a/src/runtime/workflows/workflows/singularity/rpc/args.go
+++ b/src/runtime/workflows/workflows/singularity/rpc/args.go
@@ -16,7 +16,7 @@ type MkdirArgs struct {
 type LoopArgs struct {
 	Image string
 	Mode  int
-	Info  loop.LoopInfo64
+	Info  loop.Info64
 }
 
 // MountArgs defines the arguments to mount

--- a/src/runtime/workflows/workflows/singularity/rpc/client/client.go
+++ b/src/runtime/workflows/workflows/singularity/rpc/client/client.go
@@ -53,7 +53,7 @@ func (t *RPC) Chroot(root string) (int, error) {
 }
 
 // LoopDevice calls the loop device RPC using the supplied arguments
-func (t *RPC) LoopDevice(image string, mode int, info loop.LoopInfo64) (int, error) {
+func (t *RPC) LoopDevice(image string, mode int, info loop.Info64) (int, error) {
 	arguments := &args.LoopArgs{
 		Image: image,
 		Mode:  mode,

--- a/src/runtime/workflows/workflows/singularity/rpc/server/server.go
+++ b/src/runtime/workflows/workflows/singularity/rpc/server/server.go
@@ -58,7 +58,7 @@ func (t *Methods) Chroot(arguments *args.ChrootArgs, reply *int) error {
 
 // LoopDevice attaches a loop device with the specified arguments
 func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) error {
-	loopdev := new(loop.LoopDevice)
+	loopdev := new(loop.Device)
 
 	if err := loopdev.Attach(arguments.Image, arguments.Mode, reply); err != nil {
 		return err


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove remaining lint from loop device package: 

```
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/header.go:9:2: exported const FlagsReadOnly should have comment (or a comment on this block) or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/header.go:37:6: exported type LoopInfo64 should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/header.go:37:6: type name will be used as loop.LoopInfo64 by other packages, and that stutters; consider calling this Info64
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/loop.go:17:7: exported const MaxLoopDevices should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/loop.go:19:6: exported type LoopDevice should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/loop.go:19:6: type name will be used as loop.LoopDevice by other packages, and that stutters; consider calling this Device
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/loop.go:23:1: comment on exported method LoopDevice.Attach should be of the form "Attach ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/util/loop/loop.go:72:1: comment on exported method LoopDevice.SetStatus should be of the form "SetStatus ..."
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin