### PR TITLE
3.0: Fix typo, use gid map instead of uid map

### DIFF
--- a/src/runtime/engines/singularity/prepare.go
+++ b/src/runtime/engines/singularity/prepare.go
@@ -44,7 +44,7 @@ func (e *EngineOperations) PrepareConfig(masterConn net.Conn, wrapperConfig *wra
 
 	if e.CommonConfig.OciConfig.Linux != nil {
 		wrapperConfig.AddUIDMappings(e.CommonConfig.OciConfig.Linux.UIDMappings)
-		wrapperConfig.AddGIDMappings(e.CommonConfig.OciConfig.Linux.UIDMappings)
+		wrapperConfig.AddGIDMappings(e.CommonConfig.OciConfig.Linux.GIDMappings)
 		wrapperConfig.SetNsFlagsFromSpec(e.CommonConfig.OciConfig.Linux.Namespaces)
 	}
 	if e.CommonConfig.OciConfig.Process != nil && e.CommonConfig.OciConfig.Process.Capabilities != nil {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix a typo where uid was used in place of gid.  Fixes mapping when the uid is not equal to gid.  This is a problem at least with unprivileged user namespaces.  I'm not sure but the typo might also result in the wrong mapping of gid when running setuid.


**This fixes or addresses the following GitHub issues:**

- Ref: #1847


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
