### PR TITLE
Development 3.0: Abort when mount error occurs for filesystems

### DIFF
--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -387,6 +387,10 @@ func (c *container) mount(point *mount.Point) error {
 			if flags&syscall.MS_REMOUNT != 0 {
 				return fmt.Errorf("can't remount %s: %s", point.Destination, err)
 			}
+			// mount error for filesystems is considered fatal
+			if point.Type != "" {
+				return fmt.Errorf("can't mount %s filesystem to %s: %s", point.Type, point.Destination, err)
+			}
 			sylog.Verbosef("can't mount %s: %s", point.Source, err)
 			return nil
 		}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes issue creating files/directories in host session directory, that happens because mount code doesn't return an error during a filesystem mount.

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
