### PR TITLE
Build test skips for short runs

### DIFF
--- a/src/pkg/build/conveyorPacker_arch_test.go
+++ b/src/pkg/build/conveyorPacker_arch_test.go
@@ -40,13 +40,12 @@ func TestArchConveyor(t *testing.T) {
 
 	ac := &ArchConveyor{}
 
-	if err := ac.Get(def); err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(ac.tmpfs)
+	err = ac.Get(def)
+	//clean up tmpfs since assembler isnt called
+	defer os.RemoveAll(ac.tmpfs)
+	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", archDef, err)
 	}
-	//clean up tmpfs since assembler isnt called
-	os.RemoveAll(ac.tmpfs)
 }
 
 func TestArchPacker(t *testing.T) {
@@ -70,13 +69,12 @@ func TestArchPacker(t *testing.T) {
 
 	acp := &ArchConveyorPacker{}
 
-	if err := acp.Get(def); err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(acp.tmpfs)
+	err = acp.Get(def)
+	//clean up tmpfs since assembler isnt called
+	defer os.RemoveAll(acp.tmpfs)
+	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", archDef, err)
 	}
-	//clean up tmpfs since assembler isnt called
-	os.RemoveAll(acp.tmpfs)
 
 	_, err = acp.Pack()
 	if err != nil {

--- a/src/pkg/build/conveyorPacker_arch_test.go
+++ b/src/pkg/build/conveyorPacker_arch_test.go
@@ -17,6 +17,10 @@ const archDef = "./testdata_good/arch/arch"
 
 func TestArchConveyor(t *testing.T) {
 
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	if _, err := exec.LookPath("pacstrap"); err != nil {
 		t.Skip("skipping test, pacstrap not installed")
 	}

--- a/src/pkg/build/conveyorPacker_busybox_test.go
+++ b/src/pkg/build/conveyorPacker_busybox_test.go
@@ -36,13 +36,12 @@ func TestBusyBoxConveyor(t *testing.T) {
 
 	bc := &BusyBoxConveyor{}
 
-	if err := bc.Get(def); err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(bc.tmpfs)
+	err = bc.Get(def)
+	//clean up tmpfs since assembler isnt called
+	defer os.RemoveAll(bc.tmpfs)
+	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", busyBoxDef, err)
 	}
-	//clean up tmpfs since assembler isnt called
-	os.RemoveAll(bc.tmpfs)
 
 }
 
@@ -64,14 +63,12 @@ func TestBusyBoxPacker(t *testing.T) {
 
 	bcp := &BusyBoxConveyorPacker{}
 
-	if err := bcp.Get(def); err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(bcp.tmpfs)
-		t.Fatalf("failed to Get from %s: %v\n", busyBoxDef, err)
-	}
-
+	err = bcp.Get(def)
 	//clean up tmpfs since assembler isnt called
 	defer os.RemoveAll(bcp.tmpfs)
+	if err != nil {
+		t.Fatalf("failed to Get from %s: %v\n", busyBoxDef, err)
+	}
 
 	_, err = bcp.Pack()
 	if err != nil {

--- a/src/pkg/build/conveyorPacker_busybox_test.go
+++ b/src/pkg/build/conveyorPacker_busybox_test.go
@@ -16,6 +16,10 @@ const busyBoxDef = "./testdata_good/busybox/busybox"
 
 func TestBusyBoxConveyor(t *testing.T) {
 
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/src/pkg/build/conveyorPacker_debootstrap_test.go
+++ b/src/pkg/build/conveyorPacker_debootstrap_test.go
@@ -37,13 +37,11 @@ func TestDebootstrapConveyor(t *testing.T) {
 	dc := DebootstrapConveyor{}
 
 	err := dc.Get(testDef)
+	//clean up tmpfs since assembler isnt called
+	defer os.RemoveAll(dc.tmpfs)
 	if err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(dc.tmpfs)
 		t.Fatalf("Debootstrap Get failed: %v", err)
 	}
-
-	os.RemoveAll(dc.tmpfs)
 }
 
 func TestDebootstrapPacker(t *testing.T) {
@@ -66,13 +64,11 @@ func TestDebootstrapPacker(t *testing.T) {
 	dcp := DebootstrapConveyorPacker{}
 
 	err := dcp.Get(testDef)
+	//clean up tmpfs since assembler isnt called
+	defer os.RemoveAll(dcp.tmpfs)
 	if err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(dcp.tmpfs)
 		t.Fatalf("Debootstrap Get failed: %v", err)
 	}
-
-	defer os.RemoveAll(dcp.tmpfs)
 
 	_, err = dcp.Pack()
 	if err != nil {

--- a/src/pkg/build/conveyorPacker_debootstrap_test.go
+++ b/src/pkg/build/conveyorPacker_debootstrap_test.go
@@ -6,6 +6,7 @@
 package build
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 
@@ -13,6 +14,10 @@ import (
 )
 
 func TestDebootstrapConveyor(t *testing.T) {
+
+	if testing.Short() {
+		t.SkipNow()
+	}
 
 	if _, err := exec.LookPath("debootstrap"); err != nil {
 		t.Skip("skipping test, debootstrap not installed")
@@ -33,8 +38,12 @@ func TestDebootstrapConveyor(t *testing.T) {
 
 	err := dc.Get(testDef)
 	if err != nil {
+		//clean up tmpfs since assembler isnt called
+		os.RemoveAll(dc.tmpfs)
 		t.Fatalf("Debootstrap Get failed: %v", err)
 	}
+
+	os.RemoveAll(dc.tmpfs)
 }
 
 func TestDebootstrapPacker(t *testing.T) {
@@ -58,8 +67,12 @@ func TestDebootstrapPacker(t *testing.T) {
 
 	err := dcp.Get(testDef)
 	if err != nil {
+		//clean up tmpfs since assembler isnt called
+		os.RemoveAll(dcp.tmpfs)
 		t.Fatalf("Debootstrap Get failed: %v", err)
 	}
+
+	defer os.RemoveAll(dcp.tmpfs)
 
 	_, err = dcp.Pack()
 	if err != nil {

--- a/src/pkg/build/conveyorPacker_debootstrap_test.go
+++ b/src/pkg/build/conveyorPacker_debootstrap_test.go
@@ -48,10 +48,10 @@ func TestDebootstrapPacker(t *testing.T) {
 	testDef := Definition{}
 
 	testDef.Header = map[string]string{
-		"Bootstrap": "debootstrap",
-		"OSVersion": "bionic",
-		"MirrorURL": "http://us.archive.ubuntu.com/ubuntu/",
-		"Include":   "apt python ",
+		"bootstrap": "debootstrap",
+		"osversion": "bionic",
+		"mirrorurl": "http://us.archive.ubuntu.com/ubuntu/",
+		"include":   "apt python ",
 	}
 
 	dcp := DebootstrapConveyorPacker{}

--- a/src/pkg/build/conveyorPacker_shub_test.go
+++ b/src/pkg/build/conveyorPacker_shub_test.go
@@ -29,13 +29,13 @@ func TestShubConveyor(t *testing.T) {
 
 	sc := &ShubConveyor{}
 
-	if err := sc.Get(def); err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(sc.tmpfs)
+	err = sc.Get(def)
+	//clean up tmpfs since assembler isnt called
+	defer os.RemoveAll(sc.tmpfs)
+	if err != nil {
+
 		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
 	}
-	//clean up tmpfs since assembler isnt called
-	os.RemoveAll(sc.tmpfs)
 }
 
 // TestShubPacker checks if we can create a Bundle from the pulled image
@@ -50,14 +50,13 @@ func TestShubPacker(t *testing.T) {
 
 	scp := &ShubConveyorPacker{}
 
-	if err := scp.Get(def); err != nil {
-		//clean up tmpfs since assembler isnt called
-		os.RemoveAll(scp.tmpfs)
-		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
-	}
-
+	err = scp.Get(def)
 	//clean up tmpfs since assembler isnt called
 	defer os.RemoveAll(scp.tmpfs)
+	if err != nil {
+
+		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
+	}
 
 	_, err = scp.Pack()
 	if err != nil {


### PR DESCRIPTION
Skips conveyor test for debootstrap, pacman, and busybox.
Adds tmpfs cleanup and a typo fix for debootstrap packer test