### PR TITLE
Enable user namespace if starter-suid is not installed

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -252,6 +252,12 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	if IpcNamespace {
 		generator.AddOrReplaceLinuxNamespace("ipc", "")
 	}
+	if !UserNamespace {
+                if _, err := os.Stat(starter); os.IsNotExist(err) {
+			sylog.Verbosef("start-suid not found, using user namespace")
+                        UserNamespace = true
+                }
+        }
 	if UserNamespace {
 		generator.AddOrReplaceLinuxNamespace("user", "")
 		starter = buildcfg.SBINDIR + "/starter"

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -253,11 +253,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		generator.AddOrReplaceLinuxNamespace("ipc", "")
 	}
 	if !UserNamespace {
-                if _, err := os.Stat(starter); os.IsNotExist(err) {
+		if _, err := os.Stat(starter); os.IsNotExist(err) {
 			sylog.Verbosef("start-suid not found, using user namespace")
-                        UserNamespace = true
-                }
-        }
+			UserNamespace = true
+		}
+	}
 	if UserNamespace {
 		generator.AddOrReplaceLinuxNamespace("user", "")
 		starter = buildcfg.SBINDIR + "/starter"

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -254,7 +254,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	}
 	if !UserNamespace {
 		if _, err := os.Stat(starter); os.IsNotExist(err) {
-			sylog.Verbosef("start-suid not found, using user namespace")
+			sylog.Verbosef("starter-suid not found, using user namespace")
 			UserNamespace = true
 		}
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR implies the -u option if starter-suid is not installed.  PR #1932 splits out the packaging so when only subpackage singularity-unpriv is installed, then there is no starter-suid.

**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
