### PR TITLE
Remove OCI Workflows Config Lint

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -2,4 +2,3 @@
 # lint. Once a package is free of lint, it must be removed from this list.
 github.com/singularityware/singularity/src/pkg/libexec
 github.com/singularityware/singularity/src/pkg/sif
-github.com/singularityware/singularity/src/pkg/workflows/oci/config

--- a/src/pkg/workflows/oci/config/annotations.go
+++ b/src/pkg/workflows/oci/config/annotations.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 )
 
+// RuntimeOciAnnotations describes the methods required for an OCI annotations implementation.
 type RuntimeOciAnnotations interface {
 	Get() map[string]string
 	Set(annotations map[string]string) error
@@ -16,6 +17,7 @@ type RuntimeOciAnnotations interface {
 	Del(key string) error
 }
 
+// DefaultRuntimeOciAnnotations describes the default runtime OCI annotations.
 type DefaultRuntimeOciAnnotations struct {
 	RuntimeOciSpec *RuntimeOciSpec
 }
@@ -26,16 +28,19 @@ func (c *DefaultRuntimeOciAnnotations) init() {
 	}
 }
 
+// Get retrieves the runtime annotations.
 func (c *DefaultRuntimeOciAnnotations) Get() map[string]string {
 	c.init()
 	return c.RuntimeOciSpec.Annotations
 }
 
+// Set sets the runtime annotations.
 func (c *DefaultRuntimeOciAnnotations) Set(annotations map[string]string) error {
 	c.RuntimeOciSpec.Annotations = annotations
 	return nil
 }
 
