### PR TITLE
Get rid of eval for exec in runscript

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -339,7 +339,10 @@ else
     SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
 fi
 
-eval ${SINGULARITY_OCI_RUN}
+# Evaluate shell expressions first and set arguments accordingly,
+# then execute final command as first container process
+eval "set ${SINGULARITY_OCI_RUN}"
+exec "$@"
 
 `)
 	if err != nil {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR replaces `eval` by `exec` in `runscript`, this is mainly a fix for SyCRI/OCI engine in order to send signal to the right container process instead of the shell process running as PID 1 because of eval use. The idea is to evaluate shell command expressions with `eval "set ${SINGULARITY_OCI_RUN}"` and set arguments in order to reuse them once evaluated with a `exec "$@"`.


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
