### PR TITLE
Use same umask as v2

### DIFF
--- a/cmd/singularity/cli/actions.go
+++ b/cmd/singularity/cli/actions.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/opencontainers/runtime-tools/generate"
@@ -294,6 +295,8 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	uid := uint32(os.Getuid())
 	gid := uint32(os.Getgid())
+
+	syscall.Umask(0022)
 
 	starter := buildcfg.LIBEXECDIR + "/singularity/bin/starter-suid"
 

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -77,6 +77,8 @@ func NewBuildJSON(r io.Reader, dest, format string, libraryURL, authToken string
 func newBuild(d types.Definition, dest, format string, libraryURL, authToken string, opts types.Options) (*Build, error) {
 	var err error
 
+	syscall.Umask(0002)
+
 	// always build a sandbox if updating an existing sandbox
 	if opts.Update {
 		format = "sandbox"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes issue where some umask values generate unusable image. This PR applies same umask as with v2. During build umask `0002` is used, during execution umask `0022`

**This fixes or addresses the following GitHub issues:**

- Fixes #2356 and #2381


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
