### PR TITLE
RPM Spec fix

### DIFF
--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -25,7 +25,7 @@ su testuser -c '
   git config --global user.name "Travis Test"
   make -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
-  BLD=`echo $HOME/rpmbuild/BUILD`
+  BLD=`echo $HOME/rpmbuild/BUILD/singularity-*`
   export GOROOT=$BLD/go
   export GOPATH=$BLD/gopath
   PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -29,6 +29,13 @@ su testuser -c '
   export GOROOT=$BLD/go
   export GOPATH=$BLD/gopath
   PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+  echo " BUILD DIR "
+  ls $HOME/rpmbuild/BUILD
+  echo " GOPATH "
+  ls $GOPATH/
+  echo " GOPATH Sylabs "
+  ls $GOPATH/src/github.com/sylabs/
+
   cd $GOPATH/src/github.com/sylabs/singularity
   make -C builddir test
 '

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -16,7 +16,7 @@ chown -R testuser .
 su testuser -c '
   set -x
   set -e
-  ./mconfig -v -V 0.0
+  ./mconfig 
   sudo yum-builddep -y dist/rpm/singularity.spec
   git fetch --all
   git config --global user.email "community@sylabs.io"

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -20,7 +20,6 @@ su testuser -c '
   set -e
   ./mconfig 
   sudo yum-builddep -y dist/rpm/singularity.spec
-  git fetch --all
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"
   make -C builddir rpm

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -23,7 +23,7 @@ su testuser -c '
   git fetch --all
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"
-  make RPMCLEAN="--define '__spec_install_pre /bin/true'" -C builddir rpm
+  make RPMCLEAN="--define \'__spec_install_pre /bin/true\'" -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
   BLD=`echo $HOME/rpmbuild/BUILD/singularity*`
   export GOROOT=$BLD/go

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -15,7 +15,7 @@ echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 chown -R testuser .
 
-cat << EOF | su testuser 
+su testuser -c '
   set -x
   set -e
   ./mconfig 
@@ -23,19 +23,15 @@ cat << EOF | su testuser
   git fetch --all
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"
-  make RPMCLEAN="--define '__spec_install_pre /bin/true'" -C builddir rpm
-  sudo yum install -y \$HOME/rpmbuild/RPMS/*/*.rpm
-  BLD=`echo \$HOME/rpmbuild/BUILD/singularity*`
-  export GOROOT=\$BLD/go
-  export GOPATH=\$BLD/gopath
-  PATH=\$GOROOT/bin:\$GOPATH/bin:\$PATH
+  make -C builddir rpm
+  sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
+  BLD=`echo $HOME/rpmbuild/BUILD`
+  export GOROOT=$BLD/go
+  export GOPATH=$BLD/gopath
+  PATH=$GOROOT/bin:$GOPATH/bin:$PATH
   echo " BUILD DIR "
-  ls \$HOME/rpmbuild/BUILD
-  echo " GOPATH "
-  ls \$GOPATH/
-  echo " GOPATH Sylabs "
-  ls \$GOPATH/src/github.com/sylabs/
 
-  cd \$GOPATH/src/github.com/sylabs/singularity
+  cd $GOPATH/src/github.com/sylabs/singularity
   make -C builddir test
-EOF
+'
+

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -17,9 +17,11 @@ su testuser -c '
   set -x
   ./mconfig -V 0.0
   sudo yum-builddep -y dist/rpm/singularity.spec
+  git config --global user.email "community@sylabs.io"
+  git config --global user.name "Travis Test"
   make -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
-  BLD=`echo $HOME/rpmbuild/BUILD/singularity-*`
+  BLD=`echo $HOME/rpmbuild/BUILD/singularity*`
   export GOROOT=$BLD/go
   export GOPATH=$BLD/gopath
   PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -23,7 +23,7 @@ su testuser -c '
   git fetch --all
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"
-  make -C builddir rpm
+  make RPMCLEAN="--define '__spec_install_pre /bin/true'" -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
   BLD=`echo $HOME/rpmbuild/BUILD/singularity*`
   export GOROOT=$BLD/go

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -16,6 +16,7 @@ chown -R testuser .
 su testuser -c '
   set -x
   set -e
+  ls -al .
   ./mconfig 
   sudo yum-builddep -y dist/rpm/singularity.spec
   git fetch --all

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -15,7 +15,8 @@ chown -R testuser .
 
 su testuser -c '
   set -x
-  ./mconfig -V 0.0
+  set -e
+  ./mconfig -v -V 0.0
   sudo yum-builddep -y dist/rpm/singularity.spec
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -16,9 +16,9 @@ chown -R testuser .
 su testuser -c '
   set -x
   set -e
-  git fetch --all
   ./mconfig -v -V 0.0
   sudo yum-builddep -y dist/rpm/singularity.spec
+  git fetch --all
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"
   make -C builddir rpm

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -23,7 +23,7 @@ su testuser -c '
   git fetch --all
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"
-  make RPMCLEAN="--define \'__spec_install_pre /bin/true\'" -C builddir rpm
+  make RPMCLEAN="--define \\'__spec_install_pre /bin/true\\'" -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
   BLD=`echo $HOME/rpmbuild/BUILD/singularity*`
   export GOROOT=$BLD/go

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -16,6 +16,7 @@ chown -R testuser .
 su testuser -c '
   set -x
   set -e
+  git fetch --all
   ./mconfig -v -V 0.0
   sudo yum-builddep -y dist/rpm/singularity.spec
   git config --global user.email "community@sylabs.io"

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -28,7 +28,6 @@ su testuser -c '
   export GOROOT=$BLD/go
   export GOPATH=$BLD/gopath
   PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-  echo " BUILD DIR "
 
   cd $GOPATH/src/github.com/sylabs/singularity
   make -C builddir test

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -8,6 +8,8 @@ yum install -y openssl-devel libuuid-devel
 
 # switch to an unprivileged user with sudo privileges
 yum install -y sudo
+# We need Git existing here prior to the run
+yum install -y git
 useradd -u 1000 --create-home -s /bin/bash testuser
 echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
@@ -16,7 +18,6 @@ chown -R testuser .
 su testuser -c '
   set -x
   set -e
-  ls -al .
   ./mconfig 
   sudo yum-builddep -y dist/rpm/singularity.spec
   git fetch --all

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -15,7 +15,7 @@ echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 chown -R testuser .
 
-su testuser -c '
+cat << EOF | su testuser 
   set -x
   set -e
   ./mconfig 
@@ -23,19 +23,19 @@ su testuser -c '
   git fetch --all
   git config --global user.email "community@sylabs.io"
   git config --global user.name "Travis Test"
-  make RPMCLEAN="--define \\'__spec_install_pre /bin/true\\'" -C builddir rpm
-  sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
-  BLD=`echo $HOME/rpmbuild/BUILD/singularity*`
-  export GOROOT=$BLD/go
-  export GOPATH=$BLD/gopath
-  PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+  make RPMCLEAN="--define '__spec_install_pre /bin/true'" -C builddir rpm
+  sudo yum install -y \$HOME/rpmbuild/RPMS/*/*.rpm
+  BLD=`echo \$HOME/rpmbuild/BUILD/singularity*`
+  export GOROOT=\$BLD/go
+  export GOPATH=\$BLD/gopath
+  PATH=\$GOROOT/bin:\$GOPATH/bin:\$PATH
   echo " BUILD DIR "
