### PR TITLE
Development 3.0: Fix app environment variable

### DIFF
--- a/src/cmd/singularity/cli/action_flags.go
+++ b/src/cmd/singularity/cli/action_flags.go
@@ -77,7 +77,7 @@ func init() {
 func initPathVars() {
 	// --app
 	actionFlags.StringVar(&AppName, "app", "", "Set container app to run")
-	actionFlags.SetAnnotation("app", "envkey", []string{"APPNAME"})
+	actionFlags.SetAnnotation("app", "envkey", []string{"APP", "APPNAME"})
 
 	// -B|--bind
 	actionFlags.StringSliceVarP(&BindPaths, "bind", "B", []string{}, "A user-bind path specification.  spec has the format src[:dest[:opts]], where src and dest are outside and inside paths.  If dest is not given, it is set equal to src.  Mount options ('opts') may be specified as 'ro' (read-only) or 'rw' (read/write, which is the default). Multiple bind paths can be given by a comma separated list.")

--- a/src/cmd/singularity/cli/action_flags.go
+++ b/src/cmd/singularity/cli/action_flags.go
@@ -77,7 +77,7 @@ func init() {
 func initPathVars() {
 	// --app
 	actionFlags.StringVar(&AppName, "app", "", "Set container app to run")
-	actionFlags.SetAnnotation("app", "envkey", []string{"APP"})
+	actionFlags.SetAnnotation("app", "envkey", []string{"APPNAME"})
 
 	// -B|--bind
 	actionFlags.StringSliceVarP(&BindPaths, "bind", "B", []string{}, "A user-bind path specification.  spec has the format src[:dest[:opts]], where src and dest are outside and inside paths.  If dest is not given, it is set equal to src.  Mount options ('opts') may be specified as 'ro' (read-only) or 'rw' (read/write, which is the default). Multiple bind paths can be given by a comma separated list.")


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes app environment variable associated with `--app` flag. `APPNAME` instead of `APP` actually


**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
