### PR TITLE
Building using Definitions and Metadata Reorganization

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -71,8 +71,8 @@ var ExecCmd = &cobra.Command{
 	TraverseChildren:      true,
 	Args:                  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		a := append([]string{"/.singularity.d/actions/exec"}, args[1:]...)
-		execWrapper(cmd, args[0], a)
+		command := addArgs(execCommand, args[1:])
+		execWrapper(cmd, args[0], command)
 	},
 
 	Use:     docs.ExecUse,
@@ -87,8 +87,8 @@ var ShellCmd = &cobra.Command{
 	TraverseChildren:      true,
 	Args:                  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		a := append([]string{"/.singularity.d/actions/shell"}, args[1:]...)
-		execWrapper(cmd, args[0], a)
+		command := addArgs(shellCommand, args[1:])
+		execWrapper(cmd, args[0], command)
 	},
 
 	Use:     docs.ShellUse,
@@ -103,8 +103,8 @@ var RunCmd = &cobra.Command{
 	TraverseChildren:      true,
 	Args:                  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		a := append([]string{"/.singularity.d/actions/run"}, args[1:]...)
-		execWrapper(cmd, args[0], a)
+		command := addArgs(runCommand, args[1:])
+		execWrapper(cmd, args[0], command)
 	},
 
 	Use:     docs.RunUse,
@@ -240,3 +240,70 @@ func execWrapper(cobraCmd *cobra.Command, image string, args []string) {
 		sylog.Fatalf("%s", err)
 	}
 }
+
+func addArgs(command string, args []string) []string {
+	argString := strings.Join(args, " ")
+	payload := strings.Replace(command, `"$@"`, argString, -1)
+	return []string{`/bin/sh`, "-c", payload}
+}
+
+const (
+	execCommand = `for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+exec "$@"
+`
+
+	runCommand = `for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -n "${SINGULARITY_APPNAME:-}"; then
+
+    if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript"; then
+        exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript" "$@"
+    else
+        echo "No Singularity runscript for contained app: ${SINGULARITY_APPNAME:-}"
+        exit 1
+    fi
+
+elif test -x "/.singularity.d/runscript"; then
+    exec "/.singularity.d/runscript" "$@"
+else
+    echo "No Singularity runscript found, executing /bin/sh"
+    exec /bin/sh "$@"
+fi
+`
+
+	shellCommand = `for script in /.singularity.d/env/*.sh; do
+	if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -n "$SINGULARITY_SHELL" -a -x "$SINGULARITY_SHELL"; then
+    exec $SINGULARITY_SHELL "$@"
+
+    echo "ERROR: Failed running shell as defined by '\$SINGULARITY_SHELL'" 1>&2
+    exit 1
+
+elif test -x /bin/bash; then
+    SHELL=/bin/bash
+    PS1="Singularity $SINGULARITY_CONTAINER:\\w> "
+    export SHELL PS1
+    exec /bin/bash --norc "$@"
+elif test -x /bin/sh; then
+    SHELL=/bin/sh
+    export SHELL
+    exec /bin/sh "$@"
+else
+    echo "ERROR: /bin/sh does not exist in container" 1>&2
+fi
+exit 1
+`
+)

--- a/src/pkg/build/assemblers/assembler_sandbox.go
+++ b/src/pkg/build/assemblers/assembler_sandbox.go
@@ -14,11 +14,38 @@ import (
 
 // SandboxAssembler doesnt store anything
 type SandboxAssembler struct {
+	b *types.Bundle
 }
 
 // Assemble creates a Sandbox image from a Bundle
 func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
+
+	a.b = b
 	defer os.RemoveAll(b.Path)
+
+	//insert help
+	err = a.insertHelpScript()
+	if err != nil {
+		return
+	}
+
+	//append environment
+	err = a.appendEnvScript()
+	if err != nil {
+		return
+	}
+
+	//insert runscript
+	err = a.insertRunScript()
+	if err != nil {
+		return
+	}
+
+	//insert test script
+	err = a.insertTestScript()
+	if err != nil {
+		return
+	}
 
 	//move bundle rootfs to sandboxdir as final sandbox
 	sylog.Debugf("Moving sandbox from %v to %v", b.Rootfs(), path)
@@ -27,5 +54,25 @@ func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		return err
 	}
 
+	return nil
+}
+
+func (a *SandboxAssembler) insertHelpScript() (err error) {
+	//this becomes .singularity.d/runscript.help
+	return nil
+}
+
+func (a *SandboxAssembler) appendEnvScript() (err error) {
+	//this goes onto .singularity.d/env/90-environment.sh
+	return nil
+}
+
+func (a *SandboxAssembler) insertRunScript() (err error) {
+	//this becomes .singularity.d/runscript
+	return nil
+}
+
+func (a *SandboxAssembler) insertTestScript() (err error) {
+	//this becomes .singularity.d/actions/test
 	return nil
 }

--- a/src/pkg/build/assemblers/assembler_sandbox.go
+++ b/src/pkg/build/assemblers/assembler_sandbox.go
@@ -6,7 +6,10 @@
 package assemblers
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/singularityware/singularity/src/pkg/build/types"
 	"github.com/singularityware/singularity/src/pkg/sylog"
