### PR TITLE
Go Test Timeout

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -138,7 +138,7 @@ test:
 	@echo "       PASS"
 	@echo " TEST sudo go test"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && sudo -E `which go` test -count=1 -tags "$(go_TAG)" -cover -race -timeout 120s ./...
+		cd $(SOURCEDIR) && sudo -E `which go` test -count=1 -tags "$(go_TAG)" -cover -race ./...
 	@echo "       PASS"
 
 .PHONY: cscope


### PR DESCRIPTION
Removing `go test` timeout of `120s`, as there are several instances of the test suite failing due only to a timeout. Reverting to the `go test` default for now, which is `10m`. 