### PR TITLE
can set description when push image

### DIFF
--- a/cmd/singularity/cli/push.go
+++ b/cmd/singularity/cli/push.go
@@ -34,7 +34,7 @@ var PushCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Push to library requires a valid authToken
 		if authToken != "" {
-			err := client.UploadImage(args[0], args[1], PushLibraryURI, authToken)
+			err := client.UploadImage(args[0], args[1], PushLibraryURI, authToken, "No Description")
 			if err != nil {
 				sylog.Fatalf("%v\n", err)
 			}

--- a/internal/pkg/client/library/api.go
+++ b/internal/pkg/client/library/api.go
@@ -136,10 +136,10 @@ func createContainer(baseURL string, authToken string, name string, collectionID
 	return res.Data, nil
 }
 
-func createImage(baseURL string, authToken string, hash string, containerID string) (image Image, err error) {
+func createImage(baseURL string, authToken string, hash string, containerID string, description string) (image Image, err error) {
 	i := Image{
 		Hash:        hash,
-		Description: "No description",
+		Description: description,
 		Container:   bson.ObjectIdHex(containerID),
 	}
 	imgJSON, err := apiCreate(i, baseURL+"/v1/images", authToken)

--- a/internal/pkg/client/library/api_test.go
+++ b/internal/pkg/client/library/api_test.go
@@ -656,7 +656,7 @@ func Test_createImage(t *testing.T) {
 
 			m.Run()
 
-			image, err := createImage(m.baseURI, testToken, tt.imageRef, bson.NewObjectId().Hex())
+			image, err := createImage(m.baseURI, testToken, tt.imageRef, bson.NewObjectId().Hex(), "No Description")
 
 			if err != nil && !tt.expectError {
 				t.Errorf("Unexpected error: %v", err)

--- a/internal/pkg/client/library/push.go
+++ b/internal/pkg/client/library/push.go
@@ -21,7 +21,7 @@ import (
 const pushTimeout = 1800
 
 // UploadImage will push a specified image up to the Container Library,
-func UploadImage(filePath string, libraryRef string, libraryURL string, authToken string) error {
+func UploadImage(filePath string, libraryRef string, libraryURL string, authToken string, description string) error {
 
 	if !IsLibraryPushRef(libraryRef) {
 		return fmt.Errorf("Not a valid library reference: %s", libraryRef)
@@ -81,7 +81,7 @@ func UploadImage(filePath string, libraryRef string, libraryURL string, authToke
 	}
 	if !found {
 		sylog.Verbosef("Image %s does not exist in library - creating it.\n", imageHash)
-		image, err = createImage(libraryURL, authToken, imageHash, container.GetID().Hex())
+		image, err = createImage(libraryURL, authToken, imageHash, container.GetID().Hex(), description)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description of the Pull Request (PR):**
When push image in remote build, should be able to set `description` of the `image`. So we can add `build/output` information to `image` for future use (search/browse).

**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
