### PR TITLE
Remove redundant if-err checks

### DIFF
--- a/src/cmd/singularity/cli/sign.go
+++ b/src/cmd/singularity/cli/sign.go
@@ -24,8 +24,8 @@ func init() {
 // SignCmd singularity sign
 var SignCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args:   cobra.ExactArgs(1),
-	PreRun: sylabsToken,
+	Args:                  cobra.ExactArgs(1),
+	PreRun:                sylabsToken,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// args[0] contains image path

--- a/src/cmd/singularity/cli/sign.go
+++ b/src/cmd/singularity/cli/sign.go
@@ -24,8 +24,8 @@ func init() {
 // SignCmd singularity sign
 var SignCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.ExactArgs(1),
-	PreRun:                sylabsToken,
+	Args:   cobra.ExactArgs(1),
+	PreRun: sylabsToken,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// args[0] contains image path
@@ -44,9 +44,5 @@ var SignCmd = &cobra.Command{
 }
 
 func doSignCmd(cpath, url string) error {
-	if err := signing.Sign(cpath, url, authToken); err != nil {
-		return err
-	}
-
-	return nil
+	return signing.Sign(cpath, url, authToken)
 }

--- a/src/cmd/singularity/cli/verify.go
+++ b/src/cmd/singularity/cli/verify.go
@@ -24,8 +24,8 @@ func init() {
 // VerifyCmd singularity verify
 var VerifyCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.ExactArgs(1),
-	PreRun:                sylabsToken,
+	Args:   cobra.ExactArgs(1),
+	PreRun: sylabsToken,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// args[0] contains image path
@@ -43,9 +43,5 @@ var VerifyCmd = &cobra.Command{
 }
 
 func doVerifyCmd(cpath, url string) error {
-	if err := signing.Verify(cpath, url, authToken); err != nil {
-		return err
-	}
-
-	return nil
+	return signing.Verify(cpath, url, authToken)
 }

--- a/src/cmd/singularity/cli/verify.go
+++ b/src/cmd/singularity/cli/verify.go
@@ -24,8 +24,8 @@ func init() {
 // VerifyCmd singularity verify
 var VerifyCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args:   cobra.ExactArgs(1),
-	PreRun: sylabsToken,
+	Args:                  cobra.ExactArgs(1),
+	PreRun:                sylabsToken,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// args[0] contains image path

--- a/src/cmd/singularity/import_export_test.go
+++ b/src/cmd/singularity/import_export_test.go
@@ -43,10 +43,7 @@ func imageExport(imagePath, exportPath string, tp tarProcessor) error {
 	if _, err := io.Copy(w, stdout); err != nil {
 		return err
 	}
-	if err := exportCmd.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return exportCmd.Wait()
 }
 
 // imageExportTAR exports the image at imagePath, and writes the result TAR

--- a/src/pkg/build/sources/packer_ext3.go
+++ b/src/pkg/build/sources/packer_ext3.go
@@ -85,8 +85,5 @@ func getLoopDevice(arguments *args.LoopArgs) error {
 		return err
 	}
 
-	if err := loopdev.SetStatus(&arguments.Info); err != nil {
-		return err
-	}
-	return nil
+	return loopdev.SetStatus(&arguments.Info)
 }

--- a/src/pkg/instance/instance.go
+++ b/src/pkg/instance/instance.go
@@ -244,9 +244,5 @@ func SetLogFile(name string) error {
 	if err := syscall.Dup3(int(stderr.Fd()), int(os.Stderr.Fd()), 0); err != nil {
 		return err
 	}
-	if err := syscall.Dup3(int(stdout.Fd()), int(os.Stdout.Fd()), 0); err != nil {
-		return err
-	}
-
-	return nil
+	return syscall.Dup3(int(stdout.Fd()), int(os.Stdout.Fd()), 0)
 }

--- a/src/pkg/syecl/syecl_test.go
+++ b/src/pkg/syecl/syecl_test.go
@@ -173,11 +173,7 @@ func copyFile(dst, src string) error {
 		return err
 	}
 
-	if err := d.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return d.Close()
 }
 
 func setup() error {
@@ -231,11 +227,7 @@ func setup() error {
 		return err
 	}
 	testContainer4 = filepath.Join(testEclDirPath3, filepath.Base(srcContainer3))
-	if err := copyFile(testContainer4, srcContainer3); err != nil {
-		return err
-	}
-
-	return nil
+	return copyFile(testContainer4, srcContainer3)
 }
 
 func shutdown() {

--- a/src/pkg/util/fs/layout/layer/overlay/overlay.go
+++ b/src/pkg/util/fs/layout/layer/overlay/overlay.go
@@ -46,10 +46,7 @@ func (o *Overlay) Add(session *layout.Session, system *mount.System) error {
 	path, _ := o.session.GetPath(lowerDir)
 	o.lowerDirs = append(o.lowerDirs, path)
 
-	if err := system.RunBeforeTag(mount.LayerTag, o.createOverlay); err != nil {
-		return err
-	}
-	return nil
+	return system.RunBeforeTag(mount.LayerTag, o.createOverlay)
 }
 
 func (o *Overlay) createOverlay(system *mount.System) error {

--- a/src/pkg/util/fs/layout/layer/underlay/underlay.go
+++ b/src/pkg/util/fs/layout/layer/underlay/underlay.go
@@ -43,10 +43,7 @@ func (u *Underlay) Add(session *layout.Session, system *mount.System) error {
 	if err := u.session.AddDir(underlayDir); err != nil {
 		return err
 	}
-	if err := system.RunBeforeTag(mount.PreLayerTag, u.createUnderlay); err != nil {
-		return err
-	}
-	return nil
+	return system.RunBeforeTag(mount.PreLayerTag, u.createUnderlay)
 }
 
 func (u *Underlay) createUnderlay(system *mount.System) error {

--- a/src/pkg/util/fs/mount/mount.go
+++ b/src/pkg/util/fs/mount/mount.go
@@ -523,10 +523,7 @@ func (p *Points) AddBind(tag AuthorizedTag, source string, dest string, flags ui
 	if !strings.HasPrefix(source, "/") {
 		return fmt.Errorf("source must be an absolute path")
 	}
-	if err := p.add(tag, source, dest, "", bindFlags, options); err != nil {
-		return err
-	}
-	return nil
+	return p.add(tag, source, dest, "", bindFlags, options)
 }
 
 // GetAllBinds returns a list of all registered bind mount points

--- a/src/pkg/util/priv/priv.go
+++ b/src/pkg/util/priv/priv.go
@@ -13,17 +13,11 @@ import (
 // Escalate escalates thread privileges
 func Escalate() error {
 	uid := os.Getuid()
-	if err := syscall.Setresuid(uid, 0, uid); err != nil {
-		return err
-	}
-	return nil
+	return syscall.Setresuid(uid, 0, uid)
 }
 
 // Drop drops thread privileges
 func Drop() error {
 	uid := os.Getuid()
-	if err := syscall.Setresuid(uid, uid, 0); err != nil {
-		return err
-	}
-	return nil
+	return syscall.Setresuid(uid, uid, 0)
 }

--- a/src/runtime/engines/singularity/rpc/server/server.go
+++ b/src/runtime/engines/singularity/rpc/server/server.go
@@ -119,10 +119,7 @@ func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) error {
 	if err := loopdev.AttachFromFile(image, arguments.Mode, reply); err != nil {
 		return err
 	}
-	if err := loopdev.SetStatus(&arguments.Info); err != nil {
-		return err
-	}
-	return nil
+	return loopdev.SetStatus(&arguments.Info)
 }
 
 // SetHostname sets hostname with the specified arguments


### PR DESCRIPTION
**Description of the Pull Request (PR):**

remove redundant if ...; err != nil check
call return error instead, preserving same behavior.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
