### PR TITLE
Add MS_MOVE chroot method and fallback to it if pivot_root failed

### DIFF
--- a/src/runtime/engines/imgbuild/create.go
+++ b/src/runtime/engines/imgbuild/create.go
@@ -128,9 +128,13 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 	}
 
 	sylog.Debugf("Chroot into %s\n", buildcfg.SESSIONDIR)
-	_, err = rpcOps.Chroot(buildcfg.SESSIONDIR)
+	_, err = rpcOps.Chroot(buildcfg.SESSIONDIR, true)
 	if err != nil {
-		return fmt.Errorf("chroot failed: %s", err)
+		sylog.Debugf("Fallback to move/chroot")
+		_, err = rpcOps.Chroot(buildcfg.SESSIONDIR, false)
+		if err != nil {
+			return fmt.Errorf("chroot failed: %s", err)
+		}
 	}
 
 	sylog.Debugf("Chdir into / to avoid errors\n")

--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -152,9 +152,13 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 	}
 
 	sylog.Debugf("Chroot into %s\n", c.session.FinalPath())
-	_, err = c.rpcOps.Chroot(c.session.FinalPath())
+	_, err = c.rpcOps.Chroot(c.session.FinalPath(), true)
 	if err != nil {
-		return fmt.Errorf("chroot failed: %s", err)
+		sylog.Debugf("Fallback to move/chroot")
+		_, err = c.rpcOps.Chroot(c.session.FinalPath(), false)
+		if err != nil {
+			return fmt.Errorf("chroot failed: %s", err)
+		}
 	}
 
 	if c.netNS && !c.userNS {

--- a/src/runtime/engines/singularity/rpc/args.go
+++ b/src/runtime/engines/singularity/rpc/args.go
@@ -35,7 +35,8 @@ type MountArgs struct {
 
 // ChrootArgs defines the arguments to chroot.
 type ChrootArgs struct {
-	Root string
+	Root     string
+	UsePivot bool
 }
 
 // HostnameArgs defines the arguments to sethostname.

--- a/src/runtime/engines/singularity/rpc/client/client.go
+++ b/src/runtime/engines/singularity/rpc/client/client.go
@@ -45,9 +45,10 @@ func (t *RPC) Mkdir(path string, perm os.FileMode) (int, error) {
 }
 
 // Chroot calls the chroot RPC using the supplied arguments.
-func (t *RPC) Chroot(root string) (int, error) {
+func (t *RPC) Chroot(root string, usePivot bool) (int, error) {
 	arguments := &args.ChrootArgs{
-		Root: root,
+		Root:     root,
+		UsePivot: usePivot,
 	}
 	var reply int
 	err := t.Client.Call(t.Name+".Chroot", arguments, &reply)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds MS_MOVE/chroot method for RPC Chroot, singularity and imgbuild engines can fallback to it if case pivot_root method fails


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
