### PR TITLE
Fix filesystem UID

### DIFF
--- a/src/runtime/starter/c/starter.c
+++ b/src/runtime/starter/c/starter.c
@@ -549,16 +549,9 @@ static void list_fd(struct fdlist *fl) {
 }
 
 static void fix_fsuid(uid_t uid) {
-    int fsuid = setfsuid(uid);
+    setfsuid(uid);
 
-    if ( fsuid == uid ) {
-        singularity_message(DEBUG, "Filesystem UID already equal to %d", uid);
-        return;
-    }
-    if ( fsuid != 0 ) {
-        singularity_message(DEBUG, "Previous filesystem UID was not 0: %d\n", fsuid);
-    }
-    if ( setfsuid(-1) != uid ) {
+    if ( setfsuid(uid) != uid ) {
         singularity_message(ERROR, "Failed to set filesystem uid to %d\n", uid);
         exit(1);
     }
@@ -1087,9 +1080,6 @@ __attribute__((constructor)) static void init(void) {
 
             if ( process == 0 ) {
                 singularity_message(VERBOSE, "Spawn RPC server\n");
-                if ( config.isSuid ) {
-                    fix_fsuid(uid);
-                }
                 execute = RPC_SERVER;
             } else if ( process > 0 ) {
                 int status;


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes filesystem UID by calling setfsuid two times, now the second call uses user ID instead of -1 to check filesystem uid is correctly set, because distribution like Centos 6 set filesystem uid to -1 and considers -1 as valid


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