+// Add adds the supplied key/value to the runtime annotations.
 func (c *DefaultRuntimeOciAnnotations) Add(key string, value string) error {
 	c.init()
 	if c.RuntimeOciSpec.Annotations[key] != "" {
@@ -45,6 +50,7 @@ func (c *DefaultRuntimeOciAnnotations) Add(key string, value string) error {
 	return nil
 }
 
+// Del deletes the supplied key from the runtime annotations.
 func (c *DefaultRuntimeOciAnnotations) Del(key string) error {
 	c.init()
 	if c.RuntimeOciSpec.Annotations[key] == "" {

--- a/src/pkg/workflows/oci/config/config.go
+++ b/src/pkg/workflows/oci/config/config.go
@@ -9,8 +9,10 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// RuntimeOciSpec is the OCI runtime specification.
 type RuntimeOciSpec specs.Spec
 
+// RuntimeOciConfig is the OCI runtime configuration.
 type RuntimeOciConfig struct {
 	RuntimeOciSpec
 	Version     RuntimeOciVersion

--- a/src/pkg/workflows/oci/config/config_linux.go
+++ b/src/pkg/workflows/oci/config/config_linux.go
@@ -5,8 +5,10 @@
 
 package config
 
+// Platform represents the current platform.
 const Platform = "linux"
 
+// RuntimeOciPlatform is the OCI runtime platform.
 type RuntimeOciPlatform struct {
 	Linux   RuntimeOciLinux
 	Solaris interface{}

--- a/src/pkg/workflows/oci/config/config_solaris.go
+++ b/src/pkg/workflows/oci/config/config_solaris.go
@@ -5,8 +5,10 @@
 
 package config
 
+// Platform represents the current platform
 const Platform = "solaris"
 
+// RuntimeOciPlatform is the OCI runtime platform.
 type RuntimeOciPlatform struct {
 	Linux   interface{}
 	Solaris RuntimeOciSolaris

--- a/src/pkg/workflows/oci/config/config_windows.go
+++ b/src/pkg/workflows/oci/config/config_windows.go
@@ -5,8 +5,10 @@
 
 package config
 
+// Platform represents the current platform
 const Platform = "windows"
 
+// RuntimeOciPlatform is the OCI runtime platform.
 type RuntimeOciPlatform struct {
 	Linux   interface{}
 	Solaris interface{}

--- a/src/pkg/workflows/oci/config/default_linux.go
+++ b/src/pkg/workflows/oci/config/default_linux.go
@@ -5,6 +5,7 @@
 
 package config
 
+// DefaultRuntimeOciConfig sets the default runtime OCI configuration.
 func DefaultRuntimeOciConfig(cfg *RuntimeOciConfig) error {
 	cfg.Version = &DefaultRuntimeOciVersion{RuntimeOciSpec: &cfg.RuntimeOciSpec}
 	cfg.Hostname = &DefaultRuntimeOciHostname{RuntimeOciSpec: &cfg.RuntimeOciSpec}

--- a/src/pkg/workflows/oci/config/hooks.go
+++ b/src/pkg/workflows/oci/config/hooks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// RuntimeOciHooks describes the methods required for an OCI hooks implementation.
 type RuntimeOciHooks interface {
 	GetSpec() *specs.Hook
 

--- a/src/pkg/workflows/oci/config/hostname.go
+++ b/src/pkg/workflows/oci/config/hostname.go
@@ -9,20 +9,24 @@ import (
 	"fmt"
 )
 
+// RuntimeOciHostname describes the methods required for an OCI hostname implementation.
 type RuntimeOciHostname interface {
 	Get() string
 	Set(hostname string)
 }
 
+// DefaultRuntimeOciHostname describes the default runtime OCI hostname.
 type DefaultRuntimeOciHostname struct {
 	RuntimeOciSpec *RuntimeOciSpec
 }
 
+// Get retrieves the hostname.
 func (c *DefaultRuntimeOciHostname) Get() string {
 	fmt.Println("Get hostname")
 	return c.RuntimeOciSpec.Hostname
 }
 
+// Set sets the hostname.
 func (c *DefaultRuntimeOciHostname) Set(hostname string) {
 	fmt.Println("Set hostname to", hostname)
 	c.RuntimeOciSpec.Hostname = hostname

--- a/src/pkg/workflows/oci/config/linux.go
+++ b/src/pkg/workflows/oci/config/linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// RuntimeOciLinux describes the linux OCI runtime interface.
 type RuntimeOciLinux interface {
 	GetSpec() *specs.Linux
 
@@ -89,6 +90,7 @@ type RuntimeOciLinux interface {
 	DelIntelRdt() error
 }
 
+// LinuxResources describes the linux resources interface.
 type LinuxResources interface {
 	GetResourcesDevices() []specs.LinuxDeviceCgroup
 	SetResourcesDevices(devices []specs.LinuxDeviceCgroup) error
@@ -131,6 +133,7 @@ type LinuxResources interface {
 		DelResourcesRdma(name string) error*/
 }
 
+// LinuxSeccomp describes the linux seccomp interface.
 type LinuxSeccomp interface {
 	GetSeccomp() *specs.LinuxSeccomp
 	SetSeccomp(seccomp *specs.LinuxSeccomp) error
@@ -142,12 +145,14 @@ type LinuxSeccomp interface {
 	SetSeccompSyscalls(syscalls []specs.LinuxSyscall) error
 }
 
+// LinuxSyscall describes the linux system call interface.
 type LinuxSyscall interface {
 	Get() []specs.LinuxSyscall
 	Set(syscalls []specs.LinuxSyscall) error
 	Add(names []string, action specs.LinuxSeccompAction, args []specs.LinuxSeccompArg) error
 }
 
+// LinuxSeccompArg describes the linux seccomp argument interface.
 type LinuxSeccompArg interface {
 	Get() []specs.LinuxSeccompArg
 	Set(args []specs.LinuxSeccompArg) error

--- a/src/pkg/workflows/oci/config/mounts.go
+++ b/src/pkg/workflows/oci/config/mounts.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// RuntimeOciMounts describes the methods required for an OCI mount implementation.
 type RuntimeOciMounts interface {
 	GetSpec() *specs.Mount
 

--- a/src/pkg/workflows/oci/config/process.go
+++ b/src/pkg/workflows/oci/config/process.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// RuntimeOciProcess describes the methods required for an OCI process implementation.
 type RuntimeOciProcess interface {
 	GetSpec() *specs.Process
 
@@ -53,6 +54,7 @@ type RuntimeOciProcess interface {
 
 var environ = map[string]int{}
 
+// DefaultRuntimeOciProcess describes the default runtime OCI process information.
 type DefaultRuntimeOciProcess struct {
 	RuntimeOciSpec *RuntimeOciSpec
 }
@@ -63,21 +65,25 @@ func (c *DefaultRuntimeOciProcess) init() {
 	}
 }
 
+// GetSpec retrieves the runtime OCI process spec.
 func (c *DefaultRuntimeOciProcess) GetSpec() *specs.Process {
 	c.init()
 	return c.RuntimeOciSpec.Process
 }
 
+// GetTerminal retrieves the runtime OCI process terminal flag.
 func (c *DefaultRuntimeOciProcess) GetTerminal() bool {
 	c.init()
 	return c.RuntimeOciSpec.Process.Terminal
 }
 
+// SetTerminal sets the runtime OCI process terminal flag.
 func (c *DefaultRuntimeOciProcess) SetTerminal(enable bool) {
 	c.init()
 	c.RuntimeOciSpec.Process.Terminal = enable
 }
 
+// GetConsoleSize retrieves the runtime OCI process console size.
 func (c *DefaultRuntimeOciProcess) GetConsoleSize() (uint, uint) {
 	c.init()
 	if c.RuntimeOciSpec.Process.ConsoleSize == nil {
@@ -86,6 +92,7 @@ func (c *DefaultRuntimeOciProcess) GetConsoleSize() (uint, uint) {
 	return c.RuntimeOciSpec.Process.ConsoleSize.Height, c.RuntimeOciSpec.Process.ConsoleSize.Width
 }
 
+// SetConsoleSize sets the runtime OCI process console size.
 func (c *DefaultRuntimeOciProcess) SetConsoleSize(height uint, width uint) {
 	c.init()
 	if c.RuntimeOciSpec.Process.ConsoleSize == nil {
@@ -95,54 +102,66 @@ func (c *DefaultRuntimeOciProcess) SetConsoleSize(height uint, width uint) {
 	c.RuntimeOciSpec.Process.ConsoleSize.Width = width
 }
 
+// GetUID retrieves the runtime OCI process UID.
 func (c *DefaultRuntimeOciProcess) GetUID() uint32 {
 	c.init()
 	return c.RuntimeOciSpec.Process.User.UID
 }
 
+// SetUID sets the runtime OCI process UID.
 func (c *DefaultRuntimeOciProcess) SetUID(uid uint32) {
 	c.init()
 	c.RuntimeOciSpec.Process.User.UID = uid
 }
 
+// GetGID retrieves the runtime OCI process GID.
 func (c *DefaultRuntimeOciProcess) GetGID() uint32 {
 	c.init()
 	return c.RuntimeOciSpec.Process.User.GID
 }
 
+// SetGID sets the runtime OCI process GID.
 func (c *DefaultRuntimeOciProcess) SetGID(gid uint32) {
 	c.init()
 	c.RuntimeOciSpec.Process.User.GID = gid
 }
 
+// GetAdditionalGids retrieves the runtime OCI additional GIDs.
 func (c *DefaultRuntimeOciProcess) GetAdditionalGids() []uint32 {
 	c.init()
 	return c.RuntimeOciSpec.Process.User.AdditionalGids
 }
 
+// SetAdditionalGids sets the runtime OCI additional GIDs.
 func (c *DefaultRuntimeOciProcess) SetAdditionalGids(gids []uint32) error {
 	c.init()
 	return nil
 }
 
+// AddAdditionalGid add a GID to the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) AddAdditionalGid(gid uint32) error {
 	c.init()
 	return nil
 }
+
+// DelAdditionalGid deletes a GID to the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) DelAdditionalGid(gid uint32) error {
 	c.init()
 	return nil
 }
 
+// GetUsername gets the username associated with the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) GetUsername() string {
 	c.init()
 	return c.RuntimeOciSpec.Process.User.Username
 }
 
+// SetUsername sets the username associated with the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) SetUsername(name string) {
 	c.init()
 }
 
+// SetArgs sets the arguments associated with the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) SetArgs(args []string) error {
 	c.init()
 	for _, arg := range args {
@@ -151,22 +170,26 @@ func (c *DefaultRuntimeOciProcess) SetArgs(args []string) error {
 	return nil
 }
 
+// GetArgs gets the arguments associated with the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) GetArgs() []string {
 	c.init()
 	return c.RuntimeOciSpec.Process.Args
 }
 
+// AddArg adds an argument to the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) AddArg(arg string) error {
 	c.init()
 	c.RuntimeOciSpec.Process.Args = append(c.RuntimeOciSpec.Process.Args, arg)
 	return nil
 }
 
+// DelArg deletes an argument from the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) DelArg(arg string) error {
 	c.init()
 	return nil
 }
 
+// SetEnv sets an environment variable in the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) SetEnv(env []string) error {
 	c.init()
 	for _, e := range env {
@@ -177,11 +200,13 @@ func (c *DefaultRuntimeOciProcess) SetEnv(env []string) error {
 	return nil
 }
 
+// GetEnv gets an environment variable from the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) GetEnv() []string {
 	c.init()
 	return c.RuntimeOciSpec.Process.Env
 }
 
+// AddEnv adds an environment variable to the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) AddEnv(env string) error {
 	c.init()
 	if i := strings.IndexByte(env, '='); i != -1 {
@@ -196,6 +221,7 @@ func (c *DefaultRuntimeOciProcess) AddEnv(env string) error {
 	return nil
 }
 
+// DelEnv deletes an environment variable from the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) DelEnv(env string) error {
 	c.init()
 	if i := strings.IndexByte(env, '='); i != -1 {
@@ -205,16 +231,17 @@ func (c *DefaultRuntimeOciProcess) DelEnv(env string) error {
 			return nil
 		}
 		return fmt.Errorf("environment variable %s doesn't exists", env[:i])
-	} else {
-		return fmt.Errorf("bad formatted environment variable: %s", env)
 	}
+	return fmt.Errorf("bad formatted environment variable: %s", env)
 }
 
+// SetCwd sets the current working directory of the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) SetCwd(cwd string) {
 	c.init()
 	c.RuntimeOciSpec.Process.Cwd = cwd
 }
 
+// GetCwd gets the current working directory of the runtime OCI process.
 func (c *DefaultRuntimeOciProcess) GetCwd() string {
 	c.init()
 	return c.RuntimeOciSpec.Process.Cwd

--- a/src/pkg/workflows/oci/config/process_linux.go
+++ b/src/pkg/workflows/oci/config/process_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/singularityware/singularity/src/pkg/util/capabilities"
 )
 
+// ProcessPlatform describes the platform process interface.
 type ProcessPlatform interface {
 	GetBoundingCapabilities() []string
 	SetBoundingCapabilities([]string) error
@@ -102,11 +103,13 @@ func (c *DefaultRuntimeOciProcess) initCapabilities() {
 	}
 }
 
+// GetBoundingCapabilities retrieves the bounding capabilities.
 func (c *DefaultRuntimeOciProcess) GetBoundingCapabilities() []string {
 	c.initCapabilities()
 	return c.RuntimeOciSpec.Process.Capabilities.Bounding
 }
 
+// SetBoundingCapabilities sets the bounding capabilities.
 func (c *DefaultRuntimeOciProcess) SetBoundingCapabilities(capabilities []string) error {
 	c.initCapabilities()
 	for _, capability := range capabilities {
@@ -117,21 +120,25 @@ func (c *DefaultRuntimeOciProcess) SetBoundingCapabilities(capabilities []string
 	return nil
 }
 
+// AddBoundingCapability adds a bounding capability.
 func (c *DefaultRuntimeOciProcess) AddBoundingCapability(capability string) error {
 	c.initCapabilities()
 	return addCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Bounding, boundingCapabilities)
 }
 
+// DelBoundingCapability deletes a bounding capability.
 func (c *DefaultRuntimeOciProcess) DelBoundingCapability(capability string) error {
 	c.initCapabilities()
 	return delCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Bounding, boundingCapabilities)
 }
 
+// GetEffectiveCapabilities retrieves the effective capabilities.
 func (c *DefaultRuntimeOciProcess) GetEffectiveCapabilities() []string {
 	c.initCapabilities()
 	return c.RuntimeOciSpec.Process.Capabilities.Effective
 }
 
+// SetEffectiveCapabilities sets the effective capabilities.
 func (c *DefaultRuntimeOciProcess) SetEffectiveCapabilities(capabilities []string) error {
 	c.initCapabilities()
 	for _, capability := range capabilities {
@@ -142,21 +149,25 @@ func (c *DefaultRuntimeOciProcess) SetEffectiveCapabilities(capabilities []strin
 	return nil
 }
 
+// AddEffectiveCapability adds an effective capability.
 func (c *DefaultRuntimeOciProcess) AddEffectiveCapability(capability string) error {
 	c.initCapabilities()
 	return addCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Effective, effectiveCapabilities)
 }
 
+// DelEffectiveCapability deletes an effective capability.
 func (c *DefaultRuntimeOciProcess) DelEffectiveCapability(capability string) error {
 	c.initCapabilities()
 	return delCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Effective, effectiveCapabilities)
 }
 
+// GetInheritableCapabilities retrieves the inheritable capabilities.
 func (c *DefaultRuntimeOciProcess) GetInheritableCapabilities() []string {
 	c.initCapabilities()
 	return []string{}
 }
 
+// SetInheritableCapabilities sets the inheritable capabilities.
 func (c *DefaultRuntimeOciProcess) SetInheritableCapabilities(capabilities []string) error {
 	c.initCapabilities()
 	for _, capability := range capabilities {
@@ -167,21 +178,25 @@ func (c *DefaultRuntimeOciProcess) SetInheritableCapabilities(capabilities []str
 	return nil
 }
 
+// AddInheritableCapability adds an inheritable capability.
 func (c *DefaultRuntimeOciProcess) AddInheritableCapability(capability string) error {
 	c.initCapabilities()
 	return addCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Inheritable, inheritableCapabilities)
 }
 
+// DelInheritableCapability deletes an inheritable capability.
 func (c *DefaultRuntimeOciProcess) DelInheritableCapability(capability string) error {
 	c.initCapabilities()
 	return delCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Inheritable, inheritableCapabilities)
 }
 
+// GetPermittedCapabilities retrieves the permitted capabilities.
 func (c *DefaultRuntimeOciProcess) GetPermittedCapabilities() []string {
 	c.initCapabilities()
 	return []string{}
 }
 
+// SetPermittedCapabilities sets the permitted capabilities.
 func (c *DefaultRuntimeOciProcess) SetPermittedCapabilities(capabilities []string) error {
 	c.initCapabilities()
 	for _, capability := range capabilities {
@@ -192,21 +207,25 @@ func (c *DefaultRuntimeOciProcess) SetPermittedCapabilities(capabilities []strin
 	return nil
 }
 
+// AddPermittedCapability adds a permitted capability.
 func (c *DefaultRuntimeOciProcess) AddPermittedCapability(capability string) error {
 	c.initCapabilities()
 	return addCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Permitted, permittedCapabilities)
 }
 
+// DelPermittedCapability deletes a permitted capability.
 func (c *DefaultRuntimeOciProcess) DelPermittedCapability(capability string) error {
 	c.initCapabilities()
 	return delCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Permitted, permittedCapabilities)
 }
 
+// GetAmbientCapabilities retrieves the ambient capabilities.
 func (c *DefaultRuntimeOciProcess) GetAmbientCapabilities() []string {
 	c.initCapabilities()
 	return []string{}
 }
 
+// SetAmbientCapabilities sets the ambient capabilities.
 func (c *DefaultRuntimeOciProcess) SetAmbientCapabilities(capabilities []string) error {
 	c.initCapabilities()
 	for _, capability := range capabilities {
@@ -217,71 +236,85 @@ func (c *DefaultRuntimeOciProcess) SetAmbientCapabilities(capabilities []string)
 	return nil
 }
 
+// AddAmbientCapability adds an ambient capability.
 func (c *DefaultRuntimeOciProcess) AddAmbientCapability(capability string) error {
 	c.initCapabilities()
 	return addCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Ambient, ambientCapabilities)
 }
 
+// DelAmbientCapability deletes an ambient capability.
 func (c *DefaultRuntimeOciProcess) DelAmbientCapability(capability string) error {
 	c.initCapabilities()
 	return delCapability(capability, &c.RuntimeOciSpec.Process.Capabilities.Ambient, ambientCapabilities)
 }
 
+// GetNoNewPrivileges gets the no new privileges flag.
 func (c *DefaultRuntimeOciProcess) GetNoNewPrivileges() bool {
 	c.init()
 	return c.RuntimeOciSpec.Process.NoNewPrivileges
 }
 
+// SetNoNewPrivileges sets the no new privileges flag.
 func (c *DefaultRuntimeOciProcess) SetNoNewPrivileges(enable bool) {
 	c.init()
 	c.RuntimeOciSpec.Process.NoNewPrivileges = enable
 }
 
+// GetApparmorProfile gets the apparmor profile.
 func (c *DefaultRuntimeOciProcess) GetApparmorProfile() string {
 	c.init()
 	return c.RuntimeOciSpec.Process.ApparmorProfile
 }
 
+// SetApparmorProfile sets the apparmor profile.
 func (c *DefaultRuntimeOciProcess) SetApparmorProfile(profile string) {
 	c.init()
 	c.RuntimeOciSpec.Process.ApparmorProfile = profile
 }
 
+// GetSelinuxLabel gets the selinux label.
 func (c *DefaultRuntimeOciProcess) GetSelinuxLabel() string {
 	c.init()
 	return c.RuntimeOciSpec.Process.SelinuxLabel
 }
 
+// SetSelinuxLabel sets the selinux label.
 func (c *DefaultRuntimeOciProcess) SetSelinuxLabel(label string) {
 	c.init()
 	c.RuntimeOciSpec.Process.SelinuxLabel = label
 }
 
+// GetOOMScoreAdj gets the OOM score adjustment value.
 func (c *DefaultRuntimeOciProcess) GetOOMScoreAdj() *int {
 	c.init()
 	return c.RuntimeOciSpec.Process.OOMScoreAdj
 }
 
+// SetOOMScoreAdj sets the OOM score adjustment value.
 func (c *DefaultRuntimeOciProcess) SetOOMScoreAdj(score int) {
 	c.init()
 	c.RuntimeOciSpec.Process.OOMScoreAdj = &score
 }
 
+// GetRlimits gets the POSIX rlimits.
 func (c *DefaultRuntimeOciProcess) GetRlimits() []specs.POSIXRlimit {
 	c.init()
 	return c.RuntimeOciSpec.Process.Rlimits
 }
 
+// SetRlimits sets the POSIX rlimits.
 func (c *DefaultRuntimeOciProcess) SetRlimits(limits []specs.POSIXRlimit) error {
 	c.init()
 	return nil
 }
 
+// AddRlimit adds a POSIX rlimit.
 func (c *DefaultRuntimeOciProcess) AddRlimit(rtype string, hard uint64, soft uint64) error {
 	c.init()
 	return nil
 }
 
+// DelRlimit deletes a POSIX rlimit.
 func (c *DefaultRuntimeOciProcess) DelRlimit(rtype string) error {
 	c.init()
 	return nil

--- a/src/pkg/workflows/oci/config/root.go
+++ b/src/pkg/workflows/oci/config/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// RuntimeOciRoot describes the methods required for an OCI root implementation.
 type RuntimeOciRoot interface {
 	GetSpec() *specs.Root
 
@@ -19,6 +20,7 @@ type RuntimeOciRoot interface {
 	SetReadOnly(enabled bool)
 }
 
+// DefaultRuntimeOciRoot describes the default runtime OCI root.
 type DefaultRuntimeOciRoot struct {
 	RuntimeOciSpec *RuntimeOciSpec
 }
@@ -29,26 +31,31 @@ func (c *DefaultRuntimeOciRoot) init() {
 	}
 }
 
+// GetSpec retrieves the runtime OCI root spec.
 func (c *DefaultRuntimeOciRoot) GetSpec() *specs.Root {
 	c.init()
 	return c.RuntimeOciSpec.Root
 }
 
+// GetPath retrieves the runtime OCI root path.
 func (c *DefaultRuntimeOciRoot) GetPath() string {
 	c.init()
 	return c.RuntimeOciSpec.Root.Path
 }
 
+// SetPath sets the runtime OCI root path.
 func (c *DefaultRuntimeOciRoot) SetPath(path string) {
 	c.init()
 	c.RuntimeOciSpec.Root.Path = path
 }
 
+// GetReadOnly gets the runtime OCI root read-only flag.
 func (c *DefaultRuntimeOciRoot) GetReadOnly() bool {
 	c.init()
 	return c.RuntimeOciSpec.Root.Readonly
 }
 
+// SetReadOnly sets the runtime OCI root read-only flag.
 func (c *DefaultRuntimeOciRoot) SetReadOnly(enabled bool) {
 	c.init()
 	c.RuntimeOciSpec.Root.Readonly = enabled

--- a/src/pkg/workflows/oci/config/version.go
+++ b/src/pkg/workflows/oci/config/version.go
@@ -9,20 +9,24 @@ import (
 	"fmt"
 )
 
+// RuntimeOciVersion describes the OCI version interface.
 type RuntimeOciVersion interface {
 	Get() string
 	Set(name string)
 }
 
+// DefaultRuntimeOciVersion describes the default runtime OCI version.
 type DefaultRuntimeOciVersion struct {
 	RuntimeOciSpec *RuntimeOciSpec
 }
 
+// Get retrieves the runtime OCI version.
 func (c *DefaultRuntimeOciVersion) Get() string {
 	fmt.Println("Get version")
 	return c.RuntimeOciSpec.Version
 }
 
+// Set sets the runtime OCI version.
 func (c *DefaultRuntimeOciVersion) Set(version string) {
 	fmt.Println("Set version to", version)
 	c.RuntimeOciSpec.Version = version


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove remaining 94 pieces of lint from `src/pkg/workflows/oci/config`:

```sh
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/annotations.go:12:6: exported type RuntimeOciAnnotations should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/annotations.go:19:6: exported type DefaultRuntimeOciAnnotations should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/annotations.go:29:1: exported method DefaultRuntimeOciAnnotations.Get should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/annotations.go:34:1: exported method DefaultRuntimeOciAnnotations.Set should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/annotations.go:39:1: exported method DefaultRuntimeOciAnnotations.Add should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/annotations.go:48:1: exported method DefaultRuntimeOciAnnotations.Del should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/config.go:12:6: exported type RuntimeOciSpec should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/config.go:14:6: exported type RuntimeOciConfig should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/config_linux.go:8:7: exported const Platform should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/config_linux.go:10:6: exported type RuntimeOciPlatform should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/default_linux.go:8:1: exported function DefaultRuntimeOciConfig should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/hooks.go:14:6: exported type RuntimeOciHooks should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/hostname.go:12:6: exported type RuntimeOciHostname should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/hostname.go:17:6: exported type DefaultRuntimeOciHostname should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/hostname.go:21:1: exported method DefaultRuntimeOciHostname.Get should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/hostname.go:26:1: exported method DefaultRuntimeOciHostname.Set should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/linux.go:16:6: exported type RuntimeOciLinux should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/linux.go:92:6: exported type LinuxResources should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/linux.go:134:6: exported type LinuxSeccomp should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/linux.go:145:6: exported type LinuxSyscall should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/linux.go:151:6: exported type LinuxSeccompArg should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/mounts.go:12:6: exported type RuntimeOciMounts should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:15:6: exported type RuntimeOciProcess should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:56:6: exported type DefaultRuntimeOciProcess should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:66:1: exported method DefaultRuntimeOciProcess.GetSpec should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:71:1: exported method DefaultRuntimeOciProcess.GetTerminal should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:76:1: exported method DefaultRuntimeOciProcess.SetTerminal should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:81:1: exported method DefaultRuntimeOciProcess.GetConsoleSize should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:89:1: exported method DefaultRuntimeOciProcess.SetConsoleSize should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:98:1: exported method DefaultRuntimeOciProcess.GetUID should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:103:1: exported method DefaultRuntimeOciProcess.SetUID should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:108:1: exported method DefaultRuntimeOciProcess.GetGID should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:113:1: exported method DefaultRuntimeOciProcess.SetGID should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:118:1: exported method DefaultRuntimeOciProcess.GetAdditionalGids should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:123:1: exported method DefaultRuntimeOciProcess.SetAdditionalGids should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:128:1: exported method DefaultRuntimeOciProcess.AddAdditionalGid should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:132:1: exported method DefaultRuntimeOciProcess.DelAdditionalGid should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:137:1: exported method DefaultRuntimeOciProcess.GetUsername should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:142:1: exported method DefaultRuntimeOciProcess.SetUsername should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:146:1: exported method DefaultRuntimeOciProcess.SetArgs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:154:1: exported method DefaultRuntimeOciProcess.GetArgs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:159:1: exported method DefaultRuntimeOciProcess.AddArg should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:165:1: exported method DefaultRuntimeOciProcess.DelArg should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:170:1: exported method DefaultRuntimeOciProcess.SetEnv should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:180:1: exported method DefaultRuntimeOciProcess.GetEnv should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:185:1: exported method DefaultRuntimeOciProcess.AddEnv should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:199:1: exported method DefaultRuntimeOciProcess.DelEnv should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:208:9: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:213:1: exported method DefaultRuntimeOciProcess.SetCwd should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process.go:218:1: exported method DefaultRuntimeOciProcess.GetCwd should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:16:6: exported type ProcessPlatform should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:105:1: exported method DefaultRuntimeOciProcess.GetBoundingCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:110:1: exported method DefaultRuntimeOciProcess.SetBoundingCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:120:1: exported method DefaultRuntimeOciProcess.AddBoundingCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:125:1: exported method DefaultRuntimeOciProcess.DelBoundingCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:130:1: exported method DefaultRuntimeOciProcess.GetEffectiveCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:135:1: exported method DefaultRuntimeOciProcess.SetEffectiveCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:145:1: exported method DefaultRuntimeOciProcess.AddEffectiveCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:150:1: exported method DefaultRuntimeOciProcess.DelEffectiveCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:155:1: exported method DefaultRuntimeOciProcess.GetInheritableCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:160:1: exported method DefaultRuntimeOciProcess.SetInheritableCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:170:1: exported method DefaultRuntimeOciProcess.AddInheritableCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:175:1: exported method DefaultRuntimeOciProcess.DelInheritableCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:180:1: exported method DefaultRuntimeOciProcess.GetPermittedCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:185:1: exported method DefaultRuntimeOciProcess.SetPermittedCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:195:1: exported method DefaultRuntimeOciProcess.AddPermittedCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:200:1: exported method DefaultRuntimeOciProcess.DelPermittedCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:205:1: exported method DefaultRuntimeOciProcess.GetAmbientCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:210:1: exported method DefaultRuntimeOciProcess.SetAmbientCapabilities should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:220:1: exported method DefaultRuntimeOciProcess.AddAmbientCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:225:1: exported method DefaultRuntimeOciProcess.DelAmbientCapability should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:230:1: exported method DefaultRuntimeOciProcess.GetNoNewPrivileges should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:235:1: exported method DefaultRuntimeOciProcess.SetNoNewPrivileges should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:240:1: exported method DefaultRuntimeOciProcess.GetApparmorProfile should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:245:1: exported method DefaultRuntimeOciProcess.SetApparmorProfile should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:250:1: exported method DefaultRuntimeOciProcess.GetSelinuxLabel should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:255:1: exported method DefaultRuntimeOciProcess.SetSelinuxLabel should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:260:1: exported method DefaultRuntimeOciProcess.GetOOMScoreAdj should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:265:1: exported method DefaultRuntimeOciProcess.SetOOMScoreAdj should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:270:1: exported method DefaultRuntimeOciProcess.GetRlimits should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:275:1: exported method DefaultRuntimeOciProcess.SetRlimits should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:280:1: exported method DefaultRuntimeOciProcess.AddRlimit should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/process_linux.go:285:1: exported method DefaultRuntimeOciProcess.DelRlimit should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/root.go:12:6: exported type RuntimeOciRoot should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/root.go:22:6: exported type DefaultRuntimeOciRoot should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/root.go:32:1: exported method DefaultRuntimeOciRoot.GetSpec should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/root.go:37:1: exported method DefaultRuntimeOciRoot.GetPath should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/root.go:42:1: exported method DefaultRuntimeOciRoot.SetPath should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/root.go:47:1: exported method DefaultRuntimeOciRoot.GetReadOnly should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/root.go:52:1: exported method DefaultRuntimeOciRoot.SetReadOnly should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/version.go:12:6: exported type RuntimeOciVersion should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/version.go:17:6: exported type DefaultRuntimeOciVersion should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/version.go:21:1: exported method DefaultRuntimeOciVersion.Get should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/workflows/oci/config/version.go:26:1: exported method DefaultRuntimeOciVersion.Set should have comment or be unexported
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin