### PR TITLE
Stop there when dep ensure fails.

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -142,7 +142,7 @@ collect:
 .PHONY: dep
 dep:
 	@printf " GO DEPS\n"
-	$(V)(dep ensure -vendor-only >/dev/null 2>&1 || true)
+	$(V)(dep ensure -vendor-only >/dev/null 2>&1)
 	$(V)(patch --silent ../vendor/github.com/opencontainers/image-tools/image/manifest.go ../patches/image_tools_manifest.go.patch)
 
 .PHONY: test


### PR DESCRIPTION
Make sure that the build stops if "make dep" fails.