### PR TITLE
Fix file system variable name in help output.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@
     - Eduardo Arango <eduardo@sylabs.io>, <arangogutierrez@gmail.com>
     - Felix Abecassis <fabecassis@nvidia.com>
     - George Hartzell <hartzell@alerce.com>
+    - Gert Hulselmans <gert.hulselmans@kuleuven.vib.be>
     - Hakon Enger <hakonenger@github.com>
     - Hugo Meiland <hugo.meiland@microsoft.com>
     - Ian Kaneshiro <ian@sylabs.io>, <iankane@umich.edu>
@@ -49,16 +50,16 @@
     - Nathan Lin <nathan.lin@yale.edu>
     - Oleksandr Moskalenko <om@rc.ufl.edu>
     - Oliver Freyermuth <freyermuth@physik.uni-bonn.de>
+    - Olivier Sallou <olivier.sallou@irisa.fr>
     - Peter Steinbach <steinbach@scionics.de>
     - Petr Votava <votava.petr@gene.com>
     - Rafal Gumienny <rafal.gumienny@gmail.com>
     - Ralph Castain <rhc@open-mpi.org>
-    - Richard Neuboeck <hawk@tbi.univie.ac.at>
     - Rémy Dernat <remy.dernat@umontpellier.fr>
+    - Richard Neuboeck <hawk@tbi.univie.ac.at>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
     - Vanessa Sochat <vsochat@stanford.edu>
     - Westley Kurtzer <westley@sylabs.io>
     - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>
     - Yaroslav Halchenko <debian@onerussian.com>
-    - Olivier Sallou <olivier.sallou@irisa.fr>

--- a/cmd/singularity/cli/build.go
+++ b/cmd/singularity/cli/build.go
@@ -61,7 +61,7 @@ func init() {
 	BuildCmd.Flags().BoolVarP(&remote, "remote", "r", false, "build image remotely (does not require root)")
 	BuildCmd.Flags().SetAnnotation("remote", "envkey", []string{"REMOTE"})
 
-	BuildCmd.Flags().BoolVarP(&detached, "detached", "d", false, "submit build job and print nuild ID (no real-time logs and requires --remote)")
+	BuildCmd.Flags().BoolVarP(&detached, "detached", "d", false, "submit build job and print build ID (no real-time logs and requires --remote)")
 	BuildCmd.Flags().SetAnnotation("detached", "envkey", []string{"DETACHED"})
 
 	BuildCmd.Flags().StringVar(&builderURL, "builder", "https://build.sylabs.io", "remote Build Service URL")

--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -20,7 +20,7 @@ const (
 	assemblerShubDestDir   = "/tmp/shub_alpine_assemble_test"
 )
 
-// TestAssembler sees if we can build a SIF image from a docke based kitchen to /tmp
+// TestSandboxAssemblerDocker sees if we can build a sandbox from an image from a Docker registry
 func TestSandboxAssemblerDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
@@ -55,6 +55,8 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 
 	defer os.RemoveAll(assemblerDockerDestDir)
 }
+
+// TestSandboxAssemblerShub sees if we can build a sandbox from an image from a Singularity registry
 func TestSandboxAssemblerShub(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/build/assemblers/assembler_sif_test.go
+++ b/internal/pkg/build/assemblers/assembler_sif_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// TestAssembler sees if we can build a SIF image from a docke based kitchen to /tmp
+// TestSIFAssemblerDocker sees if we can build a SIF image from an image from a Docker registry
 func TestSIFAssemblerDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
@@ -64,6 +64,8 @@ func TestSIFAssemblerDocker(t *testing.T) {
 
 	defer os.Remove(assemblerDockerDest)
 }
+
+// TestSIFAssemblerShub sees if we can build a SIF image from an image from a Singularity registry
 func TestSIFAssemblerShub(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/src/docs/content.go
+++ b/src/docs/content.go
@@ -69,7 +69,7 @@ Enterprise Performance Computing (EPC)`
       Library:
           Bootstrap: library
           From: debian:9
-  
+
       Docker:
           Bootstrap: docker
           From: tensorflow/tensorflow:latest
@@ -99,11 +99,11 @@ Enterprise Performance Computing (EPC)`
       %pre
           echo "This is a scriptlet that will be executed on the host, as root before"
           echo "the container has been bootstrapped. This section is not commonly used."
-  
+
       %setup
           echo "This is a scriptlet that will be executed on the host, as root, after"
           echo "the container has been bootstrapped. To install things into the container"
-          echo "reference the file system location with $SINGULARITY_BUILDROOT."
+          echo "reference the file system location with $SINGULARITY_ROOTFS."
 
       %post
           echo "This scriptlet section will be executed from within the container after"


### PR DESCRIPTION
Fix file system variable name in help output by renaming
"$SINGULARITY_BUILDROOT" to "$SINGULARITY_ROOTFS".

Fixes #2446

**Description of the Pull Request (PR):**

To refer to the filesystem in the container in %setup the definition file shown when running singularity build --help showed $SINGULARITY_BUILDROOT, but the correct name is $SINGULARITY_ROOTFS.

It also fixes another typo in the help output for "singularity build" and fixes the description of assembler test functions.