### PR TITLE
Development 3.0: Honor max loop devices configuration directive

### DIFF
--- a/src/pkg/build/sources/packer_ext3.go
+++ b/src/pkg/build/sources/packer_ext3.go
@@ -80,6 +80,7 @@ func getLoopDevice(arguments *args.LoopArgs) error {
 	var reply int
 	reply = 1
 	loopdev := new(loop.Device)
+	loopdev.MaxLoopDevices = 256
 
 	if err := loopdev.AttachFromPath(arguments.Image, arguments.Mode, &reply); err != nil {
 		return err

--- a/src/pkg/build/sources/packer_sif.go
+++ b/src/pkg/build/sources/packer_sif.go
@@ -89,6 +89,7 @@ func unpackImagePartion(src, dest, mountType string, info *loop.Info64) (err err
 	var number int
 	number = 0
 	loopdev := new(loop.Device)
+	loopdev.MaxLoopDevices = 256
 
 	if err := loopdev.AttachFromPath(src, os.O_RDONLY, &number); err != nil {
 		return err

--- a/src/pkg/util/loop/loop.go
+++ b/src/pkg/util/loop/loop.go
@@ -13,12 +13,10 @@ import (
 	"unsafe"
 )
 
-// MaxLoopDevices is the maxiumum number of loop devices that are supported
-const MaxLoopDevices = 256
-
 // Device describes a loop device
 type Device struct {
-	file *os.File
+	MaxLoopDevices int
+	file           *os.File
 }
 
 // AttachFromFile finds a free loop device, opens it, and stores file descriptor
@@ -26,7 +24,7 @@ type Device struct {
 func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error {
 	var path string
 
-	for device := 0; device < MaxLoopDevices; device++ {
+	for device := 0; device < loop.MaxLoopDevices; device++ {
 		path = fmt.Sprintf("/dev/loop%d", device)
 		if fi, err := os.Stat(path); err != nil {
 			dev := int((7 << 8) | device)
@@ -48,7 +46,7 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 			loopDev.Close()
 			continue
 		}
-		if device == MaxLoopDevices {
+		if device == loop.MaxLoopDevices {
 			break
 		}
 		loop.file = loopDev


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes `max loop devices` configuration directive from being ignored


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
