### PR TITLE
Use golang rpm to build singularity rpm

### DIFF
--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -3,7 +3,7 @@
 # this script runs as root under docker
 
 # build and install
-yum install -y rpm-build make yum-utils gcc binutils util-linux-ng which
+yum install -y rpm-build make golang yum-utils gcc binutils util-linux-ng which
 yum install -y openssl-devel libuuid-devel libseccomp-devel e2fsprogs
 
 # switch to an unprivileged user with sudo privileges
@@ -23,9 +23,8 @@ su testuser -c '
   make -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
   BLD=`echo $HOME/rpmbuild/BUILD/singularity-*`
-  export GOROOT=$BLD/go
   export GOPATH=$BLD/gopath
-  PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+  PATH=$GOPATH/bin:$PATH
 
   cd $GOPATH/src/github.com/sylabs/singularity
   make -C builddir test

--- a/.travis/rpmbuild_test
+++ b/.travis/rpmbuild_test
@@ -3,8 +3,10 @@
 # this script runs as root under docker
 
 # build and install
-yum install -y rpm-build make golang yum-utils gcc binutils util-linux-ng which
+yum install -y rpm-build make yum-utils gcc binutils util-linux-ng which
 yum install -y openssl-devel libuuid-devel libseccomp-devel e2fsprogs
+yum install -y epel-release
+yum install -y golang
 
 # switch to an unprivileged user with sudo privileges
 yum install -y sudo

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -39,6 +39,7 @@ URL: https://www.sylabs.io/singularity/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
+BuildRequires: golang
 BuildRequires: wget
 BuildRequires: git
 BuildRequires: gcc
@@ -72,17 +73,11 @@ mkdir %{name}-%{version}
 %build
 cd %{name}-%{version}
 
-#XXX: We would like to remove the download of Go in the future
-GOTAR=go%{goversion}.linux-amd64.tar.gz
-wget https://dl.google.com/go/$GOTAR
-tar -xf $GOTAR
-
 mkdir -p gopath/%{singgopath}
 tar -C "gopath/src/github.com/sylabs/" -xf "%SOURCE0"
 
-export GOROOT=$PWD/go
 export GOPATH=$PWD/gopath
-export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+export PATH=$GOPATH/bin:$PATH
 cd $GOPATH/%{singgopath}
 
 ./mconfig -V %{version}-%{release} --prefix=%{_prefix} --exec-prefix=%{_exec_prefix} \
@@ -96,9 +91,8 @@ make old_config=
 %install
 cd %{name}-%{version}
 
-export GOROOT=$PWD/go
 export GOPATH=$PWD/gopath
-export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+export PATH=$GOPATH/bin:$PATH
 cd $GOPATH/%{singgopath}/builddir
 
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -21,7 +21,6 @@
 # 
 # 
 
-%define goversion @GO_VERSION@
 %define singgopath src/github.com/sylabs/singularity
 
 # Disable debugsource packages; otherwise it ends up with an empty %files

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -38,7 +38,11 @@ URL: https://www.sylabs.io/singularity/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
+%if "%{_target_vendor}" == "suse"
+BuildRequires: go
+%else
 BuildRequires: golang
+%endif
 BuildRequires: wget
 BuildRequires: git
 BuildRequires: gcc

--- a/makeit/gengodep
+++ b/makeit/gengodep
@@ -7,7 +7,7 @@ prefix=${path%$repo*}
 
 for dep in $(go list -f '{{ .Deps }}' $1 | tr -d '[]'); do
     if [ ! -n "${dep%$repo*}" ]; then
-        for gofile in $(find $prefix$dep -name "*.go"); do
+        for gofile in $(find $prefix$dep -name "*.go" 2>/dev/null); do
             gofiles="$gofiles $gofile"
         done
     fi

