### PR TITLE
Print multiple environments from inspect if they exist.

### DIFF
--- a/cmd/singularity/cli/inspect.go
+++ b/cmd/singularity/cli/inspect.go
@@ -134,7 +134,7 @@ var InspectCmd = &cobra.Command{
 
 			// append to a[2] to run commands in container
 			a[2] += fmt.Sprintf(" echo '%v\nenvironment';", prefix)
-			a[2] += " cat .singularity.d/env/90-environment.sh;"
+			a[2] += " find .singularity.d/env -name 9*-environment.sh -exec echo -n == \\; -exec basename -z {} \\; -exec echo == \\; -exec cat {} \\; -exec echo \\;;"
 			a[2] += fmt.Sprintf(" echo '%v';", delimiter)
 		}
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR updates `singularity inspect --environment` to output all `9*-environment.sh` files (not just `90-environment.sh`). The contents of each file are prefixed by the filename. Example:

```
[jacob@gideon temp]$ singularity inspect --environment test.sif

==90-environment.sh==
#!/bin/sh

        export FOO=bar

==91-environment.sh==
export THIS=that
```

This has been manually tested. Unit tests would cause a merge conflict with PR #2122 so I'm not sure what to do there (pending discussion with @jscook2345 ).

**This fixes or addresses the following GitHub issues:**

- Fixes #2431 

Attn: @singularity-maintainers
