### PR TITLE
Add authToken to HKP keyserver requests

### DIFF
--- a/src/cmd/singularity/cli/signing.go
+++ b/src/cmd/singularity/cli/signing.go
@@ -22,12 +22,13 @@ func init() {
 // SignCmd singularity sign
 var SignCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args: cobra.ExactArgs(1),
+	Args:   cobra.ExactArgs(1),
+	PreRun: sylabsToken,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// args[0] contains image path
 		fmt.Printf("Signing image: %s\n", args[0])
-		if err := signing.Sign(args[0]); err != nil {
+		if err := signing.Sign(args[0], authToken); err != nil {
 			os.Exit(2)
 		}
 	},

--- a/src/cmd/singularity/cli/verify.go
+++ b/src/cmd/singularity/cli/verify.go
@@ -22,12 +22,13 @@ func init() {
 // VerifyCmd singularity verify
 var VerifyCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args: cobra.ExactArgs(1),
+	Args:   cobra.ExactArgs(1),
+	PreRun: sylabsToken,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// args[0] contains image path
 		fmt.Printf("Verifying image: %s\n", args[0])
-		if err := signing.Verify(args[0]); err != nil {
+		if err := signing.Verify(args[0], authToken); err != nil {
 			os.Exit(2)
 		}
 	},

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -66,7 +66,7 @@ func sifAddSignature(fingerprint [20]byte, sinfo *sif.Info, signature []byte) er
 // configuration options. In its current form, Sign also pushes public material
 // to a key server if enabled. This should be a separate step in the next round
 // of development.
-func Sign(cpath string) error {
+func Sign(cpath, authToken string) error {
 	var el openpgp.EntityList
 	var en *openpgp.Entity
 	var err error
@@ -83,7 +83,7 @@ func Sign(cpath string) error {
 			return err
 		}
 		fmt.Printf("Sending PGP public key material: %0X => %s.\n", el[0].PrimaryKey.Fingerprint, syKeysAddr)
-		err = sypgp.PushPubkey(el[0], syKeysAddr)
+		err = sypgp.PushPubkey(el[0], syKeysAddr, authToken)
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func Sign(cpath string) error {
 // partition hash against the signer's version. Verify takes care of looking
 // for PGP keys in the default local store or looks it up from a key server
 // if access is enabled.
-func Verify(cpath string) error {
+func Verify(cpath, authToken string) error {
 	var el openpgp.EntityList
 	var sinfo sif.Info
 
@@ -185,7 +185,7 @@ func Verify(cpath string) error {
 		sylog.Errorf("failed to check signature: %s\n", err)
 		/* verification with local keyring failed, try to fetch from key server */
 		sylog.Infof("Contacting sykeys PGP key management services for: %s\n", sig.GetEntity())
-		syel, err := sypgp.FetchPubkey(sig.GetEntity(), syKeysAddr)
+		syel, err := sypgp.FetchPubkey(sig.GetEntity(), syKeysAddr, authToken)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	syKeysAddr = "keys.sylabs.io:11371"
+	keyserverURI = "http://keys.sylabs.io:11371"
 )
 
 func sifDataObjectHash(sinfo *sif.Info) (*bytes.Buffer, error) {
@@ -82,8 +82,8 @@ func Sign(cpath, authToken string) error {
 		if el, err = sypgp.LoadPrivKeyring(); err != nil || el == nil {
 			return err
 		}
-		fmt.Printf("Sending PGP public key material: %0X => %s.\n", el[0].PrimaryKey.Fingerprint, syKeysAddr)
-		err = sypgp.PushPubkey(el[0], syKeysAddr, authToken)
+		fmt.Printf("Sending PGP public key material: %0X => %s.\n", el[0].PrimaryKey.Fingerprint, keyserverURI)
+		err = sypgp.PushPubkey(el[0], keyserverURI, authToken)
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func Verify(cpath, authToken string) error {
 		sylog.Errorf("failed to check signature: %s\n", err)
 		/* verification with local keyring failed, try to fetch from key server */
 		sylog.Infof("Contacting sykeys PGP key management services for: %s\n", sig.GetEntity())
-		syel, err := sypgp.FetchPubkey(sig.GetEntity(), syKeysAddr, authToken)
+		syel, err := sypgp.FetchPubkey(sig.GetEntity(), keyserverURI, authToken)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	keyserverURI = "http://keys.sylabs.io:11371"
+	keyserverURI = "https://keys.sylabs.io:11371"
 )
 
 func sifDataObjectHash(sinfo *sif.Info) (*bytes.Buffer, error) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add `authToken` to HKP push/fetch operations.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
