### PR TITLE
Development 3.0: fix build vet error reported for CLI build command

### DIFF
--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -96,7 +96,7 @@ var BuildCmd = &cobra.Command{
 
 			err = a.Assemble(bundle, args[0])
 			if err != nil {
-				sylog.Fatalf("Assembler failed to assemble:", err)
+				sylog.Fatalf("Assembler failed to assemble: %v", err)
 			}
 		}
 
@@ -155,12 +155,12 @@ func makeBundle(def build.Definition) *build.Bundle {
 	}
 
 	if err = cp.Get(def); err != nil {
-		sylog.Fatalf("Conveyor failed to get:", err)
+		sylog.Fatalf("Conveyor failed to get: %v", err)
 	}
 
 	bundle, err := cp.Pack()
 	if err != nil {
-		sylog.Fatalf("Packer failed to pack:", err)
+		sylog.Fatalf("Packer failed to pack: %v", err)
 	}
 
 	return bundle

--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -96,7 +96,7 @@ var BuildCmd = &cobra.Command{
 
 			err = a.Assemble(bundle, args[0])
 			if err != nil {
-				sylog.Fatalf("Assembler failed to assemble: %v", err)
+				sylog.Fatalf("Assembler failed to assemble: %v\n", err)
 			}
 		}
 
@@ -155,12 +155,12 @@ func makeBundle(def build.Definition) *build.Bundle {
 	}
 
 	if err = cp.Get(def); err != nil {
-		sylog.Fatalf("Conveyor failed to get: %v", err)
+		sylog.Fatalf("Conveyor failed to get: %v\n", err)
 	}
 
 	bundle, err := cp.Pack()
 	if err != nil {
-		sylog.Fatalf("Packer failed to pack: %v", err)
+		sylog.Fatalf("Packer failed to pack: %v\n", err)
 	}
 
 	return bundle


### PR DESCRIPTION
**Description of the Pull Request (PR):**

FIx error during `make -C builddir test` : 
```
src/cmd/singularity/cli/build.go:99: no formatting directive in Fatalf call
src/cmd/singularity/cli/build.go:158: no formatting directive in Fatalf call
src/cmd/singularity/cli/build.go:163: no formatting directive in Fatalf call
```
