### PR TITLE
3.0: fix compilation on RHEL6 and RHEL7

### DIFF
--- a/src/pkg/util/user/identity.go
+++ b/src/pkg/util/user/identity.go
@@ -15,11 +15,15 @@ package user
 #include <grp.h>
 
 #ifndef uid_t
+#ifndef __uid_t_defined
 typedef uid_t __uid_t;
+#endif
 #endif
 
 #ifndef gid_t
+#ifndef __gid_t_defined
 typedef gid_t __gid_t;
+#endif
 #endif
 */
 import "C"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR makes the master branch compile on RHEL6 and RHEL7.  Without it, compilation dies with these messages:
```
GO singularity
# github.com/singularityware/singularity/src/pkg/util/user
../src/pkg/util/user/identity.go:79: cannot use C.uid_t(uid) (type C.uid_t) as type C.__uid_t in argument to _C2func_getpwuid
../src/pkg/util/user/identity.go:114: cannot use C.gid_t(gid) (type C.gid_t) as type C.__gid_t in argument to _C2func_getgrgid
make: *** [singularity] Error 2
```


**This fixes or addresses the following GitHub issues:**

None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
