### PR TITLE
debian packaging: add revision and maintainer to changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ singularity-container (2.5.1-1) unstable; urgency=high
   * execution on hosts using identity services like SSSD
   * Fixed a regression that broke the debootstrap agent
 
+ -- Gregory M. Kurtzer <gmkurtzer@gmail.com>  Mon, 19 Feb 2018 14:12:13 -0700
+
 singularity-container (2.5.0-1) unstable; urgency=high
 
   * Prevent a user from creating world writable files in root-owned directories 
@@ -41,15 +43,21 @@ singularity-container (2.5.0-1) unstable; urgency=high
   * Improved the way that working directory is mounted 
   * Fixed an out of bounds array in src/lib/image/ext3/init.c
 
+ -- Gregory M. Kurtzer <gmkurtzer@gmail.com>  Mon, 19 Feb 2018 14:12:13 -0700
+
 singularity-container (2.4.6-1) unstable; urgency=high
 
   * Fix for check_mounted() to check parent directories #1436
   * Free strdupped temporary variable in joinpath #1438
 
+ -- Gregory M. Kurtzer <gmkurtzer@gmail.com>  Mon, 19 Feb 2018 14:12:13 -0700
+
 singularity-container (2.4.5-1) unstable; urgency=high
 
   * Strip authorization header on http redirect to different domain when
     interacting with docker registries.
+
+ -- Gregory M. Kurtzer <gmkurtzer@gmail.com>  Mon, 19 Feb 2018 14:12:13 -0700
 
 singularity-container (2.4.4-1) unstable; urgency=high
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-singularity-container (2.5.1) unstable; urgency=high
+singularity-container (2.5.1-1) unstable; urgency=high
 
   * Corrected a permissions error when attempting to run Singularity from a
   * directory on NFS with root_squash enabled
@@ -6,7 +6,7 @@ singularity-container (2.5.1) unstable; urgency=high
   * execution on hosts using identity services like SSSD
   * Fixed a regression that broke the debootstrap agent
 
-singularity-container (2.5.0) unstable; urgency=high
+singularity-container (2.5.0-1) unstable; urgency=high
 
   * Prevent a user from creating world writable files in root-owned directories 
     on the host system by manipulating symbolic links and bind mounts 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The debian packaging is set to use the source format `3.0 (quilt)` in `debian/source/format`, making it a non-native package. Those must contain a revision in the version string [1]. A maintainer seems also required as `dpkg-buildpackage` otherwise errors with

```
dpkg-buildpackage: error: unable to determine source changed by
```

The "add maintainer" part of this PR is currently just copy&paste and should probably be corrected to something that makes more sense (i.e. at least the date). Looking for comments as to what would be best to put in. Also against which branch should this PR be?

Thanks!

[1] https://wiki.debian.org/DebianMentorsFaq#What_is_the_difference_between_a_native_Debian_package_and_a_non-native_package.3F

**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [ ] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [ ] This PR is ready for review and/or merge


Attn: @singularityware-admin
