### PR TITLE
Cli env vars

### DIFF
--- a/src/cmd/singularity/cli/action_flags.go
+++ b/src/cmd/singularity/cli/action_flags.go
@@ -16,7 +16,7 @@ import (
 // actionflags.go contains flag variables for action-like commands to draw from
 var (
 	BindPaths   []string
-	HomePath    string
+	HomeSpec    string
 	OverlayPath []string
 	ScratchPath []string
 	WorkdirPath string
@@ -73,7 +73,7 @@ func initPathVars() {
 	actionFlags.SetAnnotation("bind", "argtag", []string{"<spec>"})
 
 	// -H|--home
-	actionFlags.StringVarP(&HomePath, "home", "H", getHomeDir(), "A home directory specification.  spec can either be a src path or src:dest pair.  src is the source path of the home directory outside the container and dest overrides the home directory within the container.")
+	actionFlags.StringVarP(&HomeSpec, "home", "H", getHomeDir(), "A home directory specification.  spec can either be a src path or src:dest pair.  src is the source path of the home directory outside the container and dest overrides the home directory within the container.")
 	actionFlags.SetAnnotation("home", "argtag", []string{"<spec>"})
 
 	// -o|--overlay

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -192,19 +192,8 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	engineConfig.SetScratchDir(ScratchPath)
 	engineConfig.SetWorkdir(WorkdirPath)
-
-	homeSlice := strings.Split(HomePath, ":")
-
-	if len(homeSlice) > 2 || len(homeSlice) == 0 {
-		sylog.Fatalf("home argument has incorrect number of elements: %v", len(homeSlice))
-	}
-
-	engineConfig.SetHomeSource(homeSlice[0])
-	if len(homeSlice) == 1 {
-		engineConfig.SetHomeDest(homeSlice[0])
-	} else {
-		engineConfig.SetHomeDest(homeSlice[1])
-	}
+	engineConfig.SetHomeSource(HomeSpec)
+	engineConfig.SetHomeDest(HomeSpec)
 
 	if IsFakeroot {
 		UserNamespace = true

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -137,6 +137,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	// temporary check for development
 	// TODO: a real URI handler
+	// if image == "" { // if image arg is blank check for an env var
+	// 	if ev := os.Getenv("SINGULARITY_IMAGE"); ev != "" {
+	// 		image = ev
+	// 	}
+	// }
 	if strings.HasPrefix(image, "instance://") {
 		instanceName := instance.ExtractName(image)
 		file, err := instance.Get(instanceName)
@@ -156,16 +161,16 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		engineConfig.SetImage(abspath)
 	}
 
-	engineConfig.SetBindPath(BindPaths)
-	engineConfig.SetOverlayImage(OverlayPath)
-	engineConfig.SetWritableImage(IsWritable)
-	engineConfig.SetNoHome(NoHome)
-	engineConfig.SetNv(Nvidia)
-	engineConfig.SetAddCaps(AddCaps)
-	engineConfig.SetDropCaps(DropCaps)
-	engineConfig.SetAllowSUID(AllowSUID)
-	engineConfig.SetKeepPrivs(KeepPrivs)
-	engineConfig.SetNoPrivs(NoPrivs)
+	engineConfig.SetBindPath(BindPaths, "SINGULARITY_BINDPATH")
+	engineConfig.SetOverlayImage(OverlayPath, "SINGULARITY_OVERLAYIMAGE")
+	engineConfig.SetWritableImage(IsWritable, "SINGULARITY_WRITABLE")
+	engineConfig.SetNoHome(NoHome, "SINGULARITY_NOHOME")
+	engineConfig.SetNv(Nvidia, "SINGULARITY_NV")
+	engineConfig.SetAddCaps(AddCaps, "SINGULARITY_ADDCAPS")
+	engineConfig.SetDropCaps(DropCaps, "SINGULARITY_DROPCAPS")
+	engineConfig.SetAllowSUID(AllowSUID, "SINGULARITY_SUID")
+	engineConfig.SetKeepPrivs(KeepPrivs, "SINGULARITY_KEEPPRIVS")
+	engineConfig.SetNoPrivs(NoPrivs, "SINGULARITY_NOPRIVS")
 
 	homeFlag := cobraCmd.Flag("home")
 	engineConfig.SetCustomHome(homeFlag.Changed)
@@ -226,7 +231,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			if Hostname == "" {
 				engineConfig.SetHostname(name)
 			}
-			engineConfig.SetDropCaps("CAP_SYS_BOOT,CAP_SYS_RAWIO")
+			engineConfig.SetDropCaps("CAP_SYS_BOOT,CAP_SYS_RAWIO", "")
 			generator.SetProcessArgs([]string{"/sbin/init"})
 		}
 		pwd, err := user.GetPwUID(uid)

--- a/src/runtime/engines/singularity/config.go
+++ b/src/runtime/engines/singularity/config.go
@@ -133,7 +133,7 @@ func (e *EngineConfig) GetWritableImage() bool {
 // SetOverlayImage sets the overlay image path to be used on top of container image.
 func (e *EngineConfig) SetOverlayImage(paths []string, envvar string) {
 	if ev := strings.Split(os.Getenv(envvar), ","); ev[0] != "" {
-		paths = ev
+		e.JSON.OverlayImage = ev
 	}
 	e.JSON.OverlayImage = paths
 }

--- a/src/runtime/engines/singularity/config.go
+++ b/src/runtime/engines/singularity/config.go
@@ -6,6 +6,9 @@
 package singularity
 
 import (
+	"os"
+	"strings"
+
 	"github.com/singularityware/singularity/src/pkg/buildcfg"
 	"github.com/singularityware/singularity/src/pkg/sylog"
 	"github.com/singularityware/singularity/src/runtime/engines/config"
@@ -104,7 +107,7 @@ func NewConfig() *EngineConfig {
 	return ret
 }
 
-// SetImage sets the container image path to be used by EngineConfig.JSON.
+// SetImage sets the container image path to be used by EngineConfig.JSON. CLI argument overrides env var if set.
 func (e *EngineConfig) SetImage(name string) {
 	e.JSON.Image = name
 }
@@ -115,7 +118,10 @@ func (e *EngineConfig) GetImage() string {
 }
 
 // SetWritableImage defines the container image as writable or not.
-func (e *EngineConfig) SetWritableImage(writable bool) {
+func (e *EngineConfig) SetWritableImage(writable bool, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		writable = true
+	}
 	e.JSON.WritableImage = writable
 }
 
@@ -125,7 +131,10 @@ func (e *EngineConfig) GetWritableImage() bool {
 }
 
 // SetOverlayImage sets the overlay image path to be used on top of container image.
-func (e *EngineConfig) SetOverlayImage(paths []string) {
+func (e *EngineConfig) SetOverlayImage(paths []string, envvar string) {
+	if ev := strings.Split(os.Getenv(envvar), ","); ev[0] != "" {
+		paths = ev
+	}
 	e.JSON.OverlayImage = paths
 }
 
@@ -155,7 +164,10 @@ func (e *EngineConfig) GetContain() bool {
 }
 
 // SetNv sets nv flag to bind cuda libraries into containee.JSON.
-func (e *EngineConfig) SetNv(nv bool) {
+func (e *EngineConfig) SetNv(nv bool, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		nv = true
+	}
 	e.JSON.Nv = nv
 }
 
@@ -214,8 +226,11 @@ func (e *EngineConfig) GetCustomHome() bool {
 	return e.JSON.CustomHome
 }
 
-// SetBindPath sets paths to bind into containee.JSON.
-func (e *EngineConfig) SetBindPath(bindpath []string) {
+// SetBindPath sets paths to bind into containee.JSON. Combines arguments and environment variables.
+func (e *EngineConfig) SetBindPath(bindpath []string, envvar string) {
+	if ev := strings.Split(os.Getenv(envvar), ","); ev[0] != "" {
+		bindpath = append(bindpath, ev...)
+	}
 	e.JSON.BindPath = bindpath
 }
 
@@ -285,7 +300,10 @@ func (e *EngineConfig) GetBootInstance() bool {
 }
 
 // SetAddCaps sets bounding/effective/permitted/inheritable/ambient capabilities to add.
-func (e *EngineConfig) SetAddCaps(caps string) {
+func (e *EngineConfig) SetAddCaps(caps string, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		caps = caps + "," + ev
+	}
 	e.JSON.AddCaps = caps
 }
 
@@ -295,7 +313,10 @@ func (e *EngineConfig) GetAddCaps() string {
 }
 
 // SetDropCaps sets bounding/effective/permitted/inheritable/ambient capabilities to drop.
-func (e *EngineConfig) SetDropCaps(caps string) {
+func (e *EngineConfig) SetDropCaps(caps string, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		caps = caps + "," + ev
+	}
 	e.JSON.DropCaps = caps
 }
 
@@ -315,7 +336,10 @@ func (e *EngineConfig) GetHostname() string {
 }
 
 // SetAllowSUID sets allow-suid flag to allow to run setuid binary inside containee.JSON.
-func (e *EngineConfig) SetAllowSUID(allow bool) {
+func (e *EngineConfig) SetAllowSUID(allow bool, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		allow = true
+	}
 	e.JSON.AllowSUID = allow
 }
 
@@ -325,7 +349,10 @@ func (e *EngineConfig) GetAllowSUID() bool {
 }
 
 // SetKeepPrivs sets keep-privs flag to allow root to retain all privileges.
-func (e *EngineConfig) SetKeepPrivs(keep bool) {
+func (e *EngineConfig) SetKeepPrivs(keep bool, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		keep = true
+	}
 	e.JSON.KeepPrivs = keep
 }
 
@@ -335,7 +362,10 @@ func (e *EngineConfig) GetKeepPrivs() bool {
 }
 
 // SetNoPrivs set no-privs flag to force root user to lose all privileges.
-func (e *EngineConfig) SetNoPrivs(nopriv bool) {
+func (e *EngineConfig) SetNoPrivs(nopriv bool, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		nopriv = true
+	}
 	e.JSON.NoPrivs = nopriv
 }
 
@@ -345,7 +375,10 @@ func (e *EngineConfig) GetNoPrivs() bool {
 }
 
 // SetNoHome set no-home flag to not mount home user home directory
-func (e *EngineConfig) SetNoHome(val bool) {
+func (e *EngineConfig) SetNoHome(val bool, envvar string) {
+	if ev := os.Getenv(envvar); ev != "" {
+		val = true
+	}
 	e.JSON.NoHome = val
 }
 

--- a/src/runtime/engines/singularity/config.go
+++ b/src/runtime/engines/singularity/config.go
@@ -197,8 +197,12 @@ func (e *EngineConfig) GetScratchDir() []string {
 }
 
 // SetHomeSource sets the source home directory path.
-func (e *EngineConfig) SetHomeSource(source string) {
-	e.JSON.HomeSource = source
+func (e *EngineConfig) SetHomeSource(homeSpec string) {
+	homeSlice := strings.Split(homeSpec, ":")
+	if len(homeSlice) > 2 || len(homeSlice) == 0 {
+		sylog.Fatalf("home argument has incorrect number of elements: %v", len(homeSlice))
+	}
+	e.JSON.HomeSource = homeSlice[0]
 }
 
 // GetHomeSource retrieves the source home directory path.
@@ -207,8 +211,16 @@ func (e *EngineConfig) GetHomeSource() string {
 }
 
 // SetHomeDest sets the container home directory path.
-func (e *EngineConfig) SetHomeDest(dest string) {
-	e.JSON.HomeDest = dest
+func (e *EngineConfig) SetHomeDest(homeSpec string) {
+	homeSlice := strings.Split(homeSpec, ":")
+	if len(homeSlice) > 2 || len(homeSlice) == 0 {
+		sylog.Fatalf("home argument has incorrect number of elements: %v", len(homeSlice))
+	}
+	if len(homeSlice) == 1 {
+		e.JSON.HomeDest = homeSlice[0]
+	} else {
+		e.JSON.HomeDest = homeSlice[1]
+	}
 }
 
 // GetHomeDest retrieves the container home directory path.


### PR DESCRIPTION
**Description of the Pull Request (PR):**
First stab at a framework for binding environment variables to flags.  

Note that viper may be able to do this?  But so far all I've figured out is that viper is able to make a hash table of your environment variables so that you can look them up easily.  Actually don't see a way to associate env vars with flags _per se_.  

Also, we need some pretty fine grained control over what the env vars do.  For instance, the variable `SINGULARITY_BINDPATH` should be combined with whatever binds are passed through the CLI.  Neither should overwrite the other.  But in the case of `SINGULARITY_OVERLAY` for instance, any CLI args should take precedence over env vars.

**This fixes or addresses the following GitHub issues:**

- Ref: #1882 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [ ] This PR is ready for review and/or merge


Attn: @singularityware-admin
