### PR TITLE
Development 3.0: fix make clean to avoid go source files deletion

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -36,7 +36,7 @@ cgo_LDFLAGS = -L$(abs_BUILDDIR)/lib -L$(BUILDDIR) -lruntime
 
 INSTALLFILES := $(singularity_INSTALL) $(starter_INSTALL) $(starter_suid_INSTALL) $(sessiondir) $(config_INSTALL)
 
-CLEANFILES += $(libruntime) $(starter) $(starter_OBJ) $(singularity) $(go_BIN) $(go_OBJ)
+CLEANFILES += $(libruntime) $(starter) $(singularity) $(go_BIN) $(go_OBJ)
 
 all: cscope collect $(libruntime) $(go_BIN) $(config) $(starter)
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix issue with `make -C builddir clean` deleting Go source files composing starter binary
