### PR TITLE
Remove skip now that all tests are passing

### DIFF
--- a/src/cmd/singularity/env_test.go
+++ b/src/cmd/singularity/env_test.go
@@ -15,10 +15,6 @@ import (
 )
 
 func TestSingularityEnv(t *testing.T) {
-	if !*runDisabled {
-		t.Skip("disabled until issue addressed") // #2045
-	}
-
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
 	var defaultImage = "docker://alpine:3.8"
 	var defaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
Remove the skip during `SINGULARITYENV_PATH` tests since they now all pass.

**Checkoff for all PRs:**

- [X] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [X] I have tested this PR locally with a `make testall`
- [X] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [X] This PR is ready for review and/or merge

Attn: @singularity-maintainers