### PR TITLE
Library Conveyor Packer

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -96,7 +96,7 @@ func replaceURIWithImage(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Unable to check if %v exists: %v", imgabs, err)
 	} else if !exists {
 		sylog.Infof("Converting OCI blobs to SIF format")
-		b, err := build.NewBuild(args[0], imgabs, "sif", false, false, nil, true)
+		b, err := build.NewBuild(args[0], imgabs, "sif", false, false, nil, true, "", "")
 		if err != nil {
 			sylog.Fatalf("Unable to create new build: %v", err)
 		}

--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -53,7 +53,7 @@ func init() {
 // BuildCmd represents the build command
 var BuildCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args: cobra.ExactArgs(2),
+	Args:                  cobra.ExactArgs(2),
 
 	Use:     docs.BuildUse,
 	Short:   docs.BuildShort,

--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -53,7 +53,7 @@ func init() {
 // BuildCmd represents the build command
 var BuildCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.ExactArgs(2),
+	Args: cobra.ExactArgs(2),
 
 	Use:     docs.BuildUse,
 	Short:   docs.BuildShort,
@@ -98,7 +98,7 @@ var BuildCmd = &cobra.Command{
 				sylog.Fatalf(err.Error())
 			}
 
-			b, err := build.NewBuild(spec, dest, buildFormat, force, update, sections, noTest)
+			b, err := build.NewBuild(spec, dest, buildFormat, force, update, sections, noTest, libraryURL, authToken)
 			if err != nil {
 				sylog.Fatalf("Unable to create build: %v", err)
 			}

--- a/src/pkg/build/conveyorPacker.go
+++ b/src/pkg/build/conveyorPacker.go
@@ -14,6 +14,7 @@ import (
 
 // validURIs contains a list of known uris
 var validURIs = map[string]bool{
+	"library":        true,
 	"shub":           true,
 	"docker":         true,
 	"docker-archive": true,

--- a/src/pkg/build/sources/conveyorPacker_library.go
+++ b/src/pkg/build/sources/conveyorPacker_library.go
@@ -38,6 +38,10 @@ func (cp *LibraryConveyorPacker) Get(b *sytypes.Bundle) (err error) {
 
 	cp.b.FSObjects["libraryImg"] = f.Name()
 
+	sylog.Debugf("Download file: %v", cp.b.FSObjects["libraryImg"])
+	sylog.Debugf("LibraryURL: %v", cp.LibraryURL)
+	sylog.Debugf("LibraryRef: %v", b.Recipe.Header["from"])
+
 	// get image from library
 	if err = client.DownloadImage(cp.b.FSObjects["libraryImg"], b.Recipe.Header["from"], cp.LibraryURL, true, cp.AuthToken); err != nil {
 		sylog.Fatalf("failed to Get from %s://%s: %v\n", cp.LibraryURL, cp.b.Recipe.Header["from"], err)

--- a/src/pkg/build/sources/conveyorPacker_library.go
+++ b/src/pkg/build/sources/conveyorPacker_library.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sources
+
+import (
+	"io/ioutil"
+	"os"
+
+	sytypes "github.com/sylabs/singularity/src/pkg/build/types"
+	"github.com/sylabs/singularity/src/pkg/client/library"
+	"github.com/sylabs/singularity/src/pkg/sylog"
+)
+
+// LibraryConveyorPacker only needs to hold a packer to pack the image it pulls
+// as well as extra information about the library it's pulling from
+type LibraryConveyorPacker struct {
+	b *sytypes.Bundle
+	LocalPacker
+	LibraryURL string
+	AuthToken  string
+}
+
+// Get downloads container from Singularityhub
+func (cp *LibraryConveyorPacker) Get(b *sytypes.Bundle) (err error) {
+	sylog.Debugf("Getting container from Library")
+
+	cp.b = b
+
+	// create file for image download
+	f, err := ioutil.TempFile(cp.b.Path, "library-img")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	cp.b.FSObjects["libraryImg"] = f.Name()
+
+	// get image from library
+	if err = client.DownloadImage(cp.b.FSObjects["libraryImg"], b.Recipe.Header["from"], cp.LibraryURL, true, cp.AuthToken); err != nil {
+		sylog.Fatalf("failed to Get from %s://%s: %v\n", cp.LibraryURL, cp.b.Recipe.Header["from"], err)
+	}
+
+	cp.LocalPacker, err = GetLocalPacker(cp.b.FSObjects["libraryImg"], cp.b)
+
+	return err
+}
+
+// CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem
+func (cp *LibraryConveyorPacker) CleanUp() {
+	os.RemoveAll(cp.b.Path)
+}

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -6,7 +6,6 @@
 package sources_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/sylabs/singularity/src/pkg/build/sources"
@@ -15,6 +14,7 @@ import (
 )
 
 const (
+	libraryURL = "https://cloud.sylabs.io/library"
 	libraryURI = "library://dtrudg/linux/alpine:latest"
 )
 
@@ -38,13 +38,13 @@ func TestLibraryConveyor(t *testing.T) {
 		t.Fatalf("unable to parse URI %s: %v\n", libraryURI, err)
 	}
 
-	fmt.Println(b.Recipe)
-
-	cp := &sources.LibraryConveyorPacker{}
+	cp := &sources.LibraryConveyorPacker{
+		LibraryURL: libraryURL,
+	}
 
 	err = cp.Get(b)
 	// clean up tmpfs since assembler isnt called
-	defer cp.CleanUp()
+	//defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", libraryURI, err)
 	}
@@ -65,7 +65,9 @@ func TestLibraryPacker(t *testing.T) {
 		t.Fatalf("unable to parse URI %s: %v\n", libraryURI, err)
 	}
 
-	cp := &sources.LibraryConveyorPacker{}
+	cp := &sources.LibraryConveyorPacker{
+		LibraryURL: libraryURL,
+	}
 
 	err = cp.Get(b)
 	// clean up tmpfs since assembler isnt called

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -50,12 +50,12 @@ func TestLibraryConveyor(t *testing.T) {
 
 // TestLibraryPacker checks if we can create a Bundle from the pulled image
 func TestLibraryPacker(t *testing.T) {
+	test.EnsurePrivilege(t)
+
 	b, err := types.NewBundle("sbuild-library")
 	if err != nil {
 		return
 	}
-
-	test.EnsurePrivilege(t)
 
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sylabs/singularity/src/pkg/build/sources"
 	"github.com/sylabs/singularity/src/pkg/build/types"
-	"github.com/sylabs/singularity/src/pkg/test"
 )
 
 const (
@@ -23,9 +22,6 @@ func TestLibraryConveyor(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
-	test.DropPrivilege(t)
-	defer test.ResetPrivilege(t)
 
 	b, err := types.NewBundle("sbuild-library")
 	if err != nil {
@@ -51,9 +47,6 @@ func TestLibraryConveyor(t *testing.T) {
 
 // TestLibraryPacker checks if we can create a Bundle from the pulled image
 func TestLibraryPacker(t *testing.T) {
-	test.DropPrivilege(t)
-	defer test.ResetPrivilege(t)
-
 	b, err := types.NewBundle("sbuild-library")
 	if err != nil {
 		return

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sylabs/singularity/src/pkg/build/sources"
 	"github.com/sylabs/singularity/src/pkg/build/types"
+	"github.com/sylabs/singularity/src/pkg/test"
 )
 
 const (
@@ -22,6 +23,8 @@ func TestLibraryConveyor(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+
+	test.EnsurePrivilege(t)
 
 	b, err := types.NewBundle("sbuild-library")
 	if err != nil {
@@ -51,6 +54,8 @@ func TestLibraryPacker(t *testing.T) {
 	if err != nil {
 		return
 	}
+
+	test.EnsurePrivilege(t)
 
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	libraryURL = "https://cloud.sylabs.io/library"
+	libraryURL = "https://library.sylabs.io/"
 	libraryURI = "library://dtrudg/linux/alpine:latest"
 )
 
@@ -44,7 +44,7 @@ func TestLibraryConveyor(t *testing.T) {
 
 	err = cp.Get(b)
 	// clean up tmpfs since assembler isnt called
-	//defer cp.CleanUp()
+	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", libraryURI, err)
 	}

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -20,7 +20,6 @@ const (
 
 // TestLibraryConveyor tests if we can pull an image from singularity hub
 func TestLibraryConveyor(t *testing.T) {
-
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sylabs/singularity/src/pkg/build/sources"
+	"github.com/sylabs/singularity/src/pkg/build/types"
+	"github.com/sylabs/singularity/src/pkg/test"
+)
+
+const (
+	libraryURI = "library://dtrudg/linux/alpine:latest"
+)
+
+// TestLibraryConveyor tests if we can pull an image from singularity hub
+func TestLibraryConveyor(t *testing.T) {
+
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	b, err := types.NewBundle("sbuild-library")
+	if err != nil {
+		return
+	}
+
+	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
+	if err != nil {
+		t.Fatalf("unable to parse URI %s: %v\n", libraryURI, err)
+	}
+
+	fmt.Println(b.Recipe)
+
+	cp := &sources.LibraryConveyorPacker{}
+
+	err = cp.Get(b)
+	// clean up tmpfs since assembler isnt called
+	defer cp.CleanUp()
+	if err != nil {
+		t.Fatalf("failed to Get from %s: %v\n", libraryURI, err)
+	}
+}
+
+// TestLibraryPacker checks if we can create a Bundle from the pulled image
+func TestLibraryPacker(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	b, err := types.NewBundle("sbuild-library")
+	if err != nil {
+		return
+	}
+
+	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
+	if err != nil {
+		t.Fatalf("unable to parse URI %s: %v\n", libraryURI, err)
+	}
+
+	cp := &sources.LibraryConveyorPacker{}
+
+	err = cp.Get(b)
+	// clean up tmpfs since assembler isnt called
+	defer cp.CleanUp()
+	if err != nil {
+		t.Fatalf("failed to Get from %s: %v\n", libraryURI, err)
+	}
+
+	_, err = cp.Pack()
+	if err != nil {
+		t.Fatalf("failed to Pack from %s: %v\n", libraryURI, err)
+	}
+}

--- a/src/pkg/libexec/pull.go
+++ b/src/pkg/libexec/pull.go
@@ -30,7 +30,7 @@ func PullShubImage(filePath, shubRef string, force bool) {
 
 // PullOciImage pulls an OCI image to a sif
 func PullOciImage(path, uri string, force bool) {
-	b, err := build.NewBuild(uri, path, "sif", force, false, nil, true)
+	b, err := build.NewBuild(uri, path, "sif", force, false, nil, true, "", "")
 	if err != nil {
 		sylog.Fatalf("Unable to pull %v: %v", uri, err)
 	}


### PR DESCRIPTION
Enables building from library.

This changes the `NewBuild()` function call to include a libraryurl and authtoken for the library conveyorPacker to use.

fixes #2039