### PR TITLE
Makeit: Allow configurable build/install paths.

### DIFF
--- a/mlocal/checks/project.chk
+++ b/mlocal/checks/project.chk
@@ -11,17 +11,20 @@ config_add_def PACKAGE_STRING \"singularity $package_version\"
 config_add_def PACKAGE_BUGREPORT \"support@sylabs.io\"
 config_add_def PACKAGE_URL \"\"
 
+# load configurable paths
+. $mfragsdir/paths.stub
+
 config_add_def BUILDDIR \"$builddir\"
 config_add_def PREFIX \"$prefix\"
 config_add_def EXECPREFIX \"$exec_prefix\"
-config_add_def BINDIR EXECPREFIX \"/bin\"
-config_add_def LIBEXECDIR EXECPREFIX \"/libexec\"
-config_add_def SBINDIR LIBEXECDIR \"/singularity/bin\"
+config_add_def BINDIR \"$bindir\"
+config_add_def LIBEXECDIR \"$libexecdir\"
+config_add_def SBINDIR \"$sbindir\"
 config_add_def DATAROOTDIR EXECPREFIX \"/share\"
 config_add_def DATADIR DATAROOTDIR
-config_add_def SYSCONFDIR PREFIX \"/etc\"
-config_add_def SHAREDSTARTEDIR PREFIX \"/com\"
-config_add_def LOCALSTATEDIR PREFIX \"/var\"
+config_add_def SYSCONFDIR \"$sysconfdir\"
+config_add_def SHAREDSTATEDIR \"$sharedstatedir\"
+config_add_def LOCALSTATEDIR \"$localstatedir\"
 config_add_def INCLUDEDIR PREFIX \"/include\"
 config_add_def OLDINCLUDEDIR \"/usr/include\"
 config_add_def DOCDIR DATAROOTDIR \"/doc/\" PACKAGE_TARNAME
@@ -30,7 +33,7 @@ config_add_def HTMLDIR DOCDIR
 config_add_def DVIDIR DOCDIR
 config_add_def PDFDIR DOCDIR
 config_add_def PSDIR DOCDIR
-config_add_def LIBDIR EXECPREFIX \"/lib\"
+config_add_def LIBDIR \"$libdir\"
 config_add_def LOCALEDIR DATAROOTDIR \"/locale\"
 config_add_def MANDIR DATAROOTDIR \"/man\"
 config_add_def SINGULARITY_CONFDIR SYSCONFDIR \"/singularity\"

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -66,7 +66,7 @@ cniplugins: $(BUILDDIR)/vendors-done
 	$(V)for p in `go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ../vendor/$(cni_plugins_REPO)/...|grep -v sample`; do \
 		if [ ! -f $(cni_builddir)/`basename $$p` ]; then \
 			echo " CNI PLUGIN" `basename $$p`; \
-			go build $(GO_TAGS) $(GO_LDFLAGS) -o $(cni_builddir)/`basename $$p` $$p; \
+			go build $(GO_BUILDMODE) $(GO_TAGS) $(GO_LDFLAGS) -o $(cni_builddir)/`basename $$p` $$p; \
 		fi \
 	done
 
@@ -88,7 +88,7 @@ $(libruntime): $(libutil_OBJ)
 # starter
 $(starter): $(go_OBJ) $(starter_OBJ) $(libruntime)
 	@echo " GO" $@
-	$(V)go build $(GO_TAGS) $(GO_LDFLAGS) -o $@ \
+	$(V)go build $(GO_BUILDMODE) $(GO_TAGS) $(GO_LDFLAGS) -o $@ \
 		$(SOURCEDIR)/src/runtime/starter/scontainer.go \
 		$(SOURCEDIR)/src/runtime/starter/smaster.go \
 		$(SOURCEDIR)/src/runtime/starter/rpc.go
@@ -96,7 +96,7 @@ $(starter): $(go_OBJ) $(starter_OBJ) $(libruntime)
 # singularity
 $(singularity): $(go_OBJ) $(libruntime) $(singularity_OBJ)
 	@echo " GO" $@
-	$(V)go build $(GO_TAGS) $(GO_LDFLAGS) -o $(BUILDDIR)/singularity $(SOURCEDIR)/src/cmd/singularity/cli.go
+	$(V)go build $(GO_BUILDMODE) $(GO_TAGS) $(GO_LDFLAGS) -o $(BUILDDIR)/singularity $(SOURCEDIR)/src/cmd/singularity/cli.go
 $(singularity_INSTALL): $(singularity)
 	@echo " INSTALL" $@
 	$(V)install -d $(@D)

--- a/mlocal/frags/go_appsec_opts.mk
+++ b/mlocal/frags/go_appsec_opts.mk
@@ -1,6 +1,7 @@
 # go tool default build options
 GO_TAGS := -tags "containers_image_openpgp apparmor selinux seccomp"
 GO_LDFLAGS :=
+GO_BUILDMODE := -buildmode=default
 
 CGO_CPPFLAGS := -I$(BUILDDIR) -I$(SOURCEDIR)/src/runtime -I$(SOURCEDIR)/src/runtime/c/lib
 CGO_CPPFLAGS += -include $(BUILDDIR_ABSPATH)/config.h

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -1,6 +1,7 @@
 # go tool default build options
 GO_TAGS := -tags "containers_image_openpgp apparmor selinux"
 GO_LDFLAGS :=
+GO_BUILDMODE := -buildmode=default
 
 CGO_CPPFLAGS := -I$(BUILDDIR) -I$(SOURCEDIR)/src/runtime -I$(SOURCEDIR)/src/runtime/c/lib
 CGO_CPPFLAGS += -include $(BUILDDIR_ABSPATH)/config.h

--- a/mlocal/frags/paths.stub
+++ b/mlocal/frags/paths.stub
@@ -1,0 +1,13 @@
+#!/bin/sh -
+#
+# Singularity configurable build and installation paths
+#
+set -e
+
+bindir=$exec_prefix/bin
+libexecdir=$exec_prefix/libexec
+sbindir=$libexecdir/singularity/bin
+sysconfdir=$prefix/etc
+sharedstatedir=$prefix/com
+localstatedir=$prefix/var
+libdir=$exec_prefix/lib


### PR DESCRIPTION
This PR allows many build and install paths to be configured via mconfig + mlocal/frags/paths.stub.

This is useful mainly for RPM and other packaging.