### PR TITLE
Clean up of src/runtime/engines/singularity/container.go session, layer, and home handling

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -54,7 +54,7 @@ func init() {
 		cmd.Flags().AddFlag(actionFlags.Lookup("add-caps"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("drop-caps"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("allow-setuid"))
-		cmd.Flags().AddFlag(actionFlags.Lookup("writable"))
+		//cmd.Flags().AddFlag(actionFlags.Lookup("writable"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("no-home"))
 		cmd.Flags().SetInterspersed(false)
 	}

--- a/src/pkg/image/sandbox.go
+++ b/src/pkg/image/sandbox.go
@@ -18,6 +18,7 @@ type sandboxFormat struct{}
 func (f *sandboxFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	if fileinfo.IsDir() {
 		img.Type = SANDBOX
+		img.Writable = true
 	} else {
 		return fmt.Errorf("not a directory image")
 	}

--- a/src/runtime/engines/imgbuild/create.go
+++ b/src/runtime/engines/imgbuild/create.go
@@ -100,6 +100,12 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 		return fmt.Errorf("mount /etc/hosts failed: %s", err)
 	}
 
+	sylog.Debugf("Set RPC mount propagation flag to SLAVE")
+	_, err = rpcOps.Mount("", "/", "", syscall.MS_SLAVE|syscall.MS_REC, "")
+	if err != nil {
+		return fmt.Errorf("mount /etc/hosts failed: %s", err)
+	}
+
 	// Run %setup script here
 	setup := exec.Command("/bin/sh", "-c", engine.EngineConfig.Recipe.BuildData.Setup)
 	setup.Stdout = os.Stdout

--- a/src/runtime/startup/c/wrapper.c
+++ b/src/runtime/startup/c/wrapper.c
@@ -822,8 +822,8 @@ __attribute__((constructor)) static void init(void) {
                 exit(1);
             }
 
-            if ( mount(NULL, "/", NULL, MS_SLAVE|MS_REC, NULL) < 0 ) {
-                singularity_message(ERROR, "Failed to propagate as SLAVE: %s\n", strerror(errno));
+            if ( mount(NULL, "/", NULL, MS_SHARED|MS_REC, NULL) < 0 ) {
+                singularity_message(ERROR, "Failed to propagate as SHARED: %s\n", strerror(errno));
             }
 
             if ( syncfd >= 0 ) {

--- a/src/runtime/startup/c/wrapper.c
+++ b/src/runtime/startup/c/wrapper.c
@@ -824,6 +824,7 @@ __attribute__((constructor)) static void init(void) {
 
             if ( mount(NULL, "/", NULL, MS_SHARED|MS_REC, NULL) < 0 ) {
                 singularity_message(ERROR, "Failed to propagate as SHARED: %s\n", strerror(errno));
+                exit(1);
             }
 
             if ( syncfd >= 0 ) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This pull request is beginning some cleanup work for `src/runtime/engines/singularity/container.go` file to improve readability and maintainability. 

Currently I have cleaned up:

- Always mount block devices as RDONLY, always mount sandbox as RDWR
- Session / Layer creation
- Home directory handling