### PR TITLE
Fix misleading token warning

### DIFF
--- a/cmd/singularity/cli/singularity.go
+++ b/cmd/singularity/cli/singularity.go
@@ -175,9 +175,6 @@ func sylabsToken(cmd *cobra.Command, args []string) {
 	if authToken == "" {
 		authToken, authWarning = auth.ReadToken(defaultTokenFile)
 	}
-	if authToken == "" && authWarning == auth.WarningTokenFileNotFound {
-		sylog.Warningf("%v : Only pulls of public images will succeed", authWarning)
-	}
 }
 
 // envAppend combines command line and environment var into a single argument

--- a/internal/pkg/util/auth/token.go
+++ b/internal/pkg/util/auth/token.go
@@ -22,7 +22,7 @@ const (
 	// WarningEmptyToken Warning return for empty token string
 	WarningEmptyToken = "Token file is empty"
 	// WarningTokenFileNotFound token file not found
-	WarningTokenFileNotFound = "Authentication token file not found"
+	WarningTokenFileNotFound = "Authentication token file not found. To generate a token, visit cloud.sylabs.io/auth"
 	// WarningCouldntReadFile Warning return for issues when reading file
 	WarningCouldntReadFile = "Couldn't read your Sylabs authentication token"
 )


### PR DESCRIPTION
Fixes a misleading warning about token not being found even when pulling from non-sylabs cloud locations. Also adds some instruction to the `WarningTokenFileNotFound` on how to generate a new token