### PR TITLE
Fix Library Image Download Perms

### DIFF
--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -85,7 +85,7 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string, Force 
 	sylog.Debugf("OK response received, beginning body download\n")
 
 	// Perms are 777 *prior* to umask
-	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 777)
+	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

According to the code, the perms of a file downloaded via DownloadImage should be rwxrwxrwx (before umask.) But it's currently setting them to -r----x--x. Switch decimal integer value to octal one to fix!

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin