### PR TITLE
[Quick FIX] add go_tag for building bash_completion file

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -85,7 +85,7 @@ $(go_OBJ): $(BUILDDIR)/vendors-done $(libruntime) $(BUILDDIR)/config.h
 $(bash_completion): $(go_OBJ)
 	@rm -f $@
 	@mkdir -p $(@D)
-	$(V)go run  $(SOURCEDIR)/etc/bash_completion.d/bash_completion.go $@
+	$(V)go run -tags "$(go_TAG)" $(SOURCEDIR)/etc/bash_completion.d/bash_completion.go $@
 
 # install singularity CLI bash_completion file
 $(bash_completion_INSTALL): $(bash_completion)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

avoid 

```bash
# github.com/singularityware/singularity/vendor/github.com/mtrmac/gpgme
../vendor/github.com/mtrmac/gpgme/data.go:4:20: fatal error: gpgme.h: No such file or directory
 // #include <gpgme.h>
```
when running `make -j$(nproc)` 

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
