### PR TITLE
Launch imgbuild engine with correct SINGULARITY_MESSAGELEVEL env var

### DIFF
--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -186,7 +186,7 @@ func (b *Build) runPreScript() error {
 
 // runBuildEngine creates an imgbuild engine and creates a container out of our bundle in order to execute %post %setup scripts in the bundle
 func (b *Build) runBuildEngine() error {
-	env := []string{"SINGULARITY_MESSAGELEVEL=" + string(sylog.GetLevel()), "SRUNTIME=" + imgbuild.Name}
+	env := []string{sylog.GetEnvVar(), "SRUNTIME=" + imgbuild.Name}
 	wrapper := filepath.Join(buildcfg.SBINDIR, "/wrapper")
 	progname := []string{"singularity image-build"}
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes imgbuild engine being launched with incorrectly set SINGULARITY_MESSAGELEVEL environment variable. This ensures that logging will occur at the proper verbosity in the imgbuild engine