### PR TITLE
Remove SIF Lint

### DIFF
--- a/.linty.conf
+++ b/.linty.conf
@@ -1,5 +1,4 @@
 # This is the LINTY configuration, which is a list of packages that contain
 # lint. Once a package is free of lint, it must be removed from this list.
 github.com/singularityware/singularity/src/pkg/libexec
-github.com/singularityware/singularity/src/pkg/sif
 github.com/singularityware/singularity/src/pkg/workflows/oci/config

--- a/src/pkg/build/builder_sif.go
+++ b/src/pkg/build/builder_sif.go
@@ -128,7 +128,7 @@ func NewSifBuilderJSON(r io.Reader, imagePath string) (b *SIFBuilder2, err error
 // Build completes a build. The supplied context can be used for cancellation.
 func (b *SIFBuilder2) Build(ctx context.Context) (err error) {
 	b.p.Provision(b.tmpfs)
-	img, err := sif.SIFFromSandbox(b.tmpfs, b.path)
+	img, err := sif.FromSandbox(b.tmpfs, b.path)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/sif/sif.go
+++ b/src/pkg/sif/sif.go
@@ -15,15 +15,16 @@ import (
 	"github.com/golang/glog"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/singularityware/singularity/src/pkg/buildcfg"
-	image "github.com/singularityware/singularity/src/pkg/image"
+	"github.com/singularityware/singularity/src/pkg/image"
 )
 
+// SIF describes a SIF image.
 type SIF struct {
 	path string
 }
 
-// SIFFromSandbox converts the sandbox, s, to a SIF file
-func SIFFromSandbox(sandbox *image.Sandbox, imagePath string) (*SIF, error) {
+// FromSandbox converts the sandbox, s, to a SIF file.
+func FromSandbox(sandbox *image.Sandbox, imagePath string) (*SIF, error) {
 	mksquashfs, err := exec.LookPath("mksquashfs")
 	if err != nil {
 		glog.Error("mksquashfs is not installed on this system")
@@ -57,19 +58,22 @@ func SIFFromSandbox(sandbox *image.Sandbox, imagePath string) (*SIF, error) {
 
 }
 
-// SIFFromPath returns a SIF object of the file located at path
-func SIFFromPath(path string) *SIF {
+// FromPath returns a SIF object of the file located at path.
+func FromPath(path string) *SIF {
 	return &SIF{}
 }
 
-func SIFFromReadSeeker(f io.ReadSeeker) *SIF {
+// FromReadSeeker returns a SIF object from the supplied ReadSeeker.
+func FromReadSeeker(f io.ReadSeeker) *SIF {
 	return &SIF{}
 }
 
+// Root returns the root specification of the SIF.
 func (i *SIF) Root() *specs.Root {
 	return &specs.Root{}
 }
 
+// Rootfs returns the root FS of the SIF.
 func (i *SIF) Rootfs() string {
 	return i.path
 }

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -21,10 +21,10 @@ const (
 	syKeysAddr = "example.org:11371"
 )
 
-func sifDataObjectHash(sinfo *sif.Sifinfo) (*bytes.Buffer, error) {
+func sifDataObjectHash(sinfo *sif.Info) (*bytes.Buffer, error) {
 	var msg = new(bytes.Buffer)
 
-	part, err := sif.SifGetPartition(sinfo, sif.DefaultGroup)
+	part, err := sif.GetPartition(sinfo, sif.DefaultGroup)
 	if err != nil {
 		sylog.Errorf("%s\n", err)
 		return nil, err
@@ -42,10 +42,10 @@ func sifDataObjectHash(sinfo *sif.Sifinfo) (*bytes.Buffer, error) {
 	return msg, nil
 }
 
-func sifAddSignature(fingerprint [20]byte, sinfo *sif.Sifinfo, signature []byte) error {
+func sifAddSignature(fingerprint [20]byte, sinfo *sif.Info, signature []byte) error {
 	var e sif.Eleminfo
 
-	part, err := sif.SifGetPartition(sinfo, sif.DefaultGroup)
+	part, err := sif.GetPartition(sinfo, sif.DefaultGroup)
 	if err != nil {
 		sylog.Errorf("%s\n", err)
 		return err
@@ -53,7 +53,7 @@ func sifAddSignature(fingerprint [20]byte, sinfo *sif.Sifinfo, signature []byte)
 
 	e.InitSignature(fingerprint, signature, part)
 
-	if err := sif.SifPutDataObj(&e, sinfo); err != nil {
+	if err := sif.PutDataObj(&e, sinfo); err != nil {
 		sylog.Errorf("%s\n", err)
 		return err
 	}
@@ -98,12 +98,12 @@ func Sign(cpath string) error {
 	}
 	sypgp.DecryptKey(en)
 
-	var sinfo sif.Sifinfo
-	if err = sif.SifLoad(cpath, &sinfo, 0); err != nil {
+	var sinfo sif.Info
+	if err = sif.Load(cpath, &sinfo, 0); err != nil {
 		sylog.Errorf("error loading sif file %s: %s\n", cpath, err)
 		return err
 	}
-	defer sif.SifUnload(&sinfo)
+	defer sif.Unload(&sinfo)
 
 	msg, err := sifDataObjectHash(&sinfo)
 	if err != nil {
@@ -139,20 +139,20 @@ func Sign(cpath string) error {
 // if access is enabled.
 func Verify(cpath string) error {
 	var el openpgp.EntityList
-	var sinfo sif.Sifinfo
+	var sinfo sif.Info
 
-	if err := sif.SifLoad(cpath, &sinfo, 0); err != nil {
+	if err := sif.Load(cpath, &sinfo, 0); err != nil {
 		sylog.Errorf("%s\n", err)
 		return err
 	}
-	defer sif.SifUnload(&sinfo)
+	defer sif.Unload(&sinfo)
 
 	msg, err := sifDataObjectHash(&sinfo)
 	if err != nil {
 		return err
 	}
 
-	sig, err := sif.SifGetSignature(&sinfo)
+	sig, err := sif.GetSignature(&sinfo)
 	if err != nil {
 		sylog.Errorf("%s\n", err)
 		return err


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove remaining lint from the `singularity/src/pkg/sif` package:

```sh
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:21:6: exported type SIF should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:26:6: func name will be used as sif.SIFFromSandbox by other packages, and that stutters; consider calling this FromSandbox
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:61:6: func name will be used as sif.SIFFromPath by other packages, and that stutters; consider calling this FromPath
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:65:1: exported function SIFFromReadSeeker should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:65:6: func name will be used as sif.SIFFromReadSeeker by other packages, and that stutters; consider calling this FromReadSeeker
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:69:1: exported method SIF.Root should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sif.go:73:1: exported method SIF.Rootfs should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:86:6: exported type Sifdescriptor should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:90:6: exported type Sifinfo should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:94:1: exported method Sifinfo.Mapstart should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:98:6: exported type Sifpartition should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:102:1: exported method Sifpartition.FileOff should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:105:1: exported method Sifpartition.FileLen should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:109:6: exported type Sifsignature should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:113:1: exported method Sifsignature.FileOff should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:117:1: exported method Sifsignature.FileLen should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:121:1: exported method Sifsignature.GetEntity should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:127:6: exported type Eleminfo should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:131:1: exported method Eleminfo.InitSignature should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:135:1: comment on exported function SifLoad should be of the form "SifLoad ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:139:6: func name will be used as sif.SifLoad by other packages, and that stutters; consider calling this Load
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:146:1: comment on exported function SifUnload should be of the form "SifUnload ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:150:6: func name will be used as sif.SifUnload by other packages, and that stutters; consider calling this Unload
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:157:1: comment on exported function SifPutDataObj should be of the form "SifPutDataObj ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:161:6: func name will be used as sif.SifPutDataObj by other packages, and that stutters; consider calling this PutDataObj
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:172:1: comment on exported function SifPrintHeader should be of the form "SifPrintHeader ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:176:6: func name will be used as sif.SifPrintHeader by other packages, and that stutters; consider calling this PrintHeader
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:180:1: comment on exported function SifPrintList should be of the form "SifPrintList ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:184:6: func name will be used as sif.SifPrintList by other packages, and that stutters; consider calling this PrintList
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:188:1: comment on exported function SifGetPartition should be of the form "SifGetPartition ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:192:6: func name will be used as sif.SifGetPartition by other packages, and that stutters; consider calling this GetPartition
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:200:1: comment on exported function SifGetLinkedDesc should be of the form "SifGetLinkedDesc ..."
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:204:6: func name will be used as sif.SifGetLinkedDesc by other packages, and that stutters; consider calling this GetLinkedDesc
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:213:1: exported function SifGetSignature should have comment or be unexported
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:213:6: func name will be used as sif.SifGetSignature by other packages, and that stutters; consider calling this GetSignature
/home/adam/go/src/github.com/singularityware/singularity/src/pkg/sif/sifcore.go:225:1: exported function CByteRange should have comment or be unexported
```
**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
