### PR TITLE
Specify cache location for HTTP image URL

### DIFF
--- a/libexec/handlers/image-http.sh
+++ b/libexec/handlers/image-http.sh
@@ -7,13 +7,19 @@
 
 NAME=`basename "$SINGULARITY_IMAGE"`
 
-if [ -f "$NAME" ]; then
-    message 2 "Using cached container in current working directory: $NAME\n"
-    SINGULARITY_IMAGE="$NAME"
+CACHE="${SINGULARITY_CACHEDIR:-${HOME}/.singularity}/image_cache"
+
+if [ ! -d ${CACHE} ]; then
+    mkdir -p ${CACHE};
+fi
+
+if [ -f "${CACHE}/${NAME}" ]; then
+    message 2 "Using cached container from: ${CACHE}/${NAME}\n"
+    SINGULARITY_IMAGE="${CACHE}/${NAME}"
 else
-    message 1 "Caching container to current working directory: $NAME\n"
-    if curl -L -k "$SINGULARITY_IMAGE" > "$NAME"; then
-        SINGULARITY_IMAGE="$NAME"
+    message 1 "Caching container to: ${CACHE}/${NAME}\n"
+    if curl -L -k "$SINGULARITY_IMAGE" > "${CACHE}/${NAME}"; then
+        SINGULARITY_IMAGE="${CACHE}/${NAME}"
     else
         ABORT 255
     fi

--- a/libexec/handlers/image-http.sh
+++ b/libexec/handlers/image-http.sh
@@ -10,7 +10,7 @@ NAME=`basename "$SINGULARITY_IMAGE"`
 CACHE="${SINGULARITY_CACHEDIR:-${HOME}/.singularity}/image_cache"
 
 if [ ! -d ${CACHE} ]; then
-    mkdir -p ${CACHE};
+    mkdir -m 0700 -p ${CACHE};
 fi
 
 if [ -f "${CACHE}/${NAME}" ]; then


### PR DESCRIPTION
**Description of the Pull Request (PR):**

When an image is specified with a location like:
  `singularity run http://some.site/my_image.img`

It is cached in the current working directory. This could possibly
lead to cases where private images are left readable by others.

To limit this possibility, we cache inside of `SINGULARITY_CACHEDIR`.

Reported by Adwait Joshi of NCC Group.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [] This PR is against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin
