### PR TITLE
Fix loop not returned in internal options with ConvertOptions

### DIFF
--- a/src/pkg/util/fs/mount/mount.go
+++ b/src/pkg/util/fs/mount/mount.go
@@ -93,7 +93,7 @@ func ConvertOptions(options []string) (uintptr, []string, []string) {
 		if !isFlag {
 			isInternal := false
 			for _, opt := range internalOptions {
-				if strings.HasPrefix(optionTrim, opt+"=") {
+				if strings.HasPrefix(optionTrim, opt+"=") || opt == optionTrim {
 					internalOpt = append(internalOpt, optionTrim)
 					isInternal = true
 					break


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix internal options returned by `ConvertOptions` function, loop option wasn't in internal options. 