### PR TITLE
Add "--app" flag to run-help command

### DIFF
--- a/internal/app/singularity/run_help.go
+++ b/internal/app/singularity/run_help.go
@@ -9,6 +9,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -23,8 +24,16 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/exec"
 )
 
+const (
+	standardHelpPath = "/.singularity.d/runscript.help"
+	appHelpPath      = "/scif/apps/%s/scif/runscript.help"
+)
+
 func init() {
 	RunHelpCmd.Flags().SetInterspersed(false)
+
+	RunHelpCmd.Flags().StringVar(&AppName, "app", "", "Get help info for specific app")
+	RunHelpCmd.Flags().SetAnnotation("app", "envkey", []string{"APP"})
 
 	SingularityCmd.AddCommand(RunHelpCmd)
 }
@@ -43,7 +52,8 @@ var RunHelpCmd = &cobra.Command{
 		// Help prints (if set) the sourced %help section on the definition file
 		abspath, err := filepath.Abs(args[0])
 		name := filepath.Base(abspath)
-		a := []string{"/bin/cat", "/.singularity.d/runscript.help"}
+
+		a := []string{"/bin/cat", getHelpPath(cmd)}
 		starter := buildcfg.LIBEXECDIR + "/singularity/bin/starter-suid"
 		procname := "Singularity help"
 		Env := []string{sylog.GetEnvVar(), "SRUNTIME=singularity"}
@@ -76,4 +86,13 @@ var RunHelpCmd = &cobra.Command{
 	Short:   docs.RunHelpShort,
 	Long:    docs.RunHelpLong,
 	Example: docs.RunHelpExample,
+}
+
+func getHelpPath(cmd *cobra.Command) string {
+	if cmd.Flags().Changed("app") {
+		sylog.Debugf("App specified. Looking for help section of %s", AppName)
+		return fmt.Sprintf(appHelpPath, AppName)
+	}
+
+	return standardHelpPath
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Allows users to see the help information for a specific app.


**This fixes or addresses the following GitHub issues:**

- Fixes #2116 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
