### PR TITLE
Remove CLI Lint

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -1,6 +1,5 @@
 # This is the LINTY configuration, which is a list of packages that contain
 # lint. Once a package is free of lint, it must be removed from this list.
-github.com/singularityware/singularity/src/cmd/singularity/cli
 github.com/singularityware/singularity/src/pkg/libexec
 github.com/singularityware/singularity/src/pkg/sif
 github.com/singularityware/singularity/src/pkg/workflows

--- a/src/cmd/singularity/cli/action_flags.go
+++ b/src/cmd/singularity/cli/action_flags.go
@@ -43,7 +43,7 @@ var (
 	DropCaps  []string
 )
 
-var actionFlags *pflag.FlagSet = pflag.NewFlagSet("ActionFlags", pflag.ExitOnError)
+var actionFlags = pflag.NewFlagSet("ActionFlags", pflag.ExitOnError)
 
 func getHomeDir() string {
 	usr, err := user.Current()

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -17,14 +17,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var execExamples string = `
+var execExamples = `
       $ singularity exec /tmp/Debian.img cat /etc/debian_version
       $ singularity exec /tmp/Debian.img python ./hello_world.py
       $ cat hello_world.py | singularity exec /tmp/Debian.img python
       $ sudo singularity exec --writable /tmp/Debian.img apt-get update
       $ singularity exec instance://my_instance ps -ef`
 
-var shellExamples string = `
+var shellExamples = `
       $ singularity shell /tmp/Debian.img
       Singularity/Debian.img> pwd
       /home/gmk/test
@@ -50,7 +50,7 @@ var shellExamples string = `
       ubuntu       2     0  0 20:01 pts/8    00:00:00 /bin/bash --norc
       ubuntu       3     2  0 20:02 pts/8    00:00:00 ps -ef`
 
-var runExamples string = `
+var runExamples = `
 `
 
 func init() {

--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -16,28 +16,28 @@ import (
 )
 
 var (
-	Remote    bool
-	RemoteURL string
-	AuthToken string
-	Sandbox   bool
-	Writable  bool
-	Force     bool
-	NoTest    bool
-	Sections  []string
+	remote    bool
+	remoteURL string
+	authToken string
+	sandbox   bool
+	writable  bool
+	force     bool
+	noTest    bool
+	sections  []string
 )
 
 func init() {
 	buildCmd.Flags().SetInterspersed(false)
 	singularityCmd.AddCommand(buildCmd)
 
-	buildCmd.Flags().BoolVarP(&Sandbox, "sandbox", "s", false, "Build image as sandbox format (chroot directory structure)")
-	buildCmd.Flags().StringSliceVar(&Sections, "section", []string{}, "Only run specific section(s) of deffile")
-	buildCmd.Flags().BoolVarP(&Writable, "writable", "w", false, "Build image as writable (SIF with writable internal overlay)")
-	buildCmd.Flags().BoolVarP(&Force, "force", "f", false, "")
-	buildCmd.Flags().BoolVarP(&NoTest, "notest", "T", false, "")
-	buildCmd.Flags().BoolVarP(&Remote, "remote", "r", false, "Build image remotely")
-	buildCmd.Flags().StringVar(&RemoteURL, "remote-url", "localhost:5050", "Specify the URL of the remote builder")
-	buildCmd.Flags().StringVar(&AuthToken, "auth-token", "", "Specify the auth token for the remote builder")
+	buildCmd.Flags().BoolVarP(&sandbox, "sandbox", "s", false, "Build image as sandbox format (chroot directory structure)")
+	buildCmd.Flags().StringSliceVar(&sections, "section", []string{}, "Only run specific section(s) of deffile")
+	buildCmd.Flags().BoolVarP(&writable, "writable", "w", false, "Build image as writable (SIF with writable internal overlay)")
+	buildCmd.Flags().BoolVarP(&force, "force", "f", false, "")
+	buildCmd.Flags().BoolVarP(&noTest, "notest", "T", false, "")
+	buildCmd.Flags().BoolVarP(&remote, "remote", "r", false, "Build image remotely")
+	buildCmd.Flags().StringVar(&remoteURL, "remote-url", "localhost:5050", "Specify the URL of the remote builder")
+	buildCmd.Flags().StringVar(&authToken, "auth-token", "", "Specify the auth token for the remote builder")
 }
 
 // buildCmd represents the build command
@@ -53,7 +53,7 @@ var buildCmd = &cobra.Command{
 			fmt.Println("Silent!")
 		}
 
-		if Sandbox {
+		if sandbox {
 			fmt.Println("Sandbox!")
 		}
 
@@ -79,8 +79,8 @@ var buildCmd = &cobra.Command{
 			sylog.Fatalf("unable to parse %s: %v\n", args[1], err)
 		}
 
-		if Remote {
-			b = build.NewRemoteBuilder(args[0], def, false, RemoteURL, AuthToken)
+		if remote {
+			b = build.NewRemoteBuilder(args[0], def, false, remoteURL, authToken)
 		} else {
 			b, err = build.NewSIFBuilder(args[0], def)
 			if err != nil {

--- a/src/cmd/singularity/cli/capability_add.go
+++ b/src/cmd/singularity/cli/capability_add.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var capabilityAddExamples string = `
+var capabilityAddExamples = `
       $ singularity capability.add /tmp/my-sql.img mysql
 
       $ singularity shell capability://mysql

--- a/src/cmd/singularity/cli/capability_drop.go
+++ b/src/cmd/singularity/cli/capability_drop.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var capabilityDropExamples string = `
+var capabilityDropExamples = `
       $ singularity capability.drop /tmp/my-sql.img mysql
 
       $ singularity shell capability://mysql

--- a/src/cmd/singularity/cli/capability_list.go
+++ b/src/cmd/singularity/cli/capability_list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var capabilityListExamples string = `
+var capabilityListExamples = `
       $ singularity capability.list /tmp/my-sql.img mysql
 
       $ singularity shell capability://mysql

--- a/src/cmd/singularity/cli/instance_start.go
+++ b/src/cmd/singularity/cli/instance_start.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var instanceStartExamples string = `
+var instanceStartExamples = `
       $ singularity instance.start /tmp/my-sql.img mysql
 
       $ singularity shell instance://mysql

--- a/src/cmd/singularity/cli/pull.go
+++ b/src/cmd/singularity/cli/pull.go
@@ -30,7 +30,7 @@ func init() {
 
 	pullCmd.Flags().StringVar(&PullLibraryURI, "libraryuri", "https://library.sylabs.io", "")
 	pullCmd.Flags().StringVar(&PullTokenFile, "tokenfile", defaultTokenFile, "path to the file holding your sylabs authentication token")
-	pullCmd.Flags().BoolVarP(&Force, "force", "F", false, "overwrite an image file if it exists")
+	pullCmd.Flags().BoolVarP(&force, "force", "F", false, "overwrite an image file if it exists")
 	singularityCmd.AddCommand(pullCmd)
 
 }
@@ -40,9 +40,9 @@ var pullCmd = &cobra.Command{
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 2 {
-			libexec.PullImage(args[0], args[1], PullLibraryURI, Force, PullTokenFile)
+			libexec.PullImage(args[0], args[1], PullLibraryURI, force, PullTokenFile)
 			return
 		}
-		libexec.PullImage("", args[0], PullLibraryURI, Force, PullTokenFile)
+		libexec.PullImage("", args[0], PullLibraryURI, force, PullTokenFile)
 	},
 }

--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -28,17 +28,16 @@ var singularityCmd = &cobra.Command{
 	Run: nil,
 }
 
-/*
-Execute adds all child commands to the root command and sets flags
-appropriately.  This is called by main.main(). It only needs to happen once to
-the root command (singularity).
-*/
+// ExecuteSingularity adds all child commands to the root command and sets
+// flags appropriately. This is called by main.main(). It only needs to happen
+// once to the root command (singularity).
 func ExecuteSingularity() {
 	if err := singularityCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }
 
+// TraverseParentsUses traverses each parent recursively and appends its usage.
 func TraverseParentsUses(cmd *cobra.Command) string {
 	if cmd.HasParent() {
 		return TraverseParentsUses(cmd.Parent()) + cmd.Use + " "


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove lint from `src/cmd/singularity/cli`:

```
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/action_flags.go:46:17: should omit type *pflag.FlagSet from declaration of var actionFlags; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/actions.go:20:18: should omit type string from declaration of var execExamples; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/actions.go:27:19: should omit type string from declaration of var shellExamples; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/actions.go:53:17: should omit type string from declaration of var runExamples; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/build.go:19:2: exported var Remote should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/capability_add.go:14:27: should omit type string from declaration of var capabilityAddExamples; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/capability_drop.go:14:28: should omit type string from declaration of var capabilityDropExamples; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/capability_list.go:14:28: should omit type string from declaration of var capabilityListExamples; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/instance_start.go:14:27: should omit type string from declaration of var instanceStartExamples; it will be inferred from the right-hand side
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/singularity.go:31:1: comment on exported function ExecuteSingularity should be of the form "ExecuteSingularity ..."
/home/adam/go/src/github.com/singularityware/singularity/src/cmd/singularity/cli/singularity.go:42:1: exported function TraverseParentsUses should have comment or be unexported
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin