### PR TITLE
Def parser fix for definitions with no header

### DIFF
--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -320,11 +320,8 @@ func makeDef(spec string) (types.Definition, error) {
 		if err != nil {
 			return def, fmt.Errorf("unable to parse URI %s: %v", spec, err)
 		}
-	}
-
-	// Non-URI passed as spec
-	if _, err := os.Stat(spec); err == nil {
-
+	} else if _, err := os.Stat(spec); err == nil {
+		// Non-URI passed as spec
 		defFile, err := os.Open(spec)
 		if err != nil {
 			return def, fmt.Errorf("unable to open file %s: %v", spec, err)

--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -338,10 +338,8 @@ func makeDef(spec string) (types.Definition, error) {
 		if err != nil {
 			return def, fmt.Errorf("unable to parse URI %s: %v", spec, err)
 		}
-	}
-	// Non-URI passed as spec
-	if _, err := os.Stat(spec); err == nil {
-
+	} else if _, err := os.Stat(spec); err == nil {
+		// Non-URI passed as spec
 		defFile, err := os.Open(spec)
 		if err != nil {
 			return def, fmt.Errorf("unable to open file %s: %v", spec, err)

--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -98,10 +98,13 @@ func newBuild(d types.Definition, dest, format string, force, update bool, secti
 
 	b.addOptions()
 
-	if c, err := getcp(b.d); err == nil {
-		b.c = c
-	} else {
-		return nil, fmt.Errorf("unable to get conveyorpacker: %s", err)
+	// dont need to get cp if we're skipping bootstrap
+	if !update || force {
+		if c, err := getcp(b.d); err == nil {
+			b.c = c
+		} else {
+			return nil, fmt.Errorf("unable to get conveyorpacker: %s", err)
+		}
 	}
 
 	switch format {

--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -289,26 +289,6 @@ func (b *Build) runBuildEngine() error {
 	return nil
 }
 
-// Bundle creates the bundle using the ConveyorPacker and returns it. If this
-// function is called multiple times it will return the already created Bundle
-// func (b *Build) Bundle() (*types.Bundle, error) {
-
-// 	if err := b.c.Get(b.b); err != nil {
-// 		return nil, fmt.Errorf("conveyor failed to get: %v", err)
-// 	}
-
-// 	bundle, err := b.c.Pack()
-// 	if err != nil {
-// 		return nil, fmt.Errorf("packer failed to pack: %v", err)
-// 	}
-
-// 	b.b = bundle
-
-// 	b.addOptions()
-
-// 	return b.b, nil
-// }
-
 func getcp(def types.Definition) (ConveyorPacker, error) {
 	switch def.Header["bootstrap"] {
 	case "shub":

--- a/src/pkg/build/types/definition.go
+++ b/src/pkg/build/types/definition.go
@@ -9,10 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"strings"
-
-	"github.com/singularityware/singularity/src/pkg/sylog"
 )
 
 // Definition describes how to build an image.
@@ -120,17 +117,4 @@ var validHeaders = map[string]bool{
 	"mirrorurl":  true,
 	"osversion":  true,
 	"include":    true,
-}
-
-// IsValidDefinition returns whether or not the given file is a valid definition
-func IsValidDefinition(source string) (valid bool, err error) {
-	defFile, err := os.Open(source)
-	if err != nil {
-		sylog.Fatalf("unable to open file %s: %v\n", source, err)
-	}
-	defer defFile.Close()
-
-	ok, _ := canGetHeader(defFile)
-
-	return ok, nil
 }

--- a/src/pkg/build/types/definition_parser_deffile.go
+++ b/src/pkg/build/types/definition_parser_deffile.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"reflect"
 	"strings"
 	"unicode"
 
@@ -202,6 +203,14 @@ func doSections(s *bufio.Scanner, d *Definition) (err error) {
 		Test:  sections["test"],
 	}
 
+	// make sure information was valid by checking if definition is not equal to an empty one
+	emptyDef := new(Definition)
+	//labels is always initialized
+	emptyDef.Labels = make(map[string]string)
+	if reflect.DeepEqual(d, emptyDef) {
+		return fmt.Errorf("parsed definition did not have any valid information")
+	}
+
 	return
 }
 
@@ -247,7 +256,7 @@ func ParseDefinitionFile(r io.Reader) (d Definition, err error) {
 	}
 
 	if err = doSections(s, &d); err != nil {
-		sylog.Warningf("failed to parse DefFile sections: %v\n", err)
+		return d, fmt.Errorf("failed to parse DefFile sections: %v", err)
 	}
 
 	return

--- a/src/pkg/build/types/definition_parser_deffile_test.go
+++ b/src/pkg/build/types/definition_parser_deffile_test.go
@@ -135,7 +135,7 @@ func TestParseDefinitionFileFailure(t *testing.T) {
 			}
 			defer defFile.Close()
 
-			if _, err := ParseDefinitionFile(defFile); err == nil {
+			if _, err = ParseDefinitionFile(defFile); err == nil {
 				t.Fatal("unexpected success parsing definition file")
 			}
 		}))

--- a/src/pkg/build/types/definition_parser_deffile_test.go
+++ b/src/pkg/build/types/definition_parser_deffile_test.go
@@ -8,6 +8,7 @@ package types
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -135,7 +136,8 @@ func TestParseDefinitionFileFailure(t *testing.T) {
 			}
 			defer defFile.Close()
 
-			if _, err = ParseDefinitionFile(defFile); err == nil {
+			if d, err := ParseDefinitionFile(defFile); err == nil {
+				fmt.Println(d)
 				t.Fatal("unexpected success parsing definition file")
 			}
 		}))

--- a/src/pkg/build/types/definition_parser_deffile_test.go
+++ b/src/pkg/build/types/definition_parser_deffile_test.go
@@ -8,7 +8,6 @@ package types
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -136,8 +135,7 @@ func TestParseDefinitionFileFailure(t *testing.T) {
 			}
 			defer defFile.Close()
 
-			if d, err := ParseDefinitionFile(defFile); err == nil {
-				fmt.Println(d)
+			if _, err := ParseDefinitionFile(defFile); err == nil {
 				t.Fatal("unexpected success parsing definition file")
 			}
 		}))


### PR DESCRIPTION
Def parser scanner returns the first section it runs into if there isn't a header, which was causing an index out of range panic. This detects if the first returned token is a header or not and parses it accordingly.