### PR TITLE
Remove obsolete sections

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -33,11 +33,9 @@ Version: @PACKAGE_VERSION@
 Release: @PACKAGE_RELEASE@%{?dist}
 # https://spdx.org/licenses/BSD-3-Clause-LBNL.html
 License: BSD-3-Clause-LBNL
-Group: System Environment/Base
 URL: https://www.sylabs.io/singularity/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
-BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 %if "%{_target_vendor}" == "suse"
 BuildRequires: go
 %else
@@ -102,9 +100,6 @@ cd $GOPATH/%{singgopath}/builddir
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 make DESTDIR=$RPM_BUILD_ROOT install man
 chmod 644 $RPM_BUILD_ROOT%{_sysconfdir}/singularity/actions/*
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files
 %attr(4755, root, root) %{_libexecdir}/singularity/bin/starter-suid


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This removes the Group and BuildRoot labels and the %clean section of singularity.spec.  They are obsolete, and were removed in Fedora rawhide by a Fedora administrator.  This backports the changes, because it's easier for me if I don't have to change singularity.spec for Fedora with each new release.


**This fixes or addresses the following GitHub issues:**

- None


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
