### PR TITLE
Sign and verify optional SIF IDs and Groups

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -374,7 +374,7 @@
   packages = ["pkg/seccomp"]
   pruneopts = "UT"
   revision = "8afc34092907d146906fcc31af112b2b46e7b5cd"
-  
+
 [[projects]]
   digest = "1:41b00533ad3d8b3f54b6a02fc093b211feeffb068a3148a7e7084cd7aeef18ec"
   name = "github.com/magiconair/properties"
@@ -624,12 +624,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:4654a6e1e8273be1aca70fa65e3e72caf18860e47c28b8fe7579a127fd73d772"
+  digest = "1:09e7bb03b8a2f75d03f3674f528330e1f937e76faf14f58042cb7376b153d849"
   name = "github.com/sylabs/sif"
   packages = ["pkg/sif"]
   pruneopts = "UT"
-  revision = "a74ff54af21df5c4b791a246f05c56ff88c81c8e"
-  version = "v1.0.0"
+  revision = "177b9338f1ab9123be5b6217740be1f0ce924206"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@ required = [
 
 [[constraint]]
   name = "github.com/sylabs/sif"
-  version = "1.0.0"
+  version = "1.0.1"
 
 [[constraint]]
   branch = "master"

--- a/src/cmd/singularity/cli/sign.go
+++ b/src/cmd/singularity/cli/sign.go
@@ -15,11 +15,18 @@ import (
 	"github.com/sylabs/singularity/src/pkg/sylog"
 )
 
+var (
+	privKey int // -k encryption key (index from 'keys list') specification
+)
+
 func init() {
 	SignCmd.Flags().SetInterspersed(false)
 
-	SignCmd.Flags().StringVarP(&keyServerURL, "url", "u", defaultKeysServer, "specify the key server URL")
+	SignCmd.Flags().StringVarP(&keyServerURL, "url", "u", defaultKeysServer, "key server URL")
 	SignCmd.Flags().SetAnnotation("url", "envkey", []string{"URL"})
+	SignCmd.Flags().Uint32VarP(&sifGroupID, "groupid", "g", 0, "group ID to be signed")
+	SignCmd.Flags().Uint32VarP(&sifDescID, "id", "i", 0, "descriptor ID to be signed")
+	SignCmd.Flags().IntVarP(&privKey, "keyidx", "k", -1, "private key to use (index from 'keys list')")
 
 	SingularityCmd.AddCommand(SignCmd)
 }
@@ -47,5 +54,18 @@ var SignCmd = &cobra.Command{
 }
 
 func doSignCmd(cpath, url string) error {
-	return signing.Sign(cpath, url, authToken)
+	if sifGroupID != 0 && sifDescID != 0 {
+		return fmt.Errorf("only one of -i or -g may be set")
+	}
+
+	var isGroup bool
+	var id uint32
+	if sifGroupID != 0 {
+		isGroup = true
+		id = sifGroupID
+	} else {
+		id = sifDescID
+	}
+
+	return signing.Sign(cpath, url, id, isGroup, privKey, authToken)
 }

--- a/src/cmd/singularity/cli/verify.go
+++ b/src/cmd/singularity/cli/verify.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	sifGroupID uint32 // -g groupid specification
-	sifDescID uint32 // -i id specification
+	sifDescID  uint32 // -i id specification
 )
 
 func init() {

--- a/src/cmd/singularity/cli/verify.go
+++ b/src/cmd/singularity/cli/verify.go
@@ -23,10 +23,10 @@ var (
 func init() {
 	VerifyCmd.Flags().SetInterspersed(false)
 
-	VerifyCmd.Flags().StringVarP(&keyServerURL, "url", "u", defaultKeysServer, "specify the key server URL")
+	VerifyCmd.Flags().StringVarP(&keyServerURL, "url", "u", defaultKeysServer, "key server URL")
 	VerifyCmd.Flags().SetAnnotation("url", "envkey", []string{"URL"})
-	VerifyCmd.Flags().Uint32VarP(&sifGroupID, "groupid", "g", 0, "specify a group ID to be verified")
-	VerifyCmd.Flags().Uint32VarP(&sifDescID, "id", "i", 0, "specify a descriptor ID to be verified")
+	VerifyCmd.Flags().Uint32VarP(&sifGroupID, "groupid", "g", 0, "group ID to be verified")
+	VerifyCmd.Flags().Uint32VarP(&sifDescID, "id", "i", 0, "descriptor ID to be verified")
 	SingularityCmd.AddCommand(VerifyCmd)
 }
 

--- a/src/pkg/signing/signing.go
+++ b/src/pkg/signing/signing.go
@@ -172,8 +172,13 @@ func getSigsPrimPart(fimg *sif.FileImage) (sigs []*sif.Descriptor, descr *sif.De
 }
 
 // return all signatures for "id" being unique or group id
-func getSigsForSelection(fimg *sif.FileImage) (sigs []*sif.Descriptor, descr *sif.Descriptor, err error) {
-	return getSigsPrimPart(fimg)
+func getSigsForSelection(fimg *sif.FileImage, id uint32, isGroup bool) (sigs []*sif.Descriptor, descr *sif.Descriptor, err error) {
+	if id == 0 {
+		return getSigsPrimPart(fimg)
+	} else if isGroup {
+		return getSigsGroup(fimg, id)
+	}
+	return getSigsDesc(fimg, id)
 }
 
 // Verify takes a container path and look for a verification block for a
@@ -181,7 +186,7 @@ func getSigsForSelection(fimg *sif.FileImage) (sigs []*sif.Descriptor, descr *si
 // partition hash against the signer's version. Verify takes care of looking
 // for OpenPGP keys in the default local store or looks it up from a key server
 // if access is enabled.
-func Verify(cpath, url, authToken string) error {
+func Verify(cpath, url string, id uint32, isGroup bool, authToken string) error {
 	fimg, err := sif.LoadContainer(cpath, true)
 	if err != nil {
 		return err
@@ -189,7 +194,7 @@ func Verify(cpath, url, authToken string) error {
 	defer fimg.UnloadContainer()
 
 	// get all signature blocks (signatures) for ID/GroupID selected (descr) from SIF file
-	signatures, descr, err := getSigsForSelection(&fimg)
+	signatures, descr, err := getSigsForSelection(&fimg, id, isGroup)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch allows to selectively sign and verify specified SIF ids (-i) and groups (-g) instead of the default, which will sign and verify the primary partition.