### PR TITLE
Add SecurityOperations interface for greater engine flexibility

### DIFF
--- a/src/pkg/util/engine/security/oci.go
+++ b/src/pkg/util/engine/security/oci.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package security
+
+import (
+	"syscall"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// OciNamespaceFlags returns the nsFlags bitfield that is specified in
+// the oci config
+func OciNamespaceFlags(l *oci.Linux) (retflags uint) {
+	for _, namespace := range l.Namespaces {
+		switch namespace.Type {
+		case oci.UserNamespace:
+			retflags |= syscall.CLONE_NEWUSER
+		case oci.IPCNamespace:
+			retflags |= syscall.CLONE_NEWIPC
+		case oci.UTSNamespace:
+			retflags |= syscall.CLONE_NEWUTS
+		case oci.PIDNamespace:
+			retflags |= syscall.CLONE_NEWPID
+		case oci.NetworkNamespace:
+			retflags |= syscall.CLONE_NEWNET
+		case oci.MountNamespace:
+			retflags |= syscall.CLONE_NEWNS
+		case oci.CgroupNamespace:
+			retflags |= 0x2000000
+		}
+	}
+
+	return
+}

--- a/src/runtime/engines/engines.go
+++ b/src/runtime/engines/engines.go
@@ -28,6 +28,7 @@ type Engine struct {
 // EngineOperations is an interface describing necessary operations to launch a
 // container process.
 type EngineOperations interface {
+	SecurityOperations
 	// Config returns the current EngineConfig, used to populate the Common struct
 	Config() config.EngineConfig
 	// InitConfig is responsible for storing the parse config.Common inside
@@ -37,8 +38,6 @@ type EngineOperations interface {
 	PrepareConfig(net.Conn) error
 	// IsRunAsInstance returns whether or not the container is an instance or batch
 	IsRunAsInstance() bool
-	// IsAllowSUID returns whether or not the engine allow SUID workflow
-	IsAllowSUID() bool
 	// CreateContainer is called in smaster and does mount operations, etc... to
 	// set up the container environment for the payload proc
 	CreateContainer(int, net.Conn) error
@@ -51,6 +50,15 @@ type EngineOperations interface {
 	// CleanupContainer is called in smaster after the MontiorContainer returns. It is responsible
 	// for ensuring that the container has been properly torn down
 	CleanupContainer() error
+}
+
+// SecurityOperations contains security related functions that an engine should
+// implement
+type SecurityOperations interface {
+	// IsAllowSUID returns whether or not the engine allow SUID workflow
+	IsAllowSUID() bool
+	// NamespaceFlags returns the set of requested namespaces as a uint bit field
+	NamespaceFlags() uint
 }
 
 // NewEngine returns the engine described by the JSON []byte configuration

--- a/src/runtime/engines/imgbuild/security.go
+++ b/src/runtime/engines/imgbuild/security.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package imgbuild
+
+import (
+	"github.com/singularityware/singularity/src/pkg/util/engine/security"
+)
+
+// NamespaceFlags uses the default OciNamespaceFlags function
+func (e *EngineOperations) NamespaceFlags() uint {
+	return security.OciNamespaceFlags(e.CommonConfig.OciConfig.Linux)
+}

--- a/src/runtime/engines/singularity/security.go
+++ b/src/runtime/engines/singularity/security.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"github.com/singularityware/singularity/src/pkg/util/engine/security"
+)
+
+// NamespaceFlags uses the default OciNamespaceFlags function
+func (e *EngineOperations) NamespaceFlags() uint {
+	return security.OciNamespaceFlags(e.CommonConfig.OciConfig.Linux)
+}

--- a/src/runtime/startup/scontainer.go
+++ b/src/runtime/startup/scontainer.go
@@ -16,10 +16,8 @@ import (
 	"encoding/json"
 	"net"
 	"os"
-	"syscall"
 	"unsafe"
 
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/singularityware/singularity/src/pkg/sylog"
 	"github.com/singularityware/singularity/src/pkg/util/capabilities"
 	"github.com/singularityware/singularity/src/runtime/engines"
@@ -84,24 +82,8 @@ func SContainer(stage C.int, masterSocket C.int, config *C.struct_cConfig, jsonC
 				cconf.gidMapping[i].hostID = C.gid_t(gid.HostID)
 				cconf.gidMapping[i].size = C.uint(gid.Size)
 			}
-			for _, namespace := range engine.OciConfig.Linux.Namespaces {
-				switch namespace.Type {
-				case specs.UserNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWUSER
-				case specs.IPCNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWIPC
-				case specs.UTSNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWUTS
-				case specs.PIDNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWPID
-				case specs.NetworkNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWNET
-				case specs.MountNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWNS
-				case specs.CgroupNamespace:
-					cconf.nsFlags |= 0x2000000
-				}
-			}
+
+			cconf.nsFlags |= C.uint(engine.NamespaceFlags())
 		}
 		if engine.OciConfig.Process != nil && engine.OciConfig.Process.Capabilities != nil {
 			var caps uint64


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Adds `SecurityOperations` interface to allow for greater engine flexibility. This will eventually be expanded to include most security features that an Engine can request. This also adds the `NamespaceFlags` function to the `SecurityOptions` interface, allowing the engine to return the `uint` bit field for the `cConf` to directly consume. Also includes a helper util package to provide default functionality.