### PR TITLE
Development 3.0: Fix bind relative source path

### DIFF
--- a/src/runtime/engines/singularity/config.go
+++ b/src/runtime/engines/singularity/config.go
@@ -80,6 +80,7 @@ type JSONConfig struct {
 	NoHome        bool          `json:"noHome,omitempty"`
 	NoInit        bool          `json:"noInit,omitempty"`
 	ImageList     []image.Image `json:"imageList,omitempty"`
+	Cwd           string        `json:"cwd,omitempty"`
 }
 
 // EngineConfig stores both the JSONConfig and the FileConfig
@@ -363,4 +364,14 @@ func (e *EngineConfig) SetImageList(list []image.Image) {
 // GetImageList returns image list containing opened images
 func (e *EngineConfig) GetImageList() []image.Image {
 	return e.JSON.ImageList
+}
+
+// SetCwd sets current working directory
+func (e *EngineConfig) SetCwd(path string) {
+	e.JSON.Cwd = path
+}
+
+// GetCwd returns current working directory
+func (e *EngineConfig) GetCwd() string {
+	return e.JSON.Cwd
 }

--- a/src/runtime/engines/singularity/prepare.go
+++ b/src/runtime/engines/singularity/prepare.go
@@ -283,6 +283,15 @@ func (e *EngineOperations) PrepareConfig(masterConn net.Conn, starterConfig *sta
 		return fmt.Errorf("SUID workflow disabled by administrator")
 	}
 
+	// Save the current working directory to restore it in stage 2
+	// for relative bind paths
+	if pwd, err := os.Getwd(); err == nil {
+		e.EngineConfig.SetCwd(pwd)
+	} else {
+		sylog.Warningf("can't determine current working directory")
+		e.EngineConfig.SetCwd("/")
+	}
+
 	if e.EngineConfig.OciConfig.Process == nil {
 		e.EngineConfig.OciConfig.Process = &specs.Process{}
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes bind relative source path when used with instances, since instances changes the current working directory, `filepath.Abs` returned an invalid absolute source path. Two methods were added to track current working directory and restore it later before mount process.

**This fixes or addresses the following GitHub issues:**

- Ref: #1989 #1963 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
