### PR TITLE
Fix URIs

### DIFF
--- a/src/docs/content.go
+++ b/src/docs/content.go
@@ -496,7 +496,7 @@ Enterprise Performance Computing (EPC)`
      `
 	PullExample string = `
   From Sylabs cloud library
-  $ singularity pull library://dtrudg/demo/alpine:latest
+  $ singularity pull library://alpine:latest
 
   From Shub
   $ singularity pull shub://vsoch/singularity-images

--- a/src/pkg/build/builder_remote.go
+++ b/src/pkg/build/builder_remote.go
@@ -25,6 +25,9 @@ import (
 	"github.com/sylabs/singularity/src/pkg/util/user-agent"
 )
 
+// CloudURI holds the URI of the Library web front-end.
+const CloudURI = "https://cloud.sylabs.io"
+
 // RemoteBuilder contains the build request and response
 type RemoteBuilder struct {
 	Client     http.Client
@@ -87,7 +90,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 	if rb.IsDetached {
 		fmt.Printf("Build submitted! Once it is complete, the image can be retrieved by running:\n")
 		fmt.Printf("\tsingularity pull --library %v library://%v\n\n", rd.LibraryURL, libraryRefRaw)
-		fmt.Printf("Alternatively, you can access it from a browser at:\n\t%v/library/%v\n", rd.LibraryURL, libraryRefRaw)
+		fmt.Printf("Alternatively, you can access it from a browser at:\n\t%v/library/%v\n", CloudURI, libraryRefRaw)
 	}
 
 	// If we're doing an attached build, stream output and then download the resulting file

--- a/src/pkg/build/sources/conveyorPacker_library_test.go
+++ b/src/pkg/build/sources/conveyorPacker_library_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	libraryURL = "https://library.sylabs.io/"
-	libraryURI = "library://dtrudg/linux/alpine:latest"
+	libraryURI = "library://alpine:latest"
 )
 
 // TestLibraryConveyor tests if we can pull an image from singularity hub


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Replace broken `library://dtrudg/demo/alpine:latest` URI in documentation (#2194.) Update `library://dtrudg/linux/alpine:latest` to use an equivalent default container `library://alpine:latest` to avoid the potential breakage should @dctrud remove that. Fix download URL in detached remote build courtesy message.

**This fixes or addresses the following GitHub issues:**

- Fixes #2194

**Checkoff for all PRs:**

- [x] I have read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] I have added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/development/CHANGELOG.md) and and documentation updates to the [user](https://www.github.com/sylabs/singularity-userdocs) and [administrator](https://www.github.com/sylabs/singularity-admindocs) documentation bases.
- [x] I have tested this PR locally with a `make testall`
- [x] This PR is against the project's master branch
- [x] I have added myself as a contributor to the [contributors's file](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge


Attn: @singularity-maintainers
