### PR TITLE
Set Version Using Semver Git Tag

### DIFF
--- a/mlocal/checks/project.chk
+++ b/mlocal/checks/project.chk
@@ -10,7 +10,7 @@ echo "" > $makecond
 ########################
 # git version
 ########################
-git_version=`git describe --match 'v[0-9]*' --long --dirty --always`
+git_version=`git describe --match 'v[0-9]*' --dirty --always | sed -e "s/^v//"`
 
 config_add_def PACKAGE_NAME \"singularity\"
 config_add_def PACKAGE_TARNAME \"singularity\"

--- a/mlocal/checks/project.chk
+++ b/mlocal/checks/project.chk
@@ -7,10 +7,15 @@ set -e
 makecond="$builddir/Makefile.cond"
 echo "" > $makecond
 
+########################
+# git version
+########################
+git_version=`git describe --match 'v[0-9]*' --long --dirty --always`
+
 config_add_def PACKAGE_NAME \"singularity\"
 config_add_def PACKAGE_TARNAME \"singularity\"
-config_add_def PACKAGE_VERSION \"3.0.0\"
-config_add_def PACKAGE_STRING \"singularity 3.0.0\"
+config_add_def PACKAGE_VERSION \"$git_version\"
+config_add_def PACKAGE_STRING \"singularity $git_version\"
 config_add_def PACKAGE_BUGREPORT \"support@sylabs.io\"
 config_add_def PACKAGE_URL \"\"
 
@@ -46,20 +51,6 @@ config_add_def CONTAINER_MOUNTDIR LOCALSTATEDIR \"/singularity/mnt/container\"
 config_add_def CONTAINER_FINALDIR LOCALSTATEDIR \"/singularity/mnt/final\"
 config_add_def CONTAINER_OVERLAY LOCALSTATEDIR \"/singularity/mnt/overlay\"
 config_add_def SESSIONDIR LOCALSTATEDIR \"/singularity/mnt/session\"
-
-########################
-# git version 
-########################
-if BRANCH=`git rev-parse --abbrev-ref HEAD 2>/dev/null`; then
-    if HASH=`git rev-parse --short HEAD 2>/dev/null`; then
-        config_add_def GIT_VERSION \"$BRANCH.$HASH\"
-    else
-        config_add_def GIT_VERSION \"$BRANCH\"
-    fi
-else
-    config_add_def GIT_VERSION \"dist\"
-fi
-
 
 ########################
 # ns: CLONE_NEWPID

--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -87,7 +87,7 @@ var SingularityCmd = &cobra.Command{
 	Run:                   nil,
 
 	Use:     docs.SingularityUse,
-	Version: fmt.Sprintf("%v-%v\n", buildcfg.PACKAGE_VERSION, buildcfg.GIT_VERSION),
+	Version: buildcfg.PACKAGE_VERSION,
 	Short:   docs.SingularityShort,
 	Long:    docs.SingularityLong,
 	Example: docs.SingularityExample,
@@ -115,7 +115,7 @@ func TraverseParentsUses(cmd *cobra.Command) string {
 var VersionCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("%v-%v\n", buildcfg.PACKAGE_VERSION, buildcfg.GIT_VERSION)
+		fmt.Println(buildcfg.PACKAGE_VERSION)
 	},
 
 	Use:   "version",


### PR DESCRIPTION
Use `git describe` to set version in `PACKAGE_VERSION` and `PACKAGE_STRING` based on latest annotated git tag. With this change, the values in this file will not need to be updated manually on release.

When the current commit is tagged as a release, the tag name is used. So, for example, when `v3.0.0` is tagged, the behavior will be:

```sh
$ singularity version
3.0.0
```

When the current commit is not tagged as a release, the format is `<version_tag>-<commits_since_version_tag>-g<commit_hash>`. In this branch, the latest version tag is `v3.0.0-alpha.1`, I have `2` commits since that tag, and the current commit hash is `e8f1270b`. Thus the version strings:

```sh
$ singularity version
3.0.0-alpha.1-2-ge8f1270b
```