--- a/mconfig
+++ b/mconfig
@@ -33,7 +33,6 @@ tgtstatic=0
 
 package_name=singularity
 package_version=`(git describe --match 'v[0-9]*' --dirty --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
-go_version="`grep -A 1 ^go: .travis.yml 2>/dev/null|sed -n 's/.*- "//;s/"//p'`"
 
 prefix=
 exec_prefix=
@@ -781,7 +780,7 @@ if [ "$host" = "unix" ]; then
             # $package_version has no dash
             release=1
         fi
-        sed "s/@PACKAGE_VERSION@/$short_version/;s/@PACKAGE_RELEASE@/$release/;s/@GO_VERSION@/$go_version/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
+        sed "s/@PACKAGE_VERSION@/$short_version/;s/@PACKAGE_RELEASE@/$release/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
 fi
 
 

--- a/mconfig
+++ b/mconfig
@@ -32,12 +32,6 @@ hststatic=0
 tgtstatic=0
 
 package_name=singularity
-
-short_version=`(git describe --abbrev=0 --match 'v[0-9]*' --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
-if echo $short_version | grep -q '\-rc'; then
-    short_version=$(echo $short_version | rev | cut -f 2- -d '-' | rev)
-fi
-
 package_version=`(git describe --match 'v[0-9]*' --dirty --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
 go_version="`grep -A 1 ^go: .travis.yml 2>/dev/null|sed -n 's/.*- "//;s/"//p'`"
 
@@ -361,6 +355,7 @@ while [ $# -ne 0 ]; do
   *) break;;
  esac
 done
+short_version="`echo "$package_version"|sed 's/-.*//'`"
 #
 # non-option param
 if [ $# != 0 ]; then
@@ -781,13 +776,12 @@ if [ "$host" = "unix" ]; then
 	RPMSPEC=singularity.spec
 	echo "=> generating $RPMSPEC ..."
 	rm -f $sourcedir/$RPMSPEC
-	VERSION="`echo "$package_version"|sed 's/-.*//'`"
-	RELEASE="`echo "$package_version"|sed 's/[^-]*-//'`"
-	if [ "$VERSION" = "$RELEASE" ]; then
-		# $package_version has no dash
-		RELEASE=1
-	fi
-	sed "s/@PACKAGE_VERSION@/$VERSION/;s/@PACKAGE_RELEASE@/$RELEASE/;s/@GO_VERSION@/$go_version/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
+        release="`echo "$package_version"|sed 's/[^-]*-//'`"
+        if [ "$short_version" = "$release" ]; then
+            # $package_version has no dash
+            release=1
+        fi
+        sed "s/@PACKAGE_VERSION@/$short_version/;s/@PACKAGE_RELEASE@/$release/;s/@GO_VERSION@/$go_version/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
 fi
 
 

--- a/mconfig
+++ b/mconfig
@@ -775,12 +775,12 @@ if [ "$host" = "unix" ]; then
 	RPMSPEC=singularity.spec
 	echo "=> generating $RPMSPEC ..."
 	rm -f $sourcedir/$RPMSPEC
-        release="`echo "$package_version"|sed 's/[^-]*-//'`"
-        if [ "$short_version" = "$release" ]; then
-            # $package_version has no dash
-            release=1
-        fi
-        sed "s/@PACKAGE_VERSION@/$short_version/;s/@PACKAGE_RELEASE@/$release/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
+	release="`echo "$package_version"|sed 's/[^-]*-//'`"
+	if [ "$short_version" = "$release" ]; then
+	    # $package_version has no dash
+	    release=1
+	fi
+	sed "s/@PACKAGE_VERSION@/$short_version/;s/@PACKAGE_RELEASE@/$release/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
 fi
 
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Converts rpm building to use an existing golang package instead of downloading an architecture-specific go language version.  This is only recently possible because RHEL 7.6 removed golang by default, so epel could add it back.  It is currently at version 1.11.2.

**This fixes or addresses the following GitHub issues:**

- Fixes #2350


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
