### PR TITLE
Do not require previous fsuid to be zero

### DIFF
--- a/src/runtime/starter/c/starter.c
+++ b/src/runtime/starter/c/starter.c
@@ -556,8 +556,7 @@ static void fix_fsuid(uid_t uid) {
         return;
     }
     if ( fsuid != 0 ) {
-        singularity_message(ERROR, "Previous filesystem UID is not equal to 0\n");
-        exit(1);
+        singularity_message(DEBUG, "Previous filesystem UID was not 0: %d\n", fsuid);
     }
     if ( setfsuid(-1) != uid ) {
         singularity_message(ERROR, "Failed to set filesystem uid to %d\n", uid);


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Change fix_fsuid to not require the previous value of setfsuid to be zero.  On centos6 the default appears to be -1 instead of zero.


**This fixes or addresses the following GitHub issues:**

- Fixes #2283


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
