### PR TITLE
Make ReST docs use :ref:

### DIFF
--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/sylabs/singularity/cmd/internal/cli"
@@ -44,7 +45,11 @@ func manDocs(outDir string) {
 func rstDocs(outDir string) {
 	assertAccess(outDir)
 	sylog.Infof("Creating Singularity RST docs at %s\n", outDir)
-	if err := doc.GenReSTTree(cli.SingularityCmd, outDir); err != nil {
+	if err := doc.GenReSTTreeCustom(cli.SingularityCmd, outDir, func(a string) string {
+		return ""
+	}, func(name, ref string) string {
+		return fmt.Sprintf(":ref:`%s <%s>`", name, ref)
+	}); err != nil {
 		sylog.Fatalf("Failed to create RST docs for singularity\n")
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a fix to the PR #2617, which introduced ReST (restructured text) documentation generation. This PR worked correctly, but it generated ReST that wasn't optimized for Sphinx, the documentation builder used by Singularity. In particular, it didn't use the `:ref:` directive for documentation cross-references, meaning that it generated ReST like this, where the links didn't work correctly:

```
SEE ALSO
~~~~~~~~

* `singularity apps <singularity_apps.rst>`_ 	 - apps <image path>
* `singularity build <singularity_build.rst>`_ 	 - Build a new Singularity container
* `singularity capability <singularity_capability.rst>`_ 	 - Manage Linux capabilities on containers
* `singularity exec <singularity_exec.rst>`_ 	 - Execute a command within container
```

This PR fixes this issue, following the method described [here](https://github.com/spf13/cobra/blob/master/doc/rest_docs.md#customize-the-output). The ReST we generate now looks like this:

```
SEE ALSO
~~~~~~~~

* :ref:`singularity apps <singularity_apps>` 	 - apps <image path>
* :ref:`singularity build <singularity_build>` 	 - Build a new Singularity container
* :ref:`singularity capability <singularity_capability>` 	 - Manage Linux capabilities on containers
* :ref:`singularity exec <singularity_exec>` 	 - Execute a command within container
```