### PR TITLE
Build package initial refactor for multistage 

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -94,7 +94,19 @@ func handleOCI(cmd *cobra.Command, u string) (string, error) {
 		return "", fmt.Errorf("unable to check if %v exists: %v", imgabs, err)
 	} else if !exists {
 		sylog.Infof("Converting OCI blobs to SIF format")
-		b, err := build.NewBuild(u, imgabs, "sif", "", "", types.Options{TmpDir: tmpDir, NoTest: true, NoHTTPS: noHTTPS, DockerAuthConfig: authConf})
+		b, err := build.NewBuild(
+			u,
+			build.Config{
+				Dest:   imgabs,
+				Format: "sif",
+				Opts: types.Options{
+					TmpDir:           tmpDir,
+					NoTest:           true,
+					NoHTTPS:          noHTTPS,
+					DockerAuthConfig: authConf,
+				},
+			},
+		)
 		if err != nil {
 			return "", fmt.Errorf("unable to create new build: %v", err)
 		}

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -77,19 +77,21 @@ func run(cmd *cobra.Command, args []string) {
 
 		b, err := build.NewBuild(
 			spec,
-			dest,
-			buildFormat,
-			libraryURL,
-			authToken,
-			types.Options{
-				TmpDir:           tmpDir,
-				Update:           update,
-				Force:            force,
-				Sections:         sections,
-				NoTest:           noTest,
-				NoHTTPS:          noHTTPS,
-				NoCleanUp:        noCleanUp,
-				DockerAuthConfig: authConf,
+			build.Config{
+				Dest:      dest,
+				Format:    buildFormat,
+				NoCleanUp: noCleanUp,
+				Opts: types.Options{
+					TmpDir:           tmpDir,
+					Update:           update,
+					Force:            force,
+					Sections:         sections,
+					NoTest:           noTest,
+					NoHTTPS:          noHTTPS,
+					LibraryURL:       libraryURL,
+					LibraryAuthToken: authToken,
+					DockerAuthConfig: authConf,
+				},
 			})
 		if err != nil {
 			sylog.Fatalf("Unable to create build: %v", err)

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -39,20 +39,20 @@ import (
 type Build struct {
 	// stages of the build
 	stages []stage
-	// Config
+	// Conf contains cross stage build configuration
 	Conf Config
 }
 
-// Config ...
+// Config defines how build is executed, including things like where final image is written.
 type Config struct {
-	// dest is the location for container after build is complete
+	// Dest is the location for container after build is complete
 	Dest string
-	// format is the format of built container, e.g., SIF, sandbox
+	// Format is the format of built container, e.g., SIF, sandbox
 	Format string
-	// noCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
+	// NoCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
 	// useful for debugging
 	NoCleanUp bool
-	// Options for bundles
+	// Opts for bundles
 	Opts types.Options
 }
 

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -9,14 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"syscall"
-	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/build/apps"
@@ -41,77 +37,90 @@ import (
 // 		Execute all of a definition using AllSections()
 // 		And finally call Assemble() to create our container image
 type Build struct {
+	// stages of the build
+	stages []stage
+	// Config
+	Conf Config
+}
+
+// Config ...
+type Config struct {
 	// dest is the location for container after build is complete
-	dest string
+	Dest string
 	// format is the format of built container, e.g., SIF, sandbox
-	format string
-	// c Gets and Packs data needed to build a container into a Bundle from various sources
-	c ConveyorPacker
-	// a Assembles a container from the information stored in a Bundle into various formats
-	a Assembler
-	// b is an intermediate structure that encapsulates all information for the container, e.g., metadata, filesystems
-	b *types.Bundle
+	Format string
+	// noCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
+	// useful for debugging
+	NoCleanUp bool
+	// Options for bundles
+	Opts types.Options
 }
 
 // NewBuild creates a new Build struct from a spec (URI, definition file, etc...)
-func NewBuild(spec, dest, format string, libraryURL, authToken string, opts types.Options) (*Build, error) {
+func NewBuild(spec string, conf Config) (*Build, error) {
 	def, err := makeDef(spec, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse spec %v: %v", spec, err)
 	}
 
-	return newBuild(def, dest, format, libraryURL, authToken, opts)
+	return newBuild([]types.Definition{def}, conf)
 }
 
 // NewBuildJSON creates a new build struct from a JSON byte slice
-func NewBuildJSON(r io.Reader, dest, format string, libraryURL, authToken string, opts types.Options) (*Build, error) {
+func NewBuildJSON(r io.Reader, conf Config) (*Build, error) {
 	def, err := types.NewDefinitionFromJSON(r)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse JSON: %v", err)
 	}
 
-	return newBuild(def, dest, format, libraryURL, authToken, opts)
+	return newBuild([]types.Definition{def}, conf)
 }
 
-func newBuild(d types.Definition, dest, format string, libraryURL, authToken string, opts types.Options) (*Build, error) {
+func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 	var err error
 
 	syscall.Umask(0002)
 
 	// always build a sandbox if updating an existing sandbox
-	if opts.Update {
-		format = "sandbox"
+	if conf.Opts.Update {
+		conf.Format = "sandbox"
 	}
 
 	b := &Build{
-		format: format,
-		dest:   dest,
+		Conf: conf,
 	}
 
-	b.b, err = types.NewBundle(opts.TmpDir, "sbuild")
-	if err != nil {
-		return nil, err
-	}
-
-	b.b.Recipe = d
-	b.b.Opts = opts
-
-	// dont need to get cp if we're skipping bootstrap
-	if !opts.Update || opts.Force {
-		if c, err := getcp(b.b.Recipe, libraryURL, authToken); err == nil {
-			b.c = c
-		} else {
-			return nil, fmt.Errorf("unable to get conveyorpacker: %s", err)
+	// create stages
+	for _, d := range defs {
+		s := stage{}
+		s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")
+		if err != nil {
+			return nil, err
 		}
+		s.b.Recipe = d
+
+		s.b.Opts = conf.Opts
+		// dont need to get cp if we're skipping bootstrap
+		if !conf.Opts.Update || conf.Opts.Force {
+			if c, err := getcp(d, conf.Opts.LibraryURL, conf.Opts.LibraryAuthToken); err == nil {
+				s.c = c
+			} else {
+				return nil, fmt.Errorf("unable to get conveyorpacker: %s", err)
+			}
+		}
+
+		b.stages = append(b.stages, s)
 	}
 
-	switch format {
+	// only need an assembler for last stage
+	lastStageIndex := len(defs) - 1
+	switch conf.Format {
 	case "sandbox":
-		b.a = &assemblers.SandboxAssembler{}
+		b.stages[lastStageIndex].a = &assemblers.SandboxAssembler{}
 	case "sif":
-		b.a = &assemblers.SIFAssembler{}
+		b.stages[lastStageIndex].a = &assemblers.SIFAssembler{}
 	default:
-		return nil, fmt.Errorf("unrecognized output format %s", format)
+		return nil, fmt.Errorf("unrecognized output format %s", conf.Format)
 	}
 
 	return b, nil
@@ -119,12 +128,21 @@ func newBuild(d types.Definition, dest, format string, libraryURL, authToken str
 
 // cleanUp removes remnants of build from file system unless NoCleanUp is specified
 func (b Build) cleanUp() {
-	if b.b.Opts.NoCleanUp {
-		sylog.Infof("Build performed with no clean up option, build bundle located at: %v", b.b.Path)
+	var bundlePaths []string
+	for _, s := range b.stages {
+		bundlePaths = append(bundlePaths, s.b.Path)
+	}
+
+	if b.Conf.NoCleanUp {
+		sylog.Infof("Build performed with no clean up option, build bundle(s) located at: %v", bundlePaths)
 		return
 	}
-	sylog.Debugf("Build bundle cleanup: %v", b.b.Path)
-	os.RemoveAll(b.b.Path)
+
+	for _, path := range bundlePaths {
+		os.RemoveAll(path)
+	}
+	sylog.Debugf("Build bundle(s) cleaned: %v", bundlePaths)
+
 }
 
 // Full runs a standard build from start to finish
@@ -142,60 +160,64 @@ func (b *Build) Full() error {
 	// clean up build normally
 	defer b.cleanUp()
 
-	if err := b.runPreScript(); err != nil {
-		return err
-	}
-
-	if b.b.Opts.Update && !b.b.Opts.Force {
-		//if updating, extract dest container to bundle
-		sylog.Infof("Building into existing container: %s", b.dest)
-		p, err := sources.GetLocalPacker(b.dest, b.b)
-		if err != nil {
+	// build each stage one after the other
+	for _, stage := range b.stages {
+		if err := stage.runPreScript(); err != nil {
 			return err
 		}
 
-		_, err = p.Pack()
-		if err != nil {
-			return err
+		if stage.b.Opts.Update && !stage.b.Opts.Force {
+			// updating, extract dest container to bundle
+			sylog.Infof("Building into existing container: %s", b.Conf.Dest)
+			p, err := sources.GetLocalPacker(b.Conf.Dest, stage.b)
+			if err != nil {
+				return err
+			}
+
+			_, err = p.Pack()
+			if err != nil {
+				return err
+			}
+		} else {
+			// regular build or force, start build from scratch
+			if err := stage.c.Get(stage.b); err != nil {
+				return fmt.Errorf("conveyor failed to get: %v", err)
+			}
+
+			_, err := stage.c.Pack()
+			if err != nil {
+				return fmt.Errorf("packer failed to pack: %v", err)
+			}
 		}
-	} else {
-		//if force, start build from scratch
-		if err := b.c.Get(b.b); err != nil {
-			return fmt.Errorf("conveyor failed to get: %v", err)
+
+		// create apps in bundle
+		a := apps.New()
+		for k, v := range stage.b.Recipe.CustomData {
+			a.HandleSection(k, v)
 		}
 
-		_, err := b.c.Pack()
-		if err != nil {
-			return fmt.Errorf("packer failed to pack: %v", err)
+		a.HandleBundle(stage.b)
+		stage.b.Recipe.BuildData.Post += a.HandlePost()
+
+		if engineRequired(stage.b.Recipe) {
+			fmt.Println("starting engine")
+			if err := runBuildEngine(stage.b); err != nil {
+				return fmt.Errorf("while running engine: %v", err)
+			}
 		}
-	}
 
-	// create apps in bundle
-	a := apps.New()
-	for k, v := range b.b.Recipe.CustomData {
-		a.HandleSection(k, v)
-	}
-
-	a.HandleBundle(b.b)
-	b.b.Recipe.BuildData.Post += a.HandlePost()
-
-	if engineRequired(b.b.Recipe) {
-		if err := b.runBuildEngine(); err != nil {
-			return fmt.Errorf("while running engine: %v", err)
+		sylog.Debugf("Inserting Metadata")
+		if err := stage.insertMetadata(); err != nil {
+			return fmt.Errorf("While inserting metadata to bundle: %v", err)
 		}
-	}
-
-	sylog.Debugf("Inserting Metadata")
-	if err := b.insertMetadata(); err != nil {
-		return fmt.Errorf("While inserting metadata to bundle: %v", err)
 	}
 
 	sylog.Debugf("Calling assembler")
-	if err := b.Assemble(b.dest); err != nil {
+	if err := b.stages[len(b.stages)-1].Assemble(b.Conf.Dest); err != nil {
 		return err
 	}
 
-	sylog.Infof("Build complete: %s", b.dest)
+	sylog.Infof("Build complete: %s", b.Conf.Dest)
 	return nil
 }
 
@@ -204,101 +226,8 @@ func engineRequired(def types.Definition) bool {
 	return def.BuildData.Post != "" || def.BuildData.Setup != "" || def.BuildData.Test != "" || len(def.BuildData.Files) != 0
 }
 
-func (b *Build) copyFiles() error {
-
-	// iterate through files transfers
-	for _, transfer := range b.b.Recipe.BuildData.Files {
-		// sanity
-		if transfer.Src == "" {
-			sylog.Warningf("Attempt to copy file with no name...")
-			continue
-		}
-		// dest = source if not specified
-		if transfer.Dst == "" {
-			transfer.Dst = transfer.Src
-		}
-		sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
-		// copy each file into bundle rootfs
-		transfer.Dst = filepath.Join(b.b.Rootfs(), transfer.Dst)
-		copy := exec.Command("/bin/cp", "-fLr", transfer.Src, transfer.Dst)
-		if err := copy.Run(); err != nil {
-			return fmt.Errorf("While copying %v to %v: %v", transfer.Src, transfer.Dst, err)
-		}
-	}
-
-	return nil
-}
-
-func (b *Build) insertMetadata() (err error) {
-	// insert help
-	err = insertHelpScript(b.b)
-	if err != nil {
-		return fmt.Errorf("While inserting help script: %v", err)
-	}
-
-	// insert labels
-	err = insertLabelsJSON(b.b)
-	if err != nil {
-		return fmt.Errorf("While inserting labels JSON: %v", err)
-	}
-
-	// insert definition
-	err = insertDefinition(b.b)
-	if err != nil {
-		return fmt.Errorf("While inserting definition: %v", err)
-	}
-
-	// insert environment
-	err = insertEnvScript(b.b)
-	if err != nil {
-		return fmt.Errorf("While inserting environment script: %v", err)
-	}
-
-	// insert startscript
-	err = insertStartScript(b.b)
-	if err != nil {
-		return fmt.Errorf("While inserting startscript: %v", err)
-	}
-
-	// insert runscript
-	err = insertRunScript(b.b)
-	if err != nil {
-		return fmt.Errorf("While inserting runscript: %v", err)
-	}
-
-	// insert test script
-	err = insertTestScript(b.b)
-	if err != nil {
-		return fmt.Errorf("While inserting test script: %v", err)
-	}
-
-	return
-}
-
-func (b *Build) runPreScript() error {
-	if b.runPre() && b.b.Recipe.BuildData.Pre != "" {
-		if syscall.Getuid() != 0 {
-			return fmt.Errorf("Attempted to build with scripts as non-root user")
-		}
-
-		// Run %pre script here
-		pre := exec.Command("/bin/sh", "-cex", b.b.Recipe.BuildData.Pre)
-		pre.Stdout = os.Stdout
-		pre.Stderr = os.Stderr
-
-		sylog.Infof("Running pre scriptlet\n")
-		if err := pre.Start(); err != nil {
-			return fmt.Errorf("failed to start %%pre proc: %v", err)
-		}
-		if err := pre.Wait(); err != nil {
-			return fmt.Errorf("pre proc: %v", err)
-		}
-	}
-	return nil
-}
-
 // runBuildEngine creates an imgbuild engine and creates a container out of our bundle in order to execute %post %setup scripts in the bundle
-func (b *Build) runBuildEngine() error {
+func runBuildEngine(b *types.Bundle) error {
 	if syscall.Getuid() != 0 {
 		return fmt.Errorf("Attempted to build with scripts as non-root user")
 	}
@@ -310,12 +239,12 @@ func (b *Build) runBuildEngine() error {
 	ociConfig := &oci.Config{}
 
 	engineConfig := &imgbuildConfig.EngineConfig{
-		Bundle:    *b.b,
+		Bundle:    *b,
 		OciConfig: ociConfig,
 	}
 
 	// surface build specific environment variables for scripts
-	sRootfs := "SINGULARITY_ROOTFS=" + b.b.Rootfs()
+	sRootfs := "SINGULARITY_ROOTFS=" + b.Rootfs()
 	sEnvironment := "SINGULARITY_ENVIRONMENT=" + "/.singularity.d/env/91-environment.sh"
 
 	ociConfig.Process = &specs.Process{}
@@ -346,10 +275,7 @@ func (b *Build) runBuildEngine() error {
 func getcp(def types.Definition, libraryURL, authToken string) (ConveyorPacker, error) {
 	switch def.Header["bootstrap"] {
 	case "library":
-		return &sources.LibraryConveyorPacker{
-			LibraryURL: libraryURL,
-			AuthToken:  authToken,
-		}, nil
+		return &sources.LibraryConveyorPacker{}, nil
 	case "shub":
 		return &sources.ShubConveyorPacker{}, nil
 	case "docker", "docker-archive", "docker-daemon", "oci", "oci-archive":
@@ -373,6 +299,11 @@ func getcp(def types.Definition, libraryURL, authToken string) (ConveyorPacker, 
 	default:
 		return nil, fmt.Errorf("invalid build source %s", def.Header["bootstrap"])
 	}
+}
+
+// MakeDef gets a definition object from a spec
+func MakeDef(spec string, remote bool) (types.Definition, error) {
+	return makeDef(spec, remote)
 }
 
 // makeDef gets a definition object from a spec
@@ -405,242 +336,4 @@ func makeDef(spec string, remote bool) (types.Definition, error) {
 	}
 
 	return d, nil
-}
-
-// runPre determines if %pre section was specified to be run from the CLI
-func (b Build) runPre() bool {
-	for _, section := range b.b.Opts.Sections {
-		if section == "none" {
-			return false
-		}
-		if section == "all" || section == "pre" {
-			return true
-		}
-	}
-	return false
-}
-
-// MakeDef gets a definition object from a spec
-func MakeDef(spec string, remote bool) (types.Definition, error) {
-	return makeDef(spec, remote)
-}
-
-// Assemble assembles the bundle to the specified path
-func (b *Build) Assemble(path string) error {
-	return b.a.Assemble(b.b, path)
-}
-
-func insertEnvScript(b *types.Bundle) error {
-	if b.RunSection("environment") && b.Recipe.ImageData.Environment != "" {
-		sylog.Infof("Adding environment to container")
-		envScriptPath := filepath.Join(b.Rootfs(), "/.singularity.d/env/90-environment.sh")
-		_, err := os.Stat(envScriptPath)
-		if os.IsNotExist(err) {
-			err := ioutil.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment+"\n"), 0755)
-			if err != nil {
-				return err
-			}
-		} else {
-			// append to script if it already exists
-			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY, 0755)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-
-			_, err = f.WriteString("\n" + b.Recipe.ImageData.Environment + "\n")
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func insertRunScript(b *types.Bundle) error {
-	if b.RunSection("runscript") && b.Recipe.ImageData.Runscript != "" {
-		sylog.Infof("Adding runscript")
-		err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/runscript"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Runscript+"\n"), 0755)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func insertStartScript(b *types.Bundle) error {
-	if b.RunSection("startscript") && b.Recipe.ImageData.Startscript != "" {
-		sylog.Infof("Adding startscript")
-		err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/startscript"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Startscript+"\n"), 0755)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func insertTestScript(b *types.Bundle) error {
-	if b.RunSection("test") && b.Recipe.ImageData.Test != "" {
-		sylog.Infof("Adding testscript")
-		err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/test"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Test+"\n"), 0755)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func insertHelpScript(b *types.Bundle) error {
-	if b.RunSection("help") && b.Recipe.ImageData.Help != "" {
-		_, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/runscript.help"))
-		if err != nil || b.Opts.Force {
-			sylog.Infof("Adding help info")
-			err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help+"\n"), 0644)
-			if err != nil {
-				return err
-			}
-		} else {
-			sylog.Warningf("Help message already exists and force option is false, not overwriting")
-		}
-	}
-	return nil
-}
-
-func insertDefinition(b *types.Bundle) error {
-
-	// if update, check for existing definition and move it to bootstrap history
-	if b.Opts.Update {
-		if _, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/Singularity")); err == nil {
-			// make bootstrap_history directory if it doesnt exist
-			if _, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history")); err != nil {
-				err = os.Mkdir(filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history"), 0755)
-				if err != nil {
-					return err
-				}
-			}
-
-			// look at number of files in bootstrap_history to give correct file name
-			files, err := ioutil.ReadDir(filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history"))
-			if err != nil {
-				return err
-			}
-
-			// name is "Singularity" concatenated with an index based on number of other files in bootstrap_history
-			len := strconv.Itoa(len(files))
-
-			histName := "Singularity" + len
-
-			// move old definition into bootstrap_history
-			err = os.Rename(filepath.Join(b.Rootfs(), "/.singularity.d/Singularity"), filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history", histName))
-			if err != nil {
-				return err
-			}
-		}
-
-	}
-
-	err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/Singularity"), b.Recipe.Raw, 0644)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func insertLabelsJSON(b *types.Bundle) (err error) {
-	var text []byte
-	labels := make(map[string]string)
-
-	if err = getExistingLabels(labels, b); err != nil {
-		return err
-	}
-
-	if err = addBuildLabels(labels, b); err != nil {
-		return err
-	}
-
-	if b.RunSection("labels") && len(b.Recipe.ImageData.Labels) > 0 {
-		sylog.Infof("Adding labels")
-
-		// add new labels to new map and check for collisions
-		for key, value := range b.Recipe.ImageData.Labels {
-			// check if label already exists
-			if _, ok := labels[key]; ok {
-				// overwrite collision if it exists and force flag is set
-				if b.Opts.Force {
-					labels[key] = value
-				} else {
-					sylog.Warningf("Label: %s already exists and force option is false, not overwriting", key)
-				}
-			} else {
-				// set if it doesnt
-				labels[key] = value
-			}
-		}
-	}
-
-	// make new map into json
-	text, err = json.MarshalIndent(labels, "", "\t")
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/labels.json"), []byte(text), 0644)
-	return err
-}
-
-func getExistingLabels(labels map[string]string, b *types.Bundle) error {
-	// check for existing labels in bundle
-	if _, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/labels.json")); err == nil {
-
-		jsonFile, err := os.Open(filepath.Join(b.Rootfs(), "/.singularity.d/labels.json"))
-		if err != nil {
-			return err
-		}
-		defer jsonFile.Close()
-
-		jsonBytes, err := ioutil.ReadAll(jsonFile)
-		if err != nil {
-			return err
-		}
-
-		err = json.Unmarshal(jsonBytes, &labels)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func addBuildLabels(labels map[string]string, b *types.Bundle) error {
-	// schema version
-	labels["org.label-schema.schema-version"] = "1.0"
-
-	// build date and time, lots of time formatting
-	currentTime := time.Now()
-	year, month, day := currentTime.Date()
-	date := strconv.Itoa(day) + `_` + month.String() + `_` + strconv.Itoa(year)
-	hour, min, sec := currentTime.Clock()
-	time := strconv.Itoa(hour) + `:` + strconv.Itoa(min) + `:` + strconv.Itoa(sec)
-	zone, _ := currentTime.Zone()
-	timeString := currentTime.Weekday().String() + `_` + date + `_` + time + `_` + zone
-	labels["org.label-schema.build-date"] = timeString
-
-	// singularity version
-	labels["org.label-schema.usage.singularity.version"] = buildcfg.PACKAGE_VERSION
-
-	// help info if help exists in the definition and is run in the build
-	if b.RunSection("help") && b.Recipe.ImageData.Help != "" {
-		labels["org.label-schema.usage"] = "/.singularity.d/runscript.help"
-		labels["org.label-schema.usage.singularity.runscript.help"] = "/.singularity.d/runscript.help"
-	}
-
-	// bootstrap header info, only if this build actually bootstrapped
-	if !b.Opts.Update || b.Opts.Force {
-		for key, value := range b.Recipe.Header {
-			labels["org.label-schema.usage.singularity.deffile."+key] = value
-		}
-	}
-
-	return nil
 }

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -1,0 +1,277 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/build/types"
+)
+
+func (s *stage) insertMetadata() (err error) {
+	// insert help
+	err = insertHelpScript(s.b)
+	if err != nil {
+		return fmt.Errorf("While inserting help script: %v", err)
+	}
+
+	// insert labels
+	err = insertLabelsJSON(s.b)
+	if err != nil {
+		return fmt.Errorf("While inserting labels JSON: %v", err)
+	}
+
+	// insert definition
+	err = insertDefinition(s.b)
+	if err != nil {
+		return fmt.Errorf("While inserting definition: %v", err)
+	}
+
+	// insert environment
+	err = insertEnvScript(s.b)
+	if err != nil {
+		return fmt.Errorf("While inserting environment script: %v", err)
+	}
+
+	// insert startscript
+	err = insertStartScript(s.b)
+	if err != nil {
+		return fmt.Errorf("While inserting startscript: %v", err)
+	}
+
+	// insert runscript
+	err = insertRunScript(s.b)
+	if err != nil {
+		return fmt.Errorf("While inserting runscript: %v", err)
+	}
+
+	// insert test script
+	err = insertTestScript(s.b)
+	if err != nil {
+		return fmt.Errorf("While inserting test script: %v", err)
+	}
+
+	return
+}
+
+func insertEnvScript(b *types.Bundle) error {
+	if b.RunSection("environment") && b.Recipe.ImageData.Environment != "" {
+		sylog.Infof("Adding environment to container")
+		envScriptPath := filepath.Join(b.Rootfs(), "/.singularity.d/env/90-environment.sh")
+		_, err := os.Stat(envScriptPath)
+		if os.IsNotExist(err) {
+			err := ioutil.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment+"\n"), 0755)
+			if err != nil {
+				return err
+			}
+		} else {
+			// append to script if it already exists
+			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY, 0755)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			_, err = f.WriteString("\n" + b.Recipe.ImageData.Environment + "\n")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func insertRunScript(b *types.Bundle) error {
+	if b.RunSection("runscript") && b.Recipe.ImageData.Runscript != "" {
+		sylog.Infof("Adding runscript")
+		err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/runscript"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Runscript+"\n"), 0755)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func insertStartScript(b *types.Bundle) error {
+	if b.RunSection("startscript") && b.Recipe.ImageData.Startscript != "" {
+		sylog.Infof("Adding startscript")
+		err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/startscript"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Startscript+"\n"), 0755)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func insertTestScript(b *types.Bundle) error {
+	if b.RunSection("test") && b.Recipe.ImageData.Test != "" {
+		sylog.Infof("Adding testscript")
+		err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/test"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Test+"\n"), 0755)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func insertHelpScript(b *types.Bundle) error {
+	if b.RunSection("help") && b.Recipe.ImageData.Help != "" {
+		_, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/runscript.help"))
+		if err != nil || b.Opts.Force {
+			sylog.Infof("Adding help info")
+			err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help+"\n"), 0644)
+			if err != nil {
+				return err
+			}
+		} else {
+			sylog.Warningf("Help message already exists and force option is false, not overwriting")
+		}
+	}
+	return nil
+}
+
+func insertDefinition(b *types.Bundle) error {
+	// if update, check for existing definition and move it to bootstrap history
+	if b.Opts.Update {
+		if _, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/Singularity")); err == nil {
+			// make bootstrap_history directory if it doesnt exist
+			if _, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history")); err != nil {
+				err = os.Mkdir(filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history"), 0755)
+				if err != nil {
+					return err
+				}
+			}
+
+			// look at number of files in bootstrap_history to give correct file name
+			files, err := ioutil.ReadDir(filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history"))
+			if err != nil {
+				return err
+			}
+
+			// name is "Singularity" concatenated with an index based on number of other files in bootstrap_history
+			len := strconv.Itoa(len(files))
+			histName := "Singularity" + len
+			// move old definition into bootstrap_history
+			err = os.Rename(filepath.Join(b.Rootfs(), "/.singularity.d/Singularity"), filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history", histName))
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	err := ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/Singularity"), b.Recipe.Raw, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func insertLabelsJSON(b *types.Bundle) (err error) {
+	var text []byte
+	labels := make(map[string]string)
+
+	if err = getExistingLabels(labels, b); err != nil {
+		return err
+	}
+
+	if err = addBuildLabels(labels, b); err != nil {
+		return err
+	}
+
+	if b.RunSection("labels") && len(b.Recipe.ImageData.Labels) > 0 {
+		sylog.Infof("Adding labels")
+
+		// add new labels to new map and check for collisions
+		for key, value := range b.Recipe.ImageData.Labels {
+			// check if label already exists
+			if _, ok := labels[key]; ok {
+				// overwrite collision if it exists and force flag is set
+				if b.Opts.Force {
+					labels[key] = value
+				} else {
+					sylog.Warningf("Label: %s already exists and force option is false, not overwriting", key)
+				}
+			} else {
+				// set if it doesnt
+				labels[key] = value
+			}
+		}
+	}
+
+	// make new map into json
+	text, err = json.MarshalIndent(labels, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(b.Rootfs(), "/.singularity.d/labels.json"), []byte(text), 0644)
+	return err
+}
+
+func getExistingLabels(labels map[string]string, b *types.Bundle) error {
+	// check for existing labels in bundle
+	if _, err := os.Stat(filepath.Join(b.Rootfs(), "/.singularity.d/labels.json")); err == nil {
+		jsonFile, err := os.Open(filepath.Join(b.Rootfs(), "/.singularity.d/labels.json"))
+		if err != nil {
+			return err
+		}
+		defer jsonFile.Close()
+
+		jsonBytes, err := ioutil.ReadAll(jsonFile)
+		if err != nil {
+			return err
+		}
+
+		err = json.Unmarshal(jsonBytes, &labels)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addBuildLabels(labels map[string]string, b *types.Bundle) error {
+	// schema version
+	labels["org.label-schema.schema-version"] = "1.0"
+
+	// build date and time, lots of time formatting
+	currentTime := time.Now()
+	year, month, day := currentTime.Date()
+	date := strconv.Itoa(day) + `_` + month.String() + `_` + strconv.Itoa(year)
+	hour, min, sec := currentTime.Clock()
+	time := strconv.Itoa(hour) + `:` + strconv.Itoa(min) + `:` + strconv.Itoa(sec)
+	zone, _ := currentTime.Zone()
+	timeString := currentTime.Weekday().String() + `_` + date + `_` + time + `_` + zone
+	labels["org.label-schema.build-date"] = timeString
+
+	// singularity version
+	labels["org.label-schema.usage.singularity.version"] = buildcfg.PACKAGE_VERSION
+
+	// help info if help exists in the definition and is run in the build
+	if b.RunSection("help") && b.Recipe.ImageData.Help != "" {
+		labels["org.label-schema.usage"] = "/.singularity.d/runscript.help"
+		labels["org.label-schema.usage.singularity.runscript.help"] = "/.singularity.d/runscript.help"
+	}
+
+	// bootstrap header info, only if this build actually bootstrapped
+	if !b.Opts.Update || b.Opts.Force {
+		for key, value := range b.Recipe.Header {
+			labels["org.label-schema.usage.singularity.deffile."+key] = value
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -21,8 +21,6 @@ import (
 type LibraryConveyorPacker struct {
 	b *types.Bundle
 	LocalPacker
-	LibraryURL string
-	AuthToken  string
 }
 
 // Get downloads container from Singularityhub
@@ -30,6 +28,9 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 	sylog.Debugf("Getting container from Library")
 
 	cp.b = b
+
+	libraryURL := b.Opts.LibraryURL
+	authToken := b.Opts.LibraryAuthToken
 
 	if err = makeBaseEnv(cp.b.Rootfs()); err != nil {
 		return fmt.Errorf("While inserting base environment: %v", err)
@@ -39,14 +40,14 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 	customLib, ok := b.Recipe.Header["library"]
 	if ok {
 		sylog.Debugf("Using custom library: %v", customLib)
-		cp.LibraryURL = customLib
+		libraryURL = customLib
 	}
 
-	sylog.Debugf("LibraryURL: %v", cp.LibraryURL)
+	sylog.Debugf("LibraryURL: %v", libraryURL)
 	sylog.Debugf("LibraryRef: %v", b.Recipe.Header["from"])
 
 	libURI := "library://" + b.Recipe.Header["from"]
-	libraryImage, err := client.GetImage(cp.LibraryURL, cp.AuthToken, libURI)
+	libraryImage, err := client.GetImage(libraryURL, authToken, libURI)
 	if err != nil {
 		return err
 	}
@@ -58,7 +59,7 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 		return fmt.Errorf("unable to check if %v exists: %v", imagePath, err)
 	} else if !exists {
 		sylog.Infof("Downloading library image")
-		if err = client.DownloadImage(imagePath, libURI, cp.LibraryURL, true, cp.AuthToken); err != nil {
+		if err = client.DownloadImage(imagePath, libURI, libraryURL, true, authToken); err != nil {
 			return fmt.Errorf("unable to Download Image: %v", err)
 		}
 

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -31,14 +31,14 @@ func TestLibraryConveyor(t *testing.T) {
 		return
 	}
 
+	b.Opts.LibraryURL = libraryURL
+
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {
 		t.Fatalf("unable to parse URI %s: %v\n", libraryURI, err)
 	}
 
-	cp := &sources.LibraryConveyorPacker{
-		LibraryURL: libraryURL,
-	}
+	cp := &sources.LibraryConveyorPacker{}
 
 	err = cp.Get(b)
 	// clean up tmpfs since assembler isnt called
@@ -57,14 +57,14 @@ func TestLibraryPacker(t *testing.T) {
 		return
 	}
 
+	b.Opts.LibraryURL = libraryURL
+
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {
 		t.Fatalf("unable to parse URI %s: %v\n", libraryURI, err)
 	}
 
-	cp := &sources.LibraryConveyorPacker{
-		LibraryURL: libraryURL,
-	}
+	cp := &sources.LibraryConveyorPacker{}
 
 	err = cp.Get(b)
 	// clean up tmpfs since assembler isnt called

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -16,7 +16,7 @@ import (
 	"github.com/sylabs/singularity/pkg/build/types"
 )
 
-// Stage ...
+// Stage represents the process of constucting a root filesystem
 type stage struct {
 	// Name of the stage
 	name string

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -16,9 +16,9 @@ import (
 	"github.com/sylabs/singularity/pkg/build/types"
 )
 
-// Stage represents the process of constucting a root filesystem
+// stage represents the process of constucting a root filesystem
 type stage struct {
-	// Name of the stage
+	// name of the stage
 	name string
 	// c Gets and Packs data needed to build a container into a Bundle from various sources
 	c ConveyorPacker

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package build
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/build/types"
+)
+
+// Stage ...
+type stage struct {
+	// Name of the stage
+	name string
+	// c Gets and Packs data needed to build a container into a Bundle from various sources
+	c ConveyorPacker
+	// a Assembles a container from the information stored in a Bundle into various formats
+	a Assembler
+	// b is an intermediate structure that encapsulates all information for the container, e.g., metadata, filesystems
+	b *types.Bundle
+}
+
+// Assemble assembles the bundle to the specified path
+func (s *stage) Assemble(path string) error {
+	return s.a.Assemble(s.b, path)
+}
+
+// copyFiles allows a stage to copy files from the host to the bundle
+func (s *stage) copyFiles() error {
+
+	// iterate through files transfers
+	for _, transfer := range s.b.Recipe.BuildData.Files {
+		// sanity
+		if transfer.Src == "" {
+			sylog.Warningf("Attempt to copy file with no name...")
+			continue
+		}
+		// dest = source if not specified
+		if transfer.Dst == "" {
+			transfer.Dst = transfer.Src
+		}
+		sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
+		// copy each file into bundle rootfs
+		transfer.Dst = filepath.Join(s.b.Rootfs(), transfer.Dst)
+		copy := exec.Command("/bin/cp", "-fLr", transfer.Src, transfer.Dst)
+		if err := copy.Run(); err != nil {
+			return fmt.Errorf("While copying %v to %v: %v", transfer.Src, transfer.Dst, err)
+		}
+	}
+
+	return nil
+}
+
+// runPreScript() executes the stages pre script on host
+func (s *stage) runPreScript() error {
+	if s.b.RunSection("pre") && s.b.Recipe.BuildData.Pre != "" {
+		if syscall.Getuid() != 0 {
+			return fmt.Errorf("Attempted to build with scripts as non-root user")
+		}
+
+		// Run %pre script here
+		pre := exec.Command("/bin/sh", "-cex", s.b.Recipe.BuildData.Pre)
+		pre.Stdout = os.Stdout
+		pre.Stderr = os.Stderr
+
+		sylog.Infof("Running pre scriptlet\n")
+		if err := pre.Start(); err != nil {
+			return fmt.Errorf("failed to start %%pre proc: %v", err)
+		}
+		if err := pre.Wait(); err != nil {
+			return fmt.Errorf("pre proc: %v", err)
+		}
+	}
+	return nil
+}

--- a/internal/pkg/libexec/pull.go
+++ b/internal/pkg/libexec/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/libexec/pull.go
+++ b/internal/pkg/libexec/pull.go
@@ -40,7 +40,7 @@ func PullShubImage(filePath, shubRef string, force, noHTTPS bool) {
 
 // PullOciImage pulls an OCI image to a sif
 func PullOciImage(path, uri string, opts types.Options) {
-	b, err := build.NewBuild(uri, path, "sif", "", "", opts)
+	b, err := build.NewBuild(uri, build.Config{Dest: path, Format: "sif", Opts: opts})
 	if err != nil {
 		sylog.Fatalf("Unable to pull %v: %v", uri, err)
 	}

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -41,6 +41,16 @@ type Bundle struct {
 
 // Options ...
 type Options struct {
+	// sections are the parts of the definition to run during the build
+	Sections []string `json:"sections"`
+	// TmpDir specifies a non-standard temporary location to perform a build
+	TmpDir string
+	// LibraryURL contains URL to library where base images can be pulled
+	LibraryURL string `json:"libraryURL"`
+	// LibraryAuthToken contains authentication token to access specified library
+	LibraryAuthToken string `json:"libraryAuthToken"`
+	// contains docker credentials if specified
+	DockerAuthConfig *ocitypes.DockerAuthConfig
 	// noTest indicates if build should skip running the test script
 	NoTest bool `json:"noTest"`
 	// force automatically deletes an existing container at build destination while performing build
@@ -49,19 +59,9 @@ type Options struct {
 	Update bool `json:"update"`
 	// noHTTPS
 	NoHTTPS bool `json:"noHTTPS"`
-	// LibraryURL contains URL to library where base images can be pulled
-	LibraryURL string `json:"libraryURL"`
-	// LibraryAuthToken contains authentication token to access specified library
-	LibraryAuthToken string `json:"libraryAuthToken"`
 	// NoCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
 	// useful for debugging
 	NoCleanUp bool `json:"noCleanUp"`
-	// TmpDir specifies a non-standard temporary location to perform a build
-	TmpDir string
-	// sections are the parts of the definition to run during the build
-	Sections []string `json:"sections"`
-	// contains docker credentials if specified
-	DockerAuthConfig *ocitypes.DockerAuthConfig
 }
 
 // NewBundle creates a Bundle environment

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -49,6 +49,10 @@ type Options struct {
 	Update bool `json:"update"`
 	// noHTTPS
 	NoHTTPS bool `json:"noHTTPS"`
+	// LibraryURL contains URL to library where base images can be pulled
+	LibraryURL string `json:"libraryURL"`
+	// LibraryAuthToken contains authentication token to access specified library
+	LibraryAuthToken string `json:"libraryAuthToken"`
 	// NoCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
 	// useful for debugging
 	NoCleanUp bool `json:"noCleanUp"`

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -39,7 +39,7 @@ type Bundle struct {
 	Opts        Options           `json:"opts"`
 }
 
-// Options ...
+// Options defines build time behavior to be executed on the bundle
 type Options struct {
 	// sections are the parts of the definition to run during the build
 	Sections []string `json:"sections"`


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Introduces the `stage` struct to the build package. This encapsulates the data needed to perform the building of a stage. Allowing the `Build` struct to hold a slice of `stage`s to be build in order when `deffile` syntax is expanded to allow for multiple `bootstraps` in a single file.

Introduces the `Config` struct to the build package. This contains build information as well as a `types.Options` struct to pass on information to newly constructed `bundles`

Moved `libraryURL` and `authToken` to `types.Options` struct since this data should exist in the `Bundle`

Created a `metadata.go` file to hold helper functions that assist the insertion of metadata to a `Bundle` during the build process.

Minor additional refinements.

**This fixes or addresses the following GitHub issues:**

- Related to #2518


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
