### PR TITLE
Lint-Friendly SIF Const Names

### DIFF
--- a/src/pkg/sif/sifcore.go
+++ b/src/pkg/sif/sifcore.go
@@ -71,15 +71,16 @@ import (
  * This portion of the file is for sif.c (internal SIF) related wrappers
  */
 
+// SIF-related constants
 const (
-	SIF_DEFAULT_GROUP = C.SIF_DEFAULT_GROUP
-	SIF_UNUSED_GROUP  = C.SIF_UNUSED_GROUP
+	DefaultGroup = C.SIF_DEFAULT_GROUP
+	UnusedGroup  = C.SIF_UNUSED_GROUP
 
-	DATA_DEFFILE   = C.DATA_DEFFILE
-	DATA_ENVVAR    = C.DATA_ENVVAR
-	DATA_LABELS    = C.DATA_LABELS
-	DATA_PARTITION = C.DATA_PARTITION
-	DATA_SIGNATURE = C.DATA_SIGNATURE
+	DataDefFile   = C.DATA_DEFFILE
+	DataEnvVar    = C.DATA_ENVVAR
+	DataLabels    = C.DATA_LABELS
+	DataPartition = C.DATA_PARTITION
+	DataSignature = C.DATA_SIGNATURE
 )
 
 type Sifdescriptor struct {

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -24,7 +24,7 @@ const (
 func sifDataObjectHash(sinfo *sif.Sifinfo) (*bytes.Buffer, error) {
 	var msg = new(bytes.Buffer)
 
-	part, err := sif.SifGetPartition(sinfo, sif.SIF_DEFAULT_GROUP)
+	part, err := sif.SifGetPartition(sinfo, sif.DefaultGroup)
 	if err != nil {
 		sylog.Errorf("%s\n", err)
 		return nil, err
@@ -45,7 +45,7 @@ func sifDataObjectHash(sinfo *sif.Sifinfo) (*bytes.Buffer, error) {
 func sifAddSignature(fingerprint [20]byte, sinfo *sif.Sifinfo, signature []byte) error {
 	var e sif.Eleminfo
 
-	part, err := sif.SifGetPartition(sinfo, sif.SIF_DEFAULT_GROUP)
+	part, err := sif.SifGetPartition(sinfo, sif.DefaultGroup)
 	if err != nil {
 		sylog.Errorf("%s\n", err)
 		return err


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Use lint-friendly const names in SIF implementation.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin