### PR TITLE
Fix stat issue (while trying to size SIF file to mmap)

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -636,8 +636,6 @@ __attribute__((constructor)) static void init(void) {
         }
     }
 
-    list_fd(&fd_before);
-
     if ( config.isSuid ) {
         singularity_message(DEBUG, "Drop privileges\n");
         if ( setegid(gid) < 0 || seteuid(uid) < 0 ) {
@@ -645,6 +643,8 @@ __attribute__((constructor)) static void init(void) {
             exit(1);
         }
     }
+
+    list_fd(&fd_before);
 
     /* reset environment variables */
     clearenv();
@@ -828,23 +828,6 @@ __attribute__((constructor)) static void init(void) {
     /* relinquish CPU to apply current directory change for current thread */
     sched_yield();
 
-    if ( (config.nsFlags & CLONE_NEWUSER) == 0 && get_nspath(user) == NULL ) {
-        priv_escalate();
-    } else {
-        if ( config.isSuid ) {
-            singularity_message(ERROR, "Running setuid workflow with user namespace is not allowed\n");
-            exit(1);
-        }
-        if ( get_nspath(user) ) {
-            if ( enter_namespace(get_nspath(user), CLONE_NEWUSER) < 0 ) {
-                singularity_message(ERROR, "Failed to enter in user namespace: %s\n", strerror(errno));
-                exit(1);
-            }
-        } else {
-            setup_userns(&config.uidMapping[0], &config.gidMapping[0]);
-        }
-    }
-
     list_fd(&fd_after);
 
     source = (char *)malloc(PATH_MAX);
@@ -903,6 +886,23 @@ __attribute__((constructor)) static void init(void) {
 
     free(source);
     free(target);
+
+    if ( (config.nsFlags & CLONE_NEWUSER) == 0 && get_nspath(user) == NULL ) {
+        priv_escalate();
+    } else {
+        if ( config.isSuid ) {
+            singularity_message(ERROR, "Running setuid workflow with user namespace is not allowed\n");
+            exit(1);
+        }
+        if ( get_nspath(user) ) {
+            if ( enter_namespace(get_nspath(user), CLONE_NEWUSER) < 0 ) {
+                singularity_message(ERROR, "Failed to enter in user namespace: %s\n", strerror(errno));
+                exit(1);
+            }
+        } else {
+            setup_userns(&config.uidMapping[0], &config.gidMapping[0]);
+        }
+    }
 
     if ( get_nspath(mnt) == NULL ) {
         unsigned long propagation = config.mountPropagation;


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes where image file descriptor is closed during file descriptor cleanup by starter due to bad privileges, the issue appears on NFS with root_squash enabled and restrictive permission on parent directory containing image.

**This fixes or addresses the following GitHub issues:**

- Fixes #2282


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
