### PR TITLE
Cleanup of code and prepare for id, groupid as argument

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -390,7 +390,7 @@
   branch = "master"
   name = "github.com/sylabs/sif"
   packages = ["pkg/sif"]
-  revision = "0edb5835dbdba7a9c39e302bef0715c88b889fc1"
+  revision = "a4f82381d252d398a7dda63a38c88f626bf68fb9"
 
 [[projects]]
   branch = "master"

--- a/src/cmd/singularity/cli/keys_list.go
+++ b/src/cmd/singularity/cli/keys_list.go
@@ -22,7 +22,7 @@ func init() {
 	KeysListCmd.Flags().BoolVarP(&secret, "secret", "s", false, "list private keys instead of the default which displays public ones")
 }
 
-// KeysListCmd is `singularity keys list' and lists local store PGP keys
+// KeysListCmd is `singularity keys list' and lists local store OpenPGP keys
 var KeysListCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
 	DisableFlagsInUseLine: true,

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -21,55 +21,63 @@ import (
 	"golang.org/x/crypto/openpgp/clearsign"
 )
 
+// computeHashStr generates a hash from a data object and generates a string
+// to be stored in the signature block
 func computeHashStr(fimg *sif.FileImage, descr *sif.Descriptor) string {
 	sum := sha512.Sum384(fimg.Filedata[descr.Fileoff : descr.Fileoff+descr.Filelen])
 
 	return fmt.Sprintf("SIFHASH:\n%x", sum)
 }
 
