### PR TITLE
Specify bytes-per-inode when creating image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Added build and packaging tests for Debian 8/9 and openSUSE 42.3/15.0 #1713
  - Restore shim init process for proper signal handling and child reaping when
    container is initiated in its own PID namespace #1221
+ - Add -i option to image.create to specify the inode ratio. #1759
 
 ### Bug fixes
   - Fix 404 when using Arch Linux bootstrap #1731

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -372,8 +372,10 @@ _singularity() {
                 create)
                     if [[ ${cur} == -s || ${cur} == --size ]]; then
                         return 0
+                    if [[ ${cur} == -i || ${cur} == --bytes-per-inode ]]; then
+                        return 0
                     elif [[ ${cur} == -* ]] ; then
-                        COMPREPLY=( $(compgen -W "--size --force --help" -- ${cur}) )
+                        COMPREPLY=( $(compgen -W "--size --force --help --bytes-per-inode" -- ${cur}) )
                     else
                         _filedir 
                     fi

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -204,7 +204,7 @@ _singularity() {
             elif [[ ${cur} == -H || ${cur} == --hash ]]; then
                 _filedir
             elif [[ ${cur} == -s || ${cur} == --size ]]; then
-                _filedir
+                return 0
             elif [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "--name --commit --hash --size --force --help" -- ${cur}) )
             else
@@ -253,8 +253,8 @@ _singularity() {
 
         image.create)
             if [[ ${cur} == -s || ${cur} == --size ]]; then
-                _filedir
-            if [[ ${cur} == -i || ${cur} == --bytes-per-inode ]]; then
+                return 0
+            elif [[ ${cur} == -i || ${cur} == --bytes-per-inode ]]; then
                 return 0
             elif [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "--size --force --help --bytes-per-inode" -- ${cur}) )
@@ -275,7 +275,7 @@ _singularity() {
 
         image.expand)
             if [[ ${cur} == -s || ${cur} == --size ]]; then
-                _filedir
+                return 0
             elif [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "--size --help" -- ${cur}) )
             else
@@ -371,7 +371,7 @@ _singularity() {
 
                 create)
                     if [[ ${cur} == -s || ${cur} == --size ]]; then
-                        _filedir
+                        return 0
                     elif [[ ${cur} == -* ]] ; then
                         COMPREPLY=( $(compgen -W "--size --force --help" -- ${cur}) )
                     else
@@ -402,7 +402,7 @@ _singularity() {
 
                 expand)
                     if [[ ${cur} == -s || ${cur} == --size ]]; then
-                        _filedir
+                        return 0
                     elif [[ ${cur} == -* ]] ; then
                         COMPREPLY=( $(compgen -W "--size --help" -- ${cur}) )
                     else

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -255,7 +255,7 @@ _singularity() {
             if [[ ${cur} == -s || ${cur} == --size ]]; then
                 _filedir
             elif [[ ${cur} == -* ]] ; then
-                COMPREPLY=( $(compgen -W "--size --force --help" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "--size --force --help -i" -- ${cur}) )
             else
                 _filedir 
             fi

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -372,7 +372,7 @@ _singularity() {
                 create)
                     if [[ ${cur} == -s || ${cur} == --size ]]; then
                         return 0
-                    if [[ ${cur} == -i || ${cur} == --bytes-per-inode ]]; then
+                    elif [[ ${cur} == -i || ${cur} == --bytes-per-inode ]]; then
                         return 0
                     elif [[ ${cur} == -* ]] ; then
                         COMPREPLY=( $(compgen -W "--size --force --help --bytes-per-inode" -- ${cur}) )

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -254,8 +254,10 @@ _singularity() {
         image.create)
             if [[ ${cur} == -s || ${cur} == --size ]]; then
                 _filedir
+            if [[ ${cur} == -i || ${cur} == --bytes-per-inode ]]; then
+                return 0
             elif [[ ${cur} == -* ]] ; then
-                COMPREPLY=( $(compgen -W "--size --force --help -i" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "--size --force --help --bytes-per-inode" -- ${cur}) )
             else
                 _filedir 
             fi

--- a/libexec/cli/image.create.exec
+++ b/libexec/cli/image.create.exec
@@ -46,7 +46,7 @@ while true; do
             export SINGULARITY_IMAGESIZE
             shift
         ;;
-        -i)
+        -i|--bytes-per-inode)
             shift
             SINGULARITY_INODESIZE="${1:-}"
             export SINGULARITY_INODESIZE

--- a/libexec/cli/image.create.exec
+++ b/libexec/cli/image.create.exec
@@ -106,11 +106,11 @@ fi
 # We want to exit before the 'dd' command
 INODE=""
 if [ -n "${SINGULARITY_INODESIZE:-}" ]; then
