### PR TITLE
Use same go version for rpm as set for travis

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -21,7 +21,7 @@
 # 
 # 
 
-%define goversion 1.11
+%define goversion @GO_VERSION@
 %define singgopath src/github.com/sylabs/singularity
 
 Summary: Application and environment virtualization

--- a/mconfig
+++ b/mconfig
@@ -36,6 +36,7 @@ tgtstatic=0
 appsec=0
 
 package_version=`(git describe --match 'v[0-9]*' --dirty --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
+go_version="`grep -A 1 ^go: .travis.yml 2>/dev/null|sed -n 's/.*- "//;s/"//p'`"
 
 
 
@@ -387,7 +388,7 @@ if [ "$VERSION" = "$RELEASE" ]; then
     # $package_version has no dash
     RELEASE=1
 fi
-sed "s/@PACKAGE_VERSION@/$VERSION/;s/@PACKAGE_RELEASE@/$RELEASE/" $RPMSPEC.in >$RPMSPEC
+sed "s/@PACKAGE_VERSION@/$VERSION/;s/@PACKAGE_RELEASE@/$RELEASE/;s/@GO_VERSION@/$go_version/" $RPMSPEC.in >$RPMSPEC
 
 
 #######################################################################


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR extracts the go version from .travis.yml and copies it to singularity.spec.  That makes one less place to change when the go version changes.


**This fixes or addresses the following GitHub issues:**

None


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