-// adds a signature block for the primary partition
-func sifAddSignature(fingerprint [20]byte, fimg *sif.FileImage, signature []byte) error {
-	part, _, err := fimg.GetPartPrimSys()
-	if err != nil {
-		return err
-	}
-
+// sifAddSignature adds a signature block to a SIF file
+func sifAddSignature(fimg *sif.FileImage, descr *sif.Descriptor, fingerprint [20]byte, signature []byte) error {
 	// data we need to create a signature descriptor
 	siginput := sif.DescriptorInput{
 		Datatype: sif.DataSignature,
-		Groupid:  sif.DescrDefaultGroup,
-		Link:     part.ID,
+		Groupid:  descr.Groupid,
+		Link:     descr.ID,
 		Fname:    "part-signature",
 		Data:     signature,
 	}
 	siginput.Size = int64(binary.Size(siginput.Data))
 
 	// extra data needed for the creation of a signature descriptor
-	err = siginput.SetSignExtra(sif.HashSHA384, hex.EncodeToString(fingerprint[:]))
+	err := siginput.SetSignExtra(sif.HashSHA384, hex.EncodeToString(fingerprint[:]))
 	if err != nil {
 		return err
 	}
 
 	// add new signature data object to SIF file
-	if err = fimg.AddObject(siginput); err != nil {
-		return fmt.Errorf("adding new signature to SIF file: %s", err)
+	err = fimg.AddObject(siginput)
+	if err != nil {
+		return err
 	}
 
 	return nil
 }
 
+// descrToSign determines via argument or interactively which descriptor to sign
+func descrToSign(fimg *sif.FileImage) (descr *sif.Descriptor, err error) {
+	descr, _, err = fimg.GetPartPrimSys()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 // Sign takes the path of a container and generates an OpenPGP signature block for
 // its system partition. Sign uses the private keys found in the default
 // location if available or helps the user by prompting with key generation
-// configuration options. In its current form, Sign also pushes public material
-// to a key server if enabled. This should be a separate step in the next round
-// of development.
+// configuration options. In its current form, Sign also pushes, when desired,
+// public material to a key server.
 func Sign(cpath, url, authToken string) error {
 	elist, err := sypgp.LoadPrivKeyring()
 	if err != nil {
 		return err
 	}
 
+	// Find a generate a private key usable for signing
 	var entity *openpgp.Entity
 	if elist == nil {
 		resp, err := sypgp.AskQuestion("No OpenPGP signing keys found, autogenerate? [Y/n] ")
@@ -105,7 +113,7 @@ func Sign(cpath, url, authToken string) error {
 		}
 	}
 
-	// Decrypt key is needed
+	// Decrypt key if needed
 	sypgp.DecryptKey(entity)
 
 	// load the container
@@ -115,16 +123,16 @@ func Sign(cpath, url, authToken string) error {
 	}
 	defer fimg.UnloadContainer()
 
-	part, _, err := fimg.GetPartPrimSys()
+	// figure out which descriptor has data to sign
+	descr, err := descrToSign(&fimg)
 	if err != nil {
 		return err
 	}
 
-	sifhash := computeHashStr(&fimg, part)
-	if err != nil {
-		return err
-	}
+	// signature also include data integrity check
+	sifhash := computeHashStr(&fimg, descr)
 
+	// create an ascii armored signature block
 	var signedmsg bytes.Buffer
 	plaintext, err := clearsign.Encode(&signedmsg, entity.PrivateKey, nil)
 	if err != nil {
@@ -138,7 +146,8 @@ func Sign(cpath, url, authToken string) error {
 		return err
 	}
 
-	err = sifAddSignature(entity.PrimaryKey.Fingerprint, &fimg, signedmsg.Bytes())
+	// finally add the signature block (for descr) as a new SIF data object
+	err = sifAddSignature(&fimg, descr, entity.PrimaryKey.Fingerprint, signedmsg.Bytes())
 	if err != nil {
 		return err
 	}
@@ -186,9 +195,6 @@ func Verify(cpath, url, authToken string) error {
 
 	// the selected data object is hashed for comparison against signature block's
 	sifhash := computeHashStr(&fimg, descr)
-	if err != nil {
-		return err
-	}
 
 	// load the public keys available locally from the cache
 	elist, err := sypgp.LoadPubKeyring()

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -155,11 +155,6 @@ func Sign(cpath, url, authToken string) error {
 	return nil
 }
 
-// XXX: move to SIF/Lookup.go
-func getDescrData(fimg *sif.FileImage, descr *sif.Descriptor) []byte {
-	return fimg.Filedata[descr.Fileoff : descr.Fileoff+descr.Filelen]
-}
-
 // return all signatures for "id" being unique or group id
 func getSigsForSelection(fimg *sif.FileImage) (sigs []*sif.Descriptor, descr *sif.Descriptor, err error) {
 	descr, _, err = fimg.GetPartPrimSys()
@@ -176,7 +171,7 @@ func getSigsForSelection(fimg *sif.FileImage) (sigs []*sif.Descriptor, descr *si
 }
 
 // Verify takes a container path and look for a verification block for a
-// system partition. If found, the signature block is used to verify the
+// specified descriptor. If found, the signature block is used to verify the
 // partition hash against the signer's version. Verify takes care of looking
 // for OpenPGP keys in the default local store or looks it up from a key server
 // if access is enabled.
@@ -205,7 +200,7 @@ func Verify(cpath, url, authToken string) error {
 	// compare freshly computed hash with hashes stored in signatures block(s)
 	for _, v := range signatures {
 		// Extract hash string from signature block
-		data := getDescrData(&fimg, v)
+		data := v.GetData(&fimg)
 		block, _ := clearsign.Decode(data)
 		if block == nil {
 			return fmt.Errorf("failed to decode clearsign message")

--- a/src/pkg/sypgp/sypgp.go
+++ b/src/pkg/sypgp/sypgp.go
@@ -311,7 +311,7 @@ func StorePubKey(e *openpgp.Entity) (err error) {
 	return
 }
 
-// GenKeyPair generates a PGP key pair and store them in the sypgp home folder
+// GenKeyPair generates an OpenPGP key pair and store them in the sypgp home folder
 func GenKeyPair() (entity *openpgp.Entity, err error) {
 	conf := &packet.Config{RSABits: 4096, DefaultHash: crypto.SHA384}
 
@@ -334,7 +334,7 @@ func GenKeyPair() (entity *openpgp.Entity, err error) {
 		return
 	}
 
-	fmt.Print("Generating Entity and PGP Key Pair... ")
+	fmt.Print("Generating Entity and OpenPGP Key Pair... ")
 	entity, err = openpgp.NewEntity(name, comment, email, conf)
 	if err != nil {
 		return
@@ -542,7 +542,7 @@ func PushPubkey(entity *openpgp.Entity, keyserverURI, authToken string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Key server did not accept PGP key, HTTP status: %v", resp.StatusCode)
+		return fmt.Errorf("Key server did not accept OpenPGP key, HTTP status: %v", resp.StatusCode)
 	}
 
 	return nil


### PR DESCRIPTION
This PR is another small step to make the code clearer and put in place functions like descrToSign() and getSigsForSelection() to later implement features allowing argument or interactive id, groupid selection.


