### PR TITLE
Set SINGULARITY_CACHEDIR with the current UID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ before_install:
   - go get -u golang.org/x/lint/golint
   - export PATH="${GOPATH}/bin:${PATH}"
 
-env:
-  global:
-    - SINGULARITY_CACHEDIR=/tmp/singularity_test/cache
-
 install:
   - ./mconfig -p /usr/local
   - make -j `nproc 2>/dev/null || echo 1` -C ./builddir

--- a/src/pkg/test/privilege.go
+++ b/src/pkg/test/privilege.go
@@ -29,7 +29,7 @@ func EnsurePrivilege(t *testing.T) {
 }
 
 // DropPrivilege drops privilege. Use this at the start of a test that does
-// not require elevated privleges. A matching call to ResetPrivilege must
+// not require elevated privileges. A matching call to ResetPrivilege must
 // occur before the test completes (a defer statement is recommended.)
 func DropPrivilege(t *testing.T) {
 
@@ -51,6 +51,9 @@ func DropPrivilege(t *testing.T) {
 			t.Fatalf("failed to set HOME environment variable: %v", err)
 		}
 	}
+
+	// set SINGULARITY_CACHEDIR
+	os.Setenv("SINGULARITY_CACHEDIR", fmt.Sprintf("/tmp/WithoutPrivilege_UID%d", os.Getuid()))
 }
 
 // ResetPrivilege returns effective privilege to the original user.
@@ -66,6 +69,9 @@ func ResetPrivilege(t *testing.T) {
 	}
 
 	runtime.UnlockOSThread()
+
+	// set SINGULARITY_CACHEDIR
+	os.Setenv("SINGULARITY_CACHEDIR", fmt.Sprintf("/tmp/WithPrivilege_UID%d", os.Getuid()))
 }
 
 // WithPrivilege wraps the supplied test function with calls to ensure
@@ -73,6 +79,9 @@ func ResetPrivilege(t *testing.T) {
 func WithPrivilege(f func(t *testing.T)) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
+
+		// set SINGULARITY_CACHEDIR
+		os.Setenv("SINGULARITY_CACHEDIR", fmt.Sprintf("/tmp/WithPrivilege_UID%d", os.Getuid()))
 
 		EnsurePrivilege(t)
 
@@ -88,6 +97,9 @@ func WithoutPrivilege(f func(t *testing.T)) func(t *testing.T) {
 
 		DropPrivilege(t)
 		defer ResetPrivilege(t)
+
+		// set SINGULARITY_CACHEDIR
+		os.Setenv("SINGULARITY_CACHEDIR", fmt.Sprintf("/tmp/WithoutPrivilege_UID%d", os.Getuid()))
 
 		f(t)
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

set the ENV VAR SINGULARITY_CACHEDIR, according to the calling user when testing
 - WithoutPrivilege
 -  WithPrivilege

```bash
[eduardo@rhel7 tmp]$ ls -l | grep With
drwxr-xr-x.   3 eduardo eduardo       17 Sep 13 14:22 WithoutPrivilege_UID1000
drwxr-xr-x.   3 root    root          17 Sep 13 14:22 WithPrivilege_UID0
```

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
