### PR TITLE
Add RPMPREFIX make rpm variable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,10 +81,16 @@ $ ./mconfig
 $ make -C builddir rpm
 ```
 
+To build an rpm with an alternative install prefix set RPMPREFIX on the
+make step, for example
+```
+$ make -C builddir rpm RPMPREFIX=/usr/local
+```
+
 To build a stable version of Singularity, check out a [release tag](https://github.com/sylabs/singularity/tags) before compiling:
 
 ```
-$ git checkout v3.0.2
+$ git checkout v3.0.3
 ```
 
 To build in a different folder and to set the install prefix to a different path:

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -84,10 +84,9 @@ export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
 cd $GOPATH/%{singgopath}
 
-./mconfig -V %{version}-%{release} --prefix=%{_prefix} --exec-prefix=%{_exec_prefix} \
-	--bindir=%{_bindir} --libexecdir=%{_libexecdir} --sysconfdir=%{_sysconfdir} \
-	--sharedstatedir=%{_sharedstatedir} --localstatedir=%{_localstatedir} \
-	--libdir=%{_libdir}
+./mconfig -V %{version}-%{release} \
+        --exec-prefix=%{_exec_prefix} --sysconfdir=%{_sysconfdir} \
+	--localstatedir=%{_localstatedir} --mandir=%{_mandir}
 
 cd builddir
 make old_config=

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -85,8 +85,8 @@ export PATH=$GOPATH/bin:$PATH
 cd $GOPATH/%{singgopath}
 
 ./mconfig -V %{version}-%{release} \
-        --exec-prefix=%{_exec_prefix} --sysconfdir=%{_sysconfdir} \
-	--localstatedir=%{_localstatedir} --mandir=%{_mandir}
+        --sysconfdir=%{_sysconfdir} --bindir=%{_bindir} --mandir=%{_mandir} \
+        --libexecdir=%{_libexecdir} --localstatedir=%{_localstatedir} 
 
 cd builddir
 make old_config=

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -84,9 +84,22 @@ export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
 cd $GOPATH/%{singgopath}
 
+# Not all of these parameters currently have an effect, but they might be
+#  used someday.  They are the same parameters as in the configure macro.
 ./mconfig -V %{version}-%{release} \
-        --sysconfdir=%{_sysconfdir} --bindir=%{_bindir} --mandir=%{_mandir} \
-        --libexecdir=%{_libexecdir} --localstatedir=%{_localstatedir} 
+        --prefix=%{_prefix} \
+        --exec-prefix=%{_exec_prefix} \
+        --bindir=%{_bindir} \
+        --sbindir=%{_sbindir} \
+        --sysconfdir=%{_sysconfdir} \
+        --datadir=%{_datadir} \
+        --includedir=%{_includedir} \
+        --libdir=%{_libdir} \
+        --libexecdir=%{_libexecdir} \
+        --localstatedir=%{_localstatedir} \
+        --sharedstatedir=%{_sharedstatedir} \
+        --mandir=%{_mandir} \
+        --infodir=%{_infodir}
 
 cd builddir
 make old_config=

--- a/mconfig
+++ b/mconfig
@@ -602,6 +602,7 @@ PSDIR := $psdir
 LIBDIR := $libdir
 LOCALEDIR := $localedir
 MANDIR := $mandir
+RPMPREFIX:=
 
 NAME := $package_name
 SHORT_VERSION := $short_version

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -53,11 +53,8 @@ rpm: dist
 	$(V)(set -x; cd $(SOURCEDIR) && \
 	  if [ -n "$(RPMPREFIX)" ]; then \
 	    rpmbuild $(RPMCLEAN) -ta \
+	      --define '_prefix $(RPMPREFIX)' \
 	      --define '_sysconfdir $(RPMPREFIX)/etc' \
-	      --define '_bindir $(RPMPREFIX)/bin' \
-	      --define '_libexecdir $(RPMPREFIX)/libexec' \
-	      --define '_localstatedir $(RPMPREFIX)/var' \
-	      --define '_mandir $(RPMPREFIX)/share/man' \
 	      $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz; \
 	  else \
 	    rpmbuild $(RPMCLEAN) -ta \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -50,7 +50,18 @@ testall: vendor-check check test
 .PHONY: rpm
 rpm: dist
 	@echo " BUILD RPM"
-	$(V)(cd $(SOURCEDIR) && rpmbuild $(RPMCLEAN) -ta $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz)
+	$(V)(set -x; cd $(SOURCEDIR) && \
+	  if [ -n "$(RPMPREFIX)" ]; then \
+	    rpmbuild $(RPMCLEAN) -ta \
+	      --define '_exec_prefix $(RPMPREFIX)' \
+	      --define '_sysconfdir $(RPMPREFIX)/etc' \
+	      --define '_localstatedir $(RPMPREFIX)/var' \
+	      --define '_mandir $(RPMPREFIX)/share/man' \
+	      $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz; \
+	  else \
+	    rpmbuild $(RPMCLEAN) -ta \
+	      $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz; \
+	  fi)
 
 .PHONY: cscope
 cscope:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -53,8 +53,9 @@ rpm: dist
 	$(V)(set -x; cd $(SOURCEDIR) && \
 	  if [ -n "$(RPMPREFIX)" ]; then \
 	    rpmbuild $(RPMCLEAN) -ta \
-	      --define '_exec_prefix $(RPMPREFIX)' \
 	      --define '_sysconfdir $(RPMPREFIX)/etc' \
+	      --define '_bindir $(RPMPREFIX)/bin' \
+	      --define '_libexecdir $(RPMPREFIX)/libexec' \
 	      --define '_localstatedir $(RPMPREFIX)/var' \
 	      --define '_mandir $(RPMPREFIX)/share/man' \
 	      $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz; \

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -16,7 +16,7 @@ $(singularity): $(singularity_build_config) $(singularity_SOURCE)
 	@echo " GO" $@ "\n    [+] GO_TAGS" \"$(GO_TAGS)\"
 	$(V)go build $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) -o $(BUILDDIR)/singularity $(SOURCEDIR)/cmd/singularity/cli.go
 
-singularity_INSTALL := $(DESTDIR)$(EXECPREFIX)/bin/singularity
+singularity_INSTALL := $(DESTDIR)$(BINDIR)/singularity
 $(singularity_INSTALL): $(singularity)
 	@echo " INSTALL" $@
 	$(V)install -d $(@D)

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -47,7 +47,7 @@ INSTALLFILES += $(sessiondir_INSTALL)
 # run-singularity script
 run_singularity := $(SOURCEDIR)/scripts/run-singularity
 
-run_singularity_INSTALL := $(DESTDIR)$(EXECPREFIX)/bin/run-singularity
+run_singularity_INSTALL := $(DESTDIR)$(BINDIR)/run-singularity
 $(run_singularity_INSTALL): $(run_singularity)
 	@echo " INSTALL" $@
 	$(V)install -d $(@D)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add an RPMPREFIX make variable to choose a different destination directory than the defaults for make rpm.


**This fixes or addresses the following GitHub issues:**

- Replaces #2606


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers, @tcooper
