### PR TITLE
Build Service JSON Response Format

### DIFF
--- a/src/pkg/build/builder_remote.go
+++ b/src/pkg/build/builder_remote.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/src/pkg/build/types"
 	"github.com/sylabs/singularity/src/pkg/client/library"
+	"github.com/sylabs/singularity/src/pkg/jsonresp"
 	"github.com/sylabs/singularity/src/pkg/sylog"
 	"github.com/sylabs/singularity/src/pkg/util/user-agent"
 )
@@ -191,12 +192,7 @@ func (rb *RemoteBuilder) doBuildRequest(ctx context.Context, d types.Definition,
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusCreated {
-		err = errors.New(res.Status)
-		return
-	}
-
-	err = json.NewDecoder(res.Body).Decode(&rd)
+	err = jsonresp.ReadResponse(res.Body, &rd)
 	return
 }
 
@@ -216,11 +212,6 @@ func (rb *RemoteBuilder) doStatusRequest(ctx context.Context, id bson.ObjectId) 
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		err = errors.New(res.Status)
-		return
-	}
-
-	err = json.NewDecoder(res.Body).Decode(&rd)
+	err = jsonresp.ReadResponse(res.Body, &rd)
 	return
 }

--- a/src/pkg/build/builder_remote_test.go
+++ b/src/pkg/build/builder_remote_test.go
@@ -21,8 +21,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/websocket"
 	"github.com/sylabs/singularity/src/pkg/build/types"
+	"github.com/sylabs/singularity/src/pkg/jsonresp"
 	"github.com/sylabs/singularity/src/pkg/test"
-	useragent "github.com/sylabs/singularity/src/pkg/util/user-agent"
+	"github.com/sylabs/singularity/src/pkg/util/user-agent"
 )
 
 const (
@@ -83,10 +84,11 @@ func (m *mockService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&rd); err != nil {
 			m.t.Fatalf("failed to parse request: %v", err)
 		}
-		w.WriteHeader(m.buildResponseCode)
 		if m.buildResponseCode == http.StatusCreated {
 			id := bson.NewObjectId()
-			json.NewEncoder(w).Encode(newResponse(m, id, rd.Definition, rd.LibraryRef))
+			jsonresp.WriteResponse(w, newResponse(m, id, rd.Definition, rd.LibraryRef), m.buildResponseCode)
+		} else {
+			jsonresp.WriteError(w, "", m.buildResponseCode)
 		}
 	} else if r.Method == http.MethodGet && strings.HasPrefix(r.RequestURI, buildPath) {
 		// Mock status endpoint
@@ -94,17 +96,19 @@ func (m *mockService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !bson.IsObjectIdHex(id) {
 			m.t.Fatalf("failed to parse ID '%v'", id)
 		}
-		w.WriteHeader(m.statusResponseCode)
 		if m.statusResponseCode == http.StatusOK {
-			json.NewEncoder(w).Encode(newResponse(m, bson.ObjectIdHex(id), types.Definition{}, ""))
+			jsonresp.WriteResponse(w, newResponse(m, bson.ObjectIdHex(id), types.Definition{}, ""), m.statusResponseCode)
+		} else {
+			jsonresp.WriteError(w, "", m.statusResponseCode)
 		}
 	} else if r.Method == http.MethodGet && strings.HasPrefix(r.RequestURI, imagePath) {
 		// Mock get image endpoint
-		w.WriteHeader(m.imageResponseCode)
 		if m.imageResponseCode == http.StatusOK {
 			if _, err := strings.NewReader(imageContents).WriteTo(w); err != nil {
 				m.t.Fatalf("failed to write image")
 			}
+		} else {
+			jsonresp.WriteError(w, "", m.imageResponseCode)
 		}
 	} else {
 		w.WriteHeader(http.StatusNotFound)

--- a/src/pkg/jsonresp/json_response.go
+++ b/src/pkg/jsonresp/json_response.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
+package jsonresp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/sylabs/singularity/src/pkg/sylog"
+)
+
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("%v (%v %v)", e.Message, e.Code, http.StatusText(e.Code))
+	}
+	return fmt.Sprintf("%v %v", e.Code, http.StatusText(e.Code))
+}
+
+// Error describes an error condition.
+type Error struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// Response is the top level container of all of our REST API responses.
+type Response struct {
+	Data  interface{} `json:"data,omitempty"`
+	Error *Error      `json:"error,omitempty"`
+}
+
+// NewError returns an error that contains the given code and message.
+func NewError(code int, message string) *Error {
+	return &Error{
+		Code:    code,
+		Message: message,
+	}
+}
+
+// WriteError encodes the supplied error in a response, and writes to w.
+func WriteError(w http.ResponseWriter, error string, code int) {
+	sylog.Warningf("%v", error)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+
+	jr := Response{
+		Error: &Error{
+			Code:    code,
+			Message: error,
+		},
+	}
+	if err := json.NewEncoder(w).Encode(jr); err != nil {
+		sylog.Warningf("failed to encode JSON response: %v", err)
+	}
+}
+
+// WriteResponse encodes the supplied data in a response, and writes to w.
+func WriteResponse(w http.ResponseWriter, data interface{}, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+
+	jr := Response{
+		Data: data,
+	}
+	if err := json.NewEncoder(w).Encode(jr); err != nil {
+		sylog.Warningf("failed to encode JSON response: %v", err)
+	}
+}
+
+// ReadResponse reads a JSON response, and unmarshals the supplied data.
+func ReadResponse(r io.Reader, v interface{}) error {
+	var u struct {
+		Data  json.RawMessage `json:"data"`
+		Error *Error          `json:"error"`
+	}
+	if err := json.NewDecoder(r).Decode(&u); err != nil {
+		sylog.Warningf("failed to decode JSON response: %v", err)
+		return err
+	}
+	if u.Error != nil {
+		return u.Error
+	}
+	if err := json.Unmarshal(u.Data, v); err != nil {
+		sylog.Warningf("failed to decode JSON response: %v", err)
+		return err
+	}
+	return nil
+}

