### PR TITLE
3.0: Change go version from 1.10.2 to 1.10.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ First, visit the [golang download page](https://golang.org/dl/) and pick a
 package archive to download.  Copy the link address and download with `wget`.
 
 ```
-$ export VERSION=1.10.2 OS=linux ARCH=amd64
+$ export VERSION=1.10.3 OS=linux ARCH=amd64
 $ cd /tmp
 $ wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz
 ```


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This changes the recommended go version from 1.10.2 to 1.10.3.   The current master branch fails to compile with 1.10.2, at least on RHEL7.


**This fixes or addresses the following GitHub issues:**

None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
