### PR TITLE
Bind mount action scripts in runtime

### DIFF
--- a/etc/actions/exec
+++ b/etc/actions/exec
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+exec "$@"

--- a/etc/actions/run
+++ b/etc/actions/run
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -n "${SINGULARITY_APPNAME:-}"; then
+
+    if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript"; then
+        exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript" "$@"
+    else
+        echo "No Singularity runscript for contained app: ${SINGULARITY_APPNAME:-}"
+        exit 1
+    fi
+
+elif test -x "/.singularity.d/runscript"; then
+    exec "/.singularity.d/runscript" "$@"
+else
+    echo "No Singularity runscript found, executing /bin/sh"
+    exec /bin/sh "$@"
+fi

--- a/etc/actions/shell
+++ b/etc/actions/shell
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -n "$SINGULARITY_SHELL" -a -x "$SINGULARITY_SHELL"; then
+    exec $SINGULARITY_SHELL "$@"
+
+    echo "ERROR: Failed running shell as defined by '\$SINGULARITY_SHELL'" 1>&2
+    exit 1
+
+elif test -x /bin/bash; then
+    SHELL=/bin/bash
+    PS1="Singularity $SINGULARITY_NAME:\\w> "
+    export SHELL PS1
+    exec /bin/bash --norc "$@"
+elif test -x /bin/sh; then
+    SHELL=/bin/sh
+    export SHELL
+    exec /bin/sh "$@"
+else
+    echo "ERROR: /bin/sh does not exist in container" 1>&2
+fi
+exit 1

--- a/etc/actions/start
+++ b/etc/actions/start
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# if we are here start notify PID 1 to continue
+# DON'T REMOVE
+kill -CONT 1
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -x "/.singularity.d/startscript"; then
+    exec "/.singularity.d/startscript"
+fi

--- a/etc/actions/test
+++ b/etc/actions/test
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+
+if test -z "${SINGULARITY_APPNAME:-}"; then
+
+    if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test"; then
+        exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test" "$@"
+    else
+        echo "No Singularity tests for contained app: ${SINGULARITY_APPNAME:-}"
+        exit 1
+    fi
+elif test -x "/.singularity.d/test"; then
+    exec "/.singularity.d/test" "$@"
+else
+    echo "No Singularity container test found, executing /bin/sh"
+    exec /bin/sh "$@"
+fi

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -50,10 +50,13 @@ cni_plugins_INSTALL := $(foreach plugin,$(notdir $(cni_plugins_EXECUTABLES)),$(E
 cni_config_LIST := $(wildcard $(SOURCEDIR)/etc/network/*.conflist)
 cni_config_INSTALL := $(PREFIX)/etc/singularity/network
 
+actions_LIST := $(wildcard $(SOURCEDIR)/etc/actions/*)
+actions_INSTALL := $(PREFIX)/etc/singularity/actions
+
 INSTALLFILES := $(singularity_INSTALL) $(starter_INSTALL) $(starter_suid_INSTALL) $(sessiondir) \
 	$(config_INSTALL) $(dist_bin_SCRIPTS_INSTALL) $(capability_JSON) $(syecl_config_INSTALL) \
-	$(bash_completion_INSTALL) $(cni_plugins_INSTALL) $(cni_config_INSTALL) $(seccomp_profile_INSTALL) \
-	$(NVIDIA_liblist_INSTALL) $(cgroups_config_INSTALL)
+	$(bash_completion_INSTALL) $(actions_INSTALL) $(cni_plugins_INSTALL) $(cni_config_INSTALL) \
+	$(seccomp_profile_INSTALL) $(NVIDIA_liblist_INSTALL) $(cgroups_config_INSTALL) 
 
 CLEANFILES += $(libruntime) $(starter) $(singularity) $(go_BIN) $(go_OBJ) $(bash_completion) \
 	$(cni_plugins_EXECUTABLES)
@@ -185,6 +188,11 @@ $(cgroups_config_INSTALL): $(cgroups_config)
 	@echo " INSTALL" $@
 	$(V)install -d $(@D)
 	$(V)install -m 0644 $< $@
+
+$(actions_INSTALL): $(actions_LIST)
+	@echo " INSTALL" $@
+	$(V)install -d $(actions_INSTALL)
+	$(V)install -m 0755 $? $@
 
 .PHONY: man
 man:

--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -1593,7 +1593,6 @@ func (c *container) addActionsMount(system *mount.System) error {
 	if err != nil {
 		return fmt.Errorf("unable to add %s to mount list: %s", containerDir, err)
 	}
-	system.Points.AddRemount(mount.BindsTag, containerDir, flags)
 
-	return nil
+	return system.Points.AddRemount(mount.BindsTag, containerDir, flags)
 }

--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -1587,11 +1587,13 @@ func (c *container) addHostnameMount(system *mount.System) error {
 func (c *container) addActionsMount(system *mount.System) error {
 	hostDir := filepath.Join(buildcfg.SYSCONFDIR, "/singularity/actions")
 	containerDir := "/.singularity.d/actions"
+	flags := uintptr(syscall.MS_BIND | syscall.MS_RDONLY | syscall.MS_NOSUID | syscall.MS_NODEV)
 
-	err := system.Points.AddBind(mount.BindsTag, hostDir, containerDir, syscall.MS_BIND)
+	err := system.Points.AddBind(mount.BindsTag, hostDir, containerDir, flags)
 	if err != nil {
 		return fmt.Errorf("unable to add %s to mount list: %s", containerDir, err)
 	}
+	system.Points.AddRemount(mount.BindsTag, containerDir, flags)
 
 	return nil
 }

--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -142,6 +142,9 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 	if err := c.addHostnameMount(system); err != nil {
 		return err
 	}
+	if err := c.addActionsMount(system); err != nil {
+		return err
+	}
 
 	sylog.Debugf("Mount all")
 	if err := system.MountAll(); err != nil {
@@ -1578,5 +1581,17 @@ func (c *container) addHostnameMount(system *mount.System) error {
 	} else {
 		sylog.Debugf("Skipping hostname mount, not virtualizing UTS namespace on user request")
 	}
+	return nil
+}
+
+func (c *container) addActionsMount(system *mount.System) error {
+	hostDir := filepath.Join(buildcfg.SYSCONFDIR, "/singularity/actions")
+	containerDir := "/.singularity.d/actions"
+
+	err := system.Points.AddBind(mount.BindsTag, hostDir, containerDir, syscall.MS_BIND)
+	if err != nil {
+		return fmt.Errorf("unable to add %s to mount list: %s", containerDir, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
### This PR:
- Commits the runtime action scripts to `/etc/actions`
- Installs this directory to the host at `HOSTPREFIX/etc/singularity/actions` during `make install`
- Mounts this host directory to `/.singularity.d/actions` as a part of the runtime

Fixes #1980 