### PR TITLE
Remove `wget` as a build requirement for the RPM.

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -43,7 +43,6 @@ BuildRequires: go
 %else
 BuildRequires: golang
 %endif
-BuildRequires: wget
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make


### PR DESCRIPTION
**Description of the Pull Request (PR):**

`wget` is no longer a build requirement for an RPM. It was removed because we now rely on golang1.11 packages for building an RPM.

Attn: @DrDaveD @jmstover 