### PR TITLE
Adapt lookup function to new SIF lookup semantics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -390,7 +390,7 @@
   branch = "master"
   name = "github.com/sylabs/sif"
   packages = ["pkg/sif"]
-  revision = "3bdbce3fa52865b2a360ddc11ec20ffcd4db5a00"
+  revision = "8ad2fb65a618b8d83f03efd93d0fbf2ecce61a02"
 
 [[projects]]
   branch = "master"

--- a/src/pkg/build/packer_sif.go
+++ b/src/pkg/build/packer_sif.go
@@ -53,13 +53,13 @@ func (p *SIFPacker) unpackSIF(b *Bundle, rootfs string) (err error) {
 	defer fimg.UnloadContainer()
 
 	// Get the default system partition image as rootfs
-	rootfsPart, _, err := fimg.GetPartFromGroup(sif.DescrDefaultGroup)
+	rootfsParts, _, err := fimg.GetPartFromGroup(sif.DescrDefaultGroup)
 	if err != nil {
 		return err
 	}
 
 	// Check that this is a system partition
-	parttype, err := rootfsPart.GetPartType()
+	parttype, err := rootfsParts[0].GetPartType()
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (p *SIFPacker) unpackSIF(b *Bundle, rootfs string) (err error) {
 
 	// record the fs type
 	mountType := ""
-	fstype, err := rootfsPart.GetFsType()
+	fstype, err := rootfsParts[0].GetFsType()
 	if err != nil {
 		return err
 	}
@@ -82,8 +82,8 @@ func (p *SIFPacker) unpackSIF(b *Bundle, rootfs string) (err error) {
 	}
 
 	info := &loop.Info64{
-		Offset:    uint64(rootfsPart.Fileoff),
-		SizeLimit: uint64(rootfsPart.Filelen),
+		Offset:    uint64(rootfsParts[0].Fileoff),
+		SizeLimit: uint64(rootfsParts[0].Filelen),
 		Flags:     loop.FlagsAutoClear,
 	}
 

--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -376,13 +376,13 @@ func (c *container) addRootfsMount(system *mount.System) error {
 		}
 
 		// Get the default system partition image
-		part, _, err := fimg.GetPartFromGroup(sif.DescrDefaultGroup)
+		parts, _, err := fimg.GetPartFromGroup(sif.DescrDefaultGroup)
 		if err != nil {
 			return err
 		}
 
 		// Check that this is a system partition
-		parttype, err := part.GetPartType()
+		parttype, err := parts[0].GetPartType()
 		if err != nil {
 			return err
 		}
@@ -391,7 +391,7 @@ func (c *container) addRootfsMount(system *mount.System) error {
 		}
 
 		// record the fs type
-		fstype, err := part.GetFsType()
+		fstype, err := parts[0].GetFsType()
 		if err != nil {
 			return err
 		}
@@ -406,8 +406,8 @@ func (c *container) addRootfsMount(system *mount.System) error {
 			return fmt.Errorf("unknown file system type: %v", fstype)
 		}
 
-		imageObject.Offset = uint64(part.Fileoff)
-		imageObject.Size = uint64(part.Filelen)
+		imageObject.Offset = uint64(parts[0].Fileoff)
+		imageObject.Size = uint64(parts[0].Filelen)
 	case image.SQUASHFS:
 		if writable {
 			return fmt.Errorf("can't set writable flag with squashfs image")


### PR DESCRIPTION
A few SIF lookup functions now may return multiple elements matching
search criterias. Get the singularity code ready for the new usage.
