### PR TITLE
Add option to not mount home directory

### DIFF
--- a/.travis/debuild_test
+++ b/.travis/debuild_test
@@ -27,7 +27,7 @@ gdebi -n ../singularity-container_*.deb
 
 # Install python 3 and pylint
 apt-get -y install python3 python3-pip python3-setuptools
-pip3 install pylint
+pip3 install pylint==1.9.2
 
 # Install docker
 apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common

--- a/.travis/deps/opensuse_deps
+++ b/.travis/deps/opensuse_deps
@@ -24,7 +24,7 @@ install_rpms () {
 
 install_test_deps () {
     zypper install -y --no-recommends ${test_deps[*]}
-    pip3 install pylint
+    pip3 install pylint==1.9.2
 }
 
 # source amendments for specific centos release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - Added build and packaging tests for Debian 8/9 and openSUSE 42.3/15.0 #1713
  - Restore shim init process for proper signal handling and child reaping when
    container is initiated in its own PID namespace #1221
+ - Add --no-home option to not mount user $HOME if it is not the $CWD and
+   `mount home = yes` is set. #1761
 
 ### Bug fixes
   - Fix 404 when using Arch Linux bootstrap #1731

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -100,7 +100,7 @@ _singularity() {
             elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -* ]] ; then
-                opts="--app --bind --contain --containall --cleanenv --home --ipc --net --nv --overlay --pid --pwd --scratch --user --workdir --writable --help "
+                opts="--app --bind --contain --containall --cleanenv --home --ipc --net --no-home --nv --overlay --pid --pwd --scratch --user --workdir --writable --help "
                 case "${cmd}" in
                     shell)
                         opts="$opts --shell"
@@ -224,7 +224,7 @@ _singularity() {
             elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -* ]] ; then
-                COMPREPLY=( $(compgen -W "--bind --contain --home --net --nv --overlay --scratch --workdir --writable --help" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "--bind --contain --home --net --no-home --nv --overlay --scratch --workdir --writable --help" -- ${cur}) )
             else
                 _filedir 
             fi
@@ -320,7 +320,7 @@ _singularity() {
                     elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                         COMPREPLY=( $(compgen -f -- ${cur}) )
                     elif [[ ${cur} == -* ]] ; then
-                        COMPREPLY=( $(compgen -W "--bind --contain --home --net --nv --overlay --scratch --workdir --writable --help" -- ${cur}) )
+                        COMPREPLY=( $(compgen -W "--bind --contain --home --net --no-home --nv --overlay --scratch --workdir --writable --help" -- ${cur}) )
                     else
                         _filedir 
                     fi

--- a/libexec/cli/action_argparser.sh
+++ b/libexec/cli/action_argparser.sh
@@ -58,6 +58,11 @@ while true; do
             export SINGULARITY_HOME
             shift
         ;;
+        --no-home)
+            shift
+            SINGULARITY_NOHOME=1
+            export SINGULARITY_NOHOME
+        ;;
         -W|--wdir|--workdir|--workingdir)
             shift
             SINGULARITY_WORKDIR="$1"

--- a/libexec/cli/exec.info
+++ b/libexec/cli/exec.info
@@ -27,6 +27,8 @@ EXEC OPTIONS:
                         src path or src:dest pair.  src is the source path
                         of the home directory outside the container and dest
                         overrides the home directory within the container
+    --no-home           Do NOT mount users home directory if home is not the
+                        current working directory.
     -i|--ipc            Run container in a new IPC namespace
     -n|--net            Run container in a new network namespace (loopback is
                         only network device active)

--- a/libexec/cli/run.info
+++ b/libexec/cli/run.info
@@ -32,6 +32,8 @@ RUN OPTIONS:
                         src path or src:dest pair.  src is the source path
                         of the home directory outside the container and dest
                         overrides the home directory within the container
+    --no-home           Do NOT mount users home directory if home is not the
+                        current working directory.
     -i|--ipc            Run container in a new IPC namespace
     -n|--net            Run container in a new network namespace (loopback is
                         only network device active)

