### PR TITLE
Fix USER_PATH by appending default singularity PATH

### DIFF
--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"strings"
 	"text/template"
 
 	"github.com/spf13/cobra"
@@ -103,10 +104,13 @@ var SingularityCmd = &cobra.Command{
 // flags appropriately. This is called by main.main(). It only needs to happen
 // once to the root command (singularity).
 func ExecuteSingularity() {
-	// backup user PATH
-	os.Setenv("USER_PATH", os.Getenv("PATH"))
+	defaultEnv := "/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin"
 
-	os.Setenv("PATH", "/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin")
+	// backup user PATH
+	userEnv := strings.Join([]string{os.Getenv("PATH"), defaultEnv}, ":")
+	os.Setenv("USER_PATH", userEnv)
+
+	os.Setenv("PATH", defaultEnv)
 	if err := SingularityCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -104,7 +104,7 @@ var SingularityCmd = &cobra.Command{
 // flags appropriately. This is called by main.main(). It only needs to happen
 // once to the root command (singularity).
 func ExecuteSingularity() {
-	defaultEnv := "/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin"
+	defaultEnv := "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
 	// backup user PATH
 	userEnv := strings.Join([]string{os.Getenv("PATH"), defaultEnv}, ":")


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes environment variables grabbed from user environment by appending default PATH `/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin`, some distribution doesn't set /sbin in user PATH and that broke `--nv` when searching for ldconfig and nvidia binaries


**This fixes or addresses the following GitHub issues:**

- Fixes  #2252


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
