### PR TITLE
Development 3.0: runtime adjustements/fixes

### DIFF
--- a/src/runtime/engines/engines.go
+++ b/src/runtime/engines/engines.go
@@ -34,7 +34,7 @@ type EngineOperations interface {
 	// the EngineOperations implementation.
 	InitConfig(*config.Common)
 	// PrepareConfig is called in stage1 to validate and prepare container configuration
-	PrepareConfig() error
+	PrepareConfig(net.Conn) error
 	// IsRunAsInstance returns whether or not the container is an instance or batch
 	IsRunAsInstance() bool
 	// IsAllowSUID returns whether or not the engine allow SUID workflow
@@ -44,7 +44,7 @@ type EngineOperations interface {
 	CreateContainer(int, net.Conn) error
 	// StartProcess is called in stage2 after waiting on RPC server exit. It is
 	// responsible for exec'ing the payload proc in the container
-	StartProcess() error
+	StartProcess(net.Conn) error
 	// MonitorContainer is called in smaster once the container proc has been spawned. It
 	// will typically block until the container proc exists
 	MonitorContainer(int) (syscall.WaitStatus, error)

--- a/src/runtime/engines/imgbuild/engine.go
+++ b/src/runtime/engines/imgbuild/engine.go
@@ -6,6 +6,7 @@
 package imgbuild
 
 import (
+	"net"
 	"os"
 	"syscall"
 
@@ -31,7 +32,7 @@ func (e *EngineOperations) Config() config.EngineConfig {
 }
 
 // PrepareConfig validates/prepares EngineConfig setup
-func (e *EngineOperations) PrepareConfig() error {
+func (e *EngineOperations) PrepareConfig(masterConn net.Conn) error {
 	e.CommonConfig.OciConfig.SetProcessNoNewPrivileges(true)
 
 	if syscall.Getuid() != 0 {

--- a/src/runtime/engines/imgbuild/process.go
+++ b/src/runtime/engines/imgbuild/process.go
@@ -7,6 +7,7 @@ package imgbuild
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -15,13 +16,8 @@ import (
 	"github.com/singularityware/singularity/src/pkg/sylog"
 )
 
-// PrestartProcess _
-func (e *EngineOperations) PrestartProcess() error {
-	return nil
-}
-
 // StartProcess runs the %post script
-func (e *EngineOperations) StartProcess() error {
+func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 	// Run %post script here
 
 	post := exec.Command("/bin/sh", "-c", e.EngineConfig.Recipe.BuildData.Post)

--- a/src/runtime/engines/singularity/prepare.go
+++ b/src/runtime/engines/singularity/prepare.go
@@ -7,10 +7,11 @@ package singularity
 
 import (
 	"fmt"
+	"net"
 )
 
 // PrepareConfig checks and prepares the runtime engine config
-func (engine *EngineOperations) PrepareConfig() error {
+func (engine *EngineOperations) PrepareConfig(masterConn net.Conn) error {
 	if engine.CommonConfig.EngineName != Name {
 		return fmt.Errorf("incorrect engine")
 	}

--- a/src/runtime/engines/singularity/process.go
+++ b/src/runtime/engines/singularity/process.go
@@ -7,12 +7,13 @@ package singularity
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"syscall"
 )
 
 // StartProcess starts the process
-func (engine *EngineOperations) StartProcess() error {
+func (engine *EngineOperations) StartProcess(masterConn net.Conn) error {
 	os.Setenv("PS1", "shell> ")
 
 	os.Chdir("/")

--- a/src/runtime/startup/scontainer.go
+++ b/src/runtime/startup/scontainer.go
@@ -14,6 +14,7 @@ import "C"
 
 import (
 	"encoding/json"
+	"net"
 	"os"
 	"syscall"
 	"unsafe"
@@ -32,8 +33,22 @@ func bool2int(b bool) uint8 {
 }
 
 // SContainer performs container startup
-func SContainer(stage C.int, config *C.struct_cConfig, jsonC *C.char) {
+func SContainer(stage C.int, masterSocket C.int, config *C.struct_cConfig, jsonC *C.char) {
+	var conn net.Conn
+	var err error
 	cconf := config
+
+	if masterSocket != -1 {
+		comm := os.NewFile(uintptr(masterSocket), "master-socket")
+		conn, err = net.FileConn(comm)
+		if err != nil {
+			sylog.Fatalf("failed to copy master unix socket descriptor: %s", err)
+			return
+		}
+		comm.Close()
+	} else {
+		conn = nil
+	}
 
 	/* get json configuration */
 	sylog.Debugf("cconf.jsonConfSize: %d\n", C.int(cconf.jsonConfSize))
@@ -51,7 +66,7 @@ func SContainer(stage C.int, config *C.struct_cConfig, jsonC *C.char) {
 			sylog.Fatalf("runtime engine %s doesn't allow SUID workflow", engine.EngineName)
 		}
 
-		if err := engine.PrepareConfig(); err != nil {
+		if err := engine.PrepareConfig(conn); err != nil {
 			sylog.Fatalf("%s\n", err)
 		}
 
@@ -129,7 +144,7 @@ func SContainer(stage C.int, config *C.struct_cConfig, jsonC *C.char) {
 		os.Stdout.Write(append(cconfPayload, jsonConf...))
 		os.Exit(0)
 	} else {
-		if err := engine.StartProcess(); err != nil {
+		if err := engine.StartProcess(conn); err != nil {
 			sylog.Fatalf("%s\n", err)
 		}
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Fix instances bug
- Rename instance_socket by master_socket for multi-purpose (pass file descriptor)
- Add master socket connection as parameter for PrepareConfig and StartProcess.
- Clear environment variables in Go section because Go use its own duplicate environment variables stack.