--- a/src/pkg/jsonresp/json_response.go
+++ b/src/pkg/jsonresp/json_response.go
@@ -1,4 +1,7 @@
-// Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
 
 package jsonresp
 

--- a/src/pkg/jsonresp/json_response_test.go
+++ b/src/pkg/jsonresp/json_response_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+
+package jsonresp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          int
+		message       string
+		wantErrString string
+	}{
+		{"NoMessage", http.StatusNotFound, "", "404 Not Found"},
+		{"Message", http.StatusNotFound, "blah", "blah (404 Not Found)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			je := NewError(tt.code, tt.message)
+			if je.Code != tt.code {
+				t.Errorf("got code %v, want %v", je.Code, tt.code)
+			}
+			if je.Message != tt.message {
+				t.Errorf("got message %v, want %v", je.Message, tt.message)
+			}
+			if s := je.Error(); s != tt.wantErrString {
+				t.Errorf("got string %v, want %v", s, tt.wantErrString)
+			}
+		})
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	tests := []struct {
+		name        string
+		error       string
+		code        int
+		wantMessage string
+		wantCode    int
+	}{
+		{"NoMessage", "", http.StatusNotFound, "", http.StatusNotFound},
+		{"NoMessage", "blah", http.StatusNotFound, "blah", http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+
+			WriteError(rr, tt.error, tt.code)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("got code %v, want %v", rr.Code, tt.wantCode)
+			}
+
+			var jr Response
+			if err := json.NewDecoder(rr.Body).Decode(&jr); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if jr.Error == nil {
+				t.Fatalf("nil error received")
+			}
+			if jr.Error.Message != tt.wantMessage {
+				t.Errorf("got message %v, want %v", jr.Error.Message, tt.wantMessage)
+			}
+			if jr.Error.Code != tt.wantCode {
+				t.Errorf("got code %v, want %v", jr.Error.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestWriteResponse(t *testing.T) {
+	type TestStruct struct {
+		Value string
+	}
+
+	tests := []struct {
+		name      string
+		data      interface{}
+		code      int
+		wantValue string
+		wantCode  int
+	}{
+		{"Empty", TestStruct{""}, http.StatusOK, "", http.StatusOK},
+		{"NotEmpty", TestStruct{"blah"}, http.StatusOK, "blah", http.StatusOK},
+		{"Created", TestStruct{"blah"}, http.StatusCreated, "blah", http.StatusCreated},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+
+			WriteResponse(rr, tt.data, tt.code)
+
+			var ts TestStruct
+			if err := ReadResponse(rr.Body, &ts); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if ts.Value != tt.wantValue {
+				t.Errorf("got value '%v', want '%v'", ts.Value, tt.wantValue)
+			}
+			if rr.Code != tt.wantCode {
+				t.Errorf("got code '%v', want '%v'", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func getResponseBody(v interface{}) io.Reader {
+	rr := httptest.NewRecorder()
+	WriteResponse(rr, v, http.StatusOK)
+	return rr.Body
+}
+
+func getErrorBody(error string, code int) io.Reader {
+	rr := httptest.NewRecorder()
+	WriteError(rr, error, code)
+	return rr.Body
+}
+
+func TestReadResponse(t *testing.T) {
+	type TestStruct struct {
+		Value string
+	}
+
+	tests := []struct {
+		name      string
+		r         io.Reader
+		wantErr   bool
+		wantValue string
+	}{
+		{"Empty", bytes.NewReader(nil), true, ""},
+		{"Response", getResponseBody(TestStruct{"blah"}), false, "blah"},
+		{"Error", getErrorBody("blah", http.StatusNotFound), true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ts TestStruct
+
+			err := ReadResponse(tt.r, &ts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil {
+				if ts.Value != tt.wantValue {
+					t.Errorf("got value '%v', want '%v'", ts.Value, tt.wantValue)
+				}
+			}
+		})
+	}
+}

--- a/src/pkg/jsonresp/json_response_test.go
+++ b/src/pkg/jsonresp/json_response_test.go
@@ -1,4 +1,7 @@
-// Copyright (c) 2018, Sylabs, Inc. All rights reserved.
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
 
 package jsonresp
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

As of `v1.0.0-alpha.1-68-g603ae5d`, the Build Service JSON response format has changed. The new format allows for detailed error messages to be returned by the Service, as is the case with the Library.

To implement these changes, a generic `jsonresp` package has been added that specifies the common denominators in all Service APIs. Testing for the new package is present and has a 84% code coverage.

**This fixes or addresses the following GitHub issues:**

- Fixes #2189

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge

Attn: @singularity-maintainers
