### PR TITLE
Fix --pwd warning and pwd symlink issue

### DIFF
--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -529,6 +529,10 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			if engineConfig.GetContain() {
 				generator.SetProcessCwd(engineConfig.GetHomeDest())
 			} else {
+				pwd, err := filepath.EvalSymlinks(pwd)
+				if err != nil {
+					sylog.Fatalf("Failed to evaluate current working directory %s: %s", pwd, err)
+				}
 				generator.SetProcessCwd(pwd)
 			}
 		}

--- a/src/cmd/singularity/cli/actions.go
+++ b/src/cmd/singularity/cli/actions.go
@@ -522,6 +522,9 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	// Clean environment
 	env.SetContainerEnv(&generator, environment, IsCleanEnv, engineConfig.GetHomeDest())
 
+	// force to use getwd syscall
+	os.Unsetenv("PWD")
+
 	if pwd, err := os.Getwd(); err == nil {
 		if PwdPath != "" {
 			generator.SetProcessCwd(PwdPath)
@@ -529,10 +532,6 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			if engineConfig.GetContain() {
 				generator.SetProcessCwd(engineConfig.GetHomeDest())
 			} else {
-				pwd, err := filepath.EvalSymlinks(pwd)
-				if err != nil {
-					sylog.Fatalf("Failed to evaluate current working directory %s: %s", pwd, err)
-				}
 				generator.SetProcessCwd(pwd)
 			}
 		}

--- a/src/runtime/engines/singularity/container.go
+++ b/src/runtime/engines/singularity/container.go
@@ -1420,7 +1420,7 @@ func (c *container) addCwdMount(system *mount.System) error {
 	}
 	cwd = c.engine.EngineConfig.OciConfig.Process.Cwd
 	if err := os.Chdir(cwd); err != nil {
-		sylog.Debugf("can't go to container working directory: %s", err)
+		sylog.Warningf("Could not set container working directory %s: %s", cwd, err)
 		return nil
 	}
 	current, err := os.Getwd()


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes issue #2307 by displaying a warning when requested working directory doesn't exist in container. This also fixes issue when current working directory contain a symlink, Go `os.Getwd` uses PWD environment variable when set rather than getwd syscall, unset PWD and force syscall usage.


**This fixes or addresses the following GitHub issues:**

- Fixes #2307 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
