### PR TITLE
paccache is no longer in base arch repo so we need to add it with pacman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Added build and packaging tests for Debian 8/9 and openSUSE 42.3/15.0 #1713
  - Restore shim init process for proper signal handling and child reaping when
    container is initiated in its own PID namespace #1221
+ - Bind `/dev/nvidia*` into the container when the `--nv` flag is used in 
+    conjuction with the `--contain` flag #1358
 
 ### Bug fixes
-  - Fix 404 when using Arch Linux bootstrap #1731
-  - Bind `/dev/nvidia*` into the container when the `--nv` flag is used in 
-    conjuction with the `--contain` flag #1358
+ - Fix 404 when using Arch Linux bootstrap #1731
 
 ## [v2.5.2](https://github.com/singularityware/singularity/releases/tag/2.5.2) (2018-07-03)
 

--- a/examples/arch/Singularity
+++ b/examples/arch/Singularity
@@ -41,4 +41,5 @@ Bootstrap: arch
     pacman -Sy --noconfirm vim bash-completion
 
     # Remove the packages downloaded to image's Pacman cache dir.
+    pacman -Sy --noconfirm pacman-contrib
     paccache -r -k0


### PR DESCRIPTION

**Description of the Pull Request (PR):**

We want to use paccache in the example definition file for arch to keep the container size small, but paccache (in the pacman-contrib package) has been moved out of the default container

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
