### PR TITLE
Allow local build definition spec for remote builds

### DIFF
--- a/src/cmd/singularity/cli/build_darwin.go
+++ b/src/cmd/singularity/cli/build_darwin.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/src/pkg/build/remotebuilder"
-	"github.com/sylabs/singularity/src/pkg/build/types"
 	"github.com/sylabs/singularity/src/pkg/sylog"
 )
 
@@ -37,9 +36,9 @@ func run(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Unable to submit build job: %v", authWarning)
 	}
 
-	def, err := types.NewDefinitionFromURI(spec)
+	def, err := definitionFromSpec(spec)
 	if err != nil {
-		return
+		sylog.Fatalf("Unable to build from %s: %v", spec, err)
 	}
 
 	b, err := remotebuilder.New(dest, libraryURL, def, detached, force, builderURL, authToken)

--- a/src/cmd/singularity/cli/build_linux.go
+++ b/src/cmd/singularity/cli/build_linux.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/src/pkg/build"
 	"github.com/sylabs/singularity/src/pkg/build/remotebuilder"
-	"github.com/sylabs/singularity/src/pkg/build/types"
 	"github.com/sylabs/singularity/src/pkg/sylog"
 	"github.com/sylabs/singularity/src/pkg/syplugin"
 )
@@ -42,9 +41,9 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("Unable to submit build job: %v", authWarning)
 		}
 
-		def, err := types.NewDefinitionFromURI(spec)
+		def, err := definitionFromSpec(spec)
 		if err != nil {
-			return
+			sylog.Fatalf("Unable to build from %s: %v", spec, err)
 		}
 
 		b, err := remotebuilder.New(dest, libraryURL, def, detached, force, builderURL, authToken)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR enables using the remote builder with local build definition files.

**This fixes or addresses the following GitHub issues:**

- Fixes #2262 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
