### PR TITLE
make allow setuid = no imply using user namespaces

### DIFF
--- a/internal/app/singularity/actions.go
+++ b/internal/app/singularity/actions.go
@@ -498,7 +498,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		engineConfig.SetHomeDest(homeSlice[1])
 	}
 
-	if IsFakeroot {
+	if !engineConfig.File.AllowSetuid || IsFakeroot {
 		UserNamespace = true
 	}
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

If a system administrator sets 'allow setuid = no' /etc/singularity/singularity.conf, currently users of singularity-3 get an error "FATAL:   SUID workflow disabled by administrator" unless they also add the -u option in order to make singularity run a container unprivileged.  This PR makes -u be implied if that config option is set.  I was very surprised to find it didn't already do that, but I guess I had not tried it before.  singularity-2.6 did it that way and it just makes sense.


**This fixes or addresses the following GitHub issues:**

- None


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers especially @cclerget 
