### PR TITLE
Fix environment variables clearing for instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 ### Bug fixes
  - Fix 404 when using Arch Linux bootstrap #1731
+ - Fix environment variables clearing while starting instances #1766
 
 ## [v2.5.2](https://github.com/singularityware/singularity/releases/tag/2.5.2) (2018-07-03)
 

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -224,7 +224,7 @@ _singularity() {
             elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                 COMPREPLY=( $(compgen -f -- ${cur}) )
             elif [[ ${cur} == -* ]] ; then
-                COMPREPLY=( $(compgen -W "--bind --contain --home --net --no-home --nv --overlay --scratch --workdir --writable --help" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "--bind --contain --home --net --no-home --nv --overlay --scratch --workdir --writable --help --cleanenv" -- ${cur}) )
             else
                 _filedir 
             fi

--- a/etc/bash_completion.d/singularity
+++ b/etc/bash_completion.d/singularity
@@ -322,7 +322,7 @@ _singularity() {
                     elif [[ ${cur} == -W || ${cur} == --workdir || ${cur} == --wdir ]]; then
                         COMPREPLY=( $(compgen -f -- ${cur}) )
                     elif [[ ${cur} == -* ]] ; then
-                        COMPREPLY=( $(compgen -W "--bind --contain --home --net --no-home --nv --overlay --scratch --workdir --writable --help" -- ${cur}) )
+                        COMPREPLY=( $(compgen -W "--bind --contain --home --net --no-home --nv --overlay --scratch --workdir --writable --help --cleanenv" -- ${cur}) )
                     else
                         _filedir 
                     fi

--- a/libexec/cli/instance.start.exec
+++ b/libexec/cli/instance.start.exec
@@ -74,6 +74,11 @@ while true; do
             SINGULARITY_CONTAIN=1
             export SINGULARITY_CONTAIN
         ;;
+        -e|--cleanenv)
+            shift
+            SINGULARITY_CLEANENV=1
+            export SINGULARITY_CLEANENV
+        ;;
         -o|--overlay)
             shift
             SINGULARITY_OVERLAYIMAGE="${1:-}"

--- a/libexec/cli/instance.start.info
+++ b/libexec/cli/instance.start.info
@@ -18,6 +18,7 @@ START OPTIONS:
                         default). This option can be called multiple times.
     -c|--contain        Use minimal /dev and empty other directories (e.g. /tmp
                         and $HOME) instead of sharing filesystems on your host
+    -e|--cleanenv       Clean environment before running container
     -H|--home <spec>    A home directory specification.  spec can either be a
                         src path or src:dest pair.  src is the source path
                         of the home directory outside the container and dest

--- a/src/start.c
+++ b/src/start.c
@@ -122,12 +122,8 @@ int main(int argc, char **argv) {
     stderr_log = make_logfile("stderr");
 
     singularity_runtime_enter();
+    singularity_runtime_environment();
     singularity_priv_drop_perm();
-
-    if ( envclean() != 0 ) {
-        singularity_message(ERROR, "Failed sanitizing the environment\n");
-        ABORT(255);
-    }
 
     singularity_install_signal_handler();
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Instances always clear environment variables, this PR fix that by changing the default behaviour to not clear environment variables by default and add `-e/--cleanenv` flag for `instance.start`


**This fixes or addresses the following GitHub issues:**

- Ref: #1766


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [ ] This PR is NOT against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
