### PR TITLE
Recreating PR#2209 (Allow colon in image names for release-3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.0.0
+  
+  - Support colons in image file names
 
 # v3.0.0 - [2018.10.08]
 

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -151,7 +151,7 @@ func handleShub(u string) (string, error) {
 }
 
 func replaceURIWithImage(cmd *cobra.Command, args []string) {
-	// If args[0] is not transport:ref (ex. intance://...) formatted return, not a URI
+	// If args[0] is not transport:ref (ex. instance://...) formatted return, not a URI
 	t, _ := uri.SplitURI(args[0])
 	if t == "instance" || t == "" {
 		return

--- a/src/pkg/build/build.go
+++ b/src/pkg/build/build.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sylabs/singularity/src/pkg/sylog"
 	"github.com/sylabs/singularity/src/pkg/syplugin"
 	syexec "github.com/sylabs/singularity/src/pkg/util/exec"
+	"github.com/sylabs/singularity/src/pkg/util/uri"
 	"github.com/sylabs/singularity/src/runtime/engines/config"
 	"github.com/sylabs/singularity/src/runtime/engines/config/oci"
 	"github.com/sylabs/singularity/src/runtime/engines/imgbuild"
@@ -357,7 +358,7 @@ func getcp(def types.Definition, libraryURL, authToken string) (ConveyorPacker, 
 
 // makeDef gets a definition object from a spec
 func makeDef(spec string, remote bool) (types.Definition, error) {
-	if ok, err := IsValidURI(spec); ok && err == nil {
+	if ok, err := uri.IsValidURI(spec); ok && err == nil {
 		// URI passed as spec
 		return types.NewDefinitionFromURI(spec)
 	}

--- a/src/pkg/build/conveyorPacker.go
+++ b/src/pkg/build/conveyorPacker.go
@@ -6,22 +6,8 @@
 package build
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/sylabs/singularity/src/pkg/build/types"
 )
-
-// validURIs contains a list of known uris
-var validURIs = map[string]bool{
-	"library":        true,
-	"shub":           true,
-	"docker":         true,
-	"docker-archive": true,
-	"docker-daemon":  true,
-	"oci":            true,
-	"oci-archive":    true,
-}
 
 // Conveyor is responsible for downloading from remote sources (library, shub, docker...)
 type Conveyor interface {
@@ -38,20 +24,4 @@ type Packer interface {
 type ConveyorPacker interface {
 	Conveyor
 	Packer
-}
-
-// IsValidURI returns whether or not the given source is valid
-func IsValidURI(source string) (valid bool, err error) {
-
-	u := strings.SplitN(source, ":", 2)
-
-	if len(u) != 2 {
-		return false, fmt.Errorf("Invalid URI %s", source)
-	}
-
-	if _, ok := validURIs[u[0]]; ok {
-		return true, nil
-	}
-
-	return false, fmt.Errorf("Invalid URI %s", source)
 }

--- a/src/pkg/util/uri/uri.go
+++ b/src/pkg/util/uri/uri.go
@@ -17,6 +17,33 @@ const (
 	Shub = "shub"
 )
 
+// validURIs contains a list of known uris
+var validURIs = map[string]bool{
+	"library":        true,
+	"shub":           true,
+	"docker":         true,
+	"docker-archive": true,
+	"docker-daemon":  true,
+	"oci":            true,
+	"oci-archive":    true,
+}
+
+// IsValidURI returns whether or not the given source is valid
+func IsValidURI(source string) (valid bool, err error) {
+
+	u := strings.SplitN(source, ":", 2)
+
+	if len(u) != 2 {
+		return false, fmt.Errorf("Invalid URI %s", source)
+	}
+
+	if _, ok := validURIs[u[0]]; ok {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("Invalid URI %s", source)
+}
+
 // NameFromURI turns a transport:ref URI into a name containing the top-level identifier
 // of the image. For example, docker://godlovedc/lolcow returns lolcow
 //

--- a/src/pkg/util/uri/uri.go
+++ b/src/pkg/util/uri/uri.go
@@ -49,13 +49,13 @@ func IsValidURI(source string) (valid bool, err error) {
 //
 // Returns "" when not in transport:ref format
 func NameFromURI(uri string) string {
-	uriSplit := strings.SplitN(uri, ":", 2) // split URI into transport:ref:tag
-	if len(uriSplit) == 1 {
+	transport, ref := SplitURI(uri)
+	if transport == "" {
 		return ""
 	}
 
-	ref := strings.TrimLeft(uriSplit[1], "/") // Trim leading "/" characters
-	refSplit := strings.Split(ref, "/")       // Split ref into parts
+	ref = strings.TrimLeft(ref, "/")    // Trim leading "/" characters
+	refSplit := strings.Split(ref, "/") // Split ref into parts
 
 	// Default tag is latest
 	tags := []string{"latest"}
@@ -75,16 +75,30 @@ func NameFromURI(uri string) string {
 
 // SplitURI splits a URI into it's components which can be used directly through containers/image
 //
+// This can be tricky if there is no type but a file name contains a colon.
+//
 // Examples:
 //   docker://ubuntu -> docker, //ubuntu
 //   docker://ubuntu:18.04 -> docker, //ubuntu:18.04
 //   oci-archive:path/to/archive -> oci-archive, path/to/archive
 //   ubuntu -> "", ubuntu
+//   ubuntu:18.04.img -> "", ubuntu:18.04.img
 func SplitURI(uri string) (transport string, ref string) {
 	uriSplit := strings.SplitN(uri, ":", 2)
 	if len(uriSplit) == 1 {
-		return "", uriSplit[0]
+		// no colon
+		return "", uri
 	}
 
-	return uriSplit[0], uriSplit[1]
+	if uriSplit[1][0:1] == "//" {
+		// the format was ://, so try it whether or not valid URI
+		return uriSplit[0], uriSplit[1]
+	}
+
+	if ok, err := IsValidURI(uri); ok && err == nil {
+		// also accept recognized URIs
+		return uriSplit[0], uriSplit[1]
+	}
+
+	return "", uri
 }

--- a/src/pkg/util/uri/uri_test.go
+++ b/src/pkg/util/uri/uri_test.go
@@ -42,6 +42,7 @@ func Test_SplitURI(t *testing.T) {
 		{"library basic", "library://image", "library", "//image"},
 		{"library scoped", "library://collection/image", "library", "//collection/image"},
 		{"without transport", "ubuntu", "", "ubuntu"},
+		{"without transport with colon", "ubuntu:18.04.img", "", "ubuntu:18.04.img"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This allows colons in image names for the release-3.0 branch, in case there's going to be a 3.0.1.  Recreating PR because #2209 refused to run all the circleci pieces.


**This fixes or addresses the following GitHub issues:**




**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
