### PR TITLE
More thorough instance tests

### DIFF
--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -13,24 +13,172 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
-func startInstance(image string, instance string) ([]byte, error) {
-	args := []string{"instance", "start", image, instance}
-	cmd := exec.Command(cmdPath, args...)
+type startOpts struct {
+	add_caps       string
+	allow_setuid   bool
+	apply_cgroups  string
+	bind           string
+	boot           bool
+	cleanenv       bool
+	contain        bool
+	containall     bool
+	dns            string
+	drop_caps      string
+	home           string
+	hostname       string
+	keep_privs     bool
+	net            bool
+	network        string
+	network_args   string
+	no_home        bool
+	no_privs       bool
+	nv             bool
+	overlay        string
+	scratch        string
+	security       string
+	userns         bool
+	uts            bool
+	workdir        string
+	writable       bool
+	writable_tmpfs bool
+}
 
+type listOpts struct {
+	json      bool
+	user      string
+	container string
+}
+
+type stopOpts struct {
+	all     bool
+	force   bool
+	signal  string
+	timeout string
+	user    string
+}
+
+func startInstance(image string, instance string, opts startOpts) ([]byte, error) {
+	args := []string{"instance", "start"}
+	if opts.add_caps != "" {
+		args = append(args, "--add-caps", opts.add_caps)
+	}
+	if opts.allow_setuid {
+		args = append(args, "--allow-setuid")
+	}
+	if opts.apply_cgroups != "" {
+		args = append(args, "--apply-cgroups", opts.apply_cgroups)
+	}
+	if opts.bind != "" {
+		args = append(args, "--bind", opts.bind)
+	}
+	if opts.boot {
+		args = append(args, "--boot")
+	}
+	if opts.cleanenv {
+		args = append(args, "--cleanenv")
+	}
+	if opts.contain {
+		args = append(args, "--contain")
+	}
+	if opts.containall {
+		args = append(args, "--containall")
+	}
+	if opts.dns != "" {
+		args = append(args, "--dns", opts.dns)
+	}
+	if opts.drop_caps != "" {
+		args = append(args, "--drop-caps", opts.drop_caps)
+	}
+	if opts.home != "" {
+		args = append(args, "--home", opts.home)
+	}
+	if opts.hostname != "" {
+		args = append(args, "--hostname", opts.hostname)
+	}
+	if opts.keep_privs {
+		args = append(args, "--keep-privs")
+	}
+	if opts.net {
+		args = append(args, "--net")
+	}
+	if opts.network != "" {
+		args = append(args, "--network", opts.network)
+	}
+	if opts.network_args != "" {
+		args = append(args, "--network-args", opts.network_args)
+	}
+	if opts.no_home {
+		args = append(args, "--no-home")
+	}
+	if opts.no_privs {
+		args = append(args, "--no-privs")
+	}
+	if opts.nv {
+		args = append(args, "--nv")
+	}
+	if opts.overlay != "" {
+		args = append(args, "--overlay", opts.overlay)
+	}
+	if opts.scratch != "" {
+		args = append(args, "--scratch", opts.scratch)
+	}
+	if opts.security != "" {
+		args = append(args, "--security", opts.security)
+	}
+	if opts.userns {
+		args = append(args, "--userns")
+	}
+	if opts.uts {
+		args = append(args, "--uts")
+	}
+	if opts.workdir != "" {
+		args = append(args, "--workdir", opts.workdir)
+	}
+	if opts.writable {
+		args = append(args, "--writable")
+	}
+	if opts.writable_tmpfs {
+		args = append(args, "--writable-tmpfs")
+	}
+	args = append(args, image, instance)
+	cmd := exec.Command(cmdPath, args...)
 	return cmd.CombinedOutput()
 }
 
-func listInstance() ([]byte, error) {
+func listInstance(opts listOpts) ([]byte, error) {
 	args := []string{"instance", "list"}
+	if opts.json {
+		args = append(args, "--json")
+	}
+	if opts.user != "" {
+		args = append(args, "--user", opts.user)
+	}
+	if opts.container != "" {
+		args = append(args, opts.container)
+	}
 	cmd := exec.Command(cmdPath, args...)
-
 	return cmd.CombinedOutput()
 }
 
-func stopInstance(instance string) ([]byte, error) {
-	args := []string{"instance", "stop", instance}
+func stopInstance(instance string, opts stopOpts) ([]byte, error) {
+	args := []string{"instance", "stop"}
+	if opts.all {
+		args = append(args, "--all")
+	}
+	if opts.force {
+		args = append(args, "--force")
+	}
+	if opts.signal != "" {
+		args = append(args, "--signal", opts.signal)
+	}
+	if opts.timeout != "" {
+		args = append(args, "--timeout", opts.timeout)
+	}
+	if opts.user != "" {
+		args = append(args, "--user", opts.user)
+	}
+	args = append(args, instance)
 	cmd := exec.Command(cmdPath, args...)
-
 	return cmd.CombinedOutput()
 }
 
@@ -54,17 +202,17 @@ func TestInstance(t *testing.T) {
 	t.Run("StartListStop", test.WithoutPrivilege(func(t *testing.T) {
 		var defaultInstance = "www"
 
-		startInstanceOutput, err := startInstance(imagePath, defaultInstance)
+		startInstanceOutput, err := startInstance(imagePath, defaultInstance, startOpts{})
 		if err != nil {
 			t.Fatalf("Error starting instance from an image: %v. Output follows.\n%s", err, string(startInstanceOutput))
 		}
 
-		listInstanceOutput, err := listInstance()
+		listInstanceOutput, err := listInstance(listOpts{})
 		if err != nil {
 			t.Fatalf("Error listing instances: %v. Output follows.\n%s", err, string(listInstanceOutput))
 		}
 
-		stopInstanceOutput, err := stopInstance(defaultInstance)
+		stopInstanceOutput, err := stopInstance(defaultInstance, stopOpts{})
 		if err != nil {
 			t.Fatalf("Error stopping instance by name: %v. Output follows.\n%s", err, string(stopInstanceOutput))
 		}

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -31,7 +31,7 @@ type startOpts struct {
 	addCaps       string
 	allowSetuid   bool
 	applyCgroups  string
-	bind          string
+	binds         []string
 	boot          bool
 	cleanenv      bool
 	contain       bool
@@ -93,8 +93,8 @@ func startInstance(image string, instance string, opts startOpts) ([]byte, error
 	if opts.applyCgroups != "" {
 		args = append(args, "--apply-cgroups", opts.applyCgroups)
 	}
-	if opts.bind != "" {
-		args = append(args, "--bind", opts.bind)
+	for _, bind := range opts.binds {
+		args = append(args, "--bind", bind)
 	}
 	if opts.boot {
 		args = append(args, "--boot")

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -26,33 +26,33 @@ const instanceDefinition = "../../examples/instances/Singularity"
 const instanceImagePath = "./instance_tests.sif"
 
 type startOpts struct {
-	add_caps       string
-	allow_setuid   bool
-	apply_cgroups  string
-	bind           string
-	boot           bool
-	cleanenv       bool
-	contain        bool
-	containall     bool
-	dns            string
-	drop_caps      string
-	home           string
-	hostname       string
-	keep_privs     bool
-	net            bool
-	network        string
-	network_args   string
-	no_home        bool
-	no_privs       bool
-	nv             bool
-	overlay        string
-	scratch        string
-	security       string
-	userns         bool
-	uts            bool
-	workdir        string
-	writable       bool
-	writable_tmpfs bool
+	addCaps       string
+	allowSetuid   bool
+	applyCgroups  string
+	bind          string
+	boot          bool
+	cleanenv      bool
+	contain       bool
+	containall    bool
+	dns           string
+	dropCaps      string
+	home          string
+	hostname      string
+	keepPrivs     bool
+	net           bool
+	network       string
+	networkArgs   string
+	noHome        bool
+	noPrivs       bool
+	nv            bool
+	overlay       string
+	scratch       string
+	security      string
+	userns        bool
+	uts           bool
+	workdir       string
+	writable      bool
+	writableTmpfs bool
 }
 
 type listOpts struct {
@@ -82,14 +82,14 @@ type instanceList struct {
 
 func startInstance(image string, instance string, opts startOpts) ([]byte, error) {
 	args := []string{"instance", "start"}
-	if opts.add_caps != "" {
-		args = append(args, "--add-caps", opts.add_caps)
+	if opts.addCaps != "" {
+		args = append(args, "--add-caps", opts.addCaps)
 	}
-	if opts.allow_setuid {
+	if opts.allowSetuid {
 		args = append(args, "--allow-setuid")
 	}
-	if opts.apply_cgroups != "" {
-		args = append(args, "--apply-cgroups", opts.apply_cgroups)
+	if opts.applyCgroups != "" {
+		args = append(args, "--apply-cgroups", opts.applyCgroups)
 	}
 	if opts.bind != "" {
 		args = append(args, "--bind", opts.bind)
@@ -109,8 +109,8 @@ func startInstance(image string, instance string, opts startOpts) ([]byte, error
 	if opts.dns != "" {
 		args = append(args, "--dns", opts.dns)
 	}
-	if opts.drop_caps != "" {
-		args = append(args, "--drop-caps", opts.drop_caps)
+	if opts.dropCaps != "" {
+		args = append(args, "--drop-caps", opts.dropCaps)
 	}
 	if opts.home != "" {
 		args = append(args, "--home", opts.home)
@@ -118,7 +118,7 @@ func startInstance(image string, instance string, opts startOpts) ([]byte, error
 	if opts.hostname != "" {
 		args = append(args, "--hostname", opts.hostname)
 	}
-	if opts.keep_privs {
+	if opts.keepPrivs {
 		args = append(args, "--keep-privs")
 	}
 	if opts.net {
@@ -127,13 +127,13 @@ func startInstance(image string, instance string, opts startOpts) ([]byte, error
 	if opts.network != "" {
 		args = append(args, "--network", opts.network)
 	}
-	if opts.network_args != "" {
-		args = append(args, "--network-args", opts.network_args)
+	if opts.networkArgs != "" {
+		args = append(args, "--network-args", opts.networkArgs)
 	}
-	if opts.no_home {
+	if opts.noHome {
 		args = append(args, "--no-home")
 	}
-	if opts.no_privs {
+	if opts.noPrivs {
 		args = append(args, "--no-privs")
 	}
 	if opts.nv {
@@ -160,7 +160,7 @@ func startInstance(image string, instance string, opts startOpts) ([]byte, error
 	if opts.writable {
 		args = append(args, "--writable")
 	}
-	if opts.writable_tmpfs {
+	if opts.writableTmpfs {
 		args = append(args, "--writable-tmpfs")
 	}
 	args = append(args, image, instance)
@@ -218,14 +218,14 @@ func execInstance(instance string, execCmd ...string) ([]byte, error) {
 // in response.
 func echo(t *testing.T, port int) {
 	const message = "b40cbeaaea293f7e8bd40fb61f389cfca9823467\n"
-	sock, sock_err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))
-	if sock_err != nil {
-		t.Fatalf("Failed to dial echo server: %v", sock_err)
+	sock, sockErr := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))
+	if sockErr != nil {
+		t.Fatalf("Failed to dial echo server: %v", sockErr)
 	}
 	fmt.Fprintf(sock, message)
-	response, response_err := bufio.NewReader(sock).ReadString('\n')
-	if response_err != nil || response != message {
-		t.Fatalf("Bad response: err = %v, response = %v", response_err, response)
+	response, responseErr := bufio.NewReader(sock).ReadString('\n')
+	if responseErr != nil || response != message {
+		t.Fatalf("Bad response: err = %v, response = %v", responseErr, response)
 	}
 }
 
@@ -279,8 +279,8 @@ func testCreateManyInstances(t *testing.T) {
 		}
 	}
 	// Verify all instances started.
-	if num_started := getNumberOfInstances(t); num_started != n {
-		t.Fatalf("Expected %d instances, but see %d.", n, num_started)
+	if numStarted := getNumberOfInstances(t); numStarted != n {
+		t.Fatalf("Expected %d instances, but see %d.", n, numStarted)
 	}
 	// Echo all n instances.
 	for i := 0; i < n; i++ {

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -268,6 +268,10 @@ func testCreateManyInstances(t *testing.T) {
 			t.Fatalf("Failed to start instance %s: %v", instanceName, err)
 		}
 	}
+	// Verify all instances started.
+	if num_started := getNumberOfInstances(t); num_started != n {
+		t.Fatalf("Expected %d instances, but only see %d.", n, num_started)
+	}
 	// Echo all n instances.
 	for i := 0; i < n; i++ {
 		echo(t, instanceStartPort+i)

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	instanceStartPort = 11372
+	instanceStartPort  = 11372
 	instanceDefinition = "../../examples/instances/Singularity"
-	instanceImagePath = "./instance_tests.sif"
+	instanceImagePath  = "./instance_tests.sif"
 )
 
 type startOpts struct {

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
-const instanceStartPort = 11372
-const instanceDefinition = "../../examples/instances/Singularity"
-const instanceImagePath = "./instance_tests.sif"
+const (
+	instanceStartPort = 11372
+	instanceDefinition = "../../examples/instances/Singularity"
+	instanceImagePath = "./instance_tests.sif"
+)
 
 type startOpts struct {
 	addCaps       string
@@ -413,13 +415,13 @@ func TestInstance(t *testing.T) {
 		{"StopAll", testStopAll, false},
 		{"FinalNoInstances", testNoInstances, false},
 	}
-	for _, currentTest := range tests {
+	for _, tt := range tests {
 		var wrappedFn func(*testing.T)
-		if currentTest.privileged {
-			wrappedFn = test.WithPrivilege(currentTest.function)
+		if tt.privileged {
+			wrappedFn = test.WithPrivilege(tt.function)
 		} else {
-			wrappedFn = test.WithoutPrivilege(currentTest.function)
+			wrappedFn = test.WithoutPrivilege(tt.function)
 		}
-		t.Run(currentTest.name, wrappedFn)
+		t.Run(tt.name, wrappedFn)
 	}
 }

--- a/examples/instances/Singularity
+++ b/examples/instances/Singularity
@@ -2,6 +2,8 @@ BootStrap: busybox
 MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
 
 %startscript
+    have_env=`printenv BHUSHAN`
+    [ -z `printenv BHUSHAN` ] || touch $HOME/bhushan
     port=11372
     while true; do
         nc -ll -p $port -e /bin/cat 2>/dev/null

--- a/examples/instances/Singularity
+++ b/examples/instances/Singularity
@@ -1,0 +1,12 @@
+BootStrap: busybox
+MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
+
+%startscript
+    port=11372
+    while true; do
+        nc -ll -p $port -e /bin/cat 2>/dev/null
+        if [ $? -eq 0 ]; then
+            exit 0
+        fi
+        port=$((port + 1))
+    done


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR includes more thorough instance tests. Not all command-line options for the start, stop, and list commands have been tested, but all command-line options are included in the option structs to make testing in the future easier if desired. The testing framework is now tabular like the other test files.

Several operations are tested including verifying the number of instances running at various stages of the test suite. A real instance recipe has been built which launches a basic echo server to test network connectivity and basic background functionality. Additionally, here is the complete list of flags currently tested:

For start: --home, --hostname, --cleanenv, --contain, --workdir
For list: --json
For stop: single instance, --all

**This fixes or addresses the following GitHub issues:**

- Fixes #2129

Attn: @singularity-maintainers
