### PR TITLE
Remove useragent dependency on buildcfg package

### DIFF
--- a/src/cmd/singularity/cli.go
+++ b/src/cmd/singularity/cli.go
@@ -5,10 +5,17 @@
 
 package main
 
-import "github.com/singularityware/singularity/src/cmd/singularity/cli"
+import (
+	"github.com/singularityware/singularity/src/cmd/singularity/cli"
+	"github.com/singularityware/singularity/src/pkg/buildcfg"
+	useragent "github.com/singularityware/singularity/src/pkg/util/user-agent"
+)
 
 func main() {
-
 	// In cli/singularity.go
 	cli.ExecuteSingularity()
+}
+
+func init() {
+	useragent.InitValue(buildcfg.PACKAGE_NAME, buildcfg.PACKAGE_VERSION)
 }

--- a/src/pkg/build/assemblers/assembler_sif_test.go
+++ b/src/pkg/build/assemblers/assembler_sif_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/singularityware/singularity/src/pkg/build/sources"
 	"github.com/singularityware/singularity/src/pkg/build/types"
 	"github.com/singularityware/singularity/src/pkg/test"
+	useragent "github.com/singularityware/singularity/src/pkg/util/user-agent"
 )
 
 const (
@@ -21,6 +22,12 @@ const (
 	assemblerShubURI    = "shub://ikaneshiro/singularityhub:latest"
 	assemblerShubDest   = "/tmp/shub_alpine_assemble_test.sif"
 )
+
+func TestMain(m *testing.M) {
+	useragent.InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
+
+	os.Exit(m.Run())
+}
 
 // TestAssembler sees if we can build a SIF image from a docke based kitchen to /tmp
 func TestSIFAssemblerDocker(t *testing.T) {

--- a/src/pkg/build/builder_remote.go
+++ b/src/pkg/build/builder_remote.go
@@ -124,7 +124,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 func (rb *RemoteBuilder) streamOutput(ctx context.Context, url string) (err error) {
 	h := http.Header{}
 	rb.setAuthHeader(h)
-	h.Set("User-Agent", useragent.Value)
+	h.Set("User-Agent", useragent.Value())
 
 	c, _, err := websocket.DefaultDialer.Dial(url, h)
 	if err != nil {
@@ -182,7 +182,7 @@ func (rb *RemoteBuilder) doBuildRequest(ctx context.Context, d types.Definition,
 	}
 	req = req.WithContext(ctx)
 	rb.setAuthHeader(req.Header)
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := rb.Client.Do(req)
@@ -208,7 +208,7 @@ func (rb *RemoteBuilder) doStatusRequest(ctx context.Context, id bson.ObjectId) 
 	}
 	req = req.WithContext(ctx)
 	rb.setAuthHeader(req.Header)
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 
 	res, err := rb.Client.Do(req)
 	if err != nil {

--- a/src/pkg/build/builder_remote_test.go
+++ b/src/pkg/build/builder_remote_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/singularityware/singularity/src/pkg/build/types"
 	"github.com/singularityware/singularity/src/pkg/test"
+	useragent "github.com/singularityware/singularity/src/pkg/util/user-agent"
 )
 
 const (
@@ -44,6 +45,12 @@ type mockService struct {
 }
 
 var upgrader = websocket.Upgrader{}
+
+func TestMain(m *testing.M) {
+	useragent.InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
+
+	os.Exit(m.Run())
+}
 
 func newResponse(m *mockService, id bson.ObjectId, d types.Definition, libraryRef string) types.ResponseData {
 	wsURL := url.URL{

--- a/src/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/src/pkg/build/sources/conveyorPacker_oci_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/singularityware/singularity/src/pkg/build/sources"
 	"github.com/singularityware/singularity/src/pkg/build/types"
 	"github.com/singularityware/singularity/src/pkg/test"
+	useragent "github.com/singularityware/singularity/src/pkg/util/user-agent"
 )
 
 const (
@@ -25,6 +26,12 @@ const (
 	ociArchiveURI     = "https://s3.amazonaws.com/singularity-ci-public/alpine-oci-archive.tar"
 	dockerDaemonImage = "alpine:latest"
 )
+
+func TestMain(m *testing.M) {
+	useragent.InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
+
+	os.Exit(m.Run())
+}
 
 // TestOCIConveyorDocker tests if we can pull an alpine image from dockerhub
 func TestOCIConveyorDocker(t *testing.T) {

--- a/src/pkg/library/client/api.go
+++ b/src/pkg/library/client/api.go
@@ -212,7 +212,7 @@ func apiCreate(o interface{}, url string, authToken string) (objJSON []byte, err
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 
 	client := &http.Client{
 		Timeout: (httpTimeout * time.Second),
@@ -248,7 +248,7 @@ func apiGet(url string, authToken string) (objJSON []byte, found bool, err error
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 	res, err := client.Do(req)
 	if err != nil {
 		return []byte{}, false, fmt.Errorf("error making request to server:\n\t%v", err)
@@ -285,7 +285,7 @@ func apiGetTags(url string, authToken string) (tags TagMap, err error) {
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request to server:\n\t%v", err)
@@ -318,7 +318,7 @@ func apiSetTag(url string, authToken string, t ImageTag) (err error) {
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 	client := &http.Client{
 		Timeout: (httpTimeout * time.Second),
 	}

--- a/src/pkg/library/client/api_test.go
+++ b/src/pkg/library/client/api_test.go
@@ -9,11 +9,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/singularityware/singularity/src/pkg/test"
+	useragent "github.com/singularityware/singularity/src/pkg/util/user-agent"
 )
 
 const testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
@@ -73,6 +75,12 @@ type mockService struct {
 	httpPath    string
 	httpServer  *httptest.Server
 	baseURI     string
+}
+
+func TestMain(m *testing.M) {
+	useragent.InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
+
+	os.Exit(m.Run())
 }
 
 func (m *mockService) Run() {

--- a/src/pkg/library/client/pull.go
+++ b/src/pkg/library/client/pull.go
@@ -63,7 +63,7 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string, Force 
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/src/pkg/library/client/push.go
+++ b/src/pkg/library/client/push.go
@@ -138,7 +138,7 @@ func postFile(baseURL string, authToken string, filePath string, imageID string)
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 	// Content length is required by the API
 	req.ContentLength = fileSize
 	client := &http.Client{

--- a/src/pkg/shub/client/api.go
+++ b/src/pkg/shub/client/api.go
@@ -74,7 +74,7 @@ func getManifest(uri ShubURI) (manifest ShubAPIResponse, err error) {
 	if err != nil {
 		return ShubAPIResponse{}, err
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 
 	// Do the request, if status isn't success, return error
 	res, err := httpc.Do(req)

--- a/src/pkg/shub/client/pull.go
+++ b/src/pkg/shub/client/pull.go
@@ -62,7 +62,7 @@ func DownloadImage(filePath string, shubRef string, force bool) (err error) {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", useragent.Value)
+	req.Header.Set("User-Agent", useragent.Value())
 
 	// Do the request, if status isn't success, return error
 	resp, err := httpc.Do(req)

--- a/src/pkg/shub/client/util_test.go
+++ b/src/pkg/shub/client/util_test.go
@@ -7,9 +7,11 @@ package client
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/singularityware/singularity/src/pkg/test"
+	useragent "github.com/singularityware/singularity/src/pkg/util/user-agent"
 )
 
 var (
@@ -27,6 +29,12 @@ var (
 		`shub://myprivateregistry.sylabs.io/sylabs/container:latest`,
 	}
 )
+
+func TestMain(m *testing.M) {
+	useragent.InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
+
+	os.Exit(m.Run())
+}
 
 // TestShubParser checks if the Shub ref parser is working as expected
 func TestIsShubPullRef(t *testing.T) {

--- a/src/pkg/sypgp/sypgp.go
+++ b/src/pkg/sypgp/sypgp.go
@@ -434,7 +434,7 @@ func SearchPubkey(search, keyserverURI, authToken string) (string, error) {
 	if authToken != "" {
 		r.Header.Set("Authorization", fmt.Sprintf("BEARER %s", authToken))
 	}
-	r.Header.Set("User-Agent", useragent.Value)
+	r.Header.Set("User-Agent", useragent.Value())
 
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
@@ -475,7 +475,7 @@ func FetchPubkey(fingerprint, keyserverURI, authToken string) (openpgp.EntityLis
 	if authToken != "" {
 		r.Header.Set("Authorization", fmt.Sprintf("BEARER %s", authToken))
 	}
-	r.Header.Set("User-Agent", useragent.Value)
+	r.Header.Set("User-Agent", useragent.Value())
 
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
@@ -532,7 +532,7 @@ func PushPubkey(entity *openpgp.Entity, keyserverURI, authToken string) error {
 	if authToken != "" {
 		r.Header.Set("Authorization", fmt.Sprintf("BEARER %s", authToken))
 	}
-	r.Header.Set("User-Agent", useragent.Value)
+	r.Header.Set("User-Agent", useragent.Value())
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := http.DefaultClient.Do(r)

--- a/src/pkg/sypgp/sypgp_test.go
+++ b/src/pkg/sypgp/sypgp_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"testing"
 
+	useragent "github.com/singularityware/singularity/src/pkg/util/user-agent"
 	"golang.org/x/crypto/openpgp"
 )
 
@@ -24,6 +25,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	useragent.InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
+
 	e, err := openpgp.NewEntity(testName, testComment, testEmail, nil)
 	if err != nil {
 		log.Fatalf("failed to create entity: %v", err)

--- a/src/pkg/util/user-agent/agent.go
+++ b/src/pkg/util/user-agent/agent.go
@@ -9,30 +9,37 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-
-	"github.com/singularityware/singularity/src/pkg/buildcfg"
 )
 
 // Value contains the Singularity user agent.
 //
 // For example, "Singularity/3.0.0 (linux amd64) Go/1.10.3".
-var Value string
+func Value() string {
+	if value == "" {
+		panic("useragent.InitValue() must be called before calling useragent.Value()")
+	}
 
-func singularityVersion() string {
-	product := strings.Title(buildcfg.PACKAGE_NAME)
-	version := strings.Split(buildcfg.PACKAGE_VERSION, "-")[0]
-	return fmt.Sprintf("%v/%v", product, version)
+	return value
+}
+
+var value string
+
+// InitValue does ...
+func InitValue(name, version string) {
+	value = fmt.Sprintf("%v (%v %v) %v",
+		singularityVersion(name, version),
+		strings.Title(runtime.GOOS),
+		runtime.GOARCH,
+		goVersion())
+}
+
+func singularityVersion(name, version string) string {
+	product := strings.Title(name)
+	ver := strings.Split(version, "-")[0]
+	return fmt.Sprintf("%v/%v", product, ver)
 }
 
 func goVersion() string {
 	version := strings.TrimPrefix(runtime.Version(), "go")
 	return fmt.Sprintf("Go/%v", version)
-}
-
-func init() {
-	Value = fmt.Sprintf("%v (%v %v) %v",
-		singularityVersion(),
-		strings.Title(runtime.GOOS),
-		runtime.GOARCH,
-		goVersion())
 }

--- a/src/pkg/util/user-agent/agent_test.go
+++ b/src/pkg/util/user-agent/agent_test.go
@@ -11,8 +11,10 @@ import (
 )
 
 func TestSingularityVersion(t *testing.T) {
+	InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
+
 	re := regexp.MustCompile("Singularity/[[:digit:]]+(.[[:digit:]]+){2} \\(Linux [[:alnum:]]+\\) Go/[[:digit:]]+(.[[:digit:]]+){2}")
-	if !re.MatchString(Value) {
+	if !re.MatchString(Value()) {
 		t.Fatalf("user agent did not match regexp")
 	}
 }


### PR DESCRIPTION
Users of `useragent` package should now reference `useragent.Value()` after setting value via `useragent.InitValue()`