### PR TITLE
CentOS 6 Tests Rebase

### DIFF
--- a/.travis/centos6_setup
+++ b/.travis/centos6_setup
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+mkdir /run
+mkdir /tmp/yum-download
+yum -y --downloadonly --downloaddir /tmp/yum-download install util-linux-ng
+cd /tmp/yum-download
+rpm2cpio util-linux-ng*.rpm | cpio -idmv
+mv bin/mount /bin/mount
+

--- a/.travis/centos6_setup
+++ b/.travis/centos6_setup
@@ -1,5 +1,4 @@
 #!/bin/bash -ex
-
 mkdir /run
 mkdir /tmp/yum-download
 yum -y --downloadonly --downloaddir /tmp/yum-download install util-linux-ng

--- a/.travis/centos_run
+++ b/.travis/centos_run
@@ -1,25 +1,35 @@
 #!/bin/bash -ex
 
-# This script starts docker and (on el7) systemd and runs a test
-
-if [ "$OS_VERSION" = "6" ]; then
-    sudo docker run --privileged --rm=true -v `pwd`:/build:rw centos:${OS_VERSION} /bin/bash -exc "cd /build;.travis/rpmbuild_test $OS_VERSION"
-    exit
-fi
+# This script starts docker and systemd and runs a test
 
 # Mount /var/run/docker.sock and set --network=host so we can call docker from inside
 # cause some tests need it. Cannot mount to /var/run/docker.sock inside cause CentOS
 # /usr/sbin/init mounts another overlayfs on top of it
-docker run --privileged -d -ti -e "container=docker" -v /var/run/docker.sock:/docker.sock --network=host \
-       -v /sys/fs/cgroup:/sys/fs/cgroup -v `pwd`:/build:rw  centos:${OS_VERSION}   /usr/sbin/init
-DOCKER_CONTAINER_ID=$(docker ps | grep centos | awk '{print $1}')
-docker logs $DOCKER_CONTAINER_ID
-docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -exc "
+
+DOCKER_CONTAINER_NAME="test_centos_${OS_VERSION}"
+
+if [ "$OS_VERSION" = "6" ]; then
+    docker run --privileged -ti -e "container=docker" -v /var/run/docker.sock:/docker.sock \
+      --network=host -v "$(pwd):/build:rw"  --name "$DOCKER_CONTAINER_NAME" \
+      "centos:${OS_VERSION}" /bin/bash -exc "
+    export DOCKER_HOST=unix:///docker.sock
+    chmod o+rw /docker.sock &&
+    cd /build &&
+    .travis/centos6_setup &&
+    .travis/rpmbuild_test $OS_VERSION
+"
+else
+    docker run --privileged -d -ti -e "container=docker" -v /var/run/docker.sock:/docker.sock \
+      --network=host -v /sys/fs/cgroup:/sys/fs/cgroup -v "$(pwd):/build:rw"  --name $DOCKER_CONTAINER_NAME \
+      centos:${OS_VERSION} /usr/sbin/init
+    docker exec -ti "$DOCKER_CONTAINER_NAME" /bin/bash -exc "
     export DOCKER_HOST=unix:///docker.sock
     chmod o+rw /docker.sock &&
     cd /build &&
     .travis/rpmbuild_test $OS_VERSION
 "
+fi
+
 docker ps -a
