### PR TITLE
Shub pull panic fix

### DIFF
--- a/src/pkg/shub/client/api.go
+++ b/src/pkg/shub/client/api.go
@@ -21,7 +21,7 @@ import (
 const (
 	defaultRegistry string = `https://singularity-hub.org`
 	shubAPIRoute    string = "/api/container/"
-	//URINotSupported if we are using a non default registry error out for now
+	// URINotSupported if we are using a non default registry error out for now
 	URINotSupported string = "Only the default Singularity Hub registry is suported for now"
 )
 

--- a/src/pkg/shub/client/api.go
+++ b/src/pkg/shub/client/api.go
@@ -78,6 +78,9 @@ func getManifest(uri ShubURI) (manifest ShubAPIResponse, err error) {
 
 	// Do the request, if status isn't success, return error
 	res, err := httpc.Do(req)
+	if res == nil {
+		return ShubAPIResponse{}, fmt.Errorf("No response received from singularity hub")
+	}
 	if res.StatusCode == http.StatusNotFound {
 		return ShubAPIResponse{}, fmt.Errorf("The requested manifest was not found in singularity hub")
 	}

--- a/src/pkg/shub/client/pull.go
+++ b/src/pkg/shub/client/pull.go
@@ -66,6 +66,9 @@ func DownloadImage(filePath string, shubRef string, force bool) (err error) {
 
 	// Do the request, if status isn't success, return error
 	resp, err := httpc.Do(req)
+	if resp == nil {
+		return fmt.Errorf("No response received from singularity hub")
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("The requested image was not found in singularity hub")
 	}

--- a/src/pkg/shub/client/pull.go
+++ b/src/pkg/shub/client/pull.go
@@ -26,7 +26,7 @@ const pullTimeout = 7200
 func DownloadImage(filePath string, shubRef string, force bool) (err error) {
 	sylog.Debugf("Downloading container from Shub")
 
-	//use custom parser to make sure we have a valid shub URI
+	// use custom parser to make sure we have a valid shub URI
 	if ok := isShubPullRef(shubRef); !ok {
 		sylog.Fatalf("Invalid shub URI: %v", err)
 	}
@@ -106,7 +106,7 @@ func DownloadImage(filePath string, shubRef string, force bool) (err error) {
 	if err != nil {
 		return err
 	}
-	//Simple check to make sure image received is the correct size
+	// Simple check to make sure image received is the correct size
 	if bytesWritten != resp.ContentLength {
 		return fmt.Errorf("Image received is not the right size. Supposed to be: %v  Actually: %v", resp.ContentLength, bytesWritten)
 	}

--- a/src/pkg/shub/client/util.go
+++ b/src/pkg/shub/client/util.go
@@ -14,14 +14,14 @@ import (
 // isShubPullRef returns true if the provided string is a valid Shub
 // reference for a pull operation.
 func isShubPullRef(shubRef string) bool {
-	//define regex for each URI component
-	registryRegexp := `([-.a-zA-Z0-9/]{1,64}\/)?`           //target is very open, outside registry
-	nameRegexp := `([-a-zA-Z0-9]{1,39}\/)`                  //target valid github usernames
-	containerRegexp := `([-_.a-zA-Z0-9]{1,64})`             //target valid github repo names
-	tagRegexp := `(:[-_.a-zA-Z0-9]{1,64})?`                 //target is very open, file extensions or branch names
-	digestRegexp := `((\@[a-f0-9]{32})|(\@[a-f0-9]{40}))?$` //target file md5 has, git commit hash, git branch
+	// define regex for each URI component
+	registryRegexp := `([-.a-zA-Z0-9/]{1,64}\/)?`           // target is very open, outside registry
+	nameRegexp := `([-a-zA-Z0-9]{1,39}\/)`                  // target valid github usernames
+	containerRegexp := `([-_.a-zA-Z0-9]{1,64})`             // target valid github repo names
+	tagRegexp := `(:[-_.a-zA-Z0-9]{1,64})?`                 // target is very open, file extensions or branch names
+	digestRegexp := `((\@[a-f0-9]{32})|(\@[a-f0-9]{40}))?$` // target file md5 has, git commit hash, git branch
 
-	//expression is anchored
+	// expression is anchored
 	shubRegex, err := regexp.Compile(`^(shub://)` + registryRegexp + nameRegexp + containerRegexp + tagRegexp + digestRegexp + `$`)
 	if err != nil {
 		return false
@@ -29,8 +29,8 @@ func isShubPullRef(shubRef string) bool {
 
 	found := shubRegex.FindString(shubRef)
 
-	//sanity check
-	//if found string is not equal to the input, input isn't a valid URI
+	// sanity check
+	// if found string is not equal to the input, input isn't a valid URI
 	if strings.Compare(shubRef, found) != 0 {
 		return false
 	}
@@ -46,12 +46,12 @@ func shubParseReference(src string) (uri ShubURI, err error) {
 	refParts := strings.Split(ShubRef, "/")
 
 	if l := len(refParts); l > 2 {
-		//more than two pieces indicates a custom registry
+		// more than two pieces indicates a custom registry
 		uri.registry = strings.Join(refParts[:l-2], "") + shubAPIRoute
 		uri.user = refParts[l-2]
 		src = refParts[l-1]
 	} else if l == 2 {
-		//two pieces means default registry
+		// two pieces means default registry
 		uri.registry = defaultRegistry + shubAPIRoute
 		uri.user = refParts[l-2]
 		src = refParts[l-1]
@@ -59,21 +59,21 @@ func shubParseReference(src string) (uri ShubURI, err error) {
 		return ShubURI{}, errors.New("Not a valid Shub reference")
 	}
 
-	//look for an @ and split if it exists
+	// look for an @ and split if it exists
 	if strings.Contains(src, `@`) {
 		refParts = strings.Split(src, `@`)
 		uri.digest = `@` + refParts[1]
 		src = refParts[0]
 	}
 
-	//look for a : and split if it exists
+	// look for a : and split if it exists
 	if strings.Contains(src, `:`) {
 		refParts = strings.Split(src, `:`)
 		uri.tag = `:` + refParts[1]
 		src = refParts[0]
 	}
 
-	//container name is left over after other parts are split from it
+	// container name is left over after other parts are split from it
 	uri.container = src
 
 	return uri, nil


### PR DESCRIPTION
Fixes the panic caused by a nil http response, output below:

```DEBUG[U=2000,P=15176]   Get()                         Getting container from Shub
DEBUG[U=2000,P=15176]   NewBundle()                   Created temporary directory for bundle /tmp/sbuild-shub-103409937
DEBUG[U=2000,P=15176]   DownloadImage()               Downloading container from Shub
--- FAIL: TestShubConveyor (30.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xc4dd6a]
goroutine 174 [running]:
testing.tRunner.func1(0xc4202ea0f0)
	/home/travis/.gimme/versions/go1.10.4.linux.amd64/src/testing/testing.go:742 +0x567
panic(0xd646c0, 0x1488240)
	/home/travis/.gimme/versions/go1.10.4.linux.amd64/src/runtime/panic.go:502 +0x24a
github.com/singularityware/singularity/src/pkg/shub/client.getManifest(0xe48f3e, 0x2a, 0xc42040a007, 0xa, 0xc42040a012, 0xe, 0xc4203b02a0, 0x7, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/singularityware/singularity/src/pkg/shub/client/api.go:81 +0x86a
github.com/singularityware/singularity/src/pkg/shub/client.DownloadImage(0xc42040a030, 0x2c, 0xc42040a000, 0x27, 0xc4200b6301, 0x0, 0x0)
	/home/travis/gopath/src/github.com/singularityware/singularity/src/pkg/shub/client/pull.go:51 +0x2ba
github.com/singularityware/singularity/src/pkg/build/sources.(*ShubConveyorPacker).Get(0xc420791e80, 0xc420136000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/singularityware/singularity/src/pkg/build/sources/conveyorPacker_shub.go:48 +0x4a0
github.com/singularityware/singularity/src/pkg/build/sources_test.TestShubConveyor(0xc4202ea0f0)
	/home/travis/gopath/src/github.com/singularityware/singularity/src/pkg/build/sources/conveyorPacker_shub_test.go:37 +0x2c1
testing.tRunner(0xc4202ea0f0, 0xe5f9a0)
	/home/travis/.gimme/versions/go1.10.4.linux.amd64/src/testing/testing.go:777 +0x16e
created by testing.(*T).Run
	/home/travis/.gimme/versions/go1.10.4.linux.amd64/src/testing/testing.go:824 +0x565```


Also, some comment formatting fixes