### PR TITLE
Fix passwd abort when user identity not found

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -50,8 +50,13 @@
 #endif
 
 int close_fd(int fd, struct stat *st) {
-    if ( S_ISDIR(st->st_mode) || S_ISSOCK(st->st_mode) ) {
+    if ( S_ISDIR(st->st_mode) ) {
         return(1);
+    }
+    if ( singularity_registry_get("UNSHARE_NET") != NULL ) {
+        if ( S_ISSOCK(st->st_mode) ) {
+            return(1);
+        }
     }
     return(0);
 }

--- a/src/lib/runtime/files/passwd/passwd.c
+++ b/src/lib/runtime/files/passwd/passwd.c
@@ -72,15 +72,15 @@ int _singularity_runtime_files_passwd(void) {
         ABORT(255);
     }
 
-    if ( pwent == NULL ) {
-        singularity_message(ERROR, "Failed to obtain user identity information\n");
-        ABORT(255);
-    }
-
     singularity_message(DEBUG, "Checking configuration option: 'config passwd'\n");
     if ( singularity_config_get_bool(CONFIG_PASSWD) <= 0 ) {
         singularity_message(VERBOSE, "Skipping bind of the host's /etc/passwd\n");
         return(0);
+    }
+
+    if ( pwent == NULL ) {
+        singularity_message(ERROR, "Failed to obtain user identity information\n");
+        ABORT(255);
     }
 
     source_file = joinpath(containerdir, "/etc/passwd");


### PR DESCRIPTION
**Description of the Pull Request (PR):**

When user identity is not found singularity abort and ignore configuration directive `config passwd`. Put the check after configuration check.
Plus close socket in `actions.c` only when network namespace is enabled

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
