### PR TITLE
Fix unprivileged sandbox mount by removing unnecessary remount

### DIFF
--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -499,7 +499,6 @@ func (c *container) addRootfsMount(system *mount.System) error {
 		if err := system.Points.AddBind(mount.RootfsTag, rootfs, c.session.RootFsPath(), flags); err != nil {
 			return err
 		}
-		system.Points.AddRemount(mount.RootfsTag, c.session.RootFsPath(), flags)
 		return nil
 	}
 	flags |= syscall.MS_RDONLY

--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -499,6 +499,9 @@ func (c *container) addRootfsMount(system *mount.System) error {
 		if err := system.Points.AddBind(mount.RootfsTag, rootfs, c.session.RootFsPath(), flags); err != nil {
 			return err
 		}
+		if !c.userNS {
+			system.Points.AddRemount(mount.RootfsTag, c.session.RootFsPath(), flags)
+		}
 		return nil
 	}
 	flags |= syscall.MS_RDONLY


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR removes an unnecessary remount of the base image when it is a sandbox, which fails when running with -u with operation not permitted.   The remount did nothing useful anyway, it did not change any flags.


**This fixes or addresses the following GitHub issues:**

- None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
