### PR TITLE
Fix image build parsing 

### DIFF
--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/src/docs"
 	"github.com/sylabs/singularity/src/pkg/build"
 	"github.com/sylabs/singularity/src/pkg/sylog"
+	"github.com/sylabs/singularity/src/pkg/syplugin"
 )
 
 var (
@@ -83,7 +84,10 @@ var BuildCmd = &cobra.Command{
 	Short:   docs.BuildShort,
 	Long:    docs.BuildLong,
 	Example: docs.BuildExample,
-	PreRun:  sylabsToken,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		sylabsToken(cmd, args)
+		syplugin.Init()
+	},
 	// TODO: Can we plz move this to another file to keep the CLI the CLI
 	Run: func(cmd *cobra.Command, args []string) {
 		buildFormat := "sif"

--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sylabs/singularity/src/docs"
 	"github.com/sylabs/singularity/src/pkg/buildcfg"
 	"github.com/sylabs/singularity/src/pkg/sylog"
-	"github.com/sylabs/singularity/src/pkg/syplugin"
 	"github.com/sylabs/singularity/src/pkg/util/auth"
 )
 
@@ -154,7 +153,6 @@ func handleEnv(flag *pflag.Flag) {
 func persistentPreRun(cmd *cobra.Command, args []string) {
 	setSylogMessageLevel(cmd, args)
 	updateFlagsFromEnv(cmd)
-	syplugin.Init()
 }
 
 // sylabsToken process the authentication Token

--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -327,31 +327,15 @@ func (b *Build) runBuildEngine() error {
 		return fmt.Errorf("failed to marshal config.Common: %s", err)
 	}
 
-	// Set PIPE_EXEC_FD
-	pipefd, err := syexec.SetPipe(configData)
+	starterCmd, err := syexec.PipeCommand(starter, progname, env, configData)
 	if err != nil {
-		return fmt.Errorf("failed to set PIPE_EXEC_FD: %v", err)
+		return fmt.Errorf("failed to create cmd type: %v", err)
 	}
 
-	env = append(env, pipefd)
+	starterCmd.Stdout = os.Stdout
+	starterCmd.Stderr = os.Stderr
 
-	// Create os/exec.Command to run starter and return control once finished
-	starterCmd := &exec.Cmd{
-		Path:   starter,
-		Args:   progname,
-		Env:    env,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	}
-
-	if err := starterCmd.Start(); err != nil {
-		return fmt.Errorf("failed to start starter proc: %v", err)
-	}
-	if err := starterCmd.Wait(); err != nil {
-		return fmt.Errorf("starter proc failed: %v", err)
-	}
-
-	return nil
+	return starterCmd.Run()
 }
 
 func getcp(def types.Definition, libraryURL, authToken string) (ConveyorPacker, error) {

--- a/src/pkg/build/types/parser/deffile.go
+++ b/src/pkg/build/types/parser/deffile.go
@@ -287,6 +287,10 @@ func doHeader(h string, d *types.Definition) (err error) {
 		trimLine := strings.Split(line, "#")[0]
 
 		linetoks := strings.SplitN(trimLine, ":", 2)
+		if len(linetoks) == 1 {
+			return fmt.Errorf("header key %s had no val", linetoks[0])
+		}
+
 		key, val := strings.ToLower(strings.TrimSpace(linetoks[0])), strings.TrimSpace(linetoks[1])
 		if _, ok := validHeaders[key]; !ok {
 			return fmt.Errorf("invalid header keyword found: %s", key)
@@ -423,6 +427,13 @@ func IsValidDefinition(source string) (valid bool, err error) {
 	if err != nil {
 		return false, err
 	}
+
+	if s, err := defFile.Stat(); err != nil {
+		return false, fmt.Errorf("unable to stat file: %v", err)
+	} else if s.IsDir() {
+		return false, nil
+	}
+
 	defer defFile.Close()
 
 	ok, _ := canGetHeader(defFile)

--- a/src/pkg/syplugin/load.go
+++ b/src/pkg/syplugin/load.go
@@ -65,7 +65,7 @@ func registerPlugin(pl interface{}) {
 			sylog.Debugf("Registering plugin as type %s", plType)
 
 			if err := regFn(pl); err != nil {
-				sylog.Fatalf("Unable to register plugin??")
+				sylog.Fatalf("Unable to register plugin: %s", err)
 			}
 			regWait.Done()
 		}(plType, regFn)

--- a/src/plugins/apps/apps.go
+++ b/src/plugins/apps/apps.go
@@ -31,6 +31,17 @@ const (
 	sectionRun     = "apprun"
 )
 
+var (
+	sections = map[string]bool{
+		sectionInstall: true,
+		sectionFiles:   true,
+		sectionEnv:     true,
+		sectionTest:    true,
+		sectionHelp:    true,
+		sectionRun:     true,
+	}
+)
+
 const (
 	globalEnv94Base = `## App Global Exports For: %[1]s
 	
@@ -158,6 +169,10 @@ func getAppAndSection(ident string) (appName string, sectionName string) {
 	identSplit := strings.Split(ident, " ")
 
 	if len(identSplit) < 2 {
+		return "", ""
+	}
+
+	if _, ok := sections[identSplit[0]]; !ok {
 		return "", ""
 	}
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Parsing of definition files currently has two issues, which this pull request fixes:

1. The `apps` handling currently initializes an app for any section identifier which has two or more words. This is unintentional and causes a definition file with a line like `%post #test` to fail when attempting to run.
2. Occasionally, the parser would panic when parsing the build spec during testing on Travis. This uncovered two related issues. The first is that we're attempting to parse any path given as the spec in the command `singularity build test.sif PATH` as a file, when it's possible to pass a directory as spec when building a `sandbox` -> `SIF`. This uncovered a panic inside of the `doHeader` function when a line of a file is not in the form `key: val` (notably if the line does NOT have a semicolon). Both have been fixed

**This fixes or addresses the following GitHub issues:**

- Fixes #2092