--- a/libexec/cli/shell.info
+++ b/libexec/cli/shell.info
@@ -26,6 +26,8 @@ SHELL OPTIONS:
                         src path or src:dest pair.  src is the source path
                         of the home directory outside the container and dest
                         overrides the home directory within the container
+    --no-home           Do NOT mount users home directory if home is not the
+                        current working directory.
     -i|--ipc            Run container in a new IPC namespace
     -j|--join           Join a running named instance of the given container 
                         image

--- a/src/lib/runtime/mounts/home/home.c
+++ b/src/lib/runtime/mounts/home/home.c
@@ -56,6 +56,10 @@ int _singularity_runtime_mount_home(void) {
     }
 
     singularity_message(DEBUG, "Checking if home directories are being influenced by user\n");
+    if ( singularity_registry_get("NOHOME") != NULL ) {
+        singularity_message(VERBOSE, "Skipping home directory mount by user request.\n");
+        return(0);
+    }
     if ( singularity_registry_get("HOME") != NULL ) {
         singularity_message(DEBUG, "Checking if user bind control is allowed\n");
         if ( singularity_config_get_bool(USER_BIND_CONTROL) <= 0 ) {
@@ -65,10 +69,7 @@ int _singularity_runtime_mount_home(void) {
     } else if ( singularity_config_get_bool(MOUNT_HOME) <= 0 ) {
         singularity_message(VERBOSE, "Skipping home dir mounting (per config)\n");
         return(0);
-    } else if ( singularity_registry_get("NOHOME") == 1 ) {
-        singularity_message(VERBOSE, "Skipping home directory mount by user request.\n");
-        return(0);
-    } 
+    }
 
     singularity_message(DEBUG, "Checking ownership of home directory source: %s\n", home_source);
     if ( is_owner(home_source, singularity_priv_getuid()) != 0 ) {

--- a/src/lib/runtime/mounts/home/home.c
+++ b/src/lib/runtime/mounts/home/home.c
@@ -49,7 +49,6 @@ int _singularity_runtime_mount_home(void) {
     char *session_dir = singularity_registry_get("SESSIONDIR");
     char *container_dir = CONTAINER_FINALDIR;
 
-
     singularity_message(DEBUG, "Checking that home directry is configured: %s\n", home_dest);
     if ( home_dest == NULL ) {
         singularity_message(ERROR, "Could not obtain user's home directory\n");
@@ -66,8 +65,10 @@ int _singularity_runtime_mount_home(void) {
     } else if ( singularity_config_get_bool(MOUNT_HOME) <= 0 ) {
         singularity_message(VERBOSE, "Skipping home dir mounting (per config)\n");
         return(0);
-    }
-
+    } else if ( singularity_registry_get("NOHOME") == 1 ) {
+        singularity_message(VERBOSE, "Skipping home directory mount by user request.\n");
+        return(0);
+    } 
 
     singularity_message(DEBUG, "Checking ownership of home directory source: %s\n", home_source);
     if ( is_owner(home_source, singularity_priv_getuid()) != 0 ) {

--- a/tests/32-action_options.sh
+++ b/tests/32-action_options.sh
@@ -61,5 +61,10 @@ stest 0 sh -c "echo 'cd; test -f testfile' | singularity exec --home '$TESTDIR' 
 stest 1 singularity exec --home "/tmp" "$CONTAINER" true
 stest 1 singularity exec --home "/tmp:/home" "$CONTAINER" true
 
+# Teting --no-home
+_CWD=$(pwd)
+cd /tmp
+stest 1 singularity exec --no-home "$CONTAINER" ls -ld $HOME
+cd ${_CWD}
 
 test_cleanup


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds a `--no-home` option that will *not* mount the users home directory even if `mount home = yes` is set in `singularity.conf`

This will still mount your $HOME if it is also your current working directory. There is not logic to circumvent that. So, normal usage would be something like:

```
$ cd /tmp
$ singularity exec --no-home ~/ubuntu.img ls -l $HOME
ls: cannot access '/home/jason': No such file or directory
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularityware-admin
