### PR TITLE
Fix shebang mangle

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -115,6 +115,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/singularity/cni/*
 %dir %{_sysconfdir}/singularity
 %config(noreplace) %{_sysconfdir}/singularity/*
+%attr(755, root, root) %{_sysconfdir}/singularity/actions/exec
+%attr(755, root, root) %{_sysconfdir}/singularity/actions/run
+%attr(755, root, root) %{_sysconfdir}/singularity/actions/shell
+%attr(755, root, root) %{_sysconfdir}/singularity/actions/start
+%attr(755, root, root) %{_sysconfdir}/singularity/actions/test
 %dir %{_sysconfdir}/bash_completion.d
 %{_sysconfdir}/bash_completion.d/*
 %dir %{_localstatedir}/singularity

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -103,6 +103,7 @@ cd $GOPATH/%{singgopath}/builddir
 
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 make DESTDIR=$RPM_BUILD_ROOT install man
+chmod 644 $RPM_BUILD_ROOT%{_sysconfdir}/singularity/actions/*
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -222,7 +222,7 @@ $(cgroups_config_INSTALL): $(cgroups_config)
 $(actions_INSTALL): $(actions_LIST)
 	@echo " INSTALL" $@
 	$(V)install -d $(actions_INSTALL)
-	$(V)install -m 755 $? $@
+	$(V)install -m 0755 $? $@
 
 .PHONY: man
 man:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -222,7 +222,7 @@ $(cgroups_config_INSTALL): $(cgroups_config)
 $(actions_INSTALL): $(actions_LIST)
 	@echo " INSTALL" $@
 	$(V)install -d $(actions_INSTALL)
-	$(V)install $? $@
+	$(V)install -m 755 $? $@
 
 .PHONY: man
 man:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -222,7 +222,7 @@ $(cgroups_config_INSTALL): $(cgroups_config)
 $(actions_INSTALL): $(actions_LIST)
 	@echo " INSTALL" $@
 	$(V)install -d $(actions_INSTALL)
-	$(V)install -m 0755 $? $@
+	$(V)install $? $@
 
 .PHONY: man
 man:


### PR DESCRIPTION
RPM is mangling shebang lines like:

    #!/bin/sh  -> #!/usr/bin/sh

The causes the action scripts to fail on distributions that have
not made /bin a symlink to /usr/bin.

**This fixes or addresses the following GitHub issues:**

- Fixes #2383 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
