### PR TITLE
Set flag annotation on push cmd, not pull cmd

### DIFF
--- a/src/cmd/singularity/cli/push.go
+++ b/src/cmd/singularity/cli/push.go
@@ -23,7 +23,7 @@ func init() {
 	PushCmd.Flags().SetInterspersed(false)
 
 	PushCmd.Flags().StringVar(&PushLibraryURI, "library", "https://library.sylabs.io", "the library to push to")
-	PullCmd.Flags().SetAnnotation("library", "envkey", []string{"LIBRARY"})
+	PushCmd.Flags().SetAnnotation("library", "envkey", []string{"LIBRARY"})
 
 	SingularityCmd.AddCommand(PushCmd)
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes flag annotation for "push" command

**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
