### PR TITLE
Pass force option to remote builder

### DIFF
--- a/src/cmd/singularity/cli/build.go
+++ b/src/cmd/singularity/cli/build.go
@@ -114,7 +114,7 @@ var BuildCmd = &cobra.Command{
 				return
 			}
 
-			b, err := build.NewRemoteBuilder(dest, libraryURL, def, detached, builderURL, authToken)
+			b, err := build.NewRemoteBuilder(dest, libraryURL, def, detached, force, builderURL, authToken)
 			if err != nil {
 				sylog.Fatalf("failed to create builder: %v", err)
 			}

--- a/src/pkg/build/builder_remote.go
+++ b/src/pkg/build/builder_remote.go
@@ -47,7 +47,7 @@ func (rb *RemoteBuilder) setAuthHeader(h http.Header) {
 }
 
 // NewRemoteBuilder creates a RemoteBuilder with the specified details.
-func NewRemoteBuilder(imagePath, libraryURL string, d types.Definition, isDetached bool, builderAddr, authToken string) (rb *RemoteBuilder, err error) {
+func NewRemoteBuilder(imagePath, libraryURL string, d types.Definition, isDetached, force bool, builderAddr, authToken string) (rb *RemoteBuilder, err error) {
 	builderURL, err := url.Parse(builderAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse builder address")
@@ -58,6 +58,7 @@ func NewRemoteBuilder(imagePath, libraryURL string, d types.Definition, isDetach
 			Timeout: 30 * time.Second,
 		},
 		ImagePath:  imagePath,
+		Force:      force,
 		LibraryURL: libraryURL,
 		Definition: d,
 		IsDetached: isDetached,

--- a/src/pkg/build/builder_remote_test.go
+++ b/src/pkg/build/builder_remote_test.go
@@ -189,7 +189,7 @@ func TestBuild(t *testing.T) {
 	// Loop over test cases
 	for _, tt := range tests {
 		t.Run(tt.description, test.WithoutPrivilege(func(t *testing.T) {
-			rb, err := NewRemoteBuilder(tt.imagePath, "", types.Definition{}, tt.isDetached, s.URL, authToken)
+			rb, err := NewRemoteBuilder(tt.imagePath, "", types.Definition{}, tt.isDetached, false, s.URL, authToken)
 			if err != nil {
 				t.Fatalf("failed to get new remote builder: %v", err)
 			}


### PR DESCRIPTION
Fixes #2197 which doesn't overwrite image at destination even if the force option is specified