### PR TITLE
Respect uppercase proxy env pass-through

### DIFF
--- a/internal/pkg/util/env/clean.go
+++ b/internal/pkg/util/env/clean.go
@@ -20,10 +20,15 @@ const (
 var alwaysPassKeys = map[string]bool{
 	"TERM":        true,
 	"http_proxy":  true,
+	"HTTP_PROXY":  true,
 	"https_proxy": true,
+	"HTTPS_PROXY": true,
 	"no_proxy":    true,
+	"NO_PROXY":    true,
 	"all_proxy":   true,
+	"ALL_PROXY":   true,
 	"ftp_proxy":   true,
+	"FTP_PROXY":   true,
 }
 
 // SetContainerEnv cleans environment variables before running the container

--- a/internal/pkg/util/env/clean_test.go
+++ b/internal/pkg/util/env/clean_test.go
@@ -55,10 +55,14 @@ func TestSetContainerEnv(t *testing.T) {
 		{name: "alwaysPassKeys",
 			args: args{[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester",
 				"PS1=test", "TERM=xterm-256color", "PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C", "http_proxy=test_proxy", "no_proxy=noproxy",
-				"ftp_proxy=ftpProxy", "SINGULARITY_NAME=lolcow.sif", "SINGULARITYENV_FOO=VAR", "CLEANENV=TRUE"}, true, "/home/tester",
+				"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C",
+				"http_proxy=http_proxy", "https_proxy=https_proxy", "no_proxy=no_proxy", "all_proxy=all_proxy", "ftp_proxy=ftp_proxy",
+				"HTTP_PROXY=http_proxy", "HTTPS_PROXY=https_proxy", "NO_PROXY=no_proxy", "ALL_PROXY=all_proxy", "FTP_PROXY=ftp_proxy",
+				"SINGULARITY_NAME=lolcow.sif", "SINGULARITYENV_FOO=VAR", "CLEANENV=TRUE"}, true, "/home/tester",
 				[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester", "PS1=test", "TERM=xterm-256color", "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
-					"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C", "SINGULARITY_NAME=lolcow.sif", "FOO=VAR", "http_proxy=test_proxy", "no_proxy=noproxy", "ftp_proxy=ftpProxy"},
+					"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C", "SINGULARITY_NAME=lolcow.sif", "FOO=VAR",
+					"http_proxy=http_proxy", "https_proxy=https_proxy", "no_proxy=no_proxy", "all_proxy=all_proxy", "ftp_proxy=ftp_proxy",
+					"HTTP_PROXY=http_proxy", "HTTPS_PROXY=https_proxy", "NO_PROXY=no_proxy", "ALL_PROXY=all_proxy", "FTP_PROXY=ftp_proxy"},
 			}},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Pass through upper case proxy env vars
- Update the `clean_test.go` so it checks for all pass-through proxy env vars.

**This fixes or addresses the following GitHub issues:**

- Fixes #2504 

Attn: @singularity-maintainers
