### PR TITLE
go build tag for sif.h lib

### DIFF
--- a/mlocal/checks/project.chk
+++ b/mlocal/checks/project.chk
@@ -8,7 +8,7 @@ config_add_def PACKAGE_NAME \"singularity\"
 config_add_def PACKAGE_TARNAME \"singularity\"
 config_add_def PACKAGE_VERSION \"3.0\"
 config_add_def PACKAGE_STRING \"singularity 3.0\"
-config_add_def PACKAGE_BUGREPORT \"gmkurtzer@gmail.com\"
+config_add_def PACKAGE_BUGREPORT \"support@sylabs.io\"
 config_add_def PACKAGE_URL \"\"
 
 config_add_def BUILDDIR \"$builddir\"

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -34,7 +34,7 @@ go_BIN := $(singularity) $(sbuild)
 go_OBJ := $(SOURCEDIR)/src/pkg/buildcfg/config.go
 go_INSTALL := $(singularity_INSTALL) $(sbuild_INSTALL)
 
-go_TAG = "containers_image_openpgp"
+go_TAG = "containers_image_openpgp singularity_sif"
 
 cgo_CPPFLAGS = -I$(BUILDDIR) -I$(SOURCEDIR)/src/runtime/c -I$(SOURCEDIR)/src/runtime/c/lib
 cgo_LDFLAGS = -L`readlink -f $(BUILDDIR)`/lib
@@ -78,7 +78,7 @@ $(wrapper): $(wrapper_OBJ) $(libstartup)
 $(singularity): $(go_OBJ) $(libruntime) $(singularity_OBJ)
 	@echo " GO" $@
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		go build --tags "$(go_TAG)" -o $(BUILDDIR)/singularity $(SOURCEDIR)/src/cmd/singularity/cli.go
+		go build -tags $(go_TAG) -o $(BUILDDIR)/singularity $(SOURCEDIR)/src/cmd/singularity/cli.go
 $(singularity_INSTALL): $(singularity)
 	@echo " INSTALL" $@
 	$(V)install -d $(@D)

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -178,7 +178,7 @@ test:
 	@echo "       PASS"
 	@echo " TEST go test ./..."
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && go test -cover -race -timeout 60s ./...
+		cd $(SOURCEDIR) && go test -tags $(go_TAG) -cover -race -timeout 60s ./...
 	@echo "       PASS"
 
 .PHONY: cscope

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -170,7 +170,7 @@ test:
 	@echo "       PASS"
 	@echo " TEST go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && go vet -all ./...
+		cd $(SOURCEDIR) && go vet -tags $(go_TAG) -all ./...
 	@echo "       PASS"
 	@echo " TEST LINTY"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/src/pkg/sif/sifcore.go
+++ b/src/pkg/sif/sifcore.go
@@ -1,3 +1,5 @@
+// +build singularity_sif
+
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Currently when importing 
```go
import "github.com/singularityware/singularity/pkg/build"
```
or 
```go
import "github.com/singularityware/singularity/pkg/image"
```
leaves to the following error at build time
```
# github.com/sylabs/remote-build/vendor/github.com/singularityware/singularity/pkg/image
vendor/github.com/singularityware/singularity/pkg/image/sifcore.go:20:10: fatal error: 'sif/list.h' file not found
#include <sif/list.h>
         ^~~~~~~~~~~~
1 error generated.
```
Which can be fixed via go tooling:

adding
```go
// +build singularity_sif


```
at the top of `singularity/pkg/image/sifcore.go`


-/-
 - Also updates support mail addr



**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
