### PR TITLE
Development 3.0: Add C wrapper configuration helper for Go

### DIFF
--- a/src/pkg/util/capabilities/capabilities.go
+++ b/src/pkg/util/capabilities/capabilities.go
@@ -7,6 +7,19 @@ package capabilities
 
 import "strings"
 
+const (
+	// Permitted capability string constant
+	Permitted string = "permitted"
+	// Effective capability string constant
+	Effective = "effective"
+	// Inheritable capability string constant
+	Inheritable = "inheritable"
+	// Ambient capability string constant
+	Ambient = "ambient"
+	// Bounding capability string constant
+	Bounding = "bounding"
+)
+
 type capability struct {
 	Name        string
 	Value       uint

--- a/src/runtime/engines/common/config/wrapper/wrapper.go
+++ b/src/runtime/engines/common/config/wrapper/wrapper.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package wrapper
+
+/*
+#include <sys/types.h>
+#include "startup/c/wrapper.h"
+*/
+// #cgo CFLAGS: -I../../../..
+import "C"
+import (
+	"encoding/json"
+	"io"
+	"syscall"
+	"unsafe"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/singularityware/singularity/src/pkg/util/capabilities"
+)
+
+// CConfig is the common type for C.struct_cConfig
+type CConfig *C.struct_cConfig
+
+// Config represents structure to manipulate C wrapper configuration
+type Config struct {
+	config CConfig
+}
+
+// NewConfig takes a pointer to C wrapper configuration and returns a
+// pointer to a Config
+func NewConfig(config CConfig) *Config {
+	return &Config{config}
+}
+
+// GetIsSUID returns if SUID workflow is enabled or not
+func (c *Config) GetIsSUID() bool {
+	if c.config.isSuid == 1 {
+		return true
+	}
+	return false
+}
+
+// GetContainerPid returns container process ID
+func (c *Config) GetContainerPid() int {
+	return int(c.config.containerPid)
+}
+
+// SetInstance sets if wrapper should spawn instance or not
+func (c *Config) SetInstance(instance bool) {
+	if instance {
+		c.config.isInstance = C.uchar(1)
+	} else {
+		c.config.isInstance = C.uchar(0)
+	}
+}
+
+// GetInstance returns if container run as instance or not
+func (c *Config) GetInstance() bool {
+	if c.config.isInstance == 1 {
+		return true
+	}
+	return false
+}
+
+// SetNoNewPrivs sets NO_NEW_PRIVS flag
+func (c *Config) SetNoNewPrivs(noprivs bool) {
+	if noprivs {
+		c.config.noNewPrivs = C.uchar(1)
+	} else {
+		c.config.noNewPrivs = C.uchar(0)
+	}
+}
+
+// GetNoNewPrivs returns if NO_NEW_PRIVS flag is set or not
+func (c *Config) GetNoNewPrivs() bool {
+	if c.config.noNewPrivs == 1 {
+		return true
+	}
+	return false
+}
+
+// GetJSONConfSize returns size of JSON configuration sent
+// by wrapper
+func (c *Config) GetJSONConfSize() uint {
+	return uint(c.config.jsonConfSize)
+}
+
+// WritePayload writes raw C configuration and payload passed in
+// argument to the provided writer
+func (c *Config) WritePayload(w io.Writer, payload interface{}) {
+	jsonConf, _ := json.Marshal(payload)
+	c.config.jsonConfSize = C.uint(len(jsonConf))
+	cconfPayload := C.GoBytes(unsafe.Pointer(c.config), C.sizeof_struct_cConfig)
+
+	w.Write(append(cconfPayload, jsonConf...))
+}
+
+// AddUIDMappings sets user namespace UID mapping
+func (c *Config) AddUIDMappings(uids []specs.LinuxIDMapping) {
+	for i, uid := range uids {
+		c.config.uidMapping[i].containerID = C.uid_t(uid.ContainerID)
+		c.config.uidMapping[i].hostID = C.uid_t(uid.HostID)
+		c.config.uidMapping[i].size = C.uint(uid.Size)
+	}
+}
+
+// AddGIDMappings sets user namespace GID mapping
+func (c *Config) AddGIDMappings(gids []specs.LinuxIDMapping) {
+	for i, gid := range gids {
+		c.config.gidMapping[i].containerID = C.gid_t(gid.ContainerID)
+		c.config.gidMapping[i].hostID = C.gid_t(gid.HostID)
+		c.config.gidMapping[i].size = C.uint(gid.Size)
+	}
+}
+
+// SetNsFlags sets namespaces flag directly from flags argument
+func (c *Config) SetNsFlags(flags int) {
+	c.config.nsFlags = C.uint(flags)
+}
+
+// SetNsFlagsFromSpec sets namespaces flag from OCI spec
+func (c *Config) SetNsFlagsFromSpec(namespaces []specs.LinuxNamespace) {
+	c.config.nsFlags = 0
+	for _, namespace := range namespaces {
+		switch namespace.Type {
+		case specs.UserNamespace:
+			c.config.nsFlags |= syscall.CLONE_NEWUSER
+		case specs.IPCNamespace:
+			c.config.nsFlags |= syscall.CLONE_NEWIPC
+		case specs.UTSNamespace:
+			c.config.nsFlags |= syscall.CLONE_NEWUTS
+		case specs.PIDNamespace:
+			c.config.nsFlags |= syscall.CLONE_NEWPID
+		case specs.NetworkNamespace:
+			c.config.nsFlags |= syscall.CLONE_NEWNET
+		case specs.MountNamespace:
+			c.config.nsFlags |= syscall.CLONE_NEWNS
+		case specs.CgroupNamespace:
+			c.config.nsFlags |= 0x2000000
+		}
+	}
+}
+
+// SetNsPid sets corresponding namespace to be joined
+func (c *Config) SetNsPid(nstype specs.LinuxNamespaceType, pid int) {
+	switch nstype {
+	case specs.UserNamespace:
+		c.config.userPid = C.pid_t(pid)
+	case specs.IPCNamespace:
+		c.config.ipcPid = C.pid_t(pid)
+	case specs.UTSNamespace:
+		c.config.utsPid = C.pid_t(pid)
+	case specs.PIDNamespace:
+		c.config.pidPid = C.pid_t(pid)
+	case specs.NetworkNamespace:
+		c.config.netPid = C.pid_t(pid)
+	case specs.MountNamespace:
+		c.config.mntPid = C.pid_t(pid)
+	case specs.CgroupNamespace:
+		c.config.cgroupPid = C.pid_t(pid)
+	}
+}
+
+// SetCapabilities sets corresponding capability set identified by ctype
+// from a capability string list identified by ctype
+func (c *Config) SetCapabilities(ctype string, caps []string) {
+	switch ctype {
+	case capabilities.Permitted:
+		c.config.capPermitted = 0
+		for _, v := range caps {
+			c.config.capPermitted |= C.ulonglong(1 << capabilities.Map[v].Value)
+		}
+	case capabilities.Effective:
+		c.config.capEffective = 0
+		for _, v := range caps {
+			c.config.capEffective |= C.ulonglong(1 << capabilities.Map[v].Value)
+		}
+	case capabilities.Inheritable:
+		c.config.capInheritable = 0
+		for _, v := range caps {
+			c.config.capInheritable |= C.ulonglong(1 << capabilities.Map[v].Value)
+		}
+	case capabilities.Bounding:
+		c.config.capBounding = 0
+		for _, v := range caps {
+			c.config.capBounding |= C.ulonglong(1 << capabilities.Map[v].Value)
+		}
+	case capabilities.Ambient:
+		c.config.capAmbient = 0
+		for _, v := range caps {
+			c.config.capAmbient |= C.ulonglong(1 << capabilities.Map[v].Value)
+		}
+	}
+}

--- a/src/runtime/engines/engines.go
+++ b/src/runtime/engines/engines.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/singularityware/singularity/src/runtime/engines/common/config"
+	"github.com/singularityware/singularity/src/runtime/engines/common/config/wrapper"
 	"github.com/singularityware/singularity/src/runtime/engines/imgbuild"
 	"github.com/singularityware/singularity/src/runtime/engines/singularity"
 	singularityRpcServer "github.com/singularityware/singularity/src/runtime/engines/singularity/rpc/server"
@@ -34,11 +35,7 @@ type EngineOperations interface {
 	// the EngineOperations implementation.
 	InitConfig(*config.Common)
 	// PrepareConfig is called in stage1 to validate and prepare container configuration
-	PrepareConfig(net.Conn) error
-	// IsRunAsInstance returns whether or not the container is an instance or batch
-	IsRunAsInstance() bool
-	// IsAllowSUID returns whether or not the engine allow SUID workflow
-	IsAllowSUID() bool
+	PrepareConfig(net.Conn, *wrapper.Config) error
 	// CreateContainer is called in smaster and does mount operations, etc... to
 	// set up the container environment for the payload proc
 	CreateContainer(int, net.Conn) error

--- a/src/runtime/engines/imgbuild/engine.go
+++ b/src/runtime/engines/imgbuild/engine.go
@@ -6,12 +6,13 @@
 package imgbuild
 
 import (
+	"fmt"
 	"net"
-	"os"
 	"syscall"
 
-	"github.com/singularityware/singularity/src/pkg/sylog"
+	"github.com/singularityware/singularity/src/pkg/util/capabilities"
 	"github.com/singularityware/singularity/src/runtime/engines/common/config"
+	"github.com/singularityware/singularity/src/runtime/engines/common/config/wrapper"
 )
 
 // EngineOperations implements the engines.EngineOperations interface for
@@ -32,24 +33,30 @@ func (e *EngineOperations) Config() config.EngineConfig {
 }
 
 // PrepareConfig validates/prepares EngineConfig setup
-func (e *EngineOperations) PrepareConfig(masterConn net.Conn) error {
+func (e *EngineOperations) PrepareConfig(masterConn net.Conn, wrapperConfig *wrapper.Config) error {
 	e.CommonConfig.OciConfig.SetProcessNoNewPrivileges(true)
+	wrapperConfig.SetNoNewPrivs(e.CommonConfig.OciConfig.Process.NoNewPrivileges)
 
 	if syscall.Getuid() != 0 {
-		sylog.Fatalf("Unable to run imgbuild engine as non-root user\n")
-		os.Exit(1)
+		return fmt.Errorf("unable to run imgbuild engine as non-root user")
+	}
+
+	if wrapperConfig.GetIsSUID() {
+		return fmt.Errorf("%s don't allow SUID workflow", e.CommonConfig.EngineName)
 	}
 
 	e.CommonConfig.OciConfig.SetupPrivileged(true)
+
+	if e.CommonConfig.OciConfig.Linux != nil {
+		wrapperConfig.SetNsFlagsFromSpec(e.CommonConfig.OciConfig.Linux.Namespaces)
+	}
+	if e.CommonConfig.OciConfig.Process != nil && e.CommonConfig.OciConfig.Process.Capabilities != nil {
+		wrapperConfig.SetCapabilities(capabilities.Permitted, e.CommonConfig.OciConfig.Process.Capabilities.Permitted)
+		wrapperConfig.SetCapabilities(capabilities.Effective, e.CommonConfig.OciConfig.Process.Capabilities.Effective)
+		wrapperConfig.SetCapabilities(capabilities.Inheritable, e.CommonConfig.OciConfig.Process.Capabilities.Inheritable)
+		wrapperConfig.SetCapabilities(capabilities.Bounding, e.CommonConfig.OciConfig.Process.Capabilities.Bounding)
+		wrapperConfig.SetCapabilities(capabilities.Ambient, e.CommonConfig.OciConfig.Process.Capabilities.Ambient)
+	}
+
 	return nil
-}
-
-// IsRunAsInstance returns false
-func (e *EngineOperations) IsRunAsInstance() bool {
-	return false
-}
-
-// IsAllowSUID always returns false to not allow SUID workflow
-func (e *EngineOperations) IsAllowSUID() bool {
-	return false
 }

--- a/src/runtime/engines/singularity/engine.go
+++ b/src/runtime/engines/singularity/engine.go
@@ -26,13 +26,3 @@ func (e *EngineOperations) InitConfig(cfg *config.Common) {
 func (e *EngineOperations) Config() config.EngineConfig {
 	return e.EngineConfig
 }
-
-// IsRunAsInstance returns true if the runtime engine was run as an instance
-func (e *EngineOperations) IsRunAsInstance() bool {
-	return e.EngineConfig.GetInstance()
-}
-
-// IsAllowSUID always returns true to allow SUID workflow
-func (e *EngineOperations) IsAllowSUID() bool {
-	return true
-}

--- a/src/runtime/engines/singularity/prepare.go
+++ b/src/runtime/engines/singularity/prepare.go
@@ -10,27 +10,49 @@ import (
 	"net"
 
 	"github.com/singularityware/singularity/src/pkg/sylog"
+	"github.com/singularityware/singularity/src/pkg/util/capabilities"
+	"github.com/singularityware/singularity/src/runtime/engines/common/config/wrapper"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // PrepareConfig checks and prepares the runtime engine config
-func (engine *EngineOperations) PrepareConfig(masterConn net.Conn) error {
-	if engine.CommonConfig.EngineName != Name {
+func (e *EngineOperations) PrepareConfig(masterConn net.Conn, wrapperConfig *wrapper.Config) error {
+	if e.CommonConfig.EngineName != Name {
 		return fmt.Errorf("incorrect engine")
 	}
 
-	if !engine.EngineConfig.File.AllowPidNs && engine.CommonConfig.OciConfig.Linux != nil {
-		namespaces := engine.CommonConfig.OciConfig.Linux.Namespaces
+	if !e.EngineConfig.File.AllowSetuid && wrapperConfig.GetIsSUID() {
+		return fmt.Errorf("SUID workflow disabled by administrator")
+	}
+
+	if !e.EngineConfig.File.AllowPidNs && e.CommonConfig.OciConfig.Linux != nil {
+		namespaces := e.CommonConfig.OciConfig.Linux.Namespaces
 		for i, ns := range namespaces {
 			if ns.Type == specs.PIDNamespace {
 				sylog.Debugf("Not virtualizing PID namespace by configuration")
-				engine.CommonConfig.OciConfig.Linux.Namespaces = append(namespaces[:i], namespaces[i+1:]...)
+				e.CommonConfig.OciConfig.Linux.Namespaces = append(namespaces[:i], namespaces[i+1:]...)
 				break
 			}
 		}
 	}
 
-	engine.CommonConfig.OciConfig.SetProcessNoNewPrivileges(true)
+	e.CommonConfig.OciConfig.SetProcessNoNewPrivileges(true)
+
+	wrapperConfig.SetInstance(e.EngineConfig.GetInstance())
+	wrapperConfig.SetNoNewPrivs(e.CommonConfig.OciConfig.Process.NoNewPrivileges)
+
+	if e.CommonConfig.OciConfig.Linux != nil {
+		wrapperConfig.AddUIDMappings(e.CommonConfig.OciConfig.Linux.UIDMappings)
+		wrapperConfig.AddGIDMappings(e.CommonConfig.OciConfig.Linux.UIDMappings)
+		wrapperConfig.SetNsFlagsFromSpec(e.CommonConfig.OciConfig.Linux.Namespaces)
+	}
+	if e.CommonConfig.OciConfig.Process != nil && e.CommonConfig.OciConfig.Process.Capabilities != nil {
+		wrapperConfig.SetCapabilities(capabilities.Permitted, e.CommonConfig.OciConfig.Process.Capabilities.Permitted)
+		wrapperConfig.SetCapabilities(capabilities.Effective, e.CommonConfig.OciConfig.Process.Capabilities.Effective)
+		wrapperConfig.SetCapabilities(capabilities.Inheritable, e.CommonConfig.OciConfig.Process.Capabilities.Inheritable)
+		wrapperConfig.SetCapabilities(capabilities.Bounding, e.CommonConfig.OciConfig.Process.Capabilities.Bounding)
+		wrapperConfig.SetCapabilities(capabilities.Ambient, e.CommonConfig.OciConfig.Process.Capabilities.Ambient)
+	}
 	return nil
 }

--- a/src/runtime/startup/rpc.go
+++ b/src/runtime/startup/rpc.go
@@ -5,8 +5,6 @@
 
 package main
 
-import "C"
-
 import (
 	"net"
 	"os"
@@ -16,9 +14,7 @@ import (
 )
 
 // RPCServer serves runtime engine requests
-func RPCServer(socket C.int, sruntime *C.char) {
-	runtime := C.GoString(sruntime)
-
+func RPCServer(socket int, runtime string) {
 	comm := os.NewFile(uintptr(socket), "unix")
 
 	conn, err := net.FileConn(comm)

--- a/src/runtime/startup/scontainer.go
+++ b/src/runtime/startup/scontainer.go
@@ -5,38 +5,19 @@
 
 package main
 
-/*
-#include <sys/types.h>
-#include "startup/c/wrapper.h"
-*/
-// #cgo CFLAGS: -I..
-import "C"
-
 import (
-	"encoding/json"
 	"net"
 	"os"
-	"syscall"
-	"unsafe"
 
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/singularityware/singularity/src/pkg/sylog"
-	"github.com/singularityware/singularity/src/pkg/util/capabilities"
 	"github.com/singularityware/singularity/src/runtime/engines"
+	"github.com/singularityware/singularity/src/runtime/engines/common/config/wrapper"
 )
 
-func bool2int(b bool) uint8 {
-	if b {
-		return 1
-	}
-	return 0
-}
-
 // SContainer performs container startup
-func SContainer(stage C.int, masterSocket C.int, config *C.struct_cConfig, jsonC *C.char) {
+func SContainer(stage int, masterSocket int, wrapperConfig *wrapper.Config, jsonBytes []byte) {
 	var conn net.Conn
 	var err error
-	cconf := config
 
 	if masterSocket != -1 {
 		comm := os.NewFile(uintptr(masterSocket), "master-socket")
@@ -50,10 +31,6 @@ func SContainer(stage C.int, masterSocket C.int, config *C.struct_cConfig, jsonC
 		conn = nil
 	}
 
-	/* get json configuration */
-	sylog.Debugf("cconf.jsonConfSize: %d\n", C.int(cconf.jsonConfSize))
-	jsonBytes := C.GoBytes(unsafe.Pointer(jsonC), C.int(cconf.jsonConfSize))
-
 	engine, err := engines.NewEngine(jsonBytes)
 	if err != nil {
 		sylog.Fatalf("failed to initialize runtime engine: %s\n", err)
@@ -62,86 +39,11 @@ func SContainer(stage C.int, masterSocket C.int, config *C.struct_cConfig, jsonC
 	if stage == 1 {
 		sylog.Debugf("Entering scontainer stage 1\n")
 
-		if cconf.isSuid == 1 && engine.IsAllowSUID() == false {
-			sylog.Fatalf("runtime engine %s doesn't allow SUID workflow", engine.EngineName)
-		}
-
-		if err := engine.PrepareConfig(conn); err != nil {
+		if err := engine.PrepareConfig(conn, wrapperConfig); err != nil {
 			sylog.Fatalf("%s\n", err)
 		}
 
-		cconf.isInstance = C.uchar(bool2int(engine.IsRunAsInstance()))
-		cconf.noNewPrivs = C.uchar(bool2int(engine.OciConfig.Process.NoNewPrivileges))
-
-		if engine.OciConfig.Linux != nil {
-			for i, uid := range engine.OciConfig.Linux.UIDMappings {
-				cconf.uidMapping[i].containerID = C.uid_t(uid.ContainerID)
-				cconf.uidMapping[i].hostID = C.uid_t(uid.HostID)
-				cconf.uidMapping[i].size = C.uint(uid.Size)
-			}
-			for i, gid := range engine.OciConfig.Linux.UIDMappings {
-				cconf.gidMapping[i].containerID = C.gid_t(gid.ContainerID)
-				cconf.gidMapping[i].hostID = C.gid_t(gid.HostID)
-				cconf.gidMapping[i].size = C.uint(gid.Size)
-			}
-			for _, namespace := range engine.OciConfig.Linux.Namespaces {
-				switch namespace.Type {
-				case specs.UserNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWUSER
-				case specs.IPCNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWIPC
-				case specs.UTSNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWUTS
-				case specs.PIDNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWPID
-				case specs.NetworkNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWNET
-				case specs.MountNamespace:
-					cconf.nsFlags |= syscall.CLONE_NEWNS
-				case specs.CgroupNamespace:
-					cconf.nsFlags |= 0x2000000
-				}
-			}
-		}
-		if engine.OciConfig.Process != nil && engine.OciConfig.Process.Capabilities != nil {
-			var caps uint64
-
-			for _, v := range engine.OciConfig.Process.Capabilities.Permitted {
-				caps |= (1 << capabilities.Map[v].Value)
-			}
-			cconf.capPermitted = C.ulonglong(caps)
-
-			caps = 0
-			for _, v := range engine.OciConfig.Process.Capabilities.Effective {
-				caps |= (1 << capabilities.Map[v].Value)
-			}
-			cconf.capEffective = C.ulonglong(caps)
-
-			caps = 0
-			for _, v := range engine.OciConfig.Process.Capabilities.Inheritable {
-				caps |= (1 << capabilities.Map[v].Value)
-			}
-			cconf.capInheritable = C.ulonglong(caps)
-
-			caps = 0
-			for _, v := range engine.OciConfig.Process.Capabilities.Bounding {
-				caps |= (1 << capabilities.Map[v].Value)
-			}
-			cconf.capBounding = C.ulonglong(caps)
-
-			caps = 0
-			for _, v := range engine.OciConfig.Process.Capabilities.Ambient {
-				caps |= (1 << capabilities.Map[v].Value)
-			}
-			cconf.capAmbient = C.ulonglong(caps)
-		}
-
-		jsonConf, _ := json.Marshal(engine.Common)
-		cconf.jsonConfSize = C.uint(len(jsonConf))
-		sylog.Debugf("jsonConfSize = %v\n", cconf.jsonConfSize)
-		cconfPayload := C.GoBytes(unsafe.Pointer(cconf), C.sizeof_struct_cConfig)
-
-		os.Stdout.Write(append(cconfPayload, jsonConf...))
+		wrapperConfig.WritePayload(os.Stdout, engine.Common)
 		os.Exit(0)
 	} else {
 		if err := engine.StartProcess(conn); err != nil {

--- a/src/runtime/startup/scontainer.go
+++ b/src/runtime/startup/scontainer.go
@@ -43,7 +43,9 @@ func SContainer(stage int, masterSocket int, wrapperConfig *wrapper.Config, json
 			sylog.Fatalf("%s\n", err)
 		}
 
-		wrapperConfig.WritePayload(os.Stdout, engine.Common)
+		if err := wrapperConfig.WritePayload(os.Stdout, engine.Common); err != nil {
+			sylog.Fatalf("%s", err)
+		}
 		os.Exit(0)
 	} else {
 		if err := engine.StartProcess(conn); err != nil {

--- a/src/runtime/startup/smaster.go
+++ b/src/runtime/startup/smaster.go
@@ -8,6 +8,7 @@ package main
 /*
 #include "c/wrapper.c"
 */
+// #cgo CFLAGS: -I..
 import "C"
 
 import (
@@ -20,20 +21,21 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/singularityware/singularity/src/runtime/engines/common/config/wrapper"
+
 	"github.com/singularityware/singularity/src/pkg/sylog"
 	"github.com/singularityware/singularity/src/runtime/engines"
 )
 
 // SMaster initializes a runtime engine and runs it
-func SMaster(socket C.int, masterSocket C.int, config *C.struct_cConfig, jsonC *C.char) {
+func SMaster(socket int, masterSocket int, wrapperConfig *wrapper.Config, jsonBytes []byte) {
 	var fatal error
 	var status syscall.WaitStatus
 
 	fatalChan := make(chan error, 1)
 	ppid := os.Getppid()
 
-	containerPid := int(config.containerPid)
-	jsonBytes := C.GoBytes(unsafe.Pointer(jsonC), C.int(config.jsonConfSize))
+	containerPid := wrapperConfig.GetContainerPid()
 
 	engine, err := engines.NewEngine(jsonBytes)
 	if err != nil {
@@ -58,7 +60,7 @@ func SMaster(socket C.int, masterSocket C.int, config *C.struct_cConfig, jsonC *
 		runtime.Goexit()
 	}()
 
-	if engine.IsRunAsInstance() {
+	if wrapperConfig.GetInstance() {
 		go func() {
 			data := make([]byte, 1)
 
@@ -97,7 +99,7 @@ func SMaster(socket C.int, masterSocket C.int, config *C.struct_cConfig, jsonC *
 
 	if status.Exited() {
 		sylog.Debugf("Child exited with exit status %d", status.ExitStatus())
-		if engine.IsRunAsInstance() {
+		if wrapperConfig.GetInstance() {
 			if status.ExitStatus() != 0 {
 				if os.Getppid() == ppid {
 					syscall.Kill(ppid, syscall.SIGUSR2)
@@ -127,23 +129,27 @@ func main() {
 		}
 	}
 
+	cconf := unsafe.Pointer(&C.config)
+	wrapperConfig := wrapper.NewConfig(wrapper.CConfig(cconf))
+	jsonBytes := C.GoBytes(unsafe.Pointer(C.json_stdin), C.int(wrapperConfig.GetJSONConfSize()))
+
 	switch C.execute {
 	case C.SCONTAINER_STAGE1:
 		sylog.Verbosef("Execute scontainer stage 1\n")
-		SContainer(C.SCONTAINER_STAGE1, C.master_socket[1], &C.config, C.json_stdin)
+		SContainer(int(C.SCONTAINER_STAGE1), int(C.master_socket[1]), wrapperConfig, jsonBytes)
 	case C.SCONTAINER_STAGE2:
 		sylog.Verbosef("Execute scontainer stage 2\n")
-		SContainer(C.SCONTAINER_STAGE2, C.master_socket[1], &C.config, C.json_stdin)
+		SContainer(int(C.SCONTAINER_STAGE2), int(C.master_socket[1]), wrapperConfig, jsonBytes)
 	case C.SMASTER:
 		sylog.Verbosef("Execute smaster process\n")
-		SMaster(C.rpc_socket[0], C.master_socket[0], &C.config, C.json_stdin)
+		SMaster(int(C.rpc_socket[0]), int(C.master_socket[0]), wrapperConfig, jsonBytes)
 	case C.RPC_SERVER:
 		sylog.Verbosef("Serve RPC requests\n")
-		RPCServer(C.rpc_socket[1], C.sruntime)
+		RPCServer(int(C.rpc_socket[1]), C.GoString(C.sruntime))
 
 		sylog.Verbosef("Execute scontainer stage 2\n")
 		C.prepare_scontainer_stage(C.SCONTAINER_STAGE2)
-		SContainer(C.SCONTAINER_STAGE2, C.master_socket[1], &C.config, C.json_stdin)
+		SContainer(int(C.SCONTAINER_STAGE2), int(C.master_socket[1]), wrapperConfig, jsonBytes)
 	}
 	sylog.Fatalf("You should not be there\n")
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR contains :
- wrapper configuration helper for Go
- scontainer cleanup
- scontainer/smaster/rpc now use Go arguments instead of C
- removes `IsRunAsInstance` and `IsAllowSUID` from `EngineOperations` interface