-docker stop $DOCKER_CONTAINER_ID
-docker rm -v $DOCKER_CONTAINER_ID
+docker stop $DOCKER_CONTAINER_NAME
+docker rm -v $DOCKER_CONTAINER_NAME

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -13,14 +13,13 @@ rpmbuild -ta *.tar.gz
 rpm -iv ~/rpmbuild/RPMS/*/*.rpm
 
 if [ "$OS_VERSION" = 6 ]; then
-    echo "the test suite has not yet been ported to centos6 python, skipping."
-    exit
+    echo "the python tests have not yet been ported to centos6 python, and will be skipped."
+else
+    # Install python 3 and pylint
+    yum install -y epel-release
+    yum install -y python34 python34-pip python34-setuptools docker
+    yum install -y pylint
 fi
-
-# Install python 3 and pylint
-yum install -y epel-release
-yum install -y python34 python34-pip python34-setuptools docker
-yum install -y pylint
 
 # run the test suite
 yum install -y libtool sudo which e2fsprogs

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -27,7 +27,6 @@ sed -i 's,^prefix=.*,prefix=/usr,' test.sh
 sed -i 's,^sysconfdir=.*,sysconfdir=/etc,' test.sh
 sed -i 's,^localstatedir=.*,localstatedir=/var,' test.sh
 useradd -u 1000 testuser
-echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
-echo "Defaults umask=0777" >>/etc/sudoers
+echo "Defaults:testuser env_keep=DOCKER_HOST umask=0777 umask_override=1" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
-sudo -u testuser make test
+su testuser -c "make test"

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -27,6 +27,6 @@ sed -i 's,^prefix=.*,prefix=/usr,' test.sh
 sed -i 's,^sysconfdir=.*,sysconfdir=/etc,' test.sh
 sed -i 's,^localstatedir=.*,localstatedir=/var,' test.sh
 useradd -u 1000 testuser
-echo "Defaults:testuser env_keep=DOCKER_HOST umask=0777 umask_override=1" >>/etc/sudoers
+echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 su testuser -c "make test"

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -26,7 +26,8 @@ yum install -y libtool sudo which e2fsprogs
 sed -i 's,^prefix=.*,prefix=/usr,' test.sh
 sed -i 's,^sysconfdir=.*,sysconfdir=/etc,' test.sh
 sed -i 's,^localstatedir=.*,localstatedir=/var,' test.sh
-useradd testuser
+useradd -u 1000 testuser
 echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
+echo "Defaults umask=0777" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
-su testuser -c "make test"
+sudo -u testuser make test

--- a/libexec/cli/build.exec
+++ b/libexec/cli/build.exec
@@ -382,6 +382,7 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
         else
             OPTS=""
         fi
+
         if ! mksquashfs "$SINGULARITY_ROOTFS/" "$SINGULARITY_CONTAINER_OUTPUT" -noappend $OPTS > /dev/null; then
             message ERROR "Failed squashing image, left template directory at: $SINGULARITY_ROOTFS\n"
             exit 1
@@ -393,7 +394,7 @@ if [ -z "${SINGULARITY_SANDBOX:-}" ]; then
 	exit 1
     fi
 
-    chmod a+x "$SINGULARITY_CONTAINER_OUTPUT"
+    chmod a+rx "$SINGULARITY_CONTAINER_OUTPUT"
 fi
 
 message 1 "Singularity container built: $SINGULARITY_CONTAINER_OUTPUT\n"

--- a/tests/05-python-units.sh
+++ b/tests/05-python-units.sh
@@ -27,18 +27,25 @@ test_init "Checking Python unit tests"
 cd ../libexec/python
 
 if which python2 >/dev/null 2>&1; then
-    stest 0 python2 -m unittest tests.test_json
-    stest 0 python2 -m unittest tests.test_helpers
-    stest 0 python2 -m unittest tests.test_base
-    stest 0 python2 -m unittest tests.test_core
-    stest 0 python2 -m unittest tests.test_docker_import
-    stest 0 python2 -m unittest tests.test_docker_api
-    stest 0 python2 -m unittest tests.test_docker_tasks
-    stest 0 python2 -m unittest tests.test_shub_pull
-    stest 0 python2 -m unittest tests.test_shub_api
-    stest 0 python2 -m unittest tests.test_custom_cache
-    stest 0 python2 -m unittest tests.test_default_cache
-    stest 0 python2 -m unittest tests.test_disable_cache
+   
+    PY_BELOW_27=`python -c 'import sys; print("%i" % (sys.hexversion<0x02070000))'`
+
+    if [ "$PY_BELOW_27" = "1" ]; then
+        echo "Skipping python2 tests: requires python >=2.7"
+    else
+        stest 0 python2 -m unittest tests.test_json
+        stest 0 python2 -m unittest tests.test_helpers
+        stest 0 python2 -m unittest tests.test_base
+        stest 0 python2 -m unittest tests.test_core
+        stest 0 python2 -m unittest tests.test_docker_import
+        stest 0 python2 -m unittest tests.test_docker_api
+        stest 0 python2 -m unittest tests.test_docker_tasks
+        stest 0 python2 -m unittest tests.test_shub_pull
+        stest 0 python2 -m unittest tests.test_shub_api
+        stest 0 python2 -m unittest tests.test_custom_cache
+        stest 0 python2 -m unittest tests.test_default_cache
+        stest 0 python2 -m unittest tests.test_disable_cache
+    fi
 else
     echo "Skipping python2 tests: not installed"
 fi

--- a/tests/21-build_docker.sh
+++ b/tests/21-build_docker.sh
@@ -39,12 +39,12 @@ stest 0 grep busybox:latest ../examples/docker/Singularity
 stest 0 cp ../examples/docker/Singularity "$DEFFILE"
 stest 0 sudo singularity build "$CONTAINER" "$DEFFILE"
 
-stest 0 sed -i -e 's@busybox:latest@ubuntu:latest@' "$DEFFILE"
+stest 0 sed -i -e 's@busybox:latest@ubuntu:16.04@' "$DEFFILE"
 stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
 stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
-stest 0 sed -i -e 's@ubuntu:latest@centos:latest@' "$DEFFILE"
+stest 0 sed -i -e 's@ubuntu:16.04@centos:latest@' "$DEFFILE"
 stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
 stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false

--- a/tests/21-build_docker.sh
+++ b/tests/21-build_docker.sh
@@ -31,6 +31,8 @@ test_init "Docker bootstrap tests"
 CONTAINER="$SINGULARITY_TESTDIR/container.img"
 DEFFILE="$SINGULARITY_TESTDIR/example.def"
 
+KERNEL_MAJOR=$(uname -r | cut -f1 -d.)
+
 # Make sure the examples/docker/Singularity is pointing to busybox:latest (nobody mess with the examples! LOL)
 stest 0 grep busybox:latest ../examples/docker/Singularity
 
@@ -47,10 +49,14 @@ stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
 stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
-stest 0 sed -i -e 's@centos:latest@dock0/arch:latest@' "$DEFFILE"
-stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
-stest 0 singularity exec "$CONTAINER" true
-stest 1 singularity exec "$CONTAINER" false
+if [ "$KERNEL_MAJOR" = "2" ]; then
+    echo "Skipping Arch Linux tests - requires host with >=3.x kernel"
+else
+    stest 0 sed -i -e 's@centos:latest@dock0/arch:latest@' "$DEFFILE"
+    stest 0 sudo singularity build -F "$CONTAINER" "$DEFFILE"
+    stest 0 singularity exec "$CONTAINER" true
+    stest 1 singularity exec "$CONTAINER" false
+fi
 
 stest 0 sudo singularity build -F "$CONTAINER" docker://busybox
 stest 0 singularity exec "$CONTAINER" true

--- a/tests/32-action_options.sh
+++ b/tests/32-action_options.sh
@@ -54,7 +54,7 @@ stest 0 mkdir -p "$TESTDIR"
 stest 0 touch "$TESTDIR/testfile"
 stest 0 singularity exec --home "$TESTDIR" "$CONTAINER" test -f "$TESTDIR/testfile"
 stest 0 singularity exec --home "$TESTDIR:/home" "$CONTAINER" test -f "/home/testfile"
-if [  "$SINGULARITY_OVERLAY_FS" = "1" ]; then
+if [  "x${SINGULARITY_OVERLAY_FS}" = "x1" ]; then
     stest 0 singularity exec --contain --home "$TESTDIR:/blah" "$CONTAINER" test -f "/blah/testfile"
 fi
 stest 0 sh -c "echo 'cd; test -f testfile' | singularity exec --home '$TESTDIR' '$CONTAINER' /bin/sh"

--- a/tests/32-action_options.sh
+++ b/tests/32-action_options.sh
@@ -54,7 +54,7 @@ stest 0 mkdir -p "$TESTDIR"
 stest 0 touch "$TESTDIR/testfile"
 stest 0 singularity exec --home "$TESTDIR" "$CONTAINER" test -f "$TESTDIR/testfile"
 stest 0 singularity exec --home "$TESTDIR:/home" "$CONTAINER" test -f "/home/testfile"
-if [ -n "${SINGULARITY_OVERLAY_FS:-}" ]; then
+if [  "$SINGULARITY_OVERLAY_FS" = "1" ]; then
     stest 0 singularity exec --contain --home "$TESTDIR:/blah" "$CONTAINER" test -f "/blah/testfile"
 fi
 stest 0 sh -c "echo 'cd; test -f testfile' | singularity exec --home '$TESTDIR' '$CONTAINER' /bin/sh"

--- a/tests/35-userbinds.sh
+++ b/tests/35-userbinds.sh
@@ -35,7 +35,7 @@ stest 0 sudo singularity build "$CONTAINER" "../examples/busybox/Singularity"
 stest 0 touch /tmp/hello_world_test
 stest 0 singularity exec -B /tmp:/var/tmp "$CONTAINER" test -f /var/tmp/hello_world_test
 
-if [ "$SINGULARITY_OVERLAY_FS" = "1" ]; then
+if [ "x${SINGULARITY_OVERLAY_FS}" = "x1" ]; then
     stest 0 singularity exec -B /tmp:/nonexistent "$CONTAINER" test -f /nonexistent/hello_world_test
 fi
 

--- a/tests/35-userbinds.sh
+++ b/tests/35-userbinds.sh
@@ -33,9 +33,9 @@ CONTAINER="$SINGULARITY_TESTDIR/container.img"
 stest 0 sudo singularity build "$CONTAINER" "../examples/busybox/Singularity"
 
 stest 0 touch /tmp/hello_world_test
-stest 0 singularity exec -B /tmp:/opt "$CONTAINER" test -f /opt/hello_world_test
+stest 0 singularity exec -B /tmp:/var/tmp "$CONTAINER" test -f /var/tmp/hello_world_test
 
-if [ -n "$SINGULARITY_OVERLAY_FS" ]; then
+if [ "$SINGULARITY_OVERLAY_FS" = "1" ]; then
     stest 0 singularity exec -B /tmp:/nonexistent "$CONTAINER" test -f /nonexistent/hello_world_test
 fi
 

--- a/tests/40-privblock.sh
+++ b/tests/40-privblock.sh
@@ -37,6 +37,9 @@ stest 1 singularity exec "$CONTAINER" false
 stest 0 sudo singularity exec "$CONTAINER" ping -c 1 127.0.0.1
 stest 1 singularity exec "$CONTAINER" ping -c 1 127.0.0.1
 
+# Checking no new privs with setuid root
+stest 0 sudo singularity exec "$CONTAINER" /usr/sbin/pam_timestamp_check -k root
+stest 1 singularity exec "$CONTAINER" /usr/sbin/pam_timestamp_check -k root
 
 test_cleanup
 

--- a/tests/40-privblock.sh
+++ b/tests/40-privblock.sh
@@ -34,8 +34,8 @@ stest 0 singularity exec "$CONTAINER" true
 stest 1 singularity exec "$CONTAINER" false
 
 # Checking no new privs with capabilities
-stest 0 sudo singularity exec "$CONTAINER" chsh -s /bin/sh
-stest 1 singularity exec "$CONTAINER" chsh -s /bin/sh
+stest 0 sudo singularity exec "$CONTAINER" ping -c 1 127.0.0.1
+stest 1 singularity exec "$CONTAINER" ping -c 1 127.0.0.1
 
 
 test_cleanup


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Support CentOS 6 for `make test` and travis rpmbuild tests. This is important now that we have integration of libs such as libarchive (used by docker-extract) that are quite different in older versions.

Changes:

- Let travis run test suite on CentOS 6
- Skip only python tests where python <2.7 (CentOS 6 has 2.6 and test code is not compatible)
- Skip arch linux container test if we are on a 2 series kernel (will get kernel too old on CentOS 6)
- Fix `SINGULARITY_OVERLAY_FS` check - this variable is always defined, 0 or 1 - so check for that, not `-n`
- Fix busybox non-overlay user bind test - `/opt` doesn't actually exist in the busybox container, so we have to user bind somewhere else to check functionality without overlay. Use `/var/tmp` which is available and empty.
- After a squashfs image is created, `chmod a+rx` (previously a+x) as on EL6 distros it will not have 'r' by default, and is unusable by other than root until manual chmod is performed.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is NOT against the project's master branch
- [X] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge


Attn: @singularityware-admin
