### PR TITLE
Fix GC issue for lock package

### DIFF
--- a/pkg/util/fs/lock/lock.go
+++ b/pkg/util/fs/lock/lock.go
@@ -12,14 +12,13 @@ import (
 
 // Exclusive applies an exclusive lock on path
 func Exclusive(path string) (fd int, err error) {
-	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	fd, err = syscall.Open(path, os.O_RDONLY, 0)
 	if err != nil {
 		return fd, err
 	}
-	fd = int(f.Fd())
 	err = syscall.Flock(fd, syscall.LOCK_EX)
 	if err != nil {
-		f.Close()
+		syscall.Close(fd)
 		return fd, err
 	}
 	return fd, nil


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes issue with GC in lock package, previous version worked with raw file descriptor leading to weird issues during garbage collection, working with raw file descriptor returned by `(*os.File).Fd()` is not safe in Golang because GC can call finalizer function on the object when it's not referenced anymore in the code after its creation, that was the case with `Lock` function creating `*os.File` object but returning raw file descriptor, so garbage collector considered the object as unreachable meaning good for garbage collection, since garbage collector call finalizer function when an object is freed, it's an issue because finalizer for `*os.File` closes the associated file descriptor under the hood.

To illustrate this side effect :

```
fd := Lock("/dev")
defer Release(fd)
```

The reference to `*os.File` is hold in the function since it returns only raw file descriptor, so GC will consider this object unreachable since it's not used outside of `Lock` even if the function returns a field of this object. And `Release` will remove the file descriptor lock and will close the file descriptor.

But with the above snippet the following sequence can occur :

- `Lock` returns `3` as raw file descriptor
- GC close lock file descriptor returned by `Lock` (so linux kernel will use `3` as the next file descriptor number)
- a go routine is executed opening a socket returning `3` as file descriptor
- call deferred `Release` and close socket file descriptor `3` instead


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
