### PR TITLE
Respect a read-only file mode.

### DIFF
--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -148,9 +148,9 @@ func Init(path string, writable bool) (*Image, error) {
 		if mode&os.O_RDWR != 0 {
 			if err := syscall.Access(resolvedPath, 2); err != nil {
 				sylog.Debugf("Opening %s in read-only mode: no write permissions", path)
-				mode = os.O_RDONLY
-				img.Writable = false
 			}
+			mode = os.O_RDONLY
+			img.Writable = false
 		}
 
 		img.File, err = os.OpenFile(resolvedPath, mode, 0)

--- a/internal/pkg/image/image.go
+++ b/internal/pkg/image/image.go
@@ -148,9 +148,9 @@ func Init(path string, writable bool) (*Image, error) {
 		if mode&os.O_RDWR != 0 {
 			if err := syscall.Access(resolvedPath, 2); err != nil {
 				sylog.Debugf("Opening %s in read-only mode: no write permissions", path)
+				mode = os.O_RDONLY
+				img.Writable = false
 			}
-			mode = os.O_RDONLY
-			img.Writable = false
 		}
 
 		img.File, err = os.OpenFile(resolvedPath, mode, 0)

--- a/internal/pkg/image/sif.go
+++ b/internal/pkg/image/sif.go
@@ -36,5 +36,8 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 }
 
 func (f *sifFormat) openMode(writable bool) int {
-	return os.O_RDWR
+	if writable {
+		return os.O_RDWR
+	}
+	return os.O_RDONLY
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

When executing an sif image as read-only, the image is still opened in read-write mode, disregarding the read-only request. This results in a strange bug when trying to execute the image like a binary (e.g. `./testimage` more than once. This PR fixes this by respecting the read-only request, and opening the image as read-only.

The previous code attempted to circumvent the request for a read-only image by running an access system call. The new code will always respect the mode.

**This fixes or addresses the following GitHub issues:**

- Fixes #2403 

Attn: @singularity-maintainers
