### PR TITLE
Include name of container in build completion output

### DIFF
--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -181,7 +181,7 @@ func (b *Build) Full() error {
 		return err
 	}
 
-	sylog.Infof("Build complete!")
+	sylog.Infof("Build complete: %s", b.dest)
 	return nil
 }
 


### PR DESCRIPTION
As recommended by @devprincess 

### Previously
```
[...]
INFO:    Creating SIF file...
INFO:    Build complete!
```

### Now
```
[...]
INFO:    Creating SIF file...
INFO:    Build complete: test.sif
```