### PR TITLE
Change to preferred capitialization for Slurm.

### DIFF
--- a/docs/2.x-slurm/README.md
+++ b/docs/2.x-slurm/README.md
@@ -1,12 +1,12 @@
 
-Singularity plugin for SLURM
+Singularity plugin for Slurm
 ============================
 
-This plugin allows users to execute their SLURM jobs within a Singularity container without
+This plugin allows users to execute their Slurm jobs within a Singularity container without
 having to execute Singularity directly.  This assists in simplifying the invocation of the
 container and hiding the implementation details.
 
-To enable the plugin, add the following line to the SLURM plugin configuration (`/etc/slurm/plugstack.conf`):
+To enable the plugin, add the following line to the Slurm plugin configuration (`/etc/slurm/plugstack.conf`):
 
 ```
 required singularity.so

--- a/docs/2.x-slurm/singularity.c
+++ b/docs/2.x-slurm/singularity.c
@@ -175,7 +175,7 @@ static int setup_container(spank_t spank)
     singularity_priv_init();
     singularity_priv_drop();
 
-    singularity_message(VERBOSE, "Running SLURM/Singularity integration "
+    singularity_message(VERBOSE, "Running Slurm/Singularity integration "
                         "plugin\n");
 
     if ((rc = singularity_config_init()) != 0) {
@@ -233,7 +233,7 @@ static int setup_container(spank_t spank)
     singularity_message(LOG, "USER=%s, IMAGE='%s', COMMAND='%s'\n", singularity_priv_getuser(), singularity_image_name(&image), singularity_registry_get("COMMAND"));
 
     // At this point, the current process is in the runtime container environment.
-    // Return control flow back to SLURM: when execv is invoked, it'll be done from
+    // Return control flow back to Slurm: when execv is invoked, it'll be done from
     // within the container.
 
     return 0;


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The preferred styling of Slurm is Slurm. This patch is predominantly against documentation, although it does alter one singularity_message(), although I do not see any likely side effects from that.

Attn: @singularity-maintainers