### PR TITLE
Fix config parser malloc size calculation that resulted in writing off the end of the space

### DIFF
--- a/src/util/config_parser.c
+++ b/src/util/config_parser.c
@@ -53,7 +53,7 @@ static struct hsearch_data config_table;
 // By default, each hash bucket can have 7 values.  We set currently-empty
 // entries
 static ENTRY *new_hash_entry(char *key, char *value) {
-    char **hash_value = (char**) malloc(sizeof(char*) * MAX_CONFIG_ENTRIES+1);
+    char **hash_value = (char**) malloc(sizeof(char*) * (MAX_CONFIG_ENTRIES+1));
     int idx;
     hash_value[0] = value;
     for (idx=1; idx < MAX_CONFIG_ENTRIES; idx++) {hash_value[idx] = (char*)1;}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a miscalculation in malloc size in the config parser new_hash_entry() function.  I found this because I was using the valgrind malloc checker with these parameters:
```
valgrind --track-origins=yes --keep-stacktraces=alloc-and-free --tool=memcheck --trace-children=yes
```
and it had the following output
```
==7653== Invalid write of size 8
==7653==    at 0x4E3C5A6: new_hash_entry (config_parser.c:60)
==7653==    by 0x4E3C5A6: add_entry (config_parser.c:99)
==7653==    by 0x4E3C5A6: singularity_config_parse (config_parser.c:185)
==7653==    by 0x4E3C8E5: singularity_config_init (config_parser.c:212)
==7653==    by 0x10B6E4: main (action.c:70)
==7653==  Address 0x5639d50 is 512 bytes inside a block of size 513 alloc'd
==7653==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==7653==    by 0x4E3C586: new_hash_entry (config_parser.c:56)
==7653==    by 0x4E3C586: add_entry (config_parser.c:99)
==7653==    by 0x4E3C586: singularity_config_parse (config_parser.c:185)
==7653==    by 0x4E3C8E5: singularity_config_init (config_parser.c:212)
==7653==    by 0x10B6E4: main (action.c:70)
```


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
