### PR TITLE
Fail if tried to remote build a sandbox container

### DIFF
--- a/cmd/singularity/cli/build.go
+++ b/cmd/singularity/cli/build.go
@@ -93,8 +93,11 @@ var BuildCmd = &cobra.Command{
 	TraverseChildren: true,
 }
 
-// checkTargetCollision makes sure output target doesn't exist, or is ok to overwrite
+// checkTargetCollision makes sure output target doesn't exist or is ok to overwrite, & check if sandbox & remote are true
 func checkBuildTarget(path string, update bool) bool {
+	if sandbox && remote {
+		sylog.Fatalf("Unable to create build: Can't remote build a sandbox container.")
+	}
 	if f, err := os.Stat(path); err == nil {
 		if update && !f.IsDir() {
 			sylog.Fatalf("Only sandbox updating is supported.")

--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -1433,10 +1433,7 @@ func (c *container) addCwdMount(system *mount.System) error {
 		sylog.Warningf("Could not set container working directory %s: %s", cwd, err)
 		return nil
 	}
-	current, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("could not obtain current directory path: %s", err)
-	}
+	cwd = c.engine.EngineConfig.OciConfig.Process.Cwd
 	switch current {
 	case "/", "/etc", "/bin", "/mnt", "/usr", "/var", "/opt", "/sbin":
 		sylog.Verbosef("Not mounting CWD within operating system directory: %s", current)

--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -1424,7 +1424,11 @@ func (c *container) addCwdMount(system *mount.System) error {
 	if c.engine.EngineConfig.OciConfig.Process == nil {
 		return nil
 	}
-	cwd = c.engine.EngineConfig.OciConfig.Process.Cwd
+	cwd, err := os.Getwd()
+	if err != nil {
+		sylog.Warningf("Could not get container working driectory: %s", err)
+		return nil
+	}
 	if err := os.Chdir(cwd); err != nil {
 		sylog.Warningf("Could not set container working directory %s: %s", cwd, err)
 		return nil

--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -1424,16 +1424,15 @@ func (c *container) addCwdMount(system *mount.System) error {
 	if c.engine.EngineConfig.OciConfig.Process == nil {
 		return nil
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		sylog.Warningf("Could not get container working driectory: %s", err)
-		return nil
-	}
+	cwd = c.engine.EngineConfig.OciConfig.Process.Cwd
 	if err := os.Chdir(cwd); err != nil {
 		sylog.Warningf("Could not set container working directory %s: %s", cwd, err)
 		return nil
 	}
-	cwd = c.engine.EngineConfig.OciConfig.Process.Cwd
+	current, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not obtain current directory path: %s", err)
+	}
 	switch current {
 	case "/", "/etc", "/bin", "/mnt", "/usr", "/var", "/opt", "/sbin":
 		sylog.Verbosef("Not mounting CWD within operating system directory: %s", current)


### PR DESCRIPTION
# Now will fail if the user tried to remote build a sandbox container.

<br>

## Before This PR:

```
$ singularity build --remote --sandbox foo.sif library://alpine:3.8
Getting image source signatures
[...]
INFO:    Creating SIF file...
INFO:    Build complete: /tmp/image-242422562
INFO:    Now uploading /tmp/image-242422562 to the library
 26.69 MiB / 26.69 MiB  100.00% 31.69 MiB/s 0s
INFO:    Setting tag latest
 26.69 MiB / 26.69 MiB [=========================================================================================================================================] 100.00% 3.27 MiB/s 8s
```
The build will succeed, and does **Not** produce a sandbox container.

<br>

## After This PR:

```
$ singularity build --remote --sandbox foo.sif library://alpine:3.8
FATAL:   Unable to create build: Can't remote build a sandbox container.
```

The build will fail, Not producing any container.

<br>

## This fixes or addresses the following GitHub issues:

- Fixes #2415 

<br>

**NOTE:** This is most likely a temporary fix, until it is possible to remote build a sandbox container.

<br>

