### PR TITLE
Backport #1082 from development to development-2.x  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ src/start
 src/start-suid
 src/docker-extract
 src/prepheader
+src/get-configvals
 
 src/.deps/
 src/.libs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 ## [v2.6.0]
     
 ### Implemented enhancements
-  - Allow admin to specify a non-standard location for mksquashfs binary at 
-    build time with --with-mksquashfs option
+ - Allow admin to specify a non-standard location for mksquashfs binary at 
+   build time with --with-mksquashfs option
+ - --nv option will use [nvidia-container-cli](https://github.com/NVIDIA/libnvidia-container) if installed
+ - [nvliblist.conf](https://github.com/singularityware/singularity/blob/master/etc/nvliblist.conf) now has a section for binaries
+ - --nv can be made default with all action commands in singularity.conf
+ - --nv can be controlled by env vars `$SINGULARITY_NV` and `$SINGULARITY_NV_OFF`
 
 ## [v2.5.2]
 

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -1,9 +1,12 @@
 # NVLIBLIST.CONF
 # This configuration file determines which NVIDIA libraries to search for on 
 # the host system when the --nv option is invoked.  You can edit it if you have
-# different libraries on your host system.
+# different libraries on your host system.  You can also add binaries and they
+# will be mounted into the container when the --nv option is passed.
 
 # put binaries here
+# In shared environments you should ensure that permissions on these files 
+# exclude writing by non-privileged users.  
 /usr/bin/nvidia-smi
 /usr/bin/nvidia-debugdump
 /usr/bin/nvidia-persistenced

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -13,7 +13,7 @@
 /usr/bin/nvidia-cuda-mps-control
 /usr/bin/nvidia-cuda-mps-server
 
-# put libs here 
+# put libs here (must end in .so) 
 libcuda.so
 libEGL_installertest.so
 libEGL_nvidia.so

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -3,6 +3,14 @@
 # the host system when the --nv option is invoked.  You can edit it if you have
 # different libraries on your host system.
 
+# put binaries here
+/usr/bin/nvidia-smi
+/usr/bin/nvidia-debugdump
+/usr/bin/nvidia-persistenced
+/usr/bin/nvidia-cuda-mps-control
+/usr/bin/nvidia-cuda-mps-server
+
+# put libs here 
 libcuda.so
 libEGL_installertest.so
 libEGL_nvidia.so

--- a/etc/singularity.conf.in
+++ b/etc/singularity.conf.in
@@ -205,3 +205,11 @@ bind path = /etc/hosts
 # use tmpfs, so on affected version it's recommended to set this value to ramfs to avoid
 # kernel panic
 @MEMORY_FS_TYPE@ = @MEMORY_FS_TYPE_DEFAULT@
+
+
+# ALWAYS USE NV ${TYPE}: [BOOL]
+# DEFAULT: no
+# This feature allows an administrator to determine that every action command
+# should be executed implicitely with the --nv option (useful for GPU only 
+# environments). 
+@ALWAYS_USE_NV@ = @ALWAYS_USE_NV_DEFAULT@  

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -129,6 +129,7 @@ while true; do
         --nv)
             shift
             SINGULARITY_NV=1
+            export SINGULARITY_NV
         ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -128,36 +128,7 @@ while true; do
         ;;
         --nv)
             shift
