### PR TITLE
add runtime $PATH control via SINGULARITYENV_PATH / SINGULARITYENV_PREPEND_PATH / SINGULARITYENV_APPEND_PATH

### DIFF
--- a/src/pkg/build/sources/base_environment.go
+++ b/src/pkg/build/sources/base_environment.go
@@ -237,6 +237,36 @@ fi
 PS1="Singularity> "
 export LD_LIBRARY_PATH PS1
 `
+
+	// Contents of /.singularity.d/env/99-runtimevars.sh
+	base99runtimevarsShFileContent = `#!/bin/bash
+# Copyright (c) 2017-2018, SyLabs, Inc. All rights reserved.
+#
+# This software is licensed under a customized 3-clause BSD license.  Please
+# consult LICENSE file distributed with the sources of this project regarding
+# your rights to use or distribute this software.
+#
+#
+
+if [ -n "${SING_USER_DEFINED_PREPEND_PATH:-}" ]; then
+	PATH="${SING_USER_DEFINED_PREPEND_PATH}:${PATH}"
+fi
+
+if [ -n "${SING_USER_DEFINED_APPEND_PATH:-}" ]; then
+	PATH="${PATH}:${SING_USER_DEFINED_APPEND_PATH}"
+fi
+
+if [ -n "${SING_USER_DEFINED_PATH:-}" ]; then
+	PATH="${SING_USER_DEFINED_PATH}"
+fi
+
+unset SING_USER_DEFINED_PREPEND_PATH \
+	  SING_USER_DEFINED_APPEND_PATH \
+	  SING_USER_DEFINED_PATH
+
+export PATH
+`
+
 	// Contents of /.singularity.d/runscript
 	runscriptFileContent = `#!/bin/sh
 
@@ -361,6 +391,9 @@ func makeFiles(rootPath string) (err error) {
 		return
 	}
 	if err = makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-base.sh"), 0755, base99ShFileContent); err != nil {
+		return
+	}
+	if err = makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-runtimevars.sh"), 0755, base99runtimevarsShFileContent); err != nil {
 		return
 	}
 	if err = makeFile(filepath.Join(rootPath, ".singularity.d", "runscript"), 0755, runscriptFileContent); err != nil {

--- a/src/pkg/build/sources/base_environment.go
+++ b/src/pkg/build/sources/base_environment.go
@@ -243,7 +243,7 @@ export LD_LIBRARY_PATH PS1
 # Copyright (c) 2017-2018, SyLabs, Inc. All rights reserved.
 #
 # This software is licensed under a customized 3-clause BSD license.  Please
-# consult LICENSE file distributed with the sources of this project regarding
+# consult LICENSE.md file distributed with the sources of this project regarding
 # your rights to use or distribute this software.
 #
 #

--- a/src/pkg/util/env/clean.go
+++ b/src/pkg/util/env/clean.go
@@ -28,7 +28,6 @@ var alwaysPassKeys = map[string]bool{
 
 // SetContainerEnv cleans environment variables before running the container
 func SetContainerEnv(g *generate.Generator, env []string, cleanEnv bool, homeDest string) {
-
 	// first deal with special variables that allow user to control $PATH at
 	// runtime (meh... special cases)
 	if prependPath := os.Getenv("SINGULARITYENV_PREPEND_PATH"); prependPath != "" {

--- a/src/pkg/util/env/clean.go
+++ b/src/pkg/util/env/clean.go
@@ -6,6 +6,7 @@
 package env
 
 import (
+	"os"
 	"strings"
 
 	"github.com/opencontainers/runtime-tools/generate"
@@ -42,6 +43,21 @@ func SetContainerEnv(g *generate.Generator, env []string, cleanEnv bool, homeDes
 
 	g.AddProcessEnv("HOME", homeDest)
 	g.AddProcessEnv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin")
+
+	if prependPath := os.Getenv("SINGULARITYENV_PREPEND_PATH"); prependPath != "" {
+		g.AddProcessEnv("SING_USER_DEFINED_PREPEND_PATH", prependPath)
+		os.Unsetenv("SINGULARITYENV_PREPEND_PATH")
+	}
+
+	if appendPath := os.Getenv("SINGULARITYENV_APPEND_PATH"); appendPath != "" {
+		g.AddProcessEnv("SING_USER_DEFINED_APPEND_PATH", appendPath)
+		os.Unsetenv("SINGULARITYENV_APPEND_PATH")
+	}
+
+	if userPath := os.Getenv("SINGULARITYENV_PATH"); userPath != "" {
+		g.AddProcessEnv("SING_USER_DEFINED_PATH", userPath)
+		os.Unsetenv("SINGULARITYENV_PATH")
+	}
 
 	// Set LANG env
 	if cleanEnv {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

It's necessary for some users workflows to control the `$PATH` of containers at runtime with environment variables.  This PR replicates the behavior of the 2.x branch (which I originally added for this reason). 

**This fixes or addresses the following GitHub issues:**

- Fixes #2022

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [ ] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
