### PR TITLE
Update the version to use for sylabs/sif.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -389,7 +389,7 @@
 [[projects]]
   name = "github.com/sylabs/sif"
   packages = ["pkg/sif"]
-  revision = "b9d67677ad65d5287f646d9e6721b09b1a172852"
+  revision = "23238c2ac7d1f06f1fb21b0413a27426a3f4bc64"
 
 [[projects]]
   branch = "master"
@@ -472,6 +472,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b57f9818ad24fa0b74244debde1c1c91b770f7c2c839b8ed50b193c2ce957876"
+  inputs-digest = "a4bb4f7e4d8fa5993f8d45caaafd0f7c2c09fad9dadc30e17bdaf5d2e4a89dc9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/sylabs/sif"
-  revision = "b9d67677ad65d5287f646d9e6721b09b1a172852"
+  revision = "23238c2ac7d1f06f1fb21b0413a27426a3f4bc64"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
Sif has an update format. Use this new version for V3 development.