### PR TITLE
Use SINGULARITY_TMPDIR for builds

### DIFF
--- a/cmd/singularity/cli/action_flags.go
+++ b/cmd/singularity/cli/action_flags.go
@@ -151,6 +151,11 @@ func initPathVars() {
 	actionFlags.StringSliceVar(&ContainLibsPath, "containlibs", []string{}, "")
 	actionFlags.Lookup("containlibs").Hidden = true
 	actionFlags.SetAnnotation("containlibs", "envkey", []string{"CONTAINLIBS"})
+
+	// hidden flag to handle SINGULARITY_TMPDIR environment variable
+	actionFlags.StringVar(&tmpDir, "tmpdir", "", "specify a temporary directory to use for build")
+	actionFlags.Lookup("tmpdir").Hidden = true
+	actionFlags.SetAnnotation("tmpdir", "envkey", []string{"TMPDIR"})
 }
 
 // initBoolVars initializes flags that take a boolean argument

--- a/cmd/singularity/cli/actions.go
+++ b/cmd/singularity/cli/actions.go
@@ -87,6 +87,7 @@ func init() {
 		cmd.Flags().AddFlag(actionFlags.Lookup("app"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("containlibs"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("no-nv"))
+		cmd.Flags().AddFlag(actionFlags.Lookup("tmpdir"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("nohttps"))
 		if cmd == ShellCmd {
 			cmd.Flags().AddFlag(actionFlags.Lookup("shell"))
@@ -121,7 +122,7 @@ func handleOCI(u string) (string, error) {
 		return "", fmt.Errorf("unable to check if %v exists: %v", imgabs, err)
 	} else if !exists {
 		sylog.Infof("Converting OCI blobs to SIF format")
-		b, err := build.NewBuild(u, imgabs, "sif", "", "", types.Options{NoTest: true, NoHTTPS: noHTTPS})
+		b, err := build.NewBuild(u, imgabs, "sif", "", "", types.Options{TmpDir: tmpDir, NoTest: true, NoHTTPS: noHTTPS})
 		if err != nil {
 			return "", fmt.Errorf("unable to create new build: %v", err)
 		}

--- a/cmd/singularity/cli/build.go
+++ b/cmd/singularity/cli/build.go
@@ -31,6 +31,7 @@ var (
 	update     bool
 	noTest     bool
 	sections   []string
+	tmpDir     string
 	noHTTPS    bool
 )
 
@@ -68,6 +69,9 @@ func init() {
 
 	BuildCmd.Flags().StringVar(&libraryURL, "library", "https://library.sylabs.io", "container Library URL")
 	BuildCmd.Flags().SetAnnotation("library", "envkey", []string{"LIBRARY"})
+
+	BuildCmd.Flags().StringVar(&tmpDir, "tmpdir", "", "specify a temporary directory to use for build")
+	BuildCmd.Flags().SetAnnotation("tmpdir", "envkey", []string{"TMPDIR"})
 
 	BuildCmd.Flags().BoolVar(&noHTTPS, "nohttps", false, "do NOT use HTTPS, for communicating with local docker registry")
 	BuildCmd.Flags().SetAnnotation("nohttps", "envkey", []string{"NOHTTPS"})

--- a/cmd/singularity/cli/build_linux.go
+++ b/cmd/singularity/cli/build_linux.go
@@ -69,6 +69,7 @@ func run(cmd *cobra.Command, args []string) {
 			libraryURL,
 			authToken,
 			types.Options{
+				TmpDir:   tmpDir,
 				Update:   update,
 				Force:    force,
 				Sections: sections,

--- a/cmd/singularity/cli/pull.go
+++ b/cmd/singularity/cli/pull.go
@@ -43,6 +43,10 @@ func init() {
 	PullCmd.Flags().Lookup("name").Hidden = true
 	PullCmd.Flags().SetAnnotation("name", "envkey", []string{"NAME"})
 
+	PullCmd.Flags().StringVar(&tmpDir, "tmpdir", "", "specify a temporary directory to use for build")
+	PullCmd.Flags().Lookup("tmpdir").Hidden = true
+	PullCmd.Flags().SetAnnotation("tmpdir", "envkey", []string{"TMPDIR"})
+
 	PullCmd.Flags().BoolVar(&noHTTPS, "nohttps", false, "do NOT use HTTPS, for communicating with local docker registry")
 	PullCmd.Flags().SetAnnotation("nohttps", "envkey", []string{"NOHTTPS"})
 

--- a/cmd/singularity/cli/pull_linux.go
+++ b/cmd/singularity/cli/pull_linux.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/internal/pkg/build/types"
 	"github.com/sylabs/singularity/internal/pkg/libexec"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/uri"
@@ -37,6 +38,10 @@ func pullRun(cmd *cobra.Command, args []string) {
 	case HTTPProtocol, HTTPSProtocol:
 		libexec.PullNetImage(name, args[i], force)
 	default:
-		libexec.PullOciImage(name, args[i], force, noHTTPS)
+		libexec.PullOciImage(name, args[i], types.Options{
+			TmpDir:  tmpDir,
+			Force:   force,
+			NoHTTPS: noHTTPS,
+		})
 	}
 }

--- a/cmd/singularity/cli/singularity.go
+++ b/cmd/singularity/cli/singularity.go
@@ -273,6 +273,7 @@ var flagEnvFuncs = map[string]envHandle{
 	"detached": envBool,
 	"builder":  envStringNSlice,
 	"library":  envStringNSlice,
+	"tmpdir":   envStringNSlice,
 	"nohttps":  envBool,
 
 	// capability flags (and others)

--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -25,7 +25,7 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-sandboxAssembler")
+	b, err := types.NewBundle("", "sbuild-sandboxAssembler")
 	if err != nil {
 		return
 	}
@@ -59,7 +59,7 @@ func TestSandboxAssemblerShub(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-sandboxAssembler")
+	b, err := types.NewBundle("", "sbuild-sandboxAssembler")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/assemblers/assembler_sif_test.go
+++ b/internal/pkg/build/assemblers/assembler_sif_test.go
@@ -34,7 +34,7 @@ func TestSIFAssemblerDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-SIFAssembler")
+	b, err := types.NewBundle("", "sbuild-SIFAssembler")
 	if err != nil {
 		return
 	}
@@ -68,7 +68,7 @@ func TestSIFAssemblerShub(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-SIFAssembler")
+	b, err := types.NewBundle("", "sbuild-SIFAssembler")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -90,7 +90,7 @@ func newBuild(d types.Definition, dest, format string, libraryURL, authToken str
 		d:      d,
 	}
 
-	b.b, err = types.NewBundle("sbuild")
+	b.b, err = types.NewBundle(opts.TmpDir, "sbuild")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/build/sources/conveyorPacker_arch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_test.go
@@ -37,7 +37,7 @@ func TestArchConveyor(t *testing.T) {
 	defer defFile.Close()
 
 	// create bundle to build into
-	b, err := types.NewBundle("sbuild-arch")
+	b, err := types.NewBundle("", "sbuild-arch")
 	if err != nil {
 		return
 	}
@@ -71,7 +71,7 @@ func TestArchPacker(t *testing.T) {
 	defer defFile.Close()
 
 	// create bundle to build into
-	b, err := types.NewBundle("sbuild-arch")
+	b, err := types.NewBundle("", "sbuild-arch")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -32,7 +32,7 @@ func TestBusyBoxConveyor(t *testing.T) {
 	}
 	defer defFile.Close()
 
-	b, err := types.NewBundle("sbuild-busybox")
+	b, err := types.NewBundle("", "sbuild-busybox")
 	if err != nil {
 		return
 	}
@@ -62,7 +62,7 @@ func TestBusyBoxPacker(t *testing.T) {
 	}
 	defer defFile.Close()
 
-	b, err := types.NewBundle("sbuild-busybox")
+	b, err := types.NewBundle("", "sbuild-busybox")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -26,7 +26,7 @@ func TestDebootstrapConveyor(t *testing.T) {
 
 	test.EnsurePrivilege(t)
 
-	b, err := types.NewBundle("sbuild-debootstrap")
+	b, err := types.NewBundle("", "sbuild-debootstrap")
 	if err != nil {
 		return
 	}
@@ -56,7 +56,7 @@ func TestDebootstrapPacker(t *testing.T) {
 
 	test.EnsurePrivilege(t)
 
-	b, err := types.NewBundle("sbuild-debootstrap")
+	b, err := types.NewBundle("", "sbuild-debootstrap")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -26,7 +26,7 @@ func TestLibraryConveyor(t *testing.T) {
 
 	test.EnsurePrivilege(t)
 
-	b, err := types.NewBundle("sbuild-library")
+	b, err := types.NewBundle("", "sbuild-library")
 	if err != nil {
 		return
 	}
@@ -52,7 +52,7 @@ func TestLibraryConveyor(t *testing.T) {
 func TestLibraryPacker(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	b, err := types.NewBundle("sbuild-library")
+	b, err := types.NewBundle("", "sbuild-library")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -38,7 +38,7 @@ func TestOCIConveyorDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-oci")
+	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
 		return
 	}
@@ -70,7 +70,7 @@ func TestOCIConveyorDockerArchive(t *testing.T) {
 	}
 	defer os.Remove(archive)
 
-	b, err := types.NewBundle("sbuild-oci")
+	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
 		return
 	}
@@ -111,7 +111,7 @@ func TestOCIConveyorDockerDaemon(t *testing.T) {
 		return
 	}
 
-	b, err := types.NewBundle("sbuild-oci")
+	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
 		return
 	}
@@ -144,7 +144,7 @@ func TestOCIConveyorOCIArchive(t *testing.T) {
 	}
 	defer os.Remove(archive)
 
-	b, err := types.NewBundle("sbuild-oci")
+	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
 		return
 	}
@@ -190,7 +190,7 @@ func TestOCIConveyorOCILayout(t *testing.T) {
 		t.Fatalf("Error extracting oci archive to layout: %v", err)
 	}
 
-	b, err := types.NewBundle("sbuild-oci")
+	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
 		return
 	}
@@ -216,7 +216,7 @@ func TestOCIPacker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-oci")
+	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_shub_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub_test.go
@@ -27,7 +27,7 @@ func TestShubConveyor(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-shub")
+	b, err := types.NewBundle("", "sbuild-shub")
 	if err != nil {
 		return
 	}
@@ -52,7 +52,7 @@ func TestShubPacker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	b, err := types.NewBundle("sbuild-shub")
+	b, err := types.NewBundle("", "sbuild-shub")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -37,7 +37,7 @@ func TestYumConveyor(t *testing.T) {
 	defer defFile.Close()
 
 	// create bundle to build into
-	b, err := types.NewBundle("sbuild-yum")
+	b, err := types.NewBundle("", "sbuild-yum")
 	if err != nil {
 		return
 	}
@@ -73,7 +73,7 @@ func TestYumPacker(t *testing.T) {
 	defer defFile.Close()
 
 	// create bundle to build into
-	b, err := types.NewBundle("sbuild-yum")
+	b, err := types.NewBundle("", "sbuild-yum")
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/types/bundle.go
+++ b/internal/pkg/build/types/bundle.go
@@ -40,6 +40,8 @@ type Bundle struct {
 
 // Options ...
 type Options struct {
+	// TmpDir specifies a non-standard temporary location to perform a build
+	TmpDir string
 	// sections are the parts of the definition to run during the build
 	Sections []string `json:"sections"`
 	// noTest indicates if build should skip running the test script
@@ -53,14 +55,14 @@ type Options struct {
 }
 
 // NewBundle creates a Bundle environment
-func NewBundle(directoryPrefix string) (b *Bundle, err error) {
+func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
 	b = &Bundle{}
 
-	if directoryPrefix == "" {
-		directoryPrefix = "sbuild-"
+	if bundlePrefix == "" {
+		bundlePrefix = "sbuild-"
 	}
 
-	b.Path, err = ioutil.TempDir("", directoryPrefix+"-")
+	b.Path, err = ioutil.TempDir(bundleDir, bundlePrefix+"-")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/libexec/pull.go
+++ b/internal/pkg/libexec/pull.go
@@ -39,8 +39,8 @@ func PullShubImage(filePath, shubRef string, force, noHTTPS bool) {
 }
 
 // PullOciImage pulls an OCI image to a sif
-func PullOciImage(path, uri string, force, noHTTPS bool) {
-	b, err := build.NewBuild(uri, path, "sif", "", "", types.Options{Force: force, NoHTTPS: noHTTPS})
+func PullOciImage(path, uri string, opts types.Options) {
+	b, err := build.NewBuild(uri, path, "sif", "", "", opts)
 	if err != nil {
 		sylog.Fatalf("Unable to pull %v: %v", uri, err)
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

SINGULARITY_TMPDIR is used for builds performed by the `build`, `actions` and `pull` commands.


**This fixes or addresses the following GitHub issues:**

- Fixes #2305 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
