### PR TITLE
Development 3.0: Always mount underlay final in RO

### DIFF
--- a/src/pkg/util/fs/layout/layer/underlay/underlay.go
+++ b/src/pkg/util/fs/layout/layer/underlay/underlay.go
@@ -124,11 +124,18 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 		return err
 	}
 
+	flags := uintptr(syscall.MS_BIND | syscall.MS_REC | syscall.MS_RDONLY)
 	path, _ := u.session.GetPath(underlayDir)
-	err := system.Points.AddBind(mount.LayerTag, path, u.session.FinalPath(), syscall.MS_BIND|syscall.MS_REC)
+
+	err := system.Points.AddBind(mount.LayerTag, path, u.session.FinalPath(), flags)
 	if err != nil {
 		return err
 	}
+	err = system.Points.AddRemount(mount.LayerTag, u.session.FinalPath(), flags)
+	if err != nil {
+		return err
+	}
+
 	return u.session.Update()
 }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR remount underlay final mount point in read-only mode.


**This fixes or addresses the following GitHub issues:**

- Ref: #1857 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
