### PR TITLE
Remove code normally included in 2.6

### DIFF
--- a/src/lib/runtime/mounts/dev/dev.c
+++ b/src/lib/runtime/mounts/dev/dev.c
@@ -124,10 +124,6 @@ int _singularity_runtime_mount_dev(void) {
             closedir(dir);
         }
 
-        if ( strcmp("tmpfs", singularity_config_get_value(MEMORY_FS_TYPE)) != 0 ) {
-            memcpy(memfs_type, "ramfs", 5);
-        }
-
         if ( symlink("/proc/self/fd", joinpath(devdir, "/fd")) < 0 ) {
             singularity_message(ERROR, "Failed create symlink /dev/fd: %s\n", strerror(errno));
             ABORT(255);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR resolves compilation error for 2.5 release by removing code inadvertently added during merge conflict resolution. Ramfs fix for Cray CLE 5 is included in 2.6 release.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
