### PR TITLE
Clean up tmp files after failed/aborted build

### DIFF
--- a/internal/app/singularity/build.go
+++ b/internal/app/singularity/build.go
@@ -36,6 +36,7 @@ var (
 	dockerUsername string
 	dockerPassword string
 	dockerLogin    bool
+	noCleanUp      bool
 )
 
 var buildflags = pflag.NewFlagSet("BuildFlags", pflag.ExitOnError)
@@ -78,6 +79,9 @@ func init() {
 
 	BuildCmd.Flags().BoolVar(&noHTTPS, "nohttps", false, "do NOT use HTTPS, for communicating with local docker registry")
 	BuildCmd.Flags().SetAnnotation("nohttps", "envkey", []string{"NOHTTPS"})
+
+	BuildCmd.Flags().BoolVar(&noCleanUp, "no-cleanup", false, "do NOT clean up bundle after failed build, can be helpul for debugging")
+	BuildCmd.Flags().SetAnnotation("no-cleanup", "envkey", []string{"NO_CLEANUP"})
 
 	BuildCmd.Flags().AddFlag(actionFlags.Lookup("docker-username"))
 	BuildCmd.Flags().AddFlag(actionFlags.Lookup("docker-password"))

--- a/internal/app/singularity/build_linux.go
+++ b/internal/app/singularity/build_linux.go
@@ -80,6 +80,7 @@ func run(cmd *cobra.Command, args []string) {
 				Sections:         sections,
 				NoTest:           noTest,
 				NoHTTPS:          noHTTPS,
+				NoCleanUp:        noCleanUp,
 				DockerAuthConfig: authConf,
 			})
 		if err != nil {

--- a/internal/app/singularity/singularity.go
+++ b/internal/app/singularity/singularity.go
@@ -287,6 +287,7 @@ var flagEnvFuncs = map[string]envHandle{
 	"builder":         envStringNSlice,
 	"library":         envStringNSlice,
 	"nohttps":         envBool,
+	"no-cleanup":      envBool,
 	"tmpdir":          envStringNSlice,
 	"docker-username": envStringNSlice,
 	"docker-password": envStringNSlice,

--- a/internal/pkg/build/assemblers/assembler_sandbox.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox.go
@@ -20,8 +20,6 @@ type SandboxAssembler struct {
 
 // Assemble creates a Sandbox image from a Bundle
 func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
-	defer os.RemoveAll(b.Path)
-
 	sylog.Infof("Creating sandbox directory...")
 
 	// move bundle rootfs to sandboxdir as final sandbox

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -117,8 +117,6 @@ func getMksquashfsPath() (string, error) {
 
 // Assemble creates a SIF image from a Bundle
 func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
-	defer os.RemoveAll(b.Path)
-
 	sylog.Infof("Creating SIF file...")
 
 	mksquashfs, err := getMksquashfsPath()

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"syscall"
@@ -119,9 +120,30 @@ func newBuild(d types.Definition, dest, format string, libraryURL, authToken str
 	return b, nil
 }
 
+// cleanUp removes remnants of build from file system unless NoCleanUp is specified
+func (b Build) cleanUp() {
+	if b.b.Opts.NoCleanUp {
+		sylog.Infof("Build performed with no clean up option, failed build bundle located at: %v", b.b.Path)
+		return
+	}
+	sylog.Debugf("Build bundle cleanup: %v", b.b.Path)
+	os.RemoveAll(b.b.Path)
+}
+
 // Full runs a standard build from start to finish
 func (b *Build) Full() error {
 	sylog.Infof("Starting build...")
+
+	// monitor build for termination signal and clean up
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		b.cleanUp()
+		os.Exit(1)
+	}()
+	// clean up build normally
+	defer b.cleanUp()
 
 	if err := b.runPreScript(); err != nil {
 		return err

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -55,6 +55,9 @@ type Options struct {
 	NoHTTPS bool `json:"noHTTPS"`
 	// contains docker credentials if specified
 	DockerAuthConfig *ocitypes.DockerAuthConfig
+	// NoCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
+	// useful for debugging
+	NoCleanUp bool `json:"noCleanUp"`
 }
 
 // NewBundle creates a Bundle environment


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This pr adds clean up for builds that fail or are aborted. This can be disabled with the `--no-cleanup` flag, which will when print the location of the `bundle` for the failed build. This can be useful for debugging/


**This fixes or addresses the following GitHub issues:**

- Fixes #2420 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