-            SINGULARITY_NV=1
-            export SINGULARITY_NV
-            SINGULARITY_NVLIBLIST=`mktemp ${TMPDIR:-/tmp}/.singularity-nvliblist.XXXXXXXX`
-            cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" > $SINGULARITY_NVLIBLIST
-            for i in $(ldconfig -p | grep -f "${SINGULARITY_NVLIBLIST}"); do
-                if [ -f "$i" ]; then
-                    message 2 "Found NV library: $i\n"
-                    if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
-                        SINGULARITY_CONTAINLIBS="$i"
-                     else
-                        SINGULARITY_CONTAINLIBS="$SINGULARITY_CONTAINLIBS,$i"
-                    fi
-                fi
-            done
-            rm $SINGULARITY_NVLIBLIST
-            if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
-                message WARN "Could not find any Nvidia libraries on this host!\n";
-            else
-                export SINGULARITY_CONTAINLIBS
-            fi
-            if NVIDIA_SMI=$(which nvidia-smi 2>/dev/null); then
-                if [ -n "${SINGULARITY_BINDPATH:-}" ]; then
-                    SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH},${NVIDIA_SMI}"
-                else
-                    SINGULARITY_BINDPATH="${NVIDIA_SMI}"
-                fi
-                export SINGULARITY_BINDPATH
-            else
-                message WARN "Could not find the Nvidia SMI binary to bind into container\n"
-            fi
+            bind_nvidia_files
         ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -20,13 +20,6 @@
 
 message 2 "Evaluating args: '$*'\n"
 
-if [ `$SINGULARITY_libexecdir/singularity/bin/get-configvals "always use nv"` == "yes" ]; then 
-    message 2 "'always use nv = yes' found in singularity.conf\n"
-    message 2 "binding nvidia files into container\n"
-    bind_nvidia_files
-    NV_IN_CONFIG=1
-fi
-
 while true; do
     case ${1:-} in
         -h|--help|help)
@@ -135,9 +128,7 @@ while true; do
         ;;
         --nv)
             shift
-            if [ -z ${NV_IN_CONFIG:-} ]; then
-                bind_nvidia_files
-            fi
+            SINGULARITY_NV=1
         ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"
@@ -148,3 +139,17 @@ while true; do
         ;;
     esac
 done
+
+if [ -z "${SINGULARITY_NV_OFF:-}" ]; then # this is a "kill switch" provided for user
+    # if singularity.conf specifies --nv
+    if [ `$SINGULARITY_libexecdir/singularity/bin/get-configvals "always use nv"` == "yes" ]; then 
+        message 2 "'always use nv = yes' found in singularity.conf\n"
+        message 2 "binding nvidia files into container\n"
+        bind_nvidia_files
+    # or if the user asked for --nv    
+    elif [ -n "${SINGULARITY_NV:-}" ]; then
+        bind_nvidia_files
+    fi
+fi 
+
+

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -20,6 +20,13 @@
 
 message 2 "Evaluating args: '$*'\n"
 
+if grep "always use nv" "${SINGULARITY_sysconfdir}/singularity/singularity.conf" 2>/dev/null | grep -q "yes"; then
+    message 2 "'always use nv = yes' found in singularity.conf\n"
+    message 2 "binding nvidia files into container\n"
+    bind_nvidia_files
+    NV_IN_CONFIG=1
+fi
+
 while true; do
     case ${1:-} in
         -h|--help|help)
@@ -128,7 +135,9 @@ while true; do
         ;;
         --nv)
             shift
-            bind_nvidia_files
+            if [ -z ${NV_IN_CONFIG:-} ]; then
+                bind_nvidia_files
+            fi
         ;;
         -*)
             message ERROR "Unknown option: ${1:-}\n"

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -20,7 +20,7 @@
 
 message 2 "Evaluating args: '$*'\n"
 
-if grep "always use nv" "${SINGULARITY_sysconfdir}/singularity/singularity.conf" 2>/dev/null | grep -q "yes"; then
+if [ `$SINGULARITY_libexecdir/singularity/bin/get-configvals "always use nv"` == "yes" ]; then 
     message 2 "'always use nv = yes' found in singularity.conf\n"
     message 2 "binding nvidia files into container\n"
     bind_nvidia_files

