### PR TITLE
Remove anything at build destination before building SIF

### DIFF
--- a/src/pkg/build/assemblers/assembler_sif.go
+++ b/src/pkg/build/assemblers/assembler_sif.go
@@ -72,6 +72,9 @@ func createSIF(path string, definition []byte, squashfile string) (err error) {
 	// add this descriptor input element to the list
 	cinfo.InputDescr = append(cinfo.InputDescr, parinput)
 
+	// remove anything that may exist at the build destination at last moment
+	os.RemoveAll(path)
+
 	// test container creation with two partition input descriptors
 	if _, err := sif.CreateContainer(cinfo); err != nil {
 		return fmt.Errorf("while creating container: %s", err)


### PR DESCRIPTION
fixes #2017
This bug is caused when the destination is a sandbox directory. `CreateContainer()` tries to open the the destination as a file with `OpenFile()` and it gets an error because its a directory.