### PR TITLE
Update help for user namespace, non-setuid mode

### DIFF
--- a/internal/app/singularity/action_flags.go
+++ b/internal/app/singularity/action_flags.go
@@ -242,7 +242,7 @@ func initNamespaceVars() {
 	actionFlags.SetAnnotation("uts", "envkey", []string{"UTS", "UNSHARE_UTS"})
 
 	// -u|--userns
-	actionFlags.BoolVarP(&UserNamespace, "userns", "u", false, "run container in a new user namespace, allowing Singularity to run completely unprivileged on recent kernels. This may not support every feature of Singularity. (Sandbox image only)")
+	actionFlags.BoolVarP(&UserNamespace, "userns", "u", false, "run container in a new user namespace, allowing Singularity to run completely unprivileged on recent kernels. This disables some features of Singularity, for example it only works with sandbox images.")
 	actionFlags.SetAnnotation("userns", "envkey", []string{"USERNS", "UNSHARE_USERNS"})
 }
 

--- a/internal/pkg/runtime/engines/singularity/data/singularity.conf
+++ b/internal/pkg/runtime/engines/singularity/data/singularity.conf
@@ -7,7 +7,8 @@
 # DEFAULT: yes
 # Should we allow users to utilize the setuid program flow within Singularity?
 # note1: This is the default mode, and to utilize all features, this option
-# will need to be enabled.
+# will need to be enabled.  For example, without this option loop mounts of
+# image files will not work; only sandbox images can work.
 # note2: If this option is disabled, it will rely on the user namespace
 # exclusively which has not been integrated equally between the different
 # Linux distributions.

--- a/internal/pkg/runtime/engines/singularity/data/singularity.conf
+++ b/internal/pkg/runtime/engines/singularity/data/singularity.conf
@@ -7,11 +7,12 @@
 # DEFAULT: yes
 # Should we allow users to utilize the setuid program flow within Singularity?
 # note1: This is the default mode, and to utilize all features, this option
-# will need to be enabled.  For example, without this option loop mounts of
-# image files will not work; only sandbox images can work.
-# note2: If this option is disabled, it will rely on the user namespace
-# exclusively which has not been integrated equally between the different
-# Linux distributions.
+# must be enabled.  For example, without this option loop mounts of image 
+# files will not work; only sandbox image directories, which do not need loop
+# mounts, will work (subject to note 2).
+# note2: If this option is disabled, it will rely on unprivileged user
+# namespaces which have not been integrated equally between different Linux
+# distributions.
 allow setuid = {{ if eq .AllowSetuid true }}yes{{ else }}no{{ end }}
 
 # MAX LOOP DEVICES: [INT]


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR makes the explanation of the --userns option related to sandbox mode more clear, and adds a similar explanation by singularity.conf's allow setuid mode.


**This fixes or addresses the following GitHub issues:**

- Follow on to #2571 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
