### PR TITLE
Remove sexec reference

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,5 @@ install-data-hook:
 	install -d -m 0755 $(DESTDIR)$(CONTAINER_FINALDIR)
 	install -d -m 0755 $(DESTDIR)$(CONTAINER_OVERLAY)
 	install -d -m 0755 $(DESTDIR)$(SESSIONDIR)
-	test -f $(DESTDIR)$(libexecdir)/singularity/bin/copy-suid && rm -f $(DESTDIR)$(libexecdir)/singularity/bin/copy-suid || :
-
 
 ACLOCAL_AMFLAGS = -I m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,6 @@ install-data-hook:
 	install -d -m 0755 $(DESTDIR)$(CONTAINER_FINALDIR)
 	install -d -m 0755 $(DESTDIR)$(CONTAINER_OVERLAY)
 	install -d -m 0755 $(DESTDIR)$(SESSIONDIR)
-	test -f $(DESTDIR)$(libexecdir)/singularity/sexec-suid && rm -f $(DESTDIR)$(libexecdir)/singularity/sexec-suid || :
 	test -f $(DESTDIR)$(libexecdir)/singularity/bin/copy-suid && rm -f $(DESTDIR)$(libexecdir)/singularity/bin/copy-suid || :
 
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove an old reference to sexec-suid in the toplevel Makefile.am

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
