### PR TITLE
Update SIF package vendor deps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _The old changelog can be found in the `release-2.6` branch_
 # Changes Since v3.0.1
 
   - Add http/https protocols for singularity run/pull commands
+  - Update to SIF 1.0.2
 
 # v3.0.1 - [2018.10.31]
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -640,12 +640,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:09e7bb03b8a2f75d03f3674f528330e1f937e76faf14f58042cb7376b153d849"
+  digest = "1:89016522d62b3fe281177a0aaccf6f136aac0b053e36e908d542974ea91db675"
   name = "github.com/sylabs/sif"
   packages = ["pkg/sif"]
   pruneopts = "UT"
-  revision = "177b9338f1ab9123be5b6217740be1f0ce924206"
-  version = "v1.0.1"
+  revision = "39d9b2aa8931c90c87fa13c28677f2296e9ad91f"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@ required = [
 
 [[constraint]]
   name = "github.com/sylabs/sif"
-  version = "1.0.1"
+  version = "1.0.2"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/sylabs/sif/LICENSE.md
+++ b/vendor/github.com/sylabs/sif/LICENSE.md
@@ -1,3 +1,5 @@
+Copyright (c) 2018, Sylabs Inc. All rights reserved.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 

--- a/vendor/github.com/sylabs/sif/pkg/sif/init.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/init.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+// Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sif
+
+import (
+	"bytes"
+	"log"
+)
+
+var (
+	sifLoggerBuf bytes.Buffer
+	siflog       = log.New(&sifLoggerBuf, "", log.Ldate|log.Ltime|log.Lshortfile)
+)
+
+func init() {
+}

--- a/vendor/github.com/sylabs/sif/pkg/sif/lookup.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/lookup.go
@@ -236,6 +236,15 @@ func (fimg *FileImage) GetFromDescr(descr Descriptor) ([]*Descriptor, []int, err
 
 // GetData return a memory mapped byte slice mirroring the data object in a SIF file.
 func (descr *Descriptor) GetData(fimg *FileImage) []byte {
+	if fimg.Amodebuf == true {
+		fimg.Fp.Seek(descr.Fileoff, 0)
+		data := make([]byte, descr.Filelen)
+		if n, _ := fimg.Fp.Read(data); int64(n) != descr.Filelen {
+			return nil
+		}
+		return data
+	}
+
 	return fimg.Filedata[descr.Fileoff : descr.Fileoff+descr.Filelen]
 }
 

--- a/vendor/github.com/sylabs/sif/pkg/sif/sif.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/sif.go
@@ -249,6 +249,7 @@ type FileImage struct {
 	Fp         *os.File      // file pointer of opened SIF file
 	Filesize   int64         // file size of the opened SIF file
 	Filedata   []byte        // the content of the opened file
+	Amodebuf   bool          // access mode: mmap = false, buffered = true
 	Reader     *bytes.Reader // reader on top of Mapdata
 	DescrArr   []Descriptor  // slice of loaded descriptors from SIF file
 	PrimPartID uint32        // ID of primary system partition if present


### PR DESCRIPTION
This PR brings in v1.0.2 of SIF:
- new siftool version command
- revert to read/write I/O when mmap() is unavail.
- few docs improvements


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
