### PR TITLE
Display a warning rather than aborting during group lookup

### DIFF
--- a/src/lib/runtime/files/group/group.c
+++ b/src/lib/runtime/files/group/group.c
@@ -122,8 +122,7 @@ int _singularity_runtime_files_group(void) {
         // According to the man page, all of the above errno's can indicate this situation.
         singularity_message(VERBOSE3, "Skipping GID %d as group entry does not exist.\n", gid);
     } else {
-        singularity_message(ERROR, "Failed to lookup GID %d group entry: %s\n", gid, strerror(errno));
-        ABORT(255);
+        singularity_message(WARNING, "Failed to lookup GID %d group entry: %s\n", gid, strerror(errno));
     }
 
 
@@ -145,8 +144,7 @@ int _singularity_runtime_files_group(void) {
             } else if ( (errno == 0) || (errno == ESRCH) || (errno == EBADF) || (errno == EPERM) || (errno == ENOENT) ) {
                 singularity_message(VERBOSE3, "Skipping GID %d as group entry does not exist.\n", gids[i]);
             } else {
-                singularity_message(ERROR, "Failed to lookup GID %d group entry: %s\n", gids[i], strerror(errno));
-                ABORT(255);
+                singularity_message(WARNING, "Failed to lookup GID %d group entry: %s\n", gids[i], strerror(errno));
             }
         } else {
             singularity_message(VERBOSE, "Group id '%d' is out of bounds\n", gids[i]);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Actually when GID lookup fails to resolve group name, Singularity abort. This PR change the behaviour by displaying a warning rather than abort


**This fixes or addresses the following GitHub issues:**

- Ref: #1603


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
