### PR TITLE
Development 3.0: check setfsuid return

### DIFF
--- a/src/runtime/startup/c/wrapper.c
+++ b/src/runtime/startup/c/wrapper.c
@@ -854,7 +854,10 @@ __attribute__((constructor)) static void init(void) {
 
                 /* Use setfsuid to address issue about root_squash filesystems option */
                 if ( config.isSuid ) {
-                    setfsuid(uid);
+                    if ( setfsuid(uid) != 0 ) {
+                        singularity_message(ERROR, "Previous filesystem UID is not equal to 0\n");
+                        exit(1);
+                    }
                     if ( setfsuid(-1) != uid ) {
                         singularity_message(ERROR, "Failed to set filesystem uid to %d\n", uid);
                         exit(1);


### PR DESCRIPTION
Fix following compilation error with old gcc version :

```error: ignoring return value of ‘setfsuid’, declared with attribute warn_unused_result```