-  ls $HOME/rpmbuild/BUILD
+  ls \$HOME/rpmbuild/BUILD
   echo " GOPATH "
-  ls $GOPATH/
+  ls \$GOPATH/
   echo " GOPATH Sylabs "
-  ls $GOPATH/src/github.com/sylabs/
+  ls \$GOPATH/src/github.com/sylabs/
 
-  cd $GOPATH/src/github.com/sylabs/singularity
+  cd \$GOPATH/src/github.com/sylabs/singularity
   make -C builddir test
-'
+EOF

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -63,6 +63,10 @@ containers that can be used across host environments.
 %prep
 
 %build
+# Create our build root
+mkdir %{name}-%{version}
+cd %{name}-%{version}
+
 #XXX: We would like to remove the download of Go in the future
 GOTAR=go%{goversion}.linux-amd64.tar.gz
 wget https://dl.google.com/go/$GOTAR
@@ -85,6 +89,8 @@ cd builddir
 make
 
 %install
+cd %{name}-%{version}
+
 export GOROOT=$PWD/go
 export GOPATH=$PWD/gopath
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -61,15 +61,13 @@ Singularity provides functionality to make portable
 containers that can be used across host environments.
 
 %prep
-%setup -n singularity
 
+%build
 #XXX: We would like to remove the download of Go in the future
 GOTAR=go%{goversion}.linux-amd64.tar.gz
 wget https://dl.google.com/go/$GOTAR
 tar -xf $GOTAR
 
-
-%build
 mkdir -p gopath/%{singgopath}
 tar -C "gopath/src/github.com/sylabs/" -xf "%SOURCE0"
 

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -61,17 +61,18 @@ Singularity provides functionality to make portable
 containers that can be used across host environments.
 
 %prep
-%setup
+%setup -n singularity
 
-mkdir -p gopath/%{singgopath}
-mv `ls -d .??* *|grep -v gopath` gopath/%{singgopath}
-
+#XXX: We would like to remove the download of Go in the future
 GOTAR=go%{goversion}.linux-amd64.tar.gz
 wget https://dl.google.com/go/$GOTAR
 tar -xf $GOTAR
 
 
 %build
+mkdir -p gopath/%{singgopath}
+tar -C "gopath/src/github.com/sylabs/" -xf "%SOURCE0"
+
 export GOROOT=$PWD/go
 export GOPATH=$PWD/gopath
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -274,7 +274,7 @@ testall: vendor-check check test
 .PHONY: rpm
 rpm: dist
 	@echo " BUILD RPM"
