### PR TITLE
Consolidate namespace options

### DIFF
--- a/src/cmd/singularity/cli/action_flags.go
+++ b/src/cmd/singularity/cli/action_flags.go
@@ -29,6 +29,7 @@ var (
 	DNS         string
 	Security    []string
 	CgroupsPath string
+	Namespace   []string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -40,12 +41,6 @@ var (
 	Nvidia          bool
 	NoHome          bool
 	NoInit          bool
-
-	NetNamespace  bool
-	UtsNamespace  bool
-	UserNamespace bool
-	PidNamespace  bool
-	IpcNamespace  bool
 
 	AllowSUID bool
 	KeepPrivs bool
@@ -69,7 +64,6 @@ func getHomeDir() string {
 func init() {
 	initPathVars()
 	initBoolVars()
-	initNamespaceVars()
 	initPrivilegeVars()
 }
 
@@ -139,6 +133,10 @@ func initPathVars() {
 	// --apply-cgroups
 	actionFlags.StringVar(&CgroupsPath, "apply-cgroups", "", "Apply cgroups from file for container processes (requires root privileges)")
 	actionFlags.SetAnnotation("cgroups-profile", "argtag", []string{"<path>"})
+
+	// --namespace
+	actionFlags.StringSliceVarP(&Namespace, "namespace", "n", []string{}, "List of namespaces (pid,ipc,network,uts,user) for container to join separated by commas")
+	actionFlags.SetAnnotation("namespace", "argtag", []string{"<list>"})
 }
 
 // initBoolVars initializes flags that take a boolean argument
@@ -181,29 +179,6 @@ func initBoolVars() {
 	// --no-init
 	actionFlags.BoolVar(&NoInit, "no-init", false, "Do NOT start shim process with --pid.")
 	actionFlags.SetAnnotation("no-init", "envkey", []string{"NO_INIT", "NOSHIMINIT"})
-}
-
-// initNamespaceVars initializes flags that take toggle namespace support
-func initNamespaceVars() {
-	// -p|--pid
-	actionFlags.BoolVarP(&PidNamespace, "pid", "p", false, "Run container in a new PID namespace")
-	actionFlags.SetAnnotation("pid", "envkey", []string{"PID", "UNSHARE_PID"})
-
-	// -i|--ipc
-	actionFlags.BoolVarP(&IpcNamespace, "ipc", "i", false, "Run container in a new IPC namespace")
-	actionFlags.SetAnnotation("ipc", "envkey", []string{"IPC", "UNSHARE_IPC"})
-
-	// -n|--net
-	actionFlags.BoolVarP(&NetNamespace, "net", "n", false, "Run container in a new network namespace (sets up a bridge network interface by default).")
-	actionFlags.SetAnnotation("net", "envkey", []string{"NET", "UNSHARE_NET"})
-
-	// --uts
-	actionFlags.BoolVar(&UtsNamespace, "uts", false, "Run container in a new UTS namespace")
-	actionFlags.SetAnnotation("uts", "envkey", []string{"UTS", "UNSHARE_UTS"})
-
-	// -u|--userns
-	actionFlags.BoolVarP(&UserNamespace, "userns", "u", false, "Run container in a new user namespace, allowing Singularity to run completely unprivileged on recent kernels. This may not support every feature of Singularity.")
-	actionFlags.SetAnnotation("userns", "envkey", []string{"USERNS", "UNSHARE_USERNS"})
 }
 
 // initPrivilegeVars initializes flags that manipulate privileges

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sylabs/singularity/src/pkg/libexec"
+	"github.com/sylabs/singularity/src/pkg/util/arrayhelper"
 	"github.com/sylabs/singularity/src/pkg/util/nvidiautils"
 
 	"github.com/spf13/cobra"
@@ -438,19 +439,15 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		procname = "Singularity runtime parent"
 	}
 
-	// does "user" appear in the namespace array?
-	userns := false
-	for _, ns := range Namespace {
-		if ns == "user" {
-			userns = true
-		}
-	}
-	if !userns {
+	if userns := arrayhelper.IsIn(Namespace, "user"); !userns {
 		if _, err := os.Stat(starter); os.IsNotExist(err) {
 			sylog.Verbosef("starter-suid not found, using user namespace")
 			Namespace = append(Namespace, "user")
 		}
 	}
+
+	Namespace = arrayhelper.Unique(Namespace)
+	fmt.Printf("%v\n", Namespace)
 
 	for _, ns := range Namespace {
 		switch ns {

--- a/src/cmd/singularity/cli/instance_start.go
+++ b/src/cmd/singularity/cli/instance_start.go
@@ -25,7 +25,6 @@ func init() {
 		"home",
 		"hostname",
 		"keep-privs",
-		"net",
 		"network",
 		"network-args",
 		"no-home",
@@ -34,8 +33,6 @@ func init() {
 		"overlay",
 		"scratch",
 		"security",
-		"userns",
-		"uts",
 		"workdir",
 		"writable",
 		"writable-tmpfs",
@@ -50,7 +47,7 @@ func init() {
 
 // InstanceStartCmd singularity instance start
 var InstanceStartCmd = &cobra.Command{
-	Args:                  cobra.MinimumNArgs(2),
+	Args: cobra.MinimumNArgs(2),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		a := []string{"/.singularity.d/actions/start"}

--- a/src/cmd/singularity/cli/instance_start.go
+++ b/src/cmd/singularity/cli/instance_start.go
@@ -47,7 +47,7 @@ func init() {
 
 // InstanceStartCmd singularity instance start
 var InstanceStartCmd = &cobra.Command{
-	Args: cobra.MinimumNArgs(2),
+	Args:                  cobra.MinimumNArgs(2),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		a := []string{"/.singularity.d/actions/start"}

--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -236,12 +236,6 @@ var flagEnvFuncs = map[string]envHandle{
 	"no-home":    envBool,
 	"no-init":    envBool,
 
-	"pid":    envBool,
-	"ipc":    envBool,
-	"net":    envBool,
-	"uts":    envBool,
-	"userns": envBool,
-
 	"keep-privs":   envBool,
 	"no-privs":     envBool,
 	"add-caps":     envStringNSlice,

--- a/src/pkg/util/arrayhelper/arrayhelper.go
+++ b/src/pkg/util/arrayhelper/arrayhelper.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package arrayhelper
+
+// IsIn returns true if a string is found within an array and false otherwise.
+// Always returns false if the input array is empty.
+func IsIn(a []string, s string) bool {
+	found := false
+	for _, v := range a {
+		if v == s {
+			found = true
+		}
+	}
+	return found
+}
+
+// Unique returns the input string array with any duplicates removed
+func Unique(a []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, s := range a {
+		if _, value := keys[s]; !value {
+			keys[s] = true
+			list = append(list, s)
+		}
+	}
+	return list
+}

--- a/src/pkg/util/arrayhelper/arrayhelper_test.go
+++ b/src/pkg/util/arrayhelper/arrayhelper_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package arrayhelper
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_IsIn(t *testing.T) {
+	sample := []string{"foo", "bar"}
+	blank := []string{}
+
+	t.Run("string present", func(t *testing.T) {
+		if out := IsIn(sample, "foo"); !out {
+			t.Errorf("arrayhelper.IsIn returned false when searching for \"bar\" in array [\"foo\" \"bar\"]")
+		}
+	})
+
+	t.Run("string absent", func(t *testing.T) {
+		if out := IsIn(sample, "blah"); out {
+			t.Errorf("arrayhelper.IsIn returned true when searching for \"blah\" in array [\"foo\" \"bar\"]")
+		}
+	})
+
+	t.Run("blank array", func(t *testing.T) {
+		if out := IsIn(blank, "foo"); out {
+			t.Errorf("arrayhelper.IsIn returned true when searching for \"foo\" in array []")
+		}
+	})
+}
+
+func Test_Unique(t *testing.T) {
+	sampleA := []string{"foo", "bar", "bar"}
+	sampleB := []string{"foo", "bar"}
+	blank := []string{}
+
+	t.Run("duplicates present", func(t *testing.T) {
+		if out := strings.Join(Unique(sampleA), " "); out != "foo bar" {
+			t.Errorf("arrayhelper.Unique did not properly remove duplicates from array")
+		}
+	})
+
+	t.Run("duplicates absent", func(t *testing.T) {
+		if out := strings.Join(Unique(sampleB), " "); out != "foo bar" {
+			t.Errorf("arrayhelper.Unique did not properly skip removing duplicates when they were absent")
+		}
+	})
+
+	t.Run("blank array", func(t *testing.T) {
+		if out := strings.Join(Unique(blank), " "); out != "" {
+			t.Errorf("arrayhelper.Unique did not return a blank array when given a blank array as input")
+		}
+	})
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Right now we have 5 different bools for all of the different namespaces that a user can join.  This PR consolidates them all into a single comma separated string.   

It also adds a few functions for to the util directory to work more efficiently with string arrays. 

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [ ] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
