### PR TITLE
Fix the path to the yum definition file

### DIFF
--- a/src/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/src/pkg/build/sources/conveyorPacker_yum_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sylabs/singularity/src/pkg/test"
 )
 
-const yumDef = "./testdata_good/yum/yum"
+const yumDef = "../testdata_good/yum/yum"
 
 func TestYumConveyor(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix a bad path to a definition file for some yum tests.

**This fixes or addresses the following GitHub issues:**

- Fixes #2075 

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [X] I have tested this PR locally with a `make testall`
- [X] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularity-maintainers