### PR TITLE
Add format arg to sylog errorf calls

### DIFF
--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -121,7 +121,7 @@ func checkBuildTargetCollision(path string, force bool) bool {
 			fmt.Print("Build target already exists. Do you want to overwrite? [N/y] ")
 			input, err := reader.ReadString('\n')
 			if err != nil {
-				sylog.Fatalf("Error parsing input:", err)
+				sylog.Fatalf("Error parsing input: %s", err)
 			}
 			if val := strings.Compare(strings.ToLower(input), "y\n"); val == 0 {
 				os.RemoveAll(path)

--- a/src/pkg/build/assemblers/assembler_sandbox.go
+++ b/src/pkg/build/assemblers/assembler_sandbox.go
@@ -69,7 +69,7 @@ func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	//move bundle rootfs to sandboxdir as final sandbox
 	sylog.Debugf("Moving sandbox from %v to %v", b.Rootfs(), path)
 	if err := os.Rename(b.Rootfs(), path); err != nil {
-		sylog.Errorf("Sandbox Assemble Failed", err.Error())
+		sylog.Errorf("Sandbox Assemble Failed: %s", err)
 		return err
 	}
 

--- a/src/pkg/build/sources/packer_ext3.go
+++ b/src/pkg/build/sources/packer_ext3.go
@@ -31,7 +31,7 @@ func (p *Ext3Packer) Pack() (*types.Bundle, error) {
 
 	err := p.unpackExt3(p.b, p.info, rootfs)
 	if err != nil {
-		sylog.Errorf("unpackExt3 Failed", err.Error())
+		sylog.Errorf("unpackExt3 Failed: %s", err)
 		return nil, err
 	}
 
@@ -58,7 +58,7 @@ func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs strin
 	sylog.Debugf("Mounting loop device %s to %s\n", path, tmpmnt)
 	err = syscall.Mount(path, tmpmnt, "ext3", syscall.MS_NOSUID|syscall.MS_RDONLY|syscall.MS_NODEV, "errors=remount-ro")
 	if err != nil {
-		sylog.Errorf("Mount Failed", err.Error())
+		sylog.Errorf("Mount Failed: %s", err)
 		return err
 	}
 	defer syscall.Unmount(tmpmnt, 0)
@@ -68,7 +68,7 @@ func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs strin
 	cmd := exec.Command("cp", "-r", tmpmnt+`/.`, b.Rootfs())
 	err = cmd.Run()
 	if err != nil {
-		sylog.Errorf("cp Failed", err.Error())
+		sylog.Errorf("cp Failed: %s", err)
 		return err
 	}
 

--- a/src/pkg/build/sources/packer_sandbox.go
+++ b/src/pkg/build/sources/packer_sandbox.go
@@ -28,7 +28,7 @@ func (p *SandboxPacker) Pack() (*types.Bundle, error) {
 	cmd := exec.Command("cp", "-r", rootfs+`/.`, p.b.Rootfs())
 	err := cmd.Run()
 	if err != nil {
-		sylog.Errorf("cp Failed", err.Error())
+		sylog.Errorf("cp Failed: %s", err)
 		return nil, err
 	}
 

--- a/src/pkg/build/sources/packer_sif.go
+++ b/src/pkg/build/sources/packer_sif.go
@@ -29,7 +29,7 @@ func (p *SIFPacker) Pack() (*types.Bundle, error) {
 
 	err := p.unpackSIF(p.b, p.srcfile)
 	if err != nil {
-		sylog.Errorf("unpackSIF Failed", err.Error())
+		sylog.Errorf("unpackSIF Failed: %s", err)
 		return nil, err
 	}
 
@@ -108,7 +108,7 @@ func unpackImagePartion(src, dest, mountType string, info *loop.Info64) (err err
 	sylog.Debugf("Mounting loop device %s to %s\n", path, tmpmnt)
 	err = syscall.Mount(path, tmpmnt, mountType, syscall.MS_NOSUID|syscall.MS_RDONLY|syscall.MS_NODEV, "errors=remount-ro")
 	if err != nil {
-		sylog.Errorf("Mount Failed", err.Error())
+		sylog.Errorf("Mount Failed: %s", err)
 		return err
 	}
 	defer syscall.Unmount(tmpmnt, 0)
@@ -118,7 +118,7 @@ func unpackImagePartion(src, dest, mountType string, info *loop.Info64) (err err
 	cmd := exec.Command("cp", "-r", tmpmnt+`/.`, dest)
 	err = cmd.Run()
 	if err != nil {
-		sylog.Errorf("cp Failed", err.Error())
+		sylog.Errorf("cp Failed: %s", err)
 		return err
 	}
 

--- a/src/pkg/build/sources/packer_squashfs.go
+++ b/src/pkg/build/sources/packer_squashfs.go
@@ -28,7 +28,7 @@ func (p *SquashfsPacker) Pack() (*types.Bundle, error) {
 
 	err := p.unpackSquashfs(p.b, p.info, rootfs)
 	if err != nil {
-		sylog.Errorf("unpackSquashfs Failed", err.Error())
+		sylog.Errorf("unpackSquashfs Failed: %s", err)
 		return nil, err
 	}
 
@@ -44,7 +44,7 @@ func (p *SquashfsPacker) unpackSquashfs(b *types.Bundle, info *loop.Info64, root
 	cmd := exec.Command("dd", "bs="+strconv.Itoa(int(info.Offset)), "skip=1", "if="+rootfs, "of="+trimfile.Name())
 	err = cmd.Run()
 	if err != nil {
-		sylog.Errorf("Trimming header Failed", err.Error())
+		sylog.Errorf("Trimming header Failed: %s", err)
 		return err
 	}
 
@@ -53,7 +53,7 @@ func (p *SquashfsPacker) unpackSquashfs(b *types.Bundle, info *loop.Info64, root
 	cmd = exec.Command("unsquashfs", "-f", "-d", b.Rootfs(), trimfile.Name())
 	err = cmd.Run()
 	if err != nil {
-		sylog.Errorf("unsquashfs Failed", err.Error())
+		sylog.Errorf("unsquashfs Failed: %s", err)
 		return err
 	}
 

--- a/src/pkg/util/fs/files/group.go
+++ b/src/pkg/util/fs/files/group.go
@@ -65,7 +65,7 @@ func Group(path string) (content []byte, err error) {
 	for _, gid := range groups {
 		grInfo, err := user.GetGrGID(uint32(gid))
 		if err != nil || grInfo == nil {
-			sylog.Verbosef("Skipping GID %d as group entry doesn't exist.\n")
+			sylog.Verbosef("Skipping GID %d as group entry doesn't exist.\n", gid)
 			continue
 		}
 		groupLine := fmt.Sprintf("%s:x:%d:%s\n", grInfo.Name, grInfo.GID, pwInfo.Name)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Several calls for sylog.Errorf, sylog.Fatalf, and sylog.Verbosef needed some fixes to pass `go vet`. Fixing these should help with debugging in the future.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test` (make check)
- [X] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin