### PR TITLE
sanitize path at beginning of code execution

### DIFF
--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -97,6 +97,7 @@ var SingularityCmd = &cobra.Command{
 // flags appropriately. This is called by main.main(). It only needs to happen
 // once to the root command (singularity).
 func ExecuteSingularity() {
+	os.Setenv("PATH", "/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin")
 	if err := SingularityCmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

From a security standpoint I think it's a good idea to sanitize the path when code execution begins, and it is also important to make sure that things like `/sbin` are on the path, for instance when a user wants to use the `--nv` flag which requires access to the `ldconfig` binary.

**This fixes or addresses the following GitHub issues:**

- Fixes #2035 


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [ ] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
