### PR TITLE
User Agent Test Fix

### DIFF
--- a/src/pkg/util/user-agent/agent_test.go
+++ b/src/pkg/util/user-agent/agent_test.go
@@ -13,7 +13,7 @@ import (
 func TestSingularityVersion(t *testing.T) {
 	InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
 
-	re := regexp.MustCompile("Singularity/[[:digit:]]+(.[[:digit:]]+){2} \\(Linux [[:alnum:]]+\\) Go/[[:digit:]]+(.[[:digit:]]+){2}")
+	re := regexp.MustCompile("Singularity/[[:digit:]]+(.[[:digit:]]+){2} \\(Linux [[:alnum:]]+\\) Go/[[:digit:]]+(.[[:digit:]]+){1,2}")
 	if !re.MatchString(Value()) {
 		t.Fatalf("user agent did not match regexp")
 	}


### PR DESCRIPTION
The tests for User Agent were written to assume that `runtime.Version()` always returns `goX.Y.Z`. However, when the rightmost component of the version is zero, it is dropped and so `goX.Y` is returned (see golang/go#27255 for more info.)

This change opens up the test regex to accept both `goX.Y.Z` and `goX.Y`.