### PR TITLE
Remove Workflows Lint

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -2,5 +2,4 @@
 # lint. Once a package is free of lint, it must be removed from this list.
 github.com/singularityware/singularity/src/pkg/libexec
 github.com/singularityware/singularity/src/pkg/sif
-github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config

--- a/.linty.conf
+++ b/.linty.conf
@@ -2,6 +2,5 @@
 # lint. Once a package is free of lint, it must be removed from this list.
 github.com/singularityware/singularity/src/pkg/libexec
 github.com/singularityware/singularity/src/pkg/sif
-github.com/singularityware/singularity/src/pkg/workflows
 github.com/singularityware/singularity/src/pkg/workflows/config
 github.com/singularityware/singularity/src/pkg/workflows/oci/config

--- a/src/pkg/workflows/config/config.go
+++ b/src/pkg/workflows/config/config.go
@@ -11,7 +11,7 @@ import (
 	oci "github.com/singularityware/singularity/src/pkg/workflows/oci/config"
 )
 
-// Runtime template specification
+// RuntimeSpec is the runtime template specification.
 type RuntimeSpec struct {
 	RuntimeName       string              `json:"runtimeName"`
 	ID                string              `json:"containerID"`
@@ -19,22 +19,22 @@ type RuntimeSpec struct {
 	RuntimeEngineSpec RuntimeEngineSpec   `json:"runtimeConfig"`
 }
 
-// Runtime engine specification
+// RuntimeEngineSpec is the runtime engine specification.
 type RuntimeEngineSpec interface{}
 
-// Runtime engine configuration
+// RuntimeEngineConfig is the runtime engine configuration.
 type RuntimeEngineConfig struct {
 	RuntimeEngineSpec
 }
 
-// Generic runtime configuration
+// RuntimeConfig is the generic runtime configuration.
 type RuntimeConfig struct {
 	RuntimeSpec
 	OciConfig    oci.RuntimeOciConfig
 	EngineConfig RuntimeEngineConfig
 }
 
-// Return runtime configuration in JSON format
+// GetConfig returns the runtime configuration in JSON format.
 func (r *RuntimeConfig) GetConfig() ([]byte, error) {
 	b, err := json.Marshal(r.RuntimeSpec)
 	if err != nil {
@@ -43,7 +43,7 @@ func (r *RuntimeConfig) GetConfig() ([]byte, error) {
 	return b, nil
 }
 
-// Set runtime configuration based on JSON input
+// SetConfig sets the runtime configuration based on JSON input.
 func (r *RuntimeConfig) SetConfig(jsonConfig []byte) error {
 	if r.RuntimeSpec.RuntimeOciSpec == nil {
 		r.RuntimeSpec.RuntimeOciSpec = &r.OciConfig.RuntimeOciSpec

--- a/src/pkg/workflows/config/parser.go
+++ b/src/pkg/workflows/config/parser.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 )
 
+// Parser parses configuration found in the file with the specified path.
 func Parser(filepath string, f interface{}) error {
 	directives := make(map[string][]string)
 	c, _ := os.Open(filepath)

--- a/src/pkg/workflows/workflows.go
+++ b/src/pkg/workflows/workflows.go
@@ -12,19 +12,20 @@ import (
 	config "github.com/singularityware/singularity/src/pkg/workflows/config"
 )
 
-// Generic runtime engine
-type RuntimeEngine struct {
+// Engine describes the runtime engine
+type Engine struct {
 	*config.RuntimeConfig
 	Runtime
 }
 
-type RuntimeCLI struct {
+// CLI describes the runtime CLI
+type CLI struct {
 	*config.RuntimeConfig
-	OciRuntime
+	OCIRuntime
 }
 
-// OCI runtime operations
-type OciRuntime interface {
+// OCIRuntime describes the interface for an OCI runtime
+type OCIRuntime interface {
 	State(id string) *specs.State
 	Create(id string, bundle string)
 	Start(id string)

--- a/src/runtime/startup/smaster.go
+++ b/src/runtime/startup/smaster.go
@@ -39,7 +39,7 @@ func runAsInstance(conn *os.File) {
 	}
 }
 
-func handleChild(pid int, signal chan os.Signal, engine *runtime.RuntimeEngine) {
+func handleChild(pid int, signal chan os.Signal, engine *runtime.Engine) {
 	var status syscall.WaitStatus
 
 	select {

--- a/src/runtime/workflows/workflows.go
+++ b/src/runtime/workflows/workflows.go
@@ -14,11 +14,11 @@ import (
 	singularityConfig "github.com/singularityware/singularity/src/runtime/workflows/workflows/singularity/config"
 )
 
-var engines map[string]*runtime.RuntimeEngine
+var engines map[string]*runtime.Engine
 
 // NewRuntimeEngine instantiates a runtime engine based on JSON configuration
-func NewRuntimeEngine(name string, jsonConfig []byte) (*runtime.RuntimeEngine, error) {
-	var engine *runtime.RuntimeEngine
+func NewRuntimeEngine(name string, jsonConfig []byte) (*runtime.Engine, error) {
+	var engine *runtime.Engine
 
 	engine = engines[name]
 
@@ -32,9 +32,9 @@ func NewRuntimeEngine(name string, jsonConfig []byte) (*runtime.RuntimeEngine, e
 }
 
 // Register a runtime engine
-func registerRuntimeEngine(engine *runtime.RuntimeEngine, name string) {
+func registerRuntimeEngine(engine *runtime.Engine, name string) {
 	if engines == nil {
-		engines = make(map[string]*runtime.RuntimeEngine)
+		engines = make(map[string]*runtime.Engine)
 	}
 	engines[name] = engine
 	engine.RuntimeConfig = engine.InitConfig()
@@ -46,5 +46,5 @@ func registerRuntimeEngine(engine *runtime.RuntimeEngine, name string) {
 func init() {
 	// initialize singularity engine
 	e := &singularity.Engine{}
-	registerRuntimeEngine(&runtime.RuntimeEngine{Runtime: e}, singularityConfig.Name)
+	registerRuntimeEngine(&runtime.Engine{Runtime: e}, singularityConfig.Name)
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove lint in the `src/pkg/workflows` and `src/pkg/workflows/config` packages:

```
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/workflows.go:15:1: comment on exported type RuntimeEngine should be of the form "RuntimeEngine ..." (with optional leading article)
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/workflows.go:16:6: type name will be used as runtime.RuntimeEngine by other packages, and that stutters; consider calling this Engine
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/workflows.go:21:6: exported type RuntimeCLI should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/workflows.go:21:6: type name will be used as runtime.RuntimeCLI by other packages, and that stutters; consider calling this CLI
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/workflows.go:26:1: comment on exported type OciRuntime should be of the form "OciRuntime ..." (with optional leading article)
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/config/config.go:14:1: comment on exported type RuntimeSpec should be of the form "RuntimeSpec ..." (with optional leading article)
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/config/config.go:22:1: comment on exported type RuntimeEngineSpec should be of the form "RuntimeEngineSpec ..." (with optional leading article)
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/config/config.go:25:1: comment on exported type RuntimeEngineConfig should be of the form "RuntimeEngineConfig ..." (with optional leading article)
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/config/config.go:30:1: comment on exported type RuntimeConfig should be of the form "RuntimeConfig ..." (with optional leading article)
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/config/config.go:37:1: comment on exported method RuntimeConfig.GetConfig should be of the form "GetConfig ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/config/config.go:46:1: comment on exported method RuntimeConfig.SetConfig should be of the form "SetConfig ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/config/parser.go:18:1: exported function Parser should have comment or be unexported
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin