### PR TITLE
Use make rpm from travis & improve 'make rpm' message

### DIFF
--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -17,7 +17,7 @@ su testuser -c '
   set -x
   ./mconfig -V 0.0
   sudo yum-builddep -y dist/rpm/singularity.spec
-  dist/rpm/buildrpm
+  make -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
   BLD=`echo $HOME/rpmbuild/BUILD/singularity-*`
   export GOROOT=$BLD/go

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -237,7 +237,7 @@ testall: vendor-check check test
 
 .PHONY: rpm
 rpm:
-	@echo "Build RPM"
+	@echo " BUILD RPM"
 	$(V)cd $(SOURCEDIR) && dist/rpm/buildrpm
 
 .PHONY: cscope


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Changes the travis rpm test to use `make -C builddir rpm` and changes the `make rpm` message to be consistent with other similar messages from make.


**This fixes or addresses the following GitHub issues:**

- Follows on #2236 & probably should have been done there.


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
