### PR TITLE
remove .g at configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -332,7 +332,7 @@ AC_SUBST(BUILD_SUID)
 AC_MSG_CHECKING([for git version])
 if BRANCH=`git rev-parse --abbrev-ref HEAD 2>/dev/null`; then
     if HASH=`git rev-parse --short HEAD 2>/dev/null`; then
-        GIT_VERSION="-$BRANCH.g$HASH"
+        GIT_VERSION="-$BRANCH.$HASH"
     else
         GIT_VERSION="-$BRANCH"
     fi


### PR DESCRIPTION
**Description of the Pull Request (PR):**
remove .g at configure.ac which makes confusing to read the actual commit hash.


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