--- a/libexec/functions
+++ b/libexec/functions
@@ -498,15 +498,15 @@ bind_nvidia_files() {
 
     # in case we couldn't find files, warn the user. otherwise export variables
     if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
-         message WARNING "Could not find any NVIDIA libraries on this host!\n";
-         message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+        message WARNING "Could not find any NVIDIA libraries on this host!\n";
+        message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
     else
         export SINGULARITY_CONTAINLIBS
     fi
 
     if [ -z "${SINGULARITY_NVBIN:-}" ]; then
-         message WARNING "Could not find any NVIDIA binaries on this host!\n";
-         message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+        message WARNING "Could not find any NVIDIA binaries on this host!\n";
+        message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
     else
         export SINGULARITY_BINDPATH
     fi

--- a/libexec/functions
+++ b/libexec/functions
@@ -453,6 +453,66 @@ is_tar() {
 }
 
 
+bind_nvidia_files() {
+# either use nvidia-container-cli or nvliblist.conf to find nvidia libs and
+# binaries for binding at runtime with --nv 
+    if ! SINGULARITY_NVLIBLIST=`mktemp "${TMPDIR:-/tmp}"/.singularity-nvliblist.XXXXXXXX`; then
+        message ERROR "Failed to create temporary nvliblist file.\n"
+        ABORT 255
+    fi
+
+    # try to use nvidia-container-cli if installed and functional
+    if singularity_which nvidia-container-cli > /dev/null 2>&1 && SINGULARITY_NV_FILES=`nvidia-container-cli list -cguv`; then
+        # bins should have full paths
+        SINGULARITY_NVBINLIST=`echo "$SINGULARITY_NV_FILES" | grep -Ev "\.so"`
+        # libs should just be basenames ending in ".so"
+        for i in `echo "$SINGULARITY_NV_FILES" | grep -E "\.so"`; do
+            basename "$i" | awk -F "\.so" '{print $1 ".so"}' >> "$SINGULARITY_NVLIBLIST"
+        done
+
+    else # fall back to nvliblist.conf
+        message 2 "nvidia-container-cli not installed or returning error\n"
+        message 2 "falling back to $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+        # strip comments and spaces and bins do NOT end in .so
+        SINGULARITY_NVBINLIST=`cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" | grep -vE "\.so$"`
+        # strip comments and spaces and libs DO end in .so
+        cat "$SINGULARITY_sysconfdir/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" | grep -E "\.so$" > $SINGULARITY_NVLIBLIST
+    fi
+
+    # first deal with libs (pattern match from ld.so cache)
+    for i in $(ldconfig -p | grep -f "${SINGULARITY_NVLIBLIST}"); do
+        if [ -f "$i" ]; then
+            message 2 "Found NV library: $i\n"
+            SINGULARITY_CONTAINLIBS="${SINGULARITY_CONTAINLIBS:-},$i"
+        fi
+    done
+    rm $SINGULARITY_NVLIBLIST
+
+    # then deal with bins (should have full path specified)
+    for SINGULARITY_NVBIN in $SINGULARITY_NVBINLIST; do
+        if [ -f "$SINGULARITY_NVBIN" ]; then
+            message 2 "Found NV binary: $SINGULARITY_NVBIN\n"
+            SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH:-},${SINGULARITY_NVBIN}"
+        fi
+    done
+
+    # in case we couldn't find files, warn the user. otherwise export variables
+    if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
+         message WARNING "Could not find any NVIDIA libraries on this host!\n";
+         message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+    else
+        export SINGULARITY_CONTAINLIBS
+    fi
+
+    if [ -z "${SINGULARITY_NVBIN:-}" ]; then
+         message WARNING "Could not find any NVIDIA binaries on this host!\n";
+         message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+    else
+        export SINGULARITY_BINDPATH
+    fi
+}
+
+
 ##############################################################################
 # CHECKS
 ##############################################################################

