### PR TITLE
Custom library in definition

### DIFF
--- a/src/pkg/build/sources/conveyorPacker_library.go
+++ b/src/pkg/build/sources/conveyorPacker_library.go
@@ -29,6 +29,13 @@ func (cp *LibraryConveyorPacker) Get(b *sytypes.Bundle) (err error) {
 
 	cp.b = b
 
+	// check for custom library from definition
+	customLib, ok := b.Recipe.Header["library"]
+	if ok {
+		sylog.Debugf("Using custom library: %v", customLib)
+		cp.LibraryURL = customLib
+	}
+
 	// create file for image download
 	f, err := ioutil.TempFile(cp.b.Path, "library-img")
 	if err != nil {

--- a/src/pkg/build/types/parser/deffile.go
+++ b/src/pkg/build/types/parser/deffile.go
@@ -454,4 +454,5 @@ var validHeaders = map[string]bool{
 	"mirrorurl":  true,
 	"osversion":  true,
 	"include":    true,
+	"library":    true,
 }


### PR DESCRIPTION
This PR allows a custom library to be used within definitions.

### Example Usage
```
Bootstrap: library
From: dtrudg/linux/ubuntu
Library: https://library.sylabs.io
```