### PR TITLE
Set default PATH for compatibility with older images

### DIFF
--- a/src/pkg/util/env/clean.go
+++ b/src/pkg/util/env/clean.go
@@ -41,7 +41,7 @@ func SetContainerEnv(g *generate.Generator, env []string, cleanEnv bool, homeDes
 	}
 
 	g.AddProcessEnv("HOME", homeDest)
-        g.AddProcessEnv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin")
+	g.AddProcessEnv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin")
 
 	// Set LANG env
 	if cleanEnv {

--- a/src/pkg/util/env/clean.go
+++ b/src/pkg/util/env/clean.go
@@ -41,6 +41,7 @@ func SetContainerEnv(g *generate.Generator, env []string, cleanEnv bool, homeDes
 	}
 
 	g.AddProcessEnv("HOME", homeDest)
+        g.AddProcessEnv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin")
 
 	// Set LANG env
 	if cleanEnv {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR sets the same default PATH that was set with singularity-2.x.  It helps with older images that do not have /.singularity.d/env/10-docker.sh which normally sets the default PATH.

**This fixes or addresses the following GitHub issues:**

None


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
