### PR TITLE
Makefile: fix CNI configuration file permission

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -91,7 +91,7 @@ $(cni_plugins_INSTALL): $(cni_plugins_EXECUTABLES)
 $(cni_config_INSTALL): $(cni_config_LIST)
 	@echo " INSTALL CNI CONFIGURATION FILES"
 	$(V)install -d $(cni_config_INSTALL)
-	$(V)install -m 0755 $? $@
+	$(V)install -m 0644 $? $@
 
 $(libruntime): $(libutil_OBJ)
 	@echo " AR" $@


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The configuration files for CNI were set to be `0755` during the installation, this changes it to be `0644`.


**This fixes or addresses the following GitHub issues:**

- Fixes #2105


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [ ] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
