### PR TITLE
Add support for --cleanenv command

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -148,13 +148,15 @@ func execWrapper(cobraCmd *cobra.Command, image string, args []string) {
 		lvl = "5"
 	}
 
-	for _, env := range os.Environ() {
-		e := strings.SplitN(env, "=", 2)
-		if len(e) != 2 {
-			sylog.Verbosef("can't process environment variable %s", env)
-			continue
+	if !IsCleanEnv {
+		for _, env := range os.Environ() {
+			e := strings.SplitN(env, "=", 2)
+			if len(e) != 2 {
+				sylog.Verbosef("can't process environment variable %s", env)
+				continue
+			}
+			generator.AddProcessEnv(e[0], e[1])
 		}
-		generator.AddProcessEnv(e[0], e[1])
 	}
 
 	if pwd, err := os.Getwd(); err == nil {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds rudimentary support for `--cleanenv` flag in a very trivial manner. @cclerget Maybe have a smarter way to do this? For now this works.

For anybody, does this fully implement `--cleanev`? Let us know if it falls short somewhere!

