### PR TITLE
Support passing mconfig prefix to rpmbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _The old changelog can be found in the `release-2.6` branch_
   - Add http/https protocols for singularity run/pull commands
   - Update to SIF 1.0.2
   - Add _noPrompt_ parameter to `pkg/signing/Verify` function to enable silent verification
+  - Minor change in RPM generation by `mconfig` allowing install to paths other than `/usr/local`
 
 # v3.0.2 - [2019.01.04]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,7 @@
     - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
+    - Trevor Cooper <tcooper@sdsc.edu>
     - Vanessa Sochat <vsochat@stanford.edu>
     - Westley Kurtzer <westley@sylabs.io>
     - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,3 +92,12 @@ To build in a different folder and to set the install prefix to a different path
 ```
 $ ./mconfig -p /usr/local -b ./buildtree
 ```
+
+To set the install prefix to a different path and build an rpm on CentOS/RHEL use the following commands:
+
+```
+$ sudo yum install -y rpm-build
+$ cd $GOPATH/src/github.com/sylabs/singularity
+$ ./mconfig -p /usr/local
+$ make -C builddir rpm
+```

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -289,7 +289,30 @@ testall: vendor-check check test
 .PHONY: rpm
 rpm: dist
 	@echo " BUILD RPM"
-	$(V)(cd $(SOURCEDIR) && rpmbuild $(RPMCLEAN) -ta $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz)
+	$(V)(cd $(SOURCEDIR) && rpmbuild $(RPMCLEAN) -ta \
+	  --define "_prefix $(PREFIX)" \
+	  --define "_exec-prefix $(EXECPREFIX)" \
+	  --define "_bindir $(BINDIR)" \
+	  --define "_sbindir $(SBINDIR)" \
+	  --define "_libexecdir $(LIBEXECDIR)" \
+	  --define "_datarootdir $(DATAROOTDIR)" \
+	  --define "_datadir $(DATADIR)" \
+	  --define "_sysconfdir $(SYSCONFDIR)" \
+	  --define "_sharedstatedir $(SHAREDSTATEDIR)" \
+	  --define "_localstatedir $(LOCALSTATEDIR)" \
+	  --define "_runstatedir $(RUNSTATEDIR)" \
+	  --define "_includedir $(INCLUDEDIR)" \
+	  --define "_defaultdocdir $(DATAROOTDIR)" \
+	  --define "_docdir $(DOCDIR)" \
+	  --define "_infodir $(INFODIR)" \
+	  --define "_htmldir $(HTMLDIR)" \
+	  --define "_dvidir $(DVIDIR)" \
+	  --define "_pdfdir $(PDFDIR)" \
+	  --define "_psdir $(PSDIR)" \
+	  --define "_libdir $(LIBDIR)" \
+	  --define "_localedir $(LOCALEDIR)" \
+	  --define "_mandir $(MANDIR)" \
+	  $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz)
 
 .PHONY: cscope
 cscope:


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR propagates `PREFIX` supplied to mconfig through to the make rpm target with the translation of Makefile variables into `rpmbuild --define ...` statements and updates INSTALL.md to describe the usage with a specific example.


**This fixes or addresses the following GitHub issues:**

- None found


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
