### PR TITLE
docker-extract - don't resolve through symlinks that we need to whiteout

### DIFF
--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 #include <limits.h>
 #include <locale.h>
+#include <libgen.h>
 #include <archive.h>
 #include <archive_entry.h>
 
@@ -116,20 +117,94 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
 
     // Target may not exist - that's ok
     if (stat(target, &statbuf) < 0){
+        singularity_message(DEBUG, "Whiteout target doesn't exist, at: %s\n",
+                            target);
+
         return 0;
     }
 
-    target_real = realpath(target, NULL);  // Flawfinder: ignore
+    // If the whiteout target is a link, we need to remove that link (source)
+    // itself and not resolve through it
+    if(is_link(target) == 0) {
+        char *target_copy1, *target_copy2, *parent, *link, *parent_real;
 
-    if(target_real == NULL) {
-        singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
-        ABORT(255);
+        target_copy1 = strdup(target);
+        if(target_copy1 == NULL) {
+            singularity_message(ERROR, "Error allocating memory for path - aborting.\n");
+            ABORT(255);
+        }
+
+        target_copy2 = strdup(target);
+        if(target_copy2 == NULL) {
+            singularity_message(ERROR, "Error allocating memory for path - aborting.\n");
+            ABORT(255);
+        }
+
+        parent = dirname(target_copy1);
+        link = basename(target_copy2);
+
+        singularity_message(DEBUG, "Whiteout target is a symlink with parent dir: %s Link: %s\n",
+                            parent, link);
+
+
+        // First check fully resolved *parent dir* does not escape the ROOTFS
+        parent_real = realpath(parent, NULL);
+        if(parent_real == NULL) {
+            singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
+            ABORT(255);
+        }
+
+
+        singularity_message(DEBUG, "Link parent dir resolves to: %s\n",
+                            parent_real);
+
+
+        if(strncmp(rootfs_dir, parent_real, strlen(rootfs_dir)) != 0) {
+            singularity_message(ERROR, "Attempt to whiteout outside of rootfs %s - aborting.\n", parent_real);
+            ABORT(255);
+        }
+
+        // And the link cannot be called '..' (not sure if this is possible, but
+        // maybe a tar can be created like that maliciously)
+        if(strncmp(link, "..", sizeof(link) -1) == 0){
+            singularity_message(ERROR, "Whiteout target has '..' as last component: %s - aborting.\n", target);
+            ABORT(255);
+        }
+
+        // Now our real target path is the resolved parent, plus the link
+        // basename of the link
+        target_real = malloc(PATH_MAX + 1);
+        retval = snprintf(target_real, PATH_MAX - 1, "%s/%s", parent_real, link );
+        if (retval == -1 || retval >= PATH_MAX - 1) {
+            singularity_message(ERROR, "Error with pathname too long\n");
+            ABORT(255);
+        }
+
+        singularity_message(DEBUG, "Whiteout target resolves to symlink at: %s\n",
+                            target_real);
+
+        free(target_copy1);
+        free(target_copy2);
+        free(parent_real);
+
+    }else{
+
+        target_real = realpath(target, NULL);  // Flawfinder: ignore
+
+        if(target_real == NULL) {
+            singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
+            ABORT(255);
+        }
+
+        if(strncmp(rootfs_dir, target_real, strlen(rootfs_dir)) != 0) {
+            singularity_message(ERROR, "Attempt to whiteout outside of rootfs %s - aborting.\n", target_real);
+            ABORT(255);
+        }
+
+        singularity_message(DEBUG, "Whiteout target is a regular file/dir, at: %s\n",
+                            target_real);
     }
- 
-    if(strncmp(rootfs_dir, target_real, strlen(rootfs_dir)) != 0) {
-        singularity_message(ERROR, "Attempt to whiteout outside of rootfs %s - aborting.\n", target_real);
-        ABORT(255);
-    }
+
 
     if (is_dir(target_real) == 0) {
         retval = s_rmdir(target_real);

--- a/src/docker-extract.c
+++ b/src/docker-extract.c
@@ -148,7 +148,7 @@ int apply_whiteout(const char *wh_marker, char *rootfs_dir) {
 
 
         // First check fully resolved *parent dir* does not escape the ROOTFS
-        parent_real = realpath(parent, NULL);
+        parent_real = realpath(parent, NULL);   // Flawfinder: ignore
         if(parent_real == NULL) {
             singularity_message(ERROR, "Error canonicalizing whiteout path %s - aborting.\n", target);
             ABORT(255);

--- a/tests/21-build_docker.sh
+++ b/tests/21-build_docker.sh
@@ -71,6 +71,10 @@ stest 0 singularity build -F "$CONTAINER" docker://dctrud/docker-singularity-use
 stest 0 singularity exec "$CONTAINER" ls /testdir/
 stest 1 singularity exec "$CONTAINER" ls /testdir/testfile
 
+# Check whiteout of symbolic links #1592 #1576
+stest 0 singularity build -F "$CONTAINER" docker://dctrud/docker-singularity-linkwh
+stest 0 singularity exec "$CONTAINER" true
+
 if singularity_which docker >/dev/null 2>&1; then
 # make sure local test does not exist, ignore errors
 sudo docker kill registry >/dev/null 2>&1


### PR DESCRIPTION
**Description of the Pull Request (PR):**

In `docker-extract` if a whiteout (file to be deleted) is a symlink we need to remove the symlink. Currently `realpath` on the symlink (which is used to stop escape from ROOTFS) will follow it, and we'd attempt to remove the target, not the symlink itself. This is wrong, and also causes build failures when the symlink is absolute, e.g. the `/etc/localtime` symlink in #1576 :

```
$ singularity run docker://dctrud/docker-singularity-linkwh:latest
Docker image path: index.docker.io/dctrud/docker-singularity-linkwh:latest
Cache folder set to /home/dave/.singularity/docker
Creating container runtime...
Exploding layer: sha256:cc1a78bfd46becbfc3abb8a74d9a70a0e0dc7a5809bbd12e814f9382db003707.tar.gz
Exploding layer: sha256:baec03e6929c27bc05fb5fd590f9ab0203d543312b3228ff391acd751ebf6f07.tar.gz
ERROR  : Attempt to whiteout outside of rootfs /usr/share/zoneinfo/Etc/UTC - aborting.
ABORT  : Retval = 255
```

In this patch, if the target is a symlink, we use realpath to check the parent directory is within `ROOTFS_DIR` and then remove the link based on that realpath - so the link itself doesn't get resolved, and is removed instead of an attempt to remove its target.

With this patch:

```
05:19 PM $ singularity run docker://dctrud/docker-singularity-linkwh:latest
Docker image path: index.docker.io/dctrud/docker-singularity-linkwh:latest
Cache folder set to /home/dave/.singularity/docker
Creating container runtime...
Exploding layer: sha256:cc1a78bfd46becbfc3abb8a74d9a70a0e0dc7a5809bbd12e814f9382db003707.tar.gz
Exploding layer: sha256:baec03e6929c27bc05fb5fd590f9ab0203d543312b3228ff391acd751ebf6f07.tar.gz
Exploding layer: sha256:41659270d183bb048e8859f25493a2f60f58d3194f62f385a409965a4e6e7610.tar.gz
Exploding layer: sha256:19469b3b6806563b2e357ec9f27830f992bd24c142ae0ee0006ad98110691c34.tar.gz
dave@spongebob:~
05:22 PM $ cat /etc/debian_version 
9.4
```

In debug note that we have verbose log messages showing what is going on:

```
DEBUG   [U=1000,P=7696]    main()                                    Applying whiteouts for tar file /home/dave/.singularity/docker/sha256:baec03e6929c27bc05fb5fd590f9ab0203d543312b3228ff391acd751ebf6f07.tar.gz
DEBUG   [U=1000,P=7696]    apply_whiteouts()                         Whiteout Marker etc/.wh.localtime
DEBUG   [U=1000,P=7696]    apply_whiteout()                          Whiteout target is a symlink with parent dir: /tmp/.singularity-runtime.3SRNp1cg/dctrud/docker-singularity-linkwh:latest/etc Link: localtime
DEBUG   [U=1000,P=7696]    apply_whiteout()                          Link parent dir resolves to: /tmp/.singularity-runtime.3SRNp1cg/dctrud/docker-singularity-linkwh:latest/etc
DEBUG   [U=1000,P=7696]    apply_whiteout()                          Whiteout target resolves to symlink at: /tmp/.singularity-runtime.3SRNp1cg/dctrud/docker-singularity-linkwh:latest/etc/localtime
DEBUG   [U=1000,P=7696]    apply_whiteout()                          Removing whiteout-ed file: /tmp/.singularity-runtime.3SRNp1cg/dctrud/docker-singularity-linkwh:latest/etc/localtime
```

NB - we don't need to do this for opaque dir whiteouts... as the target of those must always be a real directory.

**This fixes or addresses the following GitHub issues:**

- Fixes #1576 #1592 


**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
