### PR TITLE
Expose libraryRef Validation Routines

### DIFF
--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -24,7 +24,7 @@ const pullTimeout = 1800
 // saving it into the specified file
 func DownloadImage(filePath string, libraryRef string, libraryURL string, Force bool, authToken string) error {
 
-	if !isLibraryPullRef(libraryRef) {
+	if !IsLibraryPullRef(libraryRef) {
 		return fmt.Errorf("Not a valid library reference: %s", libraryRef)
 	}
 

--- a/src/pkg/library/client/push.go
+++ b/src/pkg/library/client/push.go
@@ -22,7 +22,7 @@ const pushTimeout = 1800
 // UploadImage will push a specified image up to the Container Library,
 func UploadImage(filePath string, libraryRef string, libraryURL string, authToken string) error {
 
-	if !isLibraryPushRef(libraryRef) {
+	if !IsLibraryPushRef(libraryRef) {
 		return fmt.Errorf("Not a valid library reference: %s", libraryRef)
 	}
 

--- a/src/pkg/library/client/util.go
+++ b/src/pkg/library/client/util.go
@@ -22,12 +22,16 @@ import (
 	"github.com/golang/glog"
 )
 
-func isLibraryPullRef(libraryRef string) bool {
+// IsLibraryPullRef returns true if the provided string is a valid library
+// reference for a pull operation.
+func IsLibraryPullRef(libraryRef string) bool {
 	match, _ := regexp.MatchString("^(library://)?([a-z0-9]+(?:[._-][a-z0-9]+)*/){0,2}([a-z0-9]+(?:[._-][a-z0-9]+)*)(:[a-z0-9]+(?:[._-][a-z0-9]+)*)?$", libraryRef)
 	return match
 }
 
-func isLibraryPushRef(libraryRef string) bool {
+// IsLibraryPushRef returns true if the provided string is a valid library
+// reference for a push operation.
+func IsLibraryPushRef(libraryRef string) bool {
 	// For push we allow specifying multiple tags, delimited with ,
 	match, _ := regexp.MatchString("^(library://)?([a-z0-9]+(?:[._-][a-z0-9]+)*/){2}([a-z0-9]+(?:[._-][a-z0-9]+)*)(:[a-z0-9]+(?:[,._-][a-z0-9]+)*)?$", libraryRef)
 	return match

--- a/src/pkg/library/client/util_test.go
+++ b/src/pkg/library/client/util_test.go
@@ -38,7 +38,7 @@ func Test_isLibraryPullRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isLibraryPullRef(tt.libraryRef); got != tt.want {
+			if got := IsLibraryPullRef(tt.libraryRef); got != tt.want {
 				t.Errorf("isLibraryPullRef() = %v, want %v", got, tt.want)
 			}
 		})
@@ -67,7 +67,7 @@ func Test_isLibraryPushRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isLibraryPushRef(tt.libraryRef); got != tt.want {
+			if got := IsLibraryPushRef(tt.libraryRef); got != tt.want {
 				t.Errorf("isLibraryPushRef() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Expose `libraryRef` validation Routines, so they can be used by other packages.