### PR TITLE
Fix missing Arch package

### DIFF
--- a/libexec/bootstrap-scripts/deffile-driver-arch.sh
+++ b/libexec/bootstrap-scripts/deffile-driver-arch.sh
@@ -83,7 +83,7 @@ fi
 # having to wait for ages until entropy accumulates. See
 # https://wiki.archlinux.org/index.php/Install_from_Existing_Linux,
 # https://wiki.archlinux.org/index.php/Pacman/Package_signing.
-if ! eval "'$PACSTRAP' -C '$PACMAN_CONF' -c -d -G -M '$SINGULARITY_ROOTFS' haveged $BASE_TO_INST"; then
+if ! eval "'$PACSTRAP' -C '$PACMAN_CONF' -c -d -G -M '$SINGULARITY_ROOTFS' haveged pacman-contrib $BASE_TO_INST"; then
     rm -f "$PACMAN_CONF"
     message ERROR "\`$PACSTRAP' failed.\n"
     ABORT 255


### PR DESCRIPTION
Recently, Arch moved the paccache application (and others) to the
pacman-contrib package:
  https://bbs.archlinux.org/viewtopic.php?id=237507

paccache is one of these, and is needed ... but pacman-contrib is
not part of base.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
