### PR TITLE
Support docker:// and shub:// with just singularity-runtime rpm

### DIFF
--- a/singularity.spec.in
+++ b/singularity.spec.in
@@ -103,19 +103,14 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/pull.*
 %{_libexecdir}/singularity/cli/selftest.*
 %{_libexecdir}/singularity/helpers
-%{_libexecdir}/singularity/python
 
 # Binaries
 %{_libexecdir}/singularity/bin/builddef
-%{_libexecdir}/singularity/bin/cleanupd
 %{_libexecdir}/singularity/bin/get-section
 %{_libexecdir}/singularity/bin/mount
 %{_libexecdir}/singularity/bin/image-type
 %{_libexecdir}/singularity/bin/prepheader
 %{_libexecdir}/singularity/bin/docker-extract
-
-# Directories
-%{_libexecdir}/singularity/bootstrap-scripts
 
 #SUID programs
 %attr(4755, root, root) %{_libexecdir}/singularity/bin/mount-suid
@@ -140,11 +135,14 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cli/test.*
 %{_libexecdir}/singularity/bin/action
 %{_libexecdir}/singularity/bin/get-configvals
+%{_libexecdir}/singularity/bin/cleanupd
 %{_libexecdir}/singularity/bin/start
 %{_libexecdir}/singularity/bin/docker-extract
+%{_libexecdir}/singularity/bootstrap-scripts
 %{_libexecdir}/singularity/functions
 %{_libexecdir}/singularity/handlers
 %{_libexecdir}/singularity/image-handler.sh
+%{_libexecdir}/singularity/python
 %dir %{_sysconfdir}/singularity
 %config(noreplace) %{_sysconfdir}/singularity/*
 %{_mandir}/man1/singularity.1*


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR moves support for docker:// and shub:// into the singularity-runtime rpm, based on the release-2.6 branch.  This is already in use in EPEL/Fedora and I think it would be good to merge it into a future 2.6.x release of singularity to simplify maintenance and to make the source build more consistent with the released packaging.  Replaces PR #1324.


**This fixes or addresses the following GitHub issues:**

- Ref: #


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is NOT against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
