### PR TITLE
pull cmd to understand library vs shub URI

### DIFF
--- a/src/cmd/singularity/cli/pull.go
+++ b/src/cmd/singularity/cli/pull.go
@@ -6,9 +6,21 @@
 package cli
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/singularityware/singularity/src/docs"
 	"github.com/singularityware/singularity/src/pkg/libexec"
 	"github.com/spf13/cobra"
+)
+
+const (
+	// SyCloudLibrary holds sylabs cloud library base URI
+	// for more info refer to https://cloud.sylabs.io/library
+	SyCloudLibrary = "library"
+	// Shub holds singularity hub base URI
+	// for more info refer to https://singularity-hub.org/
+	Shub = "shub"
 )
 
 var (
@@ -31,11 +43,25 @@ var PullCmd = &cobra.Command{
 	Args:   cobra.RangeArgs(1, 2),
 	PreRun: sylabsToken,
 	Run: func(cmd *cobra.Command, args []string) {
+		var uri string
 		if len(args) == 2 {
-			libexec.PullImage(args[0], args[1], PullLibraryURI, force, authToken)
-			return
+			uri = args[1]
+		} else {
+			uri = args[0]
 		}
-		libexec.PullImage("", args[0], PullLibraryURI, force, authToken)
+		BaseURI := strings.Split(uri, "://")
+		switch BaseURI[0] {
+		case SyCloudLibrary:
+			if len(args) == 2 {
+				libexec.PullImage(args[0], uri, PullLibraryURI, force, authToken)
+				return
+			}
+			libexec.PullImage("", args[0], PullLibraryURI, force, authToken)
+		case Shub:
+			fmt.Println("Shub not yet supported")
+		default:
+			fmt.Println(BaseURI[0], "Not a supported URI")
+		}
 	},
 
 	Use:     docs.PullUse,

--- a/src/cmd/singularity/cli/pull.go
+++ b/src/cmd/singularity/cli/pull.go
@@ -6,11 +6,11 @@
 package cli
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/singularityware/singularity/src/docs"
 	"github.com/singularityware/singularity/src/pkg/libexec"
+	"github.com/singularityware/singularity/src/pkg/sylog"
 	"github.com/spf13/cobra"
 )
 
@@ -56,9 +56,9 @@ var PullCmd = &cobra.Command{
 		case SyCloudLibrary:
 			libexec.PullImage(image, uri, PullLibraryURI, force, authToken)
 		case Shub:
-			fmt.Println("Shub not yet supported")
+			sylog.Errorf("Shub not yet supported")
 		default:
-			fmt.Println(BaseURI[0], "Not a supported URI")
+			sylog.Errorf("Not a supported URI")
 		}
 	},
 

--- a/src/cmd/singularity/cli/pull.go
+++ b/src/cmd/singularity/cli/pull.go
@@ -43,20 +43,18 @@ var PullCmd = &cobra.Command{
 	Args:   cobra.RangeArgs(1, 2),
 	PreRun: sylabsToken,
 	Run: func(cmd *cobra.Command, args []string) {
-		var uri string
+		var uri, image string
+		image = ""
 		if len(args) == 2 {
 			uri = args[1]
+			image = args[0]
 		} else {
 			uri = args[0]
 		}
 		BaseURI := strings.Split(uri, "://")
 		switch BaseURI[0] {
 		case SyCloudLibrary:
-			if len(args) == 2 {
-				libexec.PullImage(args[0], uri, PullLibraryURI, force, authToken)
-				return
-			}
-			libexec.PullImage("", args[0], PullLibraryURI, force, authToken)
+			libexec.PullImage(image, uri, PullLibraryURI, force, authToken)
 		case Shub:
 			fmt.Println("Shub not yet supported")
 		default:

--- a/src/docs/content.go
+++ b/src/docs/content.go
@@ -487,24 +487,23 @@ Enterprise Performance Computing (EPC)`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// pull
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	PullUse   string = `pull [pull options...] [library://[user[collection/[<container>:tag]]]]`
+	PullUse   string = `pull [pull options...] <URI://>`
 	PullShort string = `Pull a container from a URI`
 	PullLong  string = `
   SUPPORTED URIs:
   
     library: Pull an image from the currently configured library
-    shub: Pull an image using python from Singularity Hub to /home/vagrant/versioned/singularity
-    docker: Pull a docker image using python to /home/vagrant/versioned/singularity`
+      [library://[user[collection/[container[:tag]]]]]
+    shub: Pull an image from Singularity Hub to CWD
+      shub://user/image:tag
+     `
 	PullExample string = `
-  $ singularity pull docker://ubuntu:latest
-  
+  From Sylabs cloud library
+  $ singularity pull library://dtrudg/demo/alpine:latest
+
+  From Shub
   $ singularity pull shub://vsoch/singularity-images
-  Found image vsoch/singularity-images:mongo
-  Downloading image... vsoch-singularity-images-mongo.img
-  
-  $ singularity pull --name "meatballs.img" shub://vsoch/singularity-images
-  $ singularity pull --commit shub://vsoch/singularity-images
-  $ singularity pull --hash shub://vsoch/singularity-images`
+`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// push


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Currently, singularity pull only understands library:// URI.

First step is to make src/cmd/cli/singularity/pull.go understand library:// vs shub:// and write appropriate error message when shub is specified that shub isn't yet supported


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
