### PR TITLE
Fix usage string for "singularity keys newpair"

### DIFF
--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -89,7 +89,7 @@ func Sign(cpath, authToken string) error {
 	if el, err = sypgp.LoadPrivKeyring(); err != nil {
 		return err
 	} else if el == nil {
-		return fmt.Errorf("no private keys found in %s, run 'singularity sypgp newpair' to create keys", sypgp.SecretPath())
+		return fmt.Errorf("no private keys found in %s, run 'singularity keys newpair' to create keys", sypgp.SecretPath())
 	}
 
 	if len(el) > 1 {


### PR DESCRIPTION
This was forgotten while renaming the subcommand from "sypgp" to "keys".