### PR TITLE
Escape Docker ENTRYPOINT/CMD for the shell

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@
     - Rafal Gumienny <rafal.gumienny@gmail.com>
     - Ralph Castain <rhc@open-mpi.org>
     - Rémy Dernat <remy.dernat@umontpellier.fr>
+    - Rémi Rampin <remirampin@gmail.com>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
     - Yaroslav Halchenko <debian@onerussian.com>

--- a/libexec/python/docker/tasks.py
+++ b/libexec/python/docker/tasks.py
@@ -118,6 +118,17 @@ def change_permissions(tar_file, file_permission=None, folder_permission=None):
     return final_tar
 
 
+def shell_escape(s):
+    r"""Given bl"a, returns "bl\\"a".
+    """
+    if isinstance(s, bytes):
+        s = s.decode('utf-8')
+    return '"%s"' % (s.replace('\\', '\\\\')
+                      .replace('"', '\\"')
+                      .replace('`', '\\`')
+                      .replace('$', '\\$'))
+
+
 def extract_runscript(manifest, includecmd=False):
     '''create_runscript will write a bash script with default "ENTRYPOINT"
     into the base_dir. If includecmd is True, CMD is used instead. For both.
@@ -147,7 +158,7 @@ def extract_runscript(manifest, includecmd=False):
         if not isinstance(cmd, list):
             cmd = [cmd]
 
-        cmd = " ".join(['"%s"' % x for x in cmd])
+        cmd = " ".join(shell_escape(x) for x in cmd)
 
         if not RUNSCRIPT_COMMAND_ASIS:
             cmd = 'exec %s "$@"' % cmd

--- a/libexec/python/sutils.py
+++ b/libexec/python/sutils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 '''
-utils.py: python helper for singularity command line tool
+sutils.py: python helper for singularity command line tool
 
 Copyright (c) 2016-2017, Vanessa Sochat. All rights reserved.
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Correctly escapes for the shell, rather than just putting quotes around.

**This fixes or addresses the following GitHub issues:**

- Ref: #1640

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [ ] This PR is ready for review and/or merge

**Discussion:**

I have not updated the CHANGELOG because I'm not sure what entry to put this under.

I have filed this against `master` because there is no change in behavior, it will only fix crashes for commands that required escaping.

I put the `shell_escape` function right there in `tasks.py`, maybe it should go in `shell.py` or `sutils.py`.

I do think that BOTH `entrypoint` and `cmd` should be used. Remember that the `cmd` is passed as arguments to the `entrypoint` by Docker, so the Singularity option to use `cmd` instead of `entrypoint` does not make sense, and will not work for any image that defines both `cmd` and `entrypoint`.
I am happy to update this behavior, in a subsequent PR, if the Singularity team agrees with me on this (or wants to see what I mean).

Attn: @singularityware-admin