-    INODE="-i ${SINGULARITY_INODESIZE:-16384}"
+    INODE="-i ${SINGULARITY_INODESIZE}"
 
     if [ $(expr ${SINGULARITY_INODESIZE} % 1024) -ne 0 ]; then
         message ERROR "Given inode size of ${SINGULARITY_INODESIZE} is not divisible by 1024\n"
-        exit 1
+        ABORT 255
     fi
 fi
 

--- a/libexec/cli/image.create.exec
+++ b/libexec/cli/image.create.exec
@@ -109,8 +109,7 @@ if [ -n "${SINGULARITY_INODESIZE:-}" ]; then
     INODE="-i ${SINGULARITY_INODESIZE}"
 
     if [ $(expr ${SINGULARITY_INODESIZE} % 1024) -ne 0 ]; then
-        message ERROR "Given inode size of ${SINGULARITY_INODESIZE} is not divisible by 1024\n"
-        ABORT 255
+        message WARN "--bytes-per-inode ratio of ${SINGULARITY_INODESIZE} is not divisible by 1024\n"
     fi
 fi
 

--- a/libexec/cli/image.create.exec
+++ b/libexec/cli/image.create.exec
@@ -46,6 +46,12 @@ while true; do
             export SINGULARITY_IMAGESIZE
             shift
         ;;
+        -i)
+            shift
+            SINGULARITY_INODESIZE="${1:-}"
+            export SINGULARITY_INODESIZE
+            shift
+        ;;
         -F|--force)
             shift
             OVERWRITE=1
@@ -96,6 +102,19 @@ if [ -f "$SINGULARITY_IMAGE" ]; then
     fi
 fi
 
+# Get the inode option *before* creating the empty file
+# We want to exit before the 'dd' command
+INODE=""
+if [ -n "${SINGULARITY_INODESIZE:-}" ]; then
+    INODE="-i ${SINGULARITY_INODESIZE:-16384}"
+
+    if [ $(expr ${SINGULARITY_INODESIZE} % 1024) -ne 0 ]; then
+        message ERROR "Given inode size of ${SINGULARITY_INODESIZE} is not divisible by 1024\n"
+        exit 1
+    fi
+fi
+
+
 DDSTATUS="none"
 if dd --help | grep -q 'status=noxfer'; then
     DDSTATUS="noxfer"
@@ -108,7 +127,7 @@ if ! dd if=/dev/zero of="$SINGULARITY_IMAGE" bs=1M count=${SINGULARITY_IMAGESIZE
 fi
 
 message 1 "Formatting image with ext3 file system\n"
-if ! /sbin/mkfs.ext3 -q -F "$SINGULARITY_IMAGE"; then
+if ! /sbin/mkfs.ext3 -q ${INODE} -F "$SINGULARITY_IMAGE"; then
     exit 1
 fi
 

--- a/libexec/cli/image.create.info
+++ b/libexec/cli/image.create.info
@@ -11,11 +11,14 @@ CREATE OPTIONS:
     -s|--size   Specify a size for an operation in MiB, i.e. 1024*1024B
                 (default 768MiB)
     -F|--force  Overwrite an image file if it exists
+    -i          Specify a size for the inode ratio in Bytes. Default is
+                the host system value.
 
 EXAMPLES:
 
     $ singularity image.create /tmp/Debian.img
     $ singularity image.create -s 4096 /tmp/Debian.img
+    $ singularity image.create -i 8192 /tmp/Debian.img
 
 For additional help, please visit our public documentation pages which are
 found at:

--- a/libexec/cli/image.create.info
+++ b/libexec/cli/image.create.info
@@ -11,7 +11,8 @@ CREATE OPTIONS:
     -s|--size   Specify a size for an operation in MiB, i.e. 1024*1024B
                 (default 768MiB)
     -F|--force  Overwrite an image file if it exists
-    -i          Specify a size for the inode ratio in Bytes. Default is
+    -i|--bytes-per-inode
+                Specify a size for the inode ratio in Bytes. Default is
                 the host system value.
 
 EXAMPLES:


### PR DESCRIPTION
When using image.create to make an overlay image, this will allow
the specifying of the size of an inode.

mke2fs default is 16K per inode, which if you have a lot of small
files, means you would hit the inode limit before you would hit
the space limit.

This PR adds a `-i` option to specify the size in bytes of the
inodes to mkfs.ext3.

For example:
```
$ singularity image.create -i 8192 /tmp/overlay.img
```

Issue: #1759

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
