### PR TITLE
Update Build URL

### DIFF
--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -40,8 +40,6 @@ var (
 	sections   []string
 )
 
-const defbuilderURL = "localhost:5050"
-
 func init() {
 	BuildCmd.Flags().SetInterspersed(false)
 
@@ -53,8 +51,8 @@ func init() {
 	BuildCmd.Flags().BoolVarP(&noTest, "notest", "T", false, "Bootstrap without running tests in %test section")
 	BuildCmd.Flags().BoolVarP(&remote, "remote", "r", false, "Build image remotely")
 	BuildCmd.Flags().BoolVarP(&detached, "detached", "d", false, "Submit build job and print nuild ID (no real-time logs)")
-	BuildCmd.Flags().StringVar(&builderURL, "builder", defbuilderURL, "Specify the URL of the remote builder")
-	BuildCmd.Flags().StringVar(&libraryURL, "library", "https://library.sylabs.io", "")
+	BuildCmd.Flags().StringVar(&builderURL, "builder", "https://build.sylabs.io", "Remote Build Service URL")
+	BuildCmd.Flags().StringVar(&libraryURL, "library", "https://library.sylabs.io", "Container Library URL")
 
 	SingularityCmd.AddCommand(BuildCmd)
 }
@@ -89,11 +87,14 @@ var BuildCmd = &cobra.Command{
 
 		def := makeDefinition(args[1], isJSON)
 
-		if remote || builderURL != defbuilderURL {
+		if remote {
 			// Submiting a remote build requires a valid authToken
 			var b *build.RemoteBuilder
 			if authToken != "" {
-				b = build.NewRemoteBuilder(args[0], libraryURL, def, detached, builderURL, authToken)
+				b, err = build.NewRemoteBuilder(args[0], libraryURL, def, detached, builderURL, authToken)
+				if err != nil {
+					sylog.Fatalf("failed to create builder: %v", err)
+				}
 			} else {
 				sylog.Fatalf("Unable to submit build job: %v", authWarning)
 			}

--- a/src/pkg/build/builder_remote_test.go
+++ b/src/pkg/build/builder_remote_test.go
@@ -177,7 +177,10 @@ func TestBuild(t *testing.T) {
 	// Loop over test cases
 	for _, tt := range tests {
 		t.Run(tt.description, test.WithoutPrivilege(func(t *testing.T) {
-			rb := NewRemoteBuilder(tt.imagePath, "", Definition{}, tt.isDetached, s.Listener.Addr().String(), authToken)
+			rb, err := NewRemoteBuilder(tt.imagePath, "", Definition{}, tt.isDetached, s.URL, authToken)
+			if err != nil {
+				t.Fatalf("failed to get new remote builder: %v", err)
+			}
 			rb.Force = true
 
 			// Set the response codes for each stage of the build
@@ -188,7 +191,7 @@ func TestBuild(t *testing.T) {
 			m.imageResponseCode = tt.imageResponseCode
 
 			// Do it!
-			err := rb.Build(tt.ctx)
+			err = rb.Build(tt.ctx)
 
 			if tt.expectSuccess {
 				// Ensure the handler returned no error, and the response is as expected
@@ -231,8 +234,12 @@ func TestDoBuildRequest(t *testing.T) {
 	defer s.Close()
 
 	// Enough of a struct to test with
+	url, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
 	rb := RemoteBuilder{
-		HTTPAddr: s.Listener.Addr().String(),
+		BuilderURL: url,
 	}
 
 	// Loop over test cases
@@ -293,8 +300,12 @@ func TestDoStatusRequest(t *testing.T) {
 	defer s.Close()
 
 	// Enough of a struct to test with
+	url, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
 	rb := RemoteBuilder{
-		HTTPAddr: s.Listener.Addr().String(),
+		BuilderURL: url,
 	}
 
 	// ID to test with


### PR DESCRIPTION
Update default Remote Build Service URL. Accept full URL to `--builder` param to enable HTTP/HTTPS differentiation.