### PR TITLE
Silence progress bars when appropriate flag set.

### DIFF
--- a/pkg/client/library/pull.go
+++ b/pkg/client/library/pull.go
@@ -97,6 +97,9 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string, Force 
 
 	bodySize := res.ContentLength
 	bar := pb.New(int(bodySize)).SetUnits(pb.U_BYTES)
+	if sylog.GetLevel() < 0 {
+		bar.NotPrint = true
+	}
 	bar.ShowTimeLeft = true
 	bar.ShowSpeed = true
 	bar.Start()

--- a/pkg/client/library/push.go
+++ b/pkg/client/library/push.go
@@ -127,6 +127,9 @@ func postFile(baseURL string, authToken string, filePath string, imageID string)
 
 	// create and start bar
 	bar := pb.New(int(fileSize)).SetUnits(pb.U_BYTES)
+	if sylog.GetLevel() < 0 {
+		bar.NotPrint = true
+	}
 	bar.ShowTimeLeft = true
 	bar.ShowSpeed = true
 	bar.Start()

--- a/pkg/client/net/pull.go
+++ b/pkg/client/net/pull.go
@@ -94,6 +94,9 @@ func DownloadImage(filePath string, libraryURL string, Force bool) error {
 
 	bodySize := res.ContentLength
 	bar := pb.New(int(bodySize)).SetUnits(pb.U_BYTES)
+	if sylog.GetLevel() < 0 {
+		bar.NotPrint = true
+	}
 	bar.ShowTimeLeft = true
 	bar.ShowSpeed = true
 	bar.Start()

--- a/pkg/client/shub/pull.go
+++ b/pkg/client/shub/pull.go
@@ -98,6 +98,9 @@ func DownloadImage(filePath string, shubRef string, force, noHTTPS bool) (err er
 
 	bodySize := resp.ContentLength
 	bar := pb.New(int(bodySize)).SetUnits(pb.U_BYTES)
+	if sylog.GetLevel() < 0 {
+		bar.NotPrint = true
+	}
 	bar.ShowTimeLeft = true
 	bar.ShowSpeed = true
 	bar.Start()


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR silences progress bars for pushing/pulling operations whenever the debug mode is less than 0 (`--quiet` or `--silent` is set).

**This fixes or addresses the following GitHub issues:**

- Fixes #2434

Attn: @singularity-maintainers
