### PR TITLE
Remove flag "-vendor-only" dep ensure.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -181,12 +181,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
@@ -479,6 +473,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b5a4f3db8e7b9ce196abd32da6f27af3c42393d28180ad159555491466c80a03"
+  inputs-digest = "d8f4cbc291442f0f7a09ef95674446f88bc9732cb8c9d96abf4d0bd750db2902"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -113,7 +113,7 @@ $(dist_bin_SCRIPTS_INSTALL): $(dist_bin_SCRIPTS)
 $(BUILDDIR)/vendors-done:
 	@echo " VENDORS"
 	@if [ ! -f $(BUILDDIR)/.dep-done ]; then \
-		dep ensure -vendor-only >/dev/null 2>&1 && \
+		dep ensure >/dev/null 2>&1 && \
 			touch $(BUILDDIR)/.dep-done; \
 	fi
 	@if [ ! -f $(BUILDDIR)/.patch-done ]; then \


### PR DESCRIPTION
This helps with checking that our lock file is in sync with our usage of those vendor packages.