### PR TITLE
Set the HOME environment variable when setting different privileges during testing

### DIFF
--- a/src/pkg/test/privilege.go
+++ b/src/pkg/test/privilege.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/user"
 	"runtime"
+	"strconv"
 	"syscall"
 	"testing"
 )
@@ -133,7 +134,7 @@ func getUnprivIDs(pid int) (uid int, gid int) {
 func init() {
 	origUID = os.Getuid()
 	origGID = os.Getgid()
-	origUser, err := user.LookupId(fmt.Sprintf("%d", origUID))
+	origUser, err := user.LookupId(strconv.Itoa(origUID))
 
 	if err != nil {
 		log.Fatalf("err: %s", err)
@@ -142,7 +143,7 @@ func init() {
 	origHome = origUser.HomeDir
 
 	unprivUID, unprivGID = getUnprivIDs(os.Getpid())
-	unprivUser, err := user.LookupId(fmt.Sprintf("%d", unprivUID))
+	unprivUser, err := user.LookupId(strconv.Itoa(unprivUID))
 
 	if err != nil {
 		log.Fatalf("err: %s", err)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Make sure to set the environment variable `HOME` to the correct value for whatever uid you are changing privileges to during testing.

**This fixes or addresses the following GitHub issues:**

- Fixes #1969 


**Checkoff for all PRs:**

- [ ] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [X] I have tested this PR locally with a `make test`
- [X] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularityware-admin
