### PR TITLE
Remove libexec Lint

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -1,5 +1,4 @@
 # This is the LINTY configuration, which is a list of packages that contain
 # lint. Once a package is free of lint, it must be removed from this list.
-github.com/singularityware/singularity/src/pkg/libexec
 github.com/singularityware/singularity/src/pkg/sif
 github.com/singularityware/singularity/src/pkg/workflows/oci/config

--- a/src/pkg/libexec/action.go
+++ b/src/pkg/libexec/action.go
@@ -11,22 +11,27 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// Shell drops to a shell.
 func Shell(spec *specs.Spec) {
 	fmt.Println("Shell")
 }
 
+// Exec executes the supplied command.
 func Exec(spec *specs.Spec, cmd string) {
 
 }
 
+// Run runs the image.
 func Run(spec *specs.Spec) {
 
 }
 
+// Test tests the image.
 func Test(spec *specs.Spec) {
 
 }
 
+// SelfTest runs a self-test.
 func SelfTest(spec *specs.Spec) {
 
 }

--- a/src/pkg/libexec/apps.go
+++ b/src/pkg/libexec/apps.go
@@ -9,6 +9,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// AppList lists the available applications.
 func AppList(spec *specs.Spec) {
 
 }

--- a/src/pkg/libexec/crypto.go
+++ b/src/pkg/libexec/crypto.go
@@ -10,11 +10,12 @@ import (
 	//specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// Sign signs the supplied image.
 func Sign(i image.Image) {
 
 }
 
-// Yanick please help define these function prototypes
+// Verify verifies the supplied image.
 func Verify(i image.Image) {
 
 }

--- a/src/pkg/libexec/image.go
+++ b/src/pkg/libexec/image.go
@@ -10,22 +10,27 @@ import (
 	//specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// ImageCreate creates an image.
 func ImageCreate() image.Image {
 	return image.SandboxFromPath("/path/to/sandbox")
 }
 
+// ImageBuild builds an image.
 func ImageBuild() image.Image {
 	return image.SandboxFromPath("/path/to/sandbox")
 }
 
+// ImageExpand expands an image.
 func ImageExpand() image.Image {
 	return image.SandboxFromPath("/path/to/sandbox")
 }
 
+// ImageImport imports an image.
 func ImageImport() {
 
 }
 
+// ImageExport exports an image.
 func ImageExport() {
 
 }

--- a/src/pkg/libexec/instance.go
+++ b/src/pkg/libexec/instance.go
@@ -9,14 +9,17 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// InstanceStart starts an instance.
 func InstanceStart(spec *specs.Spec) {
 
 }
 
+// InstanceStop stops an instance.
 func InstanceStop(spec *specs.Spec) {
 
 }
 
+// InstanceList lists the running instances.
 func InstanceList() []specs.State {
 	return nil
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove remaining lint from `src/pkg/libexec` package:

```sh
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:21:6: exported type SIF should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:26:6: func name will be used as sif.SIFFromSandbox by other packages, and that stutters; consider calling this FromSandbox
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:61:6: func name will be used as sif.SIFFromPath by other packages, and that stutters; consider calling this FromPath
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:65:1: exported function SIFFromReadSeeker should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:65:6: func name will be used as sif.SIFFromReadSeeker by other packages, and that stutters; consider calling this FromReadSeeker
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:69:1: exported method SIF.Root should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:73:1: exported method SIF.Rootfs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:86:6: exported type Sifdescriptor should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:90:6: exported type Sifinfo should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:94:1: exported method Sifinfo.Mapstart should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:98:6: exported type Sifpartition should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:102:1: exported method Sifpartition.FileOff should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:105:1: exported method Sifpartition.FileLen should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:109:6: exported type Sifsignature should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:113:1: exported method Sifsignature.FileOff should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:117:1: exported method Sifsignature.FileLen should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:121:1: exported method Sifsignature.GetEntity should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:127:6: exported type Eleminfo should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:131:1: exported method Eleminfo.InitSignature should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:135:1: comment on exported function SifLoad should be of the form "SifLoad ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:139:6: func name will be used as sif.SifLoad by other packages, and that stutters; consider calling this Load
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:146:1: comment on exported function SifUnload should be of the form "SifUnload ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:150:6: func name will be used as sif.SifUnload by other packages, and that stutters; consider calling this Unload
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:157:1: comment on exported function SifPutDataObj should be of the form "SifPutDataObj ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:161:6: func name will be used as sif.SifPutDataObj by other packages, and that stutters; consider calling this PutDataObj
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:172:1: comment on exported function SifPrintHeader should be of the form "SifPrintHeader ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:176:6: func name will be used as sif.SifPrintHeader by other packages, and that stutters; consider calling this PrintHeader
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:180:1: comment on exported function SifPrintList should be of the form "SifPrintList ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:184:6: func name will be used as sif.SifPrintList by other packages, and that stutters; consider calling this PrintList
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:188:1: comment on exported function SifGetPartition should be of the form "SifGetPartition ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:192:6: func name will be used as sif.SifGetPartition by other packages, and that stutters; consider calling this GetPartition
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:200:1: comment on exported function SifGetLinkedDesc should be of the form "SifGetLinkedDesc ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:204:6: func name will be used as sif.SifGetLinkedDesc by other packages, and that stutters; consider calling this GetLinkedDesc
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:213:1: exported function SifGetSignature should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:213:6: func name will be used as sif.SifGetSignature by other packages, and that stutters; consider calling this GetSignature
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:225:1: exported function CByteRange should have comment or be unexported
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin