### PR TITLE
fix image expand  behavior, issue #1076

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - changed behaviour (recipe sections work differently)
 
 ## [v2.6.0]
-    
+
+### Bug fixes
+ - Fix image expand functionality by additional losetup/mount -o bind,offset=31     
+
 ### Implemented enhancements
  - Allow admin to specify a non-standard location for mksquashfs binary at 
    build time with `--with-mksquashfs` option #1662

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,3 +51,4 @@
     - Thomas Hamel <hmlth@t-hamel.fr>
     - Yaroslav Halchenko <debian@onerussian.com>
     - Matt Wiens <mwiens91@gmail.com>
+    - Marcin Stolarek <stolarek.marcin@gmail.com>

--- a/libexec/cli/image.expand.exec
+++ b/libexec/cli/image.expand.exec
@@ -112,15 +112,30 @@ if ! dd if=/dev/zero bs=1M count=${SINGULARITY_IMAGESIZE:-768} status=${DDSTATUS
     exit 1
 fi
 
+message 1 "Create loop device\n"
+SINGULARITY_LOOP_DEVICE=$(losetup --show -o 31 -f $SINGULARITY_IMAGE 2> /dev/null)
+if [ $? -ne 0 ]; then
+       exit 1
+fi
+
+
 message 1 "Checking image's file system\n"
-if ! /sbin/e2fsck -fy "$SINGULARITY_IMAGE"; then
+if ! /sbin/e2fsck -fy "$SINGULARITY_LOOP_DEVICE"; then
+    umount "$SINGULARITY_LOOP_DEVICE"
     exit 1
 fi
 
 message 1 "Resizing image's file system\n"
-if ! /sbin/resize2fs "$SINGULARITY_IMAGE"; then
+if ! /sbin/resize2fs "$SINGULARITY_LOOP_DEVICE"; then
+    umount "$SINGULARITY_LOOP_DEVICE"
     exit 1
 fi
 
+#For some reason without this dummy sleep sometimes umount failed for me with "device busy"
+sleep 3
+message 1 "Unmounting loop device: $SINGULARITY_LOOP_DEVICE\n"
+losetup -d  "$SINGULARITY_LOOP_DEVICE"
+
 message 1 "Image is done: $SINGULARITY_IMAGE\n"
 exit 0
+


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Current implementation of image.expand.exec doesn't work, since it tries to execute tools like e2fsck/resize2fs against  file where 1st 31 bytes are shebang to singularity, effectively for instance changing location of the superblock. In case of ext/writtable images making it not usable.
Some work notes on the debugging can be found [here](https://funinit.wordpress.com/2018/10/01/solved-singularity-2-6-fails-to-resize-writable-container/)


**This fixes or addresses the following GitHub issues:**

- Fixes #1076


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
