### PR TITLE
Fully remove SINGULARITY_home variable

### DIFF
--- a/libexec/cli/bootstrap.exec
+++ b/libexec/cli/bootstrap.exec
@@ -119,7 +119,7 @@ elif [ -x "${SINGULARITY_bindir}/singularity" ]; then
     ${SINGULARITY_bindir}/singularity build -w  ${SINGULARITY_IMAGE} ${SINGULARITY_BUILDDEF}
     exit 0
 else
-    message ERROR "Could not locate the Singularity binary: $SINGULARITY_home/singularity\n"
+    message ERROR "Could not locate the Singularity binary: $SINGULARITY_bindir/singularity\n"
     exit 1
 fi
 

--- a/libexec/cli/pull.exec
+++ b/libexec/cli/pull.exec
@@ -160,7 +160,7 @@ case "$SINGULARITY_CONTAINER" in
              ${SINGULARITY_bindir}/singularity ${DBGFLAG} build ${SINGULARITY_IMAGE} ${SINGULARITY_CONTAINER}
              RETVAL=$?
          else
-             message ERROR "Could not locate the Singularity binary: $SINGULARITY_home/singularity\n"
+             message ERROR "Could not locate the Singularity binary: $SINGULARITY_bindir/singularity\n"
              exit 1
          fi
     ;;


### PR DESCRIPTION
**Description of the Pull Request (PR):**

SINGULARITY_home was not fully removed at some point. It should be SINGULARITY_bindir

**This fixes or addresses the following GitHub issues:**

Attn: @singularity-maintainers
