### PR TITLE
Separate test rule into check and test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ install:
   - sudo make -C ./builddir install
 
 script:
+  - make -C ./builddir check
   - make -C ./builddir test

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -122,20 +122,23 @@ collect:
 			>> $(BUILDDIR)/mergeddeps)			\
 	done
 
-.PHONY: test
-test:
-	@echo " TEST go fmt"
+.PHONY: check
+check:
+	@echo " CHECK go fmt"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && test -z $(go fmt ./...)
 	@echo "       PASS"
-	@echo " TEST go vet"
+	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && go vet -tags "$(go_TAG)" -all ./...
 	@echo "       PASS"
-	@echo " TEST go lint"
+	@echo " CHECK go lint"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && golint -set_exit_status `go list ./...`
 	@echo "       PASS"
+
+.PHONY: test
+test:
 	@echo " TEST sudo go test"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && sudo -E `which go` test -count=1 -tags "$(go_TAG)" -cover -race ./...


### PR DESCRIPTION
Running make test, takes a while and during development there's interest
in checking the code formatting without running tests.

This change allows that to be done easily.