### PR TITLE
3.0: fix go fmt check

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -194,7 +194,7 @@ collect:
 check:
 	@echo " CHECK go fmt"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && test -z $(go fmt ./...)
+		cd $(SOURCEDIR) && test -z `gofmt -l .|tee /dev/stderr`
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -194,7 +194,7 @@ collect:
 check:
 	@echo " CHECK go fmt"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && test -z `gofmt -l src|tee /dev/stderr`
+		cd $(SOURCEDIR) && test -z "`gofmt -l src|tee /dev/stderr`"
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -196,7 +196,7 @@ check:
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && \
 		( test -z "`go fmt -n ./... | sed 's/ -w / /' | sh | tee /dev/stderr`" || \
-		   echo "Use 'go fmt' to update formatting"; false )
+		   ( echo "Use 'go fmt' to update formatting"; false ) )
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -196,7 +196,9 @@ check:
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && \
 		( test -z "`go fmt -n ./... | sed 's/ -w / /' | sh | tee /dev/stderr`" || \
-		   ( echo "Use 'go fmt' to update formatting"; false ) )
+		   ( echo "The above files have formatting errors."; \
+		     echo "Use 'go fmt github.com/singularityware/singularity/...' to correct the errors."; \
+		     false ) )
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -195,9 +195,8 @@ check:
 	@echo " CHECK go fmt"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && \
-		( test -z "`gofmt -l $$(find * -maxdepth 0 -type d ! -name vendor)|tee /dev/stderr`" || \
-		  (gofmt -d $$(find * -maxdepth 0 -type d ! -name vendor); \
-		   echo "Use 'go fmt' to update formatting"; false) )
+		( test -z "`go fmt -n ./... | sed 's/ -w / /' | sh | tee /dev/stderr`" || \
+		   echo "Use 'go fmt' to update formatting"; false )
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -194,7 +194,7 @@ collect:
 check:
 	@echo " CHECK go fmt"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && test -z `gofmt -l .|tee /dev/stderr`
+		cd $(SOURCEDIR) && test -z `gofmt -l src|tee /dev/stderr`
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -196,7 +196,8 @@ check:
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
 		cd $(SOURCEDIR) && \
 		( test -z "`gofmt -l $$(find * -maxdepth 0 -type d ! -name vendor)|tee /dev/stderr`" || \
-		  (echo "Use 'go fmt' to update formatting"; false) )
+		  (gofmt -d $$(find * -maxdepth 0 -type d ! -name vendor); \
+		   echo "Use 'go fmt' to update formatting"; false) )
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -198,7 +198,7 @@ check:
 		( test -z "`go fmt -n ./... | sed 's/ -w / /' | sh | tee /dev/stderr`" || \
 		   ( echo "The above files have formatting errors."; \
 		     echo "Use 'go fmt github.com/singularityware/singularity/...' to correct the errors."; \
-		     false ) )
+		     false ) >&2 )
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -194,7 +194,9 @@ collect:
 check:
 	@echo " CHECK go fmt"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && test -z "`gofmt -l $$(find * -maxdepth 0 -type d ! -name vendor)|tee /dev/stderr`"
+		cd $(SOURCEDIR) && \
+		( test -z "`gofmt -l $$(find * -maxdepth 0 -type d ! -name vendor)|tee /dev/stderr`" || \
+		  (echo "Use 'go fmt' to update formatting"; false) )
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -197,7 +197,7 @@ check:
 		cd $(SOURCEDIR) && \
 		( test -z "`go fmt -n ./... | sed 's/ -w / /' | sh | tee /dev/stderr`" || \
 		   ( echo "The above files have formatting errors."; \
-		     echo "Use 'go fmt github.com/singularityware/singularity/...' to correct the errors."; \
+		     echo "Use 'go fmt github.com/sylabs/singularity/...' to correct the errors."; \
 		     false ) >&2 )
 	@echo "       PASS"
 	@echo " CHECK go vet"

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -194,7 +194,7 @@ collect:
 check:
 	@echo " CHECK go fmt"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \
-		cd $(SOURCEDIR) && test -z "`gofmt -l src|tee /dev/stderr`"
+		cd $(SOURCEDIR) && test -z "`gofmt -l $$(find * -maxdepth 0 -type d ! -name vendor)|tee /dev/stderr`"
 	@echo "       PASS"
 	@echo " CHECK go vet"
 	$(V)export CGO_CPPFLAGS="$(cgo_CPPFLAGS)" CGO_LDFLAGS="$(cgo_LDFLAGS)" && \

--- a/src/cmd/singularity/cli/inspect.go
+++ b/src/cmd/singularity/cli/inspect.go
@@ -47,7 +47,7 @@ func init() {
 // InspectCmd represents the build command
 var InspectCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args: cobra.ExactArgs(1),
+	Args:                  cobra.ExactArgs(1),
 
 	Use:     docs.InspectUse,
 	Short:   docs.InspectShort,

--- a/src/cmd/singularity/cli/keys_push.go
+++ b/src/cmd/singularity/cli/keys_push.go
@@ -24,7 +24,7 @@ func init() {
 
 // KeysPushCmd is `singularity keys list' and lists local store OpenPGP keys
 var KeysPushCmd = &cobra.Command{
-	Args: cobra.ExactArgs(1),
+	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                sylabsToken,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR makes the go fmt check do what it is supposed to do: flag if there's a problem with the the go formatting.  Also prints the file names that have problems.

The current code had three bugs:
1. it used "$(...)" to attempt to run go fmt, which was interpreted by make and turned into an empty string.  I could have fixed with "$$(...)" but instead used backquotes like was used a few lines later in the Makefile.
2. It used "go fmt" which runs "gofmt -l -w".  That would have worked, but it would have corrected problems as a side effect, which would be very confusing.  I changed it to "gofmt -l".
3. It used "./..." to indicate everything recursively under the current directory, where it should have been just "."

**This fixes or addresses the following GitHub issues:**

- Mentioned in #1971


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/singularityware/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/singularityware/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [singularityware](https://www.github.com/singularityware/singularityware.github.io) documentation base.
- [ ] I have tested this PR locally with a `make test`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/singularityware/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularityware-admin
