### PR TITLE
Attempt directory creation without OverlayFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
+## [v2.6.1]
+
+### Bug fixes
+ - Attempt directory creation with `--contain` option and no OverlayFS support for certain run conditions
+
 ## [v2.6.0]
     
 ### Implemented enhancements

--- a/src/lib/runtime/mounts/userbinds/userbinds.c
+++ b/src/lib/runtime/mounts/userbinds/userbinds.c
@@ -118,10 +118,10 @@ int _singularity_runtime_mount_userbinds(void) {
                     continue;
                 }
             } else if ( ( is_dir(source) == 0 ) && ( is_dir(joinpath(container_dir, dest)) < 0 ) ) {
-                if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL ) {
-                    singularity_message(VERBOSE3, "Creating bind directory on overlay file system: %s\n", dest);
+                if ( singularity_registry_get("OVERLAYFS_ENABLED") != NULL || singularity_registry_get("CONTAIN") != NULL ) {
+                    singularity_message(VERBOSE3, "Creating bind directory: %s\n", dest);
                     if ( container_mkpath_nopriv(joinpath(container_dir, dest), 0755) < 0 ) {
-                        singularity_message(VERBOSE3, "Retrying with privileges to create bind directory on overlay file system: %s\n", dest);
+                        singularity_message(VERBOSE3, "Retrying with privileges to create bind directory: %s\n", dest);
                         if ( container_mkpath_priv(joinpath(container_dir, dest), 0755) < 0 ) {
                             singularity_message(WARNING, "Skipping user bind, could not create bind point %s: %s\n", dest, strerror(errno));
                             continue;


### PR DESCRIPTION
Try creating directories with `--contain` even if OverlayFS isn't
supported. The reason for this is because /dev at this point is
a tmpfs, and we can write to it.

So say, for example, we want /dev/infiniband on a system that
doesn't support OverlayFS, we can do:

  `singularity exec -c -B /dev/infiniband [image] [a b c]`

And it will work.

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [] This PR is against the project's master branch
- [] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin
