### PR TITLE
Development 3.0: Reset MS_RDONLY flag in loops

### DIFF
--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -588,6 +588,7 @@ func (c *container) addOverlayMount(system *mount.System) error {
 			if err != nil {
 				return err
 			}
+			flags &^= syscall.MS_RDONLY
 		case image.SQUASHFS:
 			flags := uintptr(c.suidFlag | syscall.MS_NODEV | syscall.MS_RDONLY)
 			err = system.Points.AddImage(mount.PreLayerTag, src, dst, "squashfs", flags, imageObject.Offset, imageObject.Size)
@@ -1016,6 +1017,7 @@ func (c *container) addUserbindsMount(system *mount.System) error {
 			return fmt.Errorf("unabled to %s to mount list: %s", src, err)
 		}
 		system.Points.AddRemount(mount.UserbindsTag, dst, flags)
+		flags &^= syscall.MS_RDONLY
 	}
 	return nil
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes issue where `:ro` with user binds and overlay images is specified affecting next bind/overlay by mounting them in read-only mode. MS_RDONLY is reset for each iteration.


**This fixes or addresses the following GitHub issues:**

- Ref: #1997 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [x] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
