### PR TITLE
Remove URI from uri package function names

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -102,7 +102,7 @@ func handleOCI(u string) (string, error) {
 		return "", fmt.Errorf("failed to get SHA of %v: %v", u, err)
 	}
 
-	name := uri.NameFromURI(u)
+	name := uri.GetName(u)
 	imgabs := cache.OciTempImage(sum, name)
 
 	if exists, err := cache.OciTempExists(sum, name); err != nil {
@@ -130,7 +130,7 @@ func handleLibrary(u string) (string, error) {
 		return "", err
 	}
 
-	imageName := uri.NameFromURI(u)
+	imageName := uri.GetName(u)
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)
 
 	if exists, err := cache.LibraryImageExists(libraryImage.Hash, imageName); err != nil {
@@ -144,7 +144,7 @@ func handleLibrary(u string) (string, error) {
 }
 
 func handleShub(u string) (string, error) {
-	imageName := uri.NameFromURI(u)
+	imageName := uri.GetName(u)
 	imagePath := cache.ShubImage("hash", imageName)
 
 	libexec.PullShubImage(imagePath, u, true)
@@ -154,7 +154,7 @@ func handleShub(u string) (string, error) {
 
 func replaceURIWithImage(cmd *cobra.Command, args []string) {
 	// If args[0] is not transport:ref (ex. instance://...) formatted return, not a URI
-	t, _ := uri.SplitURI(args[0])
+	t, _ := uri.Split(args[0])
 	if t == "instance" || t == "" {
 		return
 	}

--- a/src/cmd/singularity/cli/pull_darwin.go
+++ b/src/cmd/singularity/cli/pull_darwin.go
@@ -15,7 +15,7 @@ import (
 
 func pullRun(cmd *cobra.Command, args []string) {
 	i := len(args) - 1 // uri is stored in args[len(args)-1]
-	transport, ref := uri.SplitURI(args[i])
+	transport, ref := uri.Split(args[i])
 	if ref == "" {
 		sylog.Fatalf("bad uri %s", args[i])
 	}
@@ -24,7 +24,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 	if PullImageName == "" {
 		name = args[0]
 		if len(args) == 1 {
-			name = uri.NameFromURI(args[i]) // TODO: If not library/shub & no name specified, simply put to cache
+			name = uri.GetName(args[i]) // TODO: If not library/shub & no name specified, simply put to cache
 		}
 	} else {
 		name = PullImageName

--- a/src/cmd/singularity/cli/pull_linux.go
+++ b/src/cmd/singularity/cli/pull_linux.go
@@ -14,7 +14,7 @@ import (
 
 func pullRun(cmd *cobra.Command, args []string) {
 	i := len(args) - 1 // uri is stored in args[len(args)-1]
-	transport, ref := uri.SplitURI(args[i])
+	transport, ref := uri.Split(args[i])
 	if ref == "" {
 		sylog.Fatalf("bad uri %s", args[i])
 	}
@@ -23,7 +23,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 	if PullImageName == "" {
 		name = args[0]
 		if len(args) == 1 {
-			name = uri.NameFromURI(args[i]) // TODO: If not library/shub & no name specified, simply put to cache
+			name = uri.GetName(args[i]) // TODO: If not library/shub & no name specified, simply put to cache
 		}
 	} else {
 		name = PullImageName

--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -358,7 +358,7 @@ func getcp(def types.Definition, libraryURL, authToken string) (ConveyorPacker, 
 
 // makeDef gets a definition object from a spec
 func makeDef(spec string, remote bool) (types.Definition, error) {
-	if ok, err := uri.IsValidURI(spec); ok && err == nil {
+	if ok, err := uri.IsValid(spec); ok && err == nil {
 		// URI passed as spec
 		return types.NewDefinitionFromURI(spec)
 	}

--- a/src/pkg/util/uri/uri.go
+++ b/src/pkg/util/uri/uri.go
@@ -28,8 +28,8 @@ var validURIs = map[string]bool{
 	"oci-archive":    true,
 }
 
-// IsValidURI returns whether or not the given source is valid
-func IsValidURI(source string) (valid bool, err error) {
+// IsValid returns whether or not the given source is valid
+func IsValid(source string) (valid bool, err error) {
 
 	u := strings.SplitN(source, ":", 2)
 
@@ -44,12 +44,12 @@ func IsValidURI(source string) (valid bool, err error) {
 	return false, fmt.Errorf("Invalid URI %s", source)
 }
 
-// NameFromURI turns a transport:ref URI into a name containing the top-level identifier
+// GetName turns a transport:ref URI into a name containing the top-level identifier
 // of the image. For example, docker://godlovedc/lolcow returns lolcow
 //
 // Returns "" when not in transport:ref format
-func NameFromURI(uri string) string {
-	transport, ref := SplitURI(uri)
+func GetName(uri string) string {
+	transport, ref := Split(uri)
 	if transport == "" {
 		return ""
 	}
@@ -73,7 +73,7 @@ func NameFromURI(uri string) string {
 	return fmt.Sprintf("%s_%s.sif", container, tags[0])
 }
 
-// SplitURI splits a URI into it's components which can be used directly through containers/image
+// Split splits a URI into it's components which can be used directly through containers/image
 //
 // This can be tricky if there is no type but a file name contains a colon.
 //
@@ -83,7 +83,7 @@ func NameFromURI(uri string) string {
 //   oci-archive:path/to/archive -> oci-archive, path/to/archive
 //   ubuntu -> "", ubuntu
 //   ubuntu:18.04.img -> "", ubuntu:18.04.img
-func SplitURI(uri string) (transport string, ref string) {
+func Split(uri string) (transport string, ref string) {
 	uriSplit := strings.SplitN(uri, ":", 2)
 	if len(uriSplit) == 1 {
 		// no colon
@@ -95,7 +95,7 @@ func SplitURI(uri string) (transport string, ref string) {
 		return uriSplit[0], uriSplit[1]
 	}
 
-	if ok, err := IsValidURI(uri); ok && err == nil {
+	if ok, err := IsValid(uri); ok && err == nil {
 		// also accept recognized URIs
 		return uriSplit[0], uriSplit[1]
 	}

--- a/src/pkg/util/uri/uri_test.go
+++ b/src/pkg/util/uri/uri_test.go
@@ -7,7 +7,7 @@ package uri
 
 import "testing"
 
-func Test_NameFromURI(t *testing.T) {
+func Test_GetName(t *testing.T) {
 	tests := []struct {
 		name     string
 		uri      string
@@ -21,14 +21,14 @@ func Test_NameFromURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if n := NameFromURI(tt.uri); n != tt.expected {
+			if n := GetName(tt.uri); n != tt.expected {
 				t.Errorf("incorrectly parsed name as \"%v\" (expected \"%s\")", n, tt.expected)
 			}
 		})
 	}
 }
 
-func Test_SplitURI(t *testing.T) {
+func Test_Split(t *testing.T) {
 	tests := []struct {
 		name      string
 		uri       string
@@ -47,7 +47,7 @@ func Test_SplitURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tr, r := SplitURI(tt.uri); tr != tt.transport || r != tt.ref {
+			if tr, r := Split(tt.uri); tr != tt.transport || r != tt.ref {
 				t.Errorf("incorrectly parsed uri as %s : %s (expected %s : %s)", tr, r, tt.transport, tt.ref)
 			}
 		})


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR removes the string "URI" from the end of the uri package function names.


**This fixes or addresses the following GitHub issues:**

- Suggested by @ArangoGutierrez in #2175


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
