### PR TITLE
Support read-only binds with user namespaces

### DIFF
--- a/src/lib/runtime/mounts/userbinds/userbinds.c
+++ b/src/lib/runtime/mounts/userbinds/userbinds.c
@@ -139,18 +139,14 @@ int _singularity_runtime_mount_userbinds(void) {
                 ABORT(255);
             }
             if ( read_only ) {
-                if ( singularity_priv_userns_enabled() == 1 ) {
-                    singularity_message(WARNING, "Can not make bind mount read only within the user namespace: %s\n", dest);
-                } else {
-                    singularity_message(VERBOSE, "Remounting %s read-only\n", dest);
-                    if ( singularity_mount(NULL, joinpath(container_dir, dest), NULL, MS_RDONLY|MS_BIND|MS_NOSUID|MS_NODEV|MS_REC|MS_REMOUNT, NULL) < 0 ) {
-                        singularity_message(ERROR, "There was an error write-protecting the path %s: %s\n", source, strerror(errno));
-                        ABORT(255);
-                    }
-                    if ( access(joinpath(container_dir, dest), W_OK) == 0 || (errno != EROFS && errno != EACCES) ) { // Flawfinder: ignore (precautionary confirmation, not necessary)
-                        singularity_message(ERROR, "Failed to write-protect the path %s: %s\n", source, strerror(errno));
-                        ABORT(255);
-                    }
+                singularity_message(VERBOSE, "Remounting %s read-only\n", dest);
+                if ( singularity_mount(NULL, joinpath(container_dir, dest), NULL, MS_RDONLY|MS_BIND|MS_NOSUID|MS_NODEV|MS_REC|MS_REMOUNT, NULL) < 0 ) {
+                    singularity_message(ERROR, "There was an error write-protecting the path %s: %s\n", source, strerror(errno));
+                    ABORT(255);
+                }
+                if ( access(joinpath(container_dir, dest), W_OK) == 0 || (errno != EROFS && errno != EACCES) ) { // Flawfinder: ignore (precautionary confirmation, not necessary)
+                    singularity_message(ERROR, "Failed to write-protect the path %s: %s\n", source, strerror(errno));
+                    ABORT(255);
                 }
             } else {
                 if ( singularity_priv_userns_enabled() <= 0 ) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR removes the check for not using a user namespace before remounting as read-only.  It works fine with user namespaces and there's not a reason to avoid the read-only mount in that case.  We have a case where we want to bind mount read-only, and want it to work also with user namespaces.


**This fixes or addresses the following GitHub issues:**

None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
