### PR TITLE
Set container processs as terminal foreground process

### DIFF
--- a/src/runtime/starter/c/starter.c
+++ b/src/runtime/starter/c/starter.c
@@ -965,6 +965,11 @@ __attribute__((constructor)) static void init(void) {
 
         set_parent_death_signal(SIGKILL);
 
+        if ( isatty(STDIN_FILENO) && setpgrp() < 0 ) {
+            singularity_message(ERROR, "Failed to set child process group: %s", strerror(errno));
+            exit(1);
+        };
+
         close(master_socket[0]);
 
         singularity_message(VERBOSE, "Spawn scontainer stage 2\n");
@@ -1102,6 +1107,11 @@ __attribute__((constructor)) static void init(void) {
         return;
     } else if ( stage_pid > 0 ) {
         config.containerPid = stage_pid;
+
+        if ( isatty(STDIN_FILENO) && tcsetpgrp(STDIN_FILENO, stage_pid) < 0 ) {
+            singularity_message(ERROR, "Failed to set terminal foreground process group: %s", strerror(errno));
+            exit(1);
+        }
 
         singularity_message(VERBOSE, "Spawn smaster process\n");
 

--- a/src/runtime/starter/smaster.go
+++ b/src/runtime/starter/smaster.go
@@ -98,15 +98,7 @@ func SMaster(rpcSocket, masterSocket int, starterConfig *starter.Config, jsonByt
 	go func() {
 		// catch all signals and let default handler for SIGWINCH, SIGCONT, SIGTSTP
 		signals := make(chan os.Signal, 1)
-		handledSignals := make([]os.Signal, 0)
-		for i := 0; i < 256; i++ {
-			sig := syscall.Signal(i)
-			if sig == syscall.SIGWINCH || sig == syscall.SIGCONT || sig == syscall.SIGTSTP {
-				continue
-			}
-			handledSignals = append(handledSignals, sig)
-		}
-		signal.Notify(signals, handledSignals...)
+		signal.Notify(signals)
 
 		status, err = engine.MonitorContainer(containerPid, signals)
 		fatalChan <- err

--- a/src/runtime/starter/smaster.go
+++ b/src/runtime/starter/smaster.go
@@ -96,7 +96,7 @@ func SMaster(rpcSocket, masterSocket int, starterConfig *starter.Config, jsonByt
 	}()
 
 	go func() {
-		// catch all signals and let default handler for SIGWINCH, SIGCONT, SIGTSTP
+		// catch all signals
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals)
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR set container process as the terminal foreground process and avoid parent process (smaster) to receive signals from terminal and abort when it shouldn't


**This fixes or addresses the following GitHub issues:**

- Fixes #2326 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