@@ -19,32 +22,38 @@ type SandboxAssembler struct {
 
 // Assemble creates a Sandbox image from a Bundle
 func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
-
+	//Consider changing the interface so that bundles and part of assembler declaration?
 	a.b = b
 	defer os.RemoveAll(b.Path)
 
 	//insert help
 	err = a.insertHelpScript()
 	if err != nil {
-		return
+		return fmt.Errorf("While inserting help script: %v", err)
+	}
+
+	//insert labels
+	err = a.insertLabelsJSON()
+	if err != nil {
+		return fmt.Errorf("While inserting labels JSON: %v", err)
 	}
 
 	//append environment
 	err = a.appendEnvScript()
 	if err != nil {
-		return
+		return fmt.Errorf("While inserting environment script: %v", err)
 	}
 
 	//insert runscript
 	err = a.insertRunScript()
 	if err != nil {
-		return
+		return fmt.Errorf("While inserting runscript: %v", err)
 	}
 
 	//insert test script
 	err = a.insertTestScript()
 	if err != nil {
-		return
+		return fmt.Errorf("While inserting test script: %v", err)
 	}
 
 	//move bundle rootfs to sandboxdir as final sandbox
@@ -57,22 +66,36 @@ func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	return nil
 }
 
-func (a *SandboxAssembler) insertHelpScript() (err error) {
-	//this becomes .singularity.d/runscript.help
-	return nil
+func (a *SandboxAssembler) insertHelpScript() error {
+	err := ioutil.WriteFile(filepath.Join(a.b.Rootfs(), "/.singularity.d/runscript.help"), []byte(a.b.Recipe.ImageData.Help+"\n"), 0664)
+	return err
 }
 
-func (a *SandboxAssembler) appendEnvScript() (err error) {
-	//this goes onto .singularity.d/env/90-environment.sh
-	return nil
+func (a *SandboxAssembler) appendEnvScript() error {
+	err := ioutil.WriteFile(filepath.Join(a.b.Rootfs(), "/.singularity.d/env/90-environment.sh"), []byte(a.b.Recipe.ImageData.Environment+"\n"), 0775)
+	return err
 }
 
-func (a *SandboxAssembler) insertRunScript() (err error) {
-	//this becomes .singularity.d/runscript
-	return nil
+func (a *SandboxAssembler) insertRunScript() error {
+	err := ioutil.WriteFile(filepath.Join(a.b.Rootfs(), "/.singularity.d/runscript"), []byte(a.b.Recipe.ImageData.Runscript), 0775)
+	return err
 }
 
-func (a *SandboxAssembler) insertTestScript() (err error) {
-	//this becomes .singularity.d/actions/test
-	return nil
+func (a *SandboxAssembler) insertTestScript() error {
+	err := ioutil.WriteFile(filepath.Join(a.b.Rootfs(), "/.singularity.d/actions/test"), []byte(a.b.Recipe.ImageData.Test), 0775)
+	return err
+}
+
+func (a *SandboxAssembler) insertLabelsJSON() error {
+
+	text := "{\n"
+
+	for key, val := range a.b.Recipe.ImageData.Labels {
+		text += "    \"" + key + "\": \"" + val + "\"\n"
+	}
+
+	text += "}"
+
+	err := ioutil.WriteFile(filepath.Join(a.b.Rootfs(), "/.singularity.d/labels.json"), []byte(text), 0664)
+	return err
 }

--- a/src/pkg/build/types/definition.go
+++ b/src/pkg/build/types/definition.go
@@ -25,8 +25,8 @@ type Definition struct {
 // ImageData contains any scripts, metadata, etc... that needs to be
 // present in some from in the final built image
 type ImageData struct {
-	Metadata     []byte   `json:"metadata"`
-	Labels       []string `json:"labels"`
+	Metadata     []byte            `json:"metadata"`
+	Labels       map[string]string `json:"labels"`
 	ImageScripts `json:"imageScripts"`
 }
 
@@ -41,8 +41,14 @@ type ImageScripts struct {
 // Data contains any scripts, metadata, etc... that the Builder may
 // need to know only at build time to build the image
 type Data struct {
-	Files   map[string]string `json:"files"`
+	Files   []FileTransport `json:"files"`
 	Scripts `json:"buildScripts"`
+}
+
+// FileTransport holds source and destination information of files to copy into the container
+type FileTransport struct {
+	Src string `json:"source"`
+	Dst string `json:"destination"`
 }
 
 // Scripts defines scripts that are used at build time.

--- a/src/pkg/build/types/definition.go
+++ b/src/pkg/build/types/definition.go
@@ -50,6 +50,7 @@ type Scripts struct {
 	Pre   string `json:"pre"`
 	Setup string `json:"setup"`
 	Post  string `json:"post"`
+	Test  string `json:"test"`
 }
 
 // NewDefinitionFromURI crafts a new Definition given a URI

--- a/src/pkg/build/types/definition_parser_deffile.go
+++ b/src/pkg/build/types/definition_parser_deffile.go
@@ -123,7 +123,30 @@ func doSections(s *bufio.Scanner, d *Definition) (err error) {
 	// Files are parsed as a map[string]string
 	filesSections := strings.TrimSpace(sections["files"])
 	subs := strings.Split(filesSections, "\n")
-	files := make(map[string]string)
+	var files []FileTransport
+
+	for _, line := range subs {
+
+		if line = strings.TrimSpace(line); line == "" || strings.Index(line, "#") == 0 {
+			continue
+		}
+		var src, dst string
+		lineSubs := strings.SplitN(line, " ", 2)
+		if len(lineSubs) < 2 {
+			src = strings.TrimSpace(lineSubs[0])
+			dst = ""
+		} else {
+			src = strings.TrimSpace(lineSubs[0])
+			dst = strings.TrimSpace(lineSubs[1])
+		}
+
+		files = append(files, FileTransport{src, dst})
+	}
+
+	// labels are parsed as a map[string]string
+	labelsSections := strings.TrimSpace(sections["labels"])
+	subs = strings.Split(labelsSections, "\n")
+	labels := make(map[string]string)
 
 	for _, line := range subs {
 		if line = strings.TrimSpace(line); line == "" || strings.Index(line, "#") == 0 {
@@ -139,7 +162,7 @@ func doSections(s *bufio.Scanner, d *Definition) (err error) {
 			val = strings.TrimSpace(lineSubs[1])
 		}
 
-		files[key] = val
+		labels[key] = val
 	}
 
 	d.ImageData = ImageData{
@@ -149,6 +172,7 @@ func doSections(s *bufio.Scanner, d *Definition) (err error) {
 			Runscript:   sections["runscript"],
 			Test:        sections["test"],
 		},
+		Labels: labels,
 	}
 	d.BuildData.Files = files
 	d.BuildData.Scripts = Scripts{

--- a/src/pkg/build/types/definition_parser_deffile.go
+++ b/src/pkg/build/types/definition_parser_deffile.go
@@ -155,6 +155,7 @@ func doSections(s *bufio.Scanner, d *Definition) (err error) {
 		Pre:   sections["pre"],
 		Setup: sections["setup"],
 		Post:  sections["post"],
+		Test:  sections["test"],
 	}
 
 	return

--- a/src/runtime/engines/imgbuild/create.go
+++ b/src/runtime/engines/imgbuild/create.go
@@ -44,20 +44,6 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 		return fmt.Errorf("%s is not a directory", rootfs)
 	}
 
-	// Run %pre script here
-	pre := exec.Command("/bin/sh", "-c", engine.EngineConfig.Recipe.BuildData.Pre)
-	pre.Stdout = os.Stdout
-	pre.Stderr = os.Stderr
-
-	sylog.Infof("Running %%pre script\n")
-	if err := pre.Start(); err != nil {
-		sylog.Fatalf("failed to start %%pre proc: %v\n", err)
-	}
-	if err := pre.Wait(); err != nil {
-		sylog.Fatalf("pre proc: %v\n", err)
-	}
-	sylog.Infof("Finished running %%pre script. exit status 0\n")
-
 	sylog.Debugf("Mounting image directory %s\n", rootfs)
 	_, err = rpcOps.Mount(rootfs, buildcfg.SESSIONDIR, "", syscall.MS_BIND|syscall.MS_NOSUID|syscall.MS_NODEV, "errors=remount-ro")
 	if err != nil {

--- a/src/runtime/engines/imgbuild/process.go
+++ b/src/runtime/engines/imgbuild/process.go
@@ -33,6 +33,23 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 	}
 	sylog.Infof("Finished running %%post script. exit status 0\n")
 
+	// Run %test script here if its defined
+	// this also needs to consider the --notest flag from the CLI eventually
+	if e.EngineConfig.Recipe.BuildData.Test != "" {
+		test := exec.Command("/bin/sh", "-c", e.EngineConfig.Recipe.BuildData.Test)
+		test.Stdout = os.Stdout
+		test.Stderr = os.Stderr
+
+		sylog.Infof("Running %%test script\n")
+		if err := test.Start(); err != nil {
+			sylog.Fatalf("failed to start %%test proc: %v\n", err)
+		}
+		if err := test.Wait(); err != nil {
+			sylog.Fatalf("test proc: %v\n", err)
+		}
+		sylog.Infof("Finished running %%test script. exit status 0\n")
+	}
+
 	os.Exit(0)
 	return nil
 }


### PR DESCRIPTION
### Description of the Pull Request (PR):

#### This PR will implement builds respecting definitions minimal container FS metadata Currently:

- Insert hooks into build engine and assemblers in order to properly execute sections of definitions
- build sandboxes respecting definitions
- runtime handles exec, shell and run without relying on /.singularity.d

#### Work left to be done:

- build SIF files respecting definitions
- make runtime handle SIF metadata properly since that info won't be in the FS like sandboxes or legacy images
- build system needs to detect old metadata and handle building over it

