### PR TITLE
Move Remote Builder Request/Response types to package types

### DIFF
--- a/src/pkg/build/builder_remote_test.go
+++ b/src/pkg/build/builder_remote_test.go
@@ -45,7 +45,7 @@ type mockService struct {
 
 var upgrader = websocket.Upgrader{}
 
-func newResponse(m *mockService, id bson.ObjectId, d types.Definition, libraryRef string) ResponseData {
+func newResponse(m *mockService, id bson.ObjectId, d types.Definition, libraryRef string) types.ResponseData {
 	wsURL := url.URL{
 		Scheme: "ws",
 		Host:   m.httpAddr,
@@ -59,7 +59,7 @@ func newResponse(m *mockService, id bson.ObjectId, d types.Definition, libraryRe
 		libraryRef = "library://user/collection/image"
 	}
 
-	return ResponseData{
+	return types.ResponseData{
 		ID:         id,
 		Definition: d,
 		WSURL:      wsURL.String(),
@@ -72,7 +72,7 @@ func (m *mockService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Set the respone body, depending on the type of operation
 	if r.Method == http.MethodPost && r.RequestURI == buildPath {
 		// Mock new build endpoint
-		var rd RequestData
+		var rd types.RequestData
 		if err := json.NewDecoder(r.Body).Decode(&rd); err != nil {
 			m.t.Fatalf("failed to parse request: %v", err)
 		}

--- a/src/pkg/build/types/remote.go
+++ b/src/pkg/build/types/remote.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package types
+
+import (
+	"time"
+
+	"github.com/globalsign/mgo/bson"
+)
+
+// RequestData contains the info necessary for submitting a build to a remote service
+type RequestData struct {
+	Definition  `json:"definition"`
+	LibraryRef  string `json:"libraryRef"`
+	LibraryURL  string `json:"libraryURL"`
+	CallbackURL string `json:"callbackURL"`
+}
+
+// ResponseData contains the details of an individual build
+type ResponseData struct {
+	ID            bson.ObjectId `json:"id"`
+	CreatedBy     string        `json:"createdBy"`
+	SubmitTime    time.Time     `json:"submitTime"`
+	StartTime     *time.Time    `json:"startTime,omitempty" bson:",omitempty"`
+	IsComplete    bool          `json:"isComplete"`
+	CompleteTime  *time.Time    `json:"completeTime,omitempty"`
+	ImageSize     int64         `json:"imageSize,omitempty"`
+	ImageChecksum string        `json:"imageChecksum,omitempty"`
+	Definition    Definition    `json:"definition"`
+	WSURL         string        `json:"wsURL,omitempty" bson:"-"`
+	LibraryRef    string        `json:"libraryRef"`
+	LibraryURL    string        `json:"libraryURL"`
+	CallbackURL   string        `json:"callbackURL"`
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

To resolve problems for @tri-adam we move RB data types to `src/pkg/build/types`