### PR TITLE
Return status 1 on invalid/incomplete commands.

### DIFF
--- a/cmd/singularity/cli/capability.go
+++ b/cmd/singularity/cli/capability.go
@@ -8,6 +8,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -43,13 +44,16 @@ func init() {
 
 // CapabilityCmd is the capability command
 var CapabilityCmd = &cobra.Command{
-	Run:                   nil,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("Invalid command")
+	},
 	DisableFlagsInUseLine: true,
 
-	Use:     docs.CapabilityUse,
-	Short:   docs.CapabilityShort,
-	Long:    docs.CapabilityLong,
-	Example: docs.CapabilityExample,
+	Use:           docs.CapabilityUse,
+	Short:         docs.CapabilityShort,
+	Long:          docs.CapabilityLong,
+	Example:       docs.CapabilityExample,
+	SilenceErrors: true,
 }
 
 func manageCap(capStr string, cmd int) {

--- a/cmd/singularity/cli/instance.go
+++ b/cmd/singularity/cli/instance.go
@@ -9,6 +9,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -43,13 +44,16 @@ func init() {
 
 // InstanceCmd singularity instance
 var InstanceCmd = &cobra.Command{
-	Run:                   nil,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("Invalid command")
+	},
 	DisableFlagsInUseLine: true,
 
-	Use:     docs.InstanceUse,
-	Short:   docs.InstanceShort,
-	Long:    docs.InstanceLong,
-	Example: docs.InstanceExample,
+	Use:           docs.InstanceUse,
+	Short:         docs.InstanceShort,
+	Long:          docs.InstanceLong,
+	Example:       docs.InstanceExample,
+	SilenceErrors: true,
 }
 
 func listInstance() {

--- a/cmd/singularity/cli/instance_stop.go
+++ b/cmd/singularity/cli/instance_stop.go
@@ -8,6 +8,7 @@
 package cli
 
 import (
+	"errors"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/src/docs"
 )
@@ -40,13 +41,15 @@ func init() {
 // InstanceStopCmd singularity instance stop
 var InstanceStopCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 && !stopAll {
 			stopInstance(args[0])
+			return nil
 		} else if stopAll {
 			stopInstance("*")
+			return nil
 		} else {
-			cmd.Usage()
+			return errors.New("Invalid command")
 		}
 	},
 

--- a/cmd/singularity/cli/keys.go
+++ b/cmd/singularity/cli/keys.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"errors"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/src/docs"
 )
@@ -29,11 +30,14 @@ func init() {
 
 // KeysCmd is the 'keys' command that allows management of key stores
 var KeysCmd = &cobra.Command{
-	Run:                   nil,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("Invalid command")
+	},
 	DisableFlagsInUseLine: true,
 
-	Use:     docs.KeysUse,
-	Short:   docs.KeysShort,
-	Long:    docs.KeysLong,
-	Example: docs.KeysExample,
+	Use:           docs.KeysUse,
+	Short:         docs.KeysShort,
+	Long:          docs.KeysLong,
+	Example:       docs.KeysExample,
+	SilenceErrors: true,
 }

--- a/cmd/singularity/cli/singularity.go
+++ b/cmd/singularity/cli/singularity.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -91,13 +92,16 @@ var SingularityCmd = &cobra.Command{
 	TraverseChildren:      true,
 	DisableFlagsInUseLine: true,
 	PersistentPreRun:      persistentPreRun,
-	Run:                   nil,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("Invalid command")
+	},
 
-	Use:     docs.SingularityUse,
-	Version: buildcfg.PACKAGE_VERSION,
-	Short:   docs.SingularityShort,
-	Long:    docs.SingularityLong,
-	Example: docs.SingularityExample,
+	Use:           docs.SingularityUse,
+	Version:       buildcfg.PACKAGE_VERSION,
+	Short:         docs.SingularityShort,
+	Long:          docs.SingularityLong,
+	Example:       docs.SingularityExample,
+	SilenceErrors: true,
 }
 
 // ExecuteSingularity adds all child commands to the root command and sets

--- a/cmd/singularity/cli_test.go
+++ b/cmd/singularity/cli_test.go
@@ -29,9 +29,9 @@ func TestSelfTest(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	cmd := exec.Command(cmdPath, "selftest")
-	if b, err := cmd.CombinedOutput(); err != nil {
+	if b, err := cmd.CombinedOutput(); err == nil {
 		t.Log(string(b))
-		t.Fatalf("unexpected failure running selftest: %v", err)
+		t.Fatal("selftest passed, but it isn't implemented?")
 	}
 }
 

--- a/cmd/singularity/cli_test.go
+++ b/cmd/singularity/cli_test.go
@@ -31,7 +31,7 @@ func TestSelfTest(t *testing.T) {
 	cmd := exec.Command(cmdPath, "selftest")
 	if b, err := cmd.CombinedOutput(); err == nil {
 		t.Log(string(b))
-		t.Fatal("selftest passed, but it isn't implemented?")
+		t.Fatal("unexpected success running selftest")
 	}
 }
 

--- a/cmd/singularity/help_test.go
+++ b/cmd/singularity/help_test.go
@@ -15,21 +15,26 @@ import (
 
 func TestHelpSingularity(t *testing.T) {
 	tests := []struct {
-		name string
-		argv []string
+		name       string
+		argv       []string
+		shouldPass bool
 	}{
-		{"NoCommand", []string{}},
-		{"FlagShort", []string{"-h"}},
-		{"FlagLong", []string{"--help"}},
-		{"Command", []string{"help"}},
+		{"NoCommand", []string{}, false},
+		{"FlagShort", []string{"-h"}, true},
+		{"FlagLong", []string{"--help"}, true},
+		{"Command", []string{"help"}, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
 			cmd := exec.Command(cmdPath, tt.argv...)
-			if b, err := cmd.CombinedOutput(); err != nil {
+			b, err := cmd.CombinedOutput()
+			if err != nil && tt.shouldPass {
 				t.Log(string(b))
 				t.Fatalf("unexpected failure running '%v': %v", strings.Join(tt.argv, " "), err)
+			} else if err == nil && !tt.shouldPass {
+				t.Log(string(b))
+				t.Fatalf("Test %s passed, but was expected to fail.", tt.name)
 			}
 		}))
 	}

--- a/cmd/singularity/help_test.go
+++ b/cmd/singularity/help_test.go
@@ -34,7 +34,7 @@ func TestHelpSingularity(t *testing.T) {
 				t.Fatalf("unexpected failure running '%v': %v", strings.Join(tt.argv, " "), err)
 			} else if err == nil && !tt.shouldPass {
 				t.Log(string(b))
-				t.Fatalf("Test %s passed, but was expected to fail.", tt.name)
+				t.Fatalf("unexpected success running '%v'", strings.Join(tt.argv, " "))
 			}
 		}))
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR causes singularity to exit with status code 1 (rather than 0) when given invalid commands. This has been tested only for the commands which accept sub-commands: (singularity, singularity instance, singularity capability, singularity keys). The SilenceErrors directive prevents the error from being printed to the screen. I'm not sure if there are any unintended consequences of this for e.g. debugging. A couple tests had to be modified to expect this new failure.

**This fixes or addresses the following GitHub issues:**

- Fixes #2146

Attn: @singularity-maintainers
