### PR TITLE
Fix client image pull race

### DIFF
--- a/internal/app/starter/master.go
+++ b/internal/app/starter/master.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"runtime/debug"
 	"syscall"
 	"time"
 	"unsafe"
@@ -46,8 +45,6 @@ func Master(rpcSocket, masterSocket int, isInstance bool, containerPid int, engi
 			rpcConn.Close()
 		}
 
-		// force memory release
-		debug.FreeOSMemory()
 		runtime.Goexit()
 	}()
 

--- a/pkg/client/library/pull.go
+++ b/pkg/client/library/pull.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/util/user-agent"
-	"gopkg.in/cheggaaa/pb.v1"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 // Timeout for an image pull in seconds - could be a large download...
@@ -102,10 +102,11 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string, Force 
 	}
 	bar.ShowTimeLeft = true
 	bar.ShowSpeed = true
-	bar.Start()
 
 	// create proxy reader
 	bodyProgress := bar.NewProxyReader(res.Body)
+
+	bar.Start()
 
 	// Write the body to file
 	_, err = io.Copy(out, bodyProgress)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a race in client image pull library. Also removes call to `debug.FreeOSMemory`, the call close opened file descriptors without any references, this is just the beginning because this call is done by Go automatically in the background so there is high risk that file descriptors will be closed prematurely in case of long run.


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
