### PR TITLE
Ensure %post script runs with full capabilities when running as root

### DIFF
--- a/src/runtime/engines/imgbuild/engine.go
+++ b/src/runtime/engines/imgbuild/engine.go
@@ -39,6 +39,7 @@ func (e *EngineOperations) CheckConfig() error {
 		os.Exit(1)
 	}
 
+	e.CommonConfig.OciConfig.SetupPrivileged(true)
 	return nil
 }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

When running as root, imgbuild engine must explicitly request not to drop capabilities in final proc (`%post`).

Before patch:
```
CapInh:	0000000000000000
CapPrm:	0000000000000000
CapEff:	0000000000000000
CapBnd:	0000000000000000
CapAmb:	0000000000000000
```

After patch:
```
CapInh:	0000003fffffffff
CapPrm:	0000003fffffffff
CapEff:	0000003fffffffff
CapBnd:	0000003fffffffff
CapAmb:	0000003fffffffff
```