-	$(V)cd $(SOURCEDIR) && rpmbuild -tb singularity-$(SHORT_VERSION).tar.gz
+	$(V)(cd $(SOURCEDIR) && rpmbuild -tb $(SOURCEDIR)/singularity-3.0.0.tar.gz)
 
 .PHONY: cscope
 cscope:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -274,7 +274,7 @@ testall: vendor-check check test
 .PHONY: rpm
 rpm: dist
 	@echo " BUILD RPM"
-	$(V)cd $(SOURCEDIR) && rpmbuild -tb singularity-*.tar.gz
+	$(V)cd $(SOURCEDIR) && rpmbuild -tb singularity-$(SHORT_VERSION).tar.gz
 
 .PHONY: cscope
 cscope:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -272,9 +272,9 @@ test:
 testall: vendor-check check test
 
 .PHONY: rpm
-rpm:
+rpm: dist
 	@echo " BUILD RPM"
-	$(V)cd $(SOURCEDIR) && dist/rpm/buildrpm
+	$(V)cd $(SOURCEDIR) && rpmbuild -tb singularity-*.tar.gz
 
 .PHONY: cscope
 cscope:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -274,7 +274,7 @@ testall: vendor-check check test
 .PHONY: rpm
 rpm: dist
 	@echo " BUILD RPM"
-	$(V)(cd $(SOURCEDIR) && rpmbuild -tb $(SOURCEDIR)/singularity-3.0.0.tar.gz)
+	$(V)(cd $(SOURCEDIR) && rpmbuild -tb $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz)
 
 .PHONY: cscope
 cscope:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -274,7 +274,7 @@ testall: vendor-check check test
 .PHONY: rpm
 rpm: dist
 	@echo " BUILD RPM"
-	$(V)(cd $(SOURCEDIR) && rpmbuild -tb $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz)
+	$(V)(cd $(SOURCEDIR) && rpmbuild $(RPMCLEAN) -tb $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz)
 
 .PHONY: cscope
 cscope:

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -15,5 +15,7 @@ git add VERSION
 cp dist/rpm/singularity.spec .
 git add singularity.spec
 echo " DIST create tarball: $package_name-$package_version.tar.gz"
-git archive --format=tar.gz --prefix=$package_name/ `git stash create` -o $package_name-$package_version.tar.gz
+git archive --format=tar --prefix=$package_name/ `git stash create` -o $package_name-$package_version.tar
 git reset VERSION singularity.spec
+gzip $package_name-$package_version.tar
+

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -5,8 +5,8 @@
 set -e
 
 package_name=singularity
-tree_version=`(git describe --match 'v[0-9]*' --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
-package_version=`(git describe --abbrev=0 --match 'v[0-9]*' --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
+package_version=`(git describe --match 'v[0-9]*' --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
+package_version_short=`(git describe --abbrev=0 --match 'v[0-9]*' --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
 
 echo " DIST setup VERSION: $tree_version"
 echo $tree_version > VERSION
@@ -15,7 +15,7 @@ git add VERSION
 cp dist/rpm/singularity.spec .
 git add singularity.spec
 echo " DIST create tarball: $package_name-$package_version.tar.gz"
-git archive --format=tar --prefix=$package_name/ `git stash create` -o $package_name-$package_version.tar
+git archive --format=tar --prefix=$package_name/ `git stash create` -o $package_name-$package_version_short.tar
 git reset VERSION singularity.spec
-gzip $package_name-$package_version.tar
+gzip $package_name-$package_version_short.tar
 

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -8,13 +8,18 @@ package_name=singularity
 package_version=`(git describe --match 'v[0-9]*' --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
 package_version_short=`(git describe --abbrev=0 --match 'v[0-9]*' --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
 
+# Remove Dist tarball if it exists
+if [ -f $package_name-$package_version_short.tar.gz ]; then
+    rm -f $package_name-$package_version_short.tar.gz
+fi
+
 echo " DIST setup VERSION: $tree_version"
 echo $tree_version > VERSION
 git add VERSION
 # spec file needs to be at the root of the project
 cp dist/rpm/singularity.spec .
 git add singularity.spec
-echo " DIST create tarball: $package_name-$package_version.tar.gz"
+echo " DIST create tarball: $package_name-$package_version_short.tar.gz"
 git archive --format=tar --prefix=$package_name/ `git stash create` -o $package_name-$package_version_short.tar
 git reset VERSION singularity.spec
 gzip $package_name-$package_version_short.tar


### PR DESCRIPTION
With #2261 , we need some minor tweaks to the spec to build an RPM.

With this, and #2261 the following will work:
```
./mconfig && \
make -C builddir/ dist && \
rpmbuild -tb singularity-3.0.0.tar.gz
```

Or simpler:
```
./mconfig && \
make -C builddir/ rpm
```
**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
