### PR TITLE
Fix overlay size for root user

### DIFF
--- a/internal/pkg/util/fs/layout/session.go
+++ b/internal/pkg/util/fs/layout/session.go
@@ -41,7 +41,7 @@ func NewSession(path string, fstype string, size int, system *mount.System, laye
 		return nil, err
 	}
 	options := "mode=1777"
-	if size >= 0 {
+	if size > 0 {
 		options = fmt.Sprintf("mode=1777,size=%dm", size)
 	}
 	err := system.Points.AddFS(mount.SessionTag, path, fstype, syscall.MS_NOSUID, options)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a bad size check for session directory impacting tmpfs overlay and how disk usage is reported for `df`

**This fixes or addresses the following GitHub issues:**

- Fixes #2640 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
