### PR TITLE
Improved mksquashfs error output in SIF Assembler

### DIFF
--- a/src/pkg/build/assemblers/assembler_sif.go
+++ b/src/pkg/build/assemblers/assembler_sif.go
@@ -163,7 +163,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	}
 
 	if err := mksquashfsCmd.Wait(); err != nil {
-		return fmt.Errorf("While running mksquashfs: %v: %s", err, errOut)
+		return fmt.Errorf("While running mksquashfs: %v: %s", err, strings.Replace(string(errOut), "\n", " ", -1))
 	}
 
 	err = createSIF(path, def, squashfsPath)

--- a/src/pkg/build/assemblers/assembler_sif.go
+++ b/src/pkg/build/assemblers/assembler_sif.go
@@ -138,6 +138,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	f.Close()
 	os.Remove(f.Name())
 	os.Remove(squashfsPath)
+	defer os.Remove(squashfsPath)
 
 	args := []string{b.Rootfs(), squashfsPath, "-noappend"}
 
@@ -147,15 +148,27 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	}
 
 	mksquashfsCmd := exec.Command(mksquashfs, args...)
-	err = mksquashfsCmd.Run()
-	defer os.Remove(squashfsPath)
+	stderr, err := mksquashfsCmd.StderrPipe()
 	if err != nil {
-		return
+		return fmt.Errorf("While setting up stderr pipe: %v", err)
+	}
+
+	if err := mksquashfsCmd.Start(); err != nil {
+		return fmt.Errorf("While starting mksquashfs: %v", err)
+	}
+
+	errOut, err := ioutil.ReadAll(stderr)
+	if err != nil {
+		return fmt.Errorf("While reading mksquashfs stderr: %v", err)
+	}
+
+	if err := mksquashfsCmd.Wait(); err != nil {
+		return fmt.Errorf("While running mksquashfs: %v: %s", err, errOut)
 	}
 
 	err = createSIF(path, def, squashfsPath)
 	if err != nil {
-		return
+		return fmt.Errorf("While creating SIF: %v", err)
 	}
 
 	return


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This captures the `stderr` output of `mksquashfs` and displays it to give more information about an error if it occurs.

Before
```
ian@T440s:test$ sudo singularity build test.sif docker://ubuntu
WARNING: Authentication token file not found : Only pulls of public images will succeed
Build target already exists. Do you want to overwrite? [N/y] y
INFO:    Starting build...
Getting image source signatures
Skipping fetch of repeat blob sha256:473ede7ed136b710ab2dd51579af038b7d00fbbf6a1790c6294c93666203c0a6
Skipping fetch of repeat blob sha256:c46b5fa4d940569e49988515c1ea0295f56d0a16228d8f854e27613f467ec892
Skipping fetch of repeat blob sha256:93ae3df89c92cb1d20e9c09f499e693d3a8a8cef161f7158f7a9a3b5d06e4ef2
Skipping fetch of repeat blob sha256:6b1eed27cadec5de8051d56697b0b67527e4076deedceefb41b7b2ea9b900459
Copying config sha256:b50430c3f256672c861a7d25b6df3157c378d95a72c1d11d860e184c7bdbf013
 2.42 KiB / 2.42 KiB [======================================================] 0s
Writing manifest to image destination
Storing signatures
INFO:    Creating SIF file...
FATAL:   While performing build: exit status 1
```

Now
```
ian@T440s:test$ sudo singularity build test.sif docker://ubuntu
WARNING: Authentication token file not found : Only pulls of public images will succeed
Build target already exists. Do you want to overwrite? [N/y] y
INFO:    Starting build...
Getting image source signatures
Skipping fetch of repeat blob sha256:473ede7ed136b710ab2dd51579af038b7d00fbbf6a1790c6294c93666203c0a6
Skipping fetch of repeat blob sha256:c46b5fa4d940569e49988515c1ea0295f56d0a16228d8f854e27613f467ec892
Skipping fetch of repeat blob sha256:93ae3df89c92cb1d20e9c09f499e693d3a8a8cef161f7158f7a9a3b5d06e4ef2
Skipping fetch of repeat blob sha256:6b1eed27cadec5de8051d56697b0b67527e4076deedceefb41b7b2ea9b900459
Copying config sha256:b50430c3f256672c861a7d25b6df3157c378d95a72c1d11d860e184c7bdbf013
 2.42 KiB / 2.42 KiB [======================================================] 0s
Writing manifest to image destination
Storing signatures
INFO:    Creating SIF file...
FATAL:   While performing build: While running mksquashfs: exit status 1:  Write failed because No space left on device  FATAL ERROR:Failed to write to output filesystem
```

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
