### PR TITLE
Improvements to Sylog package message formatting and level handling

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -115,8 +115,6 @@ var RunCmd = &cobra.Command{
 
 // TODO: Let's stick this in another file so that that CLI is just CLI
 func execWrapper(cobraCmd *cobra.Command, image string, args []string) {
-	lvl := "0"
-
 	wrapper := buildcfg.SBINDIR + "/wrapper-suid"
 
 	engineConfig := singularity.NewConfig()
@@ -185,13 +183,6 @@ func execWrapper(cobraCmd *cobra.Command, image string, args []string) {
 		}
 	}
 
-	if verbose {
-		lvl = "2"
-	}
-	if debug {
-		lvl = "5"
-	}
-
 	if !IsCleanEnv {
 		for _, env := range os.Environ() {
 			e := strings.SplitN(env, "=", 2)
@@ -221,7 +212,7 @@ func execWrapper(cobraCmd *cobra.Command, image string, args []string) {
 		sylog.Warningf("can't determine current working directory: %s", err)
 	}
 
-	Env := []string{"SINGULARITY_MESSAGELEVEL=" + lvl, "SRUNTIME=singularity"}
+	Env := []string{sylog.GetEnvVar(), "SRUNTIME=singularity"}
 	progname := "Singularity runtime parent"
 
 	cfg := &config.Common{

--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -60,10 +60,6 @@ var BuildCmd = &cobra.Command{
 	PreRun:  sylabsToken,
 	// TODO: Can we plz move this to another file to keep the CLI the CLI
 	Run: func(cmd *cobra.Command, args []string) {
-		if silent {
-			fmt.Println("Silent!")
-		}
-
 		buildFormat := "sif"
 		if sandbox {
 			buildFormat = "sandbox"
@@ -126,7 +122,7 @@ func checkBuildTargetCollision(path string, force bool) bool {
 			if val := strings.Compare(strings.ToLower(input), "y\n"); val == 0 {
 				os.RemoveAll(path)
 			} else {
-				fmt.Println("Stopping build.")
+				sylog.Errorf("Stopping build.")
 				return false
 			}
 		}

--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -61,11 +61,30 @@ func init() {
 	SingularityCmd.AddCommand(VersionCmd)
 }
 
+func setSylogMessageLevel(cmd *cobra.Command, args []string) {
+	var level int
+
+	if debug {
+		level = 5
+	} else if verbose {
+		level = 4
+	} else if quiet {
+		level = -1
+	} else if silent {
+		level = -3
+	} else {
+		level = 1
+	}
+
+	sylog.SetLevel(level)
+}
+
 // SingularityCmd is the base command when called without any subcommands
 var SingularityCmd = &cobra.Command{
 	TraverseChildren:      true,
 	DisableFlagsInUseLine: true,
-	Run: nil,
+	PersistentPreRun:      setSylogMessageLevel,
+	Run:                   nil,
 
 	Use:     docs.SingularityUse,
 	Version: fmt.Sprintf("%v-%v\n", buildcfg.PACKAGE_VERSION, buildcfg.GIT_VERSION),

--- a/src/pkg/sylog/sylog.go
+++ b/src/pkg/sylog/sylog.go
@@ -18,16 +18,16 @@ import (
 type messageLevel int
 
 const (
-	fatal messageLevel = iota - 4
-	error
-	warn
-	log
-	_
-	info
-	verbose
-	verbose2
-	verbose3
-	debug
+	fatal    messageLevel = iota - 4 // fatal    : -4
+	error                            // error    : -3
+	warn                             // warn     : -2
+	log                              // log      : -1
+	_                                // SKIP     : 0
+	info                             // info     : 1
+	verbose                          // verbose  : 2
+	verbose2                         // verbose2 : 3
+	verbose3                         // verbose3 : 4
+	debug                            // debug    : 5
 )
 
 func (l messageLevel) String() string {
@@ -67,7 +67,6 @@ func init() {
 	_level, ok := os.LookupEnv("SINGULARITY_MESSAGELEVEL")
 	if !ok {
 		loggerLevel = debug
-		//Printf(INFO, "SINGULARITY_MESSAGELEVEL not set, defaulting to 5")
 	} else {
 		_levelint, err := strconv.Atoi(_level)
 		if err != nil {
@@ -78,12 +77,17 @@ func init() {
 	}
 }
 
-func writef(level messageLevel, format string, a ...interface{}) {
-	if loggerLevel < level {
-		return
+func prefix(level messageLevel) string {
+	messageColor, ok := messageColors[level]
+	if !ok {
+		messageColor = "\x1b[0m"
 	}
 
-	pc, _, _, ok := runtime.Caller(2)
+	if loggerLevel < debug {
+		return fmt.Sprintf("%s%-8s ", messageColor, level.String()+":")
+	}
+
+	pc, _, _, ok := runtime.Caller(3)
 	details := runtime.FuncForPC(pc)
 
 	var funcName string
@@ -97,20 +101,20 @@ func writef(level messageLevel, format string, a ...interface{}) {
 
 	uid := os.Getuid()
 	pid := os.Getpid()
-
 	uidStr := fmt.Sprintf("[U=%d,P=%d]", uid, pid)
 
-	messageColor, ok := messageColors[level]
-	if !ok {
-		messageColor = "\x1b[0m"
+	return fmt.Sprintf("%s%-8s%s%-19s%-30s", messageColor, level, colorReset, uidStr, funcName)
+}
+
+func writef(level messageLevel, format string, a ...interface{}) {
+	if loggerLevel < level {
+		return
 	}
 
-	prefix := fmt.Sprintf("%s%-8s%s%-19s%-30s", messageColor, level, colorReset, uidStr, funcName)
 	message := fmt.Sprintf(format, a...)
-
 	message = strings.TrimSuffix(message, "\n")
 
-	fmt.Fprintf(os.Stderr, "%s%s\n", prefix, message)
+	fmt.Fprintf(os.Stderr, "%s%s\n", prefix(level), message)
 }
 
 // Fatalf is equivalent to a call to Errorf followed by os.Exit(255). Code that
@@ -148,7 +152,18 @@ func Debugf(format string, a ...interface{}) {
 	writef(debug, format, a...)
 }
 
+// SetLevel explicitly sets the loggerLevel
+func SetLevel(l int) {
+	loggerLevel = messageLevel(l)
+}
+
 // GetLevel returns the current log level as integer
 func GetLevel() int {
 	return int(loggerLevel)
+}
+
+// GetEnvVar returns a formatted environment variable string which
+// can later be interpreted by init() in a child proc
+func GetEnvVar() string {
+	return fmt.Sprintf("SINGULARITY_MESSAGELEVEL=%d", loggerLevel)
 }

--- a/src/pkg/sylog/sylog.go
+++ b/src/pkg/sylog/sylog.go
@@ -84,7 +84,7 @@ func prefix(level messageLevel) string {
 	}
 
 	if loggerLevel < debug {
-		return fmt.Sprintf("%s%-8s ", messageColor, level.String()+":")
+		return fmt.Sprintf("%s%-8s%s ", messageColor, level.String()+":", colorReset)
 	}
 
 	pc, _, _, ok := runtime.Caller(3)
@@ -99,7 +99,7 @@ func prefix(level messageLevel) string {
 		funcName = funcNameSplit[len(funcNameSplit)-1] + "()"
 	}
 
-	uid := os.Getuid()
+	uid := os.Geteuid()
 	pid := os.Getpid()
 	uidStr := fmt.Sprintf("[U=%d,P=%d]", uid, pid)
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Adds proper Sylog logger-level handling function for all commands
- Fixes formatting for messages printed without debug handling

Before: 

```
mibauer@bauer-desktop:~$ singularity shell NOT_AN_IMAGE
FATAL   [U=1000,P=18300]   SMaster()                     container creation failed: stat /home/mibauer/NOT_AN_IMAGE: no such file or directory

mibauer@bauer-desktop:~$ singularity -v shell NOT_AN_IMAGE
VERBOSE: Set messagelevel to: 2
...
VERBOSE: Spawn RPC server
VERBOSE [U=1000,P=18386]   main()                        Serve RPC requests
VERBOSE [U=1000,P=18367]   main()                        Execute smaster process
FATAL   [U=1000,P=18367]   SMaster()                     container creation failed: stat /home/mibauer/NOT_AN_IMAGE: no such file or directory

mibauer@bauer-desktop:~$ singularity -d shell NOT_AN_IMAGE
VERBOSE [U=0,P=18334]      singularity_message_level()               Set messagelevel to: 5
...
FATAL   [U=1000,P=18334]   SMaster()                     container creation failed: stat /home/mibauer/NOT_AN_IMAGE: no such file or directory
```

After:

```
mibauer@bauer-desktop:~$ singularity shell NOT_AN_IMAGE
FATAL:   container creation failed: stat /home/mibauer/NOT_AN_IMAGE: no such file or directory

mibauer@bauer-desktop:~$ singularity -v shell NOT_AN_IMAGE
VERBOSE: Set messagelevel to: 4
...
VERBOSE: Serve RPC requests
FATAL:   container creation failed: stat /home/mibauer/NOT_AN_IMAGE: no such file or directory

mibauer@bauer-desktop:~$ singularity -d shell NOT_AN_IMAGE
VERBOSE [U=0,P=15877]      singularity_message_level()               Set messagelevel to: 5
...
FATAL   [U=1000,P=15877]   SMaster()                     container creation failed: stat /home/mibauer/NOT_AN_IMAGE: no such file or directory
```