### PR TITLE
Development 3.0: Add selinux and seccomp dep constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -77,6 +77,14 @@ required = [
   name = "github.com/spf13/pflag"
   version = "1.0.0"
 
+[[constraint]]
+  name = "github.com/opencontainers/selinux"
+  version = "v1.0.0-rc1"
+
+[[constraint]]
+  name = "github.com/seccomp/libseccomp-golang"
+  version = "v0.9.0"
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds missing selinux and seccomp package dependency constraint in `Gopkg.toml`


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
