### PR TITLE
Cleanup inserted base files when bootstrapping a busybox image.

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -76,15 +76,11 @@ func (cp *BusyBoxConveyorPacker) Pack() (b *types.Bundle, err error) {
 }
 
 func (c *BusyBoxConveyor) insertBaseFiles() error {
-	if err := ioutil.WriteFile(filepath.Join(c.b.Rootfs(), "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0664); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(c.b.Rootfs(), "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh\n"), 0664); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(c.b.Rootfs(), "/etc/group"), []byte(" root:x:0:"), 0664); err != nil {
-		return err
-	}
-
-	if err := ioutil.WriteFile(filepath.Join(c.b.Rootfs(), "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0664); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(c.b.Rootfs(), "/etc/group"), []byte("root:x:0:\n"), 0664); err != nil {
 		return err
 	}
 

--- a/src/docs/content.go
+++ b/src/docs/content.go
@@ -90,6 +90,10 @@ Enterprise Performance Computing (EPC)`
           OSVersion: trusty
           MirrorURL: http://us.archive.ubuntu.com/ubuntu/
 
+      Busybox:
+          Bootstrap: busybox
+          MirrorURL: https://www.busybox.net/downloads/binaries/%{BUSYBOX_VERSION}-defconfig-multiarch/busybox-x86_64
+
       Local Image:
           Bootstrap: localimage
           From: /home/dave/starter.img


### PR DESCRIPTION
Cleanup inserted base files when bootstrapping a busybox image:
  - Write newline to the end of "/etc/passwd" and "/etc/group".
  - Remove leading space in "/etc/group".
  - Remove creation of "/etc/hosts" as "/etc/hosts" from the host
    is bind mounted anyway.

A similar patch was contained in https://github.com/sylabs/singularity/pull/2465

Attn: @singularity-maintainers
