### PR TITLE
Fix network namespace usage for users

### DIFF
--- a/internal/pkg/network/network.go
+++ b/internal/pkg/network/network.go
@@ -110,24 +110,15 @@ func NewSetup(networks []string, containerID string, netNS string, cniPath *CNIP
 			finalCNIPath.Plugin = cniPath.Plugin
 		}
 	}
-	hasNone := false
+
 	for _, network := range networks {
-		if network == "none" {
-			hasNone = true
-			break
-		}
 		nlist = append(nlist, config{
 			name:    network,
 			portMap: make([]portMap, 0),
 			args:    make([][2]string, 0),
 		})
 	}
-	if hasNone {
-		if len(networks) > 1 {
-			return nil, fmt.Errorf("none network can't be specified with another network")
-		}
-		return &Setup{configs: []config{}}, nil
-	}
+
 	return &Setup{
 			configs:     nlist,
 			cniPath:     finalCNIPath,

--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -161,8 +161,8 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 		}
 	}
 
-	if c.netNS && !c.userNS {
-		if os.Geteuid() == 0 {
+	if c.netNS {
+		if os.Geteuid() == 0 && !c.userNS {
 			/* hold a reference to container network namespace for cleanup */
 			f, err := os.Open("/proc/" + strconv.Itoa(pid) + "/ns/net")
 			if err != nil {
@@ -190,8 +190,8 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 			}
 
 			engine.EngineConfig.Network = setup
-		} else {
-			return fmt.Errorf("Network requires root permissions")
+		} else if engine.EngineConfig.GetNetwork() != "none" {
+			return fmt.Errorf("Network requires root permissions or --network=none argument as user")
 		}
 	}
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes usage of network namespace for users since user can't enable network namespace just to provide network isolation, this PR will allow users to specify `--net --network=none` to enable namespace and bring up just a loopback interface.


**This fixes or addresses the following GitHub issues:**

- Fixes #2390


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
