### PR TITLE
Use open syscall to hold container network namespace reference

### DIFF
--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -173,11 +173,11 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 	if c.netNS {
 		if os.Geteuid() == 0 && !c.userNS {
 			/* hold a reference to container network namespace for cleanup */
-			f, err := os.Open("/proc/" + strconv.Itoa(pid) + "/ns/net")
+			f, err := syscall.Open("/proc/"+strconv.Itoa(pid)+"/ns/net", os.O_RDONLY, 0)
 			if err != nil {
 				return fmt.Errorf("can't open network namespace: %s", err)
 			}
-			nspath := fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), f.Fd())
+			nspath := fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), f)
 			networks := strings.Split(engine.EngineConfig.GetNetwork(), ",")
 
 			cniPath := &network.CNIPath{}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Singularity hold a reference via file descriptor to container network namespace for network cleanup, use `syscall.Open` instead of `os.Open` to avoid GC close it

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