--- a/libexec/functions
+++ b/libexec/functions
@@ -619,3 +619,4 @@ atexit() {
 if [ -n "${SHELL_DEBUG:-}" ]; then
     set -x
 fi
+

--- a/libexec/functions
+++ b/libexec/functions
@@ -461,8 +461,22 @@ bind_nvidia_files() {
         ABORT 255
     fi
 
-    # try to use nvidia-container-cli if installed and functional
-    if singularity_which nvidia-container-cli > /dev/null 2>&1 && SINGULARITY_NV_FILES=`nvidia-container-cli list -cguv`; then
+    # check to see if nvidia-container-cli is producing plausible output
+    if ! singularity_which nvidia-container-cli > /dev/null 2>&1 || ! SINGULARITY_NV_FILES=`nvidia-container-cli list -cguv`; then
+        message 2 "nvidia-container-cli not installed or not working\n"
+        SINGULARITY_USE_NVLIBLIST_CONF=1
+    else
+        for i in $SINGULARITY_NV_FILES; do
+            if [ ! -f $i ]; then
+                message 2 "nvidia-container-cli is returning unusable output\n"
+                SINGULARITY_USE_NVLIBLIST_CONF=1
+            fi
+        done
+    fi
+
+    # first choice use nvidia-container-cli
+    if [ -z ${SINGULARITY_USE_NVLIBLIST_CONF:-} ]; then
+        message 2 "Using nvidia-container-cli to locate nvidia libraries and binaries.\n"
         # bins should have full paths
         SINGULARITY_NVBINLIST=`echo "$SINGULARITY_NV_FILES" | grep -Ev "\.so"`
         # libs should just be basenames ending in ".so"
@@ -470,9 +484,9 @@ bind_nvidia_files() {
             basename "$i" | awk -F "\.so" '{print $1 ".so"}' >> "$SINGULARITY_NVLIBLIST"
         done
 
-    else # fall back to nvliblist.conf
-        message 2 "nvidia-container-cli not installed or returning error\n"
-        message 2 "falling back to $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+    # if it's absent, or broken fall back to nvliblist.conf
+    else [ -n ${USE_NVLIBLIST_CONF:-} ]
+        message 2 "Falling back to $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
         # strip comments and spaces and bins do NOT end in .so
         SINGULARITY_NVBINLIST=`cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" | grep -vE "\.so$"`
         # strip comments and spaces and libs DO end in .so

--- a/libexec/functions
+++ b/libexec/functions
@@ -506,6 +506,7 @@ bind_nvidia_files() {
     for SINGULARITY_NVBIN in $SINGULARITY_NVBINLIST; do
         if [ -f "$SINGULARITY_NVBIN" ]; then
             message 2 "Found NV binary: $SINGULARITY_NVBIN\n"
+            SINGULARITY_BIN_FOUND=1
             SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH:-},${SINGULARITY_NVBIN}"
         fi
     done
@@ -518,7 +519,7 @@ bind_nvidia_files() {
         export SINGULARITY_CONTAINLIBS
     fi
 
-    if [ -z "${SINGULARITY_NVBIN:-}" ]; then
+    if [ -z "${SINGULARITY_BIN_FOUND:-}" ]; then
         message WARNING "Could not find any NVIDIA binaries on this host!\n";
         message WARNING "You may need to edit ${SINGULARITY_sysconfdir}/singularity/nvliblist.conf\n"
     else

--- a/libexec/functions
+++ b/libexec/functions
@@ -476,7 +476,7 @@ bind_nvidia_files() {
         # strip comments and spaces and bins do NOT end in .so
         SINGULARITY_NVBINLIST=`cat $SINGULARITY_sysconfdir"/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" | grep -vE "\.so$"`
         # strip comments and spaces and libs DO end in .so
-        cat "$SINGULARITY_sysconfdir/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" | grep -E "\.so$" > $SINGULARITY_NVLIBLIST
+        cat "${SINGULARITY_sysconfdir}/singularity/nvliblist.conf" | grep -Ev "^#|^\s*$" | grep -E "\.so$" > $SINGULARITY_NVLIBLIST
     fi
 
     # first deal with libs (pattern match from ld.so cache)
@@ -499,14 +499,14 @@ bind_nvidia_files() {
     # in case we couldn't find files, warn the user. otherwise export variables
     if [ -z "${SINGULARITY_CONTAINLIBS:-}" ]; then
         message WARNING "Could not find any NVIDIA libraries on this host!\n";
-        message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+        message WARNING "You may need to edit ${SINGULARITY_sysconfdir}/singularity/nvliblist.conf\n"
     else
         export SINGULARITY_CONTAINLIBS
     fi
 
     if [ -z "${SINGULARITY_NVBIN:-}" ]; then
         message WARNING "Could not find any NVIDIA binaries on this host!\n";
-        message WARNING "You may need to edit $SINGULARITY_sysconfdir/singularity/nvliblist.conf\n"
+        message WARNING "You may need to edit ${SINGULARITY_sysconfdir}/singularity/nvliblist.conf\n"
     else
         export SINGULARITY_BINDPATH
     fi

--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -108,6 +108,7 @@ rm -rf $RPM_BUILD_ROOT
 # Binaries
 %{_libexecdir}/singularity/bin/builddef
 %{_libexecdir}/singularity/bin/cleanupd
+%{_libexecdir}/singularity/bin/get-configvals
 %{_libexecdir}/singularity/bin/get-section
 %{_libexecdir}/singularity/bin/mount
 %{_libexecdir}/singularity/bin/image-type

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = -DBINDIR=\"$(bindir)\" -DSYSCONFDIR=\"$(sysconfdir)\" -DLOCALSTATE
 
 lexecdir = $(libexecdir)/singularity/bin
 
-lexec_PROGRAMS = action builddef cleanupd docker-extract get-section image-type mount prepheader start $(BUILD_SUID)
+lexec_PROGRAMS = action builddef cleanupd docker-extract get-section get-configvals image-type mount prepheader start $(BUILD_SUID)
 EXTRA_PROGRAMS = action-suid mount-suid start-suid
 
 cleanupd_SOURCES = cleanupd.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c
@@ -43,6 +43,9 @@ prepheader_CPPFLAGS = $(AM_CPPFLAGS)
 
 get_section_SOURCES = get-section.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c
 get_section_CPPFLAGS = $(AM_CPPFLAGS)
+
+get_configvals_SOURCES = get-configvals.c util/util.c util/config_parser.c util/message.c util/registry.c util/file.c util/privilege.c
+get_configvals_CPPFLAGS = $(AM_CPPFLAGS)
 
 image_type_SOURCES = image-type.c util/util.c util/message.c util/config_parser.c util/file.c
 image_type_LDADD = lib/image/libsingularity-image.la

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,9 @@ prepheader_CPPFLAGS = $(AM_CPPFLAGS)
 get_section_SOURCES = get-section.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c
 get_section_CPPFLAGS = $(AM_CPPFLAGS)
 
+get_configvals_SOURCES = get-configvals.c util/util.c util/config_parser.c util/message.c util/registry.c util/file.c util/privilege.c util/suid.c
+get_configvals_CPPFLAGS = $(AM_CPPFLAGS)
+
 image_type_SOURCES = image-type.c util/util.c util/message.c util/config_parser.c util/file.c
 image_type_LDADD = lib/image/libsingularity-image.la
 image_type_CPPFLAGS = $(AM_CPPFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,9 +44,6 @@ prepheader_CPPFLAGS = $(AM_CPPFLAGS)
 get_section_SOURCES = get-section.c util/util.c util/file.c util/message.c util/privilege.c util/config_parser.c util/registry.c
 get_section_CPPFLAGS = $(AM_CPPFLAGS)
 
-get_configvals_SOURCES = get-configvals.c util/util.c util/config_parser.c util/message.c util/registry.c util/file.c util/privilege.c
-get_configvals_CPPFLAGS = $(AM_CPPFLAGS)
-
 image_type_SOURCES = image-type.c util/util.c util/message.c util/config_parser.c util/file.c
 image_type_LDADD = lib/image/libsingularity-image.la
 image_type_CPPFLAGS = $(AM_CPPFLAGS)

--- a/src/get-configvals.c
+++ b/src/get-configvals.c
@@ -32,12 +32,12 @@ int main(int argc, char **argv) {
 
     /* 
     If the key does not exist in the singularity.conf file, this is just 
-    going to return null char.  The function was originally designed to return
-    the default value if the value does not exist in the conf file, but I don't 
+    going to return "NULL".  The function was originally designed to return the
+    default value if the value does not exist in the conf file, but I don't
     know how to do that using only strings, and the key needs to be based on 
     user input, not hardcoded. 
     */
-    printf("%s\n", _singularity_config_get_value_impl(key, "\0"));
+    printf("%s\n", _singularity_config_get_value_impl(key, "NULL"));
 
     free(key);
     return(0);

--- a/src/get-configvals.c
+++ b/src/get-configvals.c
@@ -8,7 +8,6 @@
 */
 
 
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <string.h>
 
@@ -26,8 +25,6 @@ int main(int argc, char **argv) {
         exit(0);
     }
 
-    char *key = strdup(argv[1]);
-
     singularity_config_init(joinpath(SYSCONFDIR, "/singularity/singularity.conf"));
 
     /* 
@@ -37,8 +34,7 @@ int main(int argc, char **argv) {
     know how to do that using only strings, and the key needs to be based on 
     user input, not hardcoded. 
     */
-    printf("%s\n", _singularity_config_get_value_impl(key, "NULL"));
+    printf("%s\n", _singularity_config_get_value_impl(argv[1], "NULL"));
 
-    free(key);
     return(0);
 }

--- a/src/get-configvals.c
+++ b/src/get-configvals.c
@@ -1,5 +1,5 @@
 /* 
-* Copyright (c) 2017, SyLabs, Inc. All rights reserved.
+* Copyright (c) 2017, SingularityWare, LLC., Inc. All rights reserved.
 * 
 * This software is licensed under a 3-clause BSD license.  Please
 * consult LICENSE file distributed with the sources of this project regarding

--- a/src/get-configvals.c
+++ b/src/get-configvals.c
@@ -1,0 +1,44 @@
+/* 
+* Copyright (c) 2017, SyLabs, Inc. All rights reserved.
+* 
+* This software is licensed under a 3-clause BSD license.  Please
+* consult LICENSE file distributed with the sources of this project regarding
+* your rights to use or distribute this software.
+* 
+*/
+
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+
+#include "util/util.h"
+#include "util/config_parser.h"
+
+#ifndef SYSCONFDIR
+#error SYSCONFDIR not defined
+#endif
+
+int main(int argc, char **argv) {
+
+    if ( argc < 2 ) {
+        printf("USAGE: %s [key]\n", argv[0]);
+        exit(0);
+    }
+
+    char *key = strdup(argv[1]);
+
+    singularity_config_init(joinpath(SYSCONFDIR, "/singularity/singularity.conf"));
+
+    /* 
+    If the key does not exist in the singularity.conf file, this is just 
+    going to return null char.  The function was originally designed to return
+    the default value if the value does not exist in the conf file, but I don't 
+    know how to do that using only strings, and the key needs to be based on 
+    user input, not hardcoded. 
+    */
+    printf("%s\n", _singularity_config_get_value_impl(key, "\0"));
+
+    free(key);
+    return(0);
+}

--- a/src/util/config_defaults.h.in
+++ b/src/util/config_defaults.h.in
@@ -110,4 +110,7 @@
 #define MEMORY_FS_TYPE "memory fs type"
 #define MEMORY_FS_TYPE_DEFAULT "tmpfs"
 
+#define ALWAYS_USE_NV "always use nv"
+#define ALWAYS_USE_NV_DEFAULT "no"
+
 #endif  // __SINGULARITY_CONFIG_DEFAULTS_H_


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is just a backport of #1082 which adds substantial functionality to the `--nv` option.  This feature set is slated for inclusion in 2.6.0

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
