### PR TITLE
Catch non-existant run-help file and print message cleanly

### DIFF
--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -25,6 +25,7 @@ import (
 const (
 	standardHelpPath = "/.singularity.d/runscript.help"
 	appHelpPath      = "/scif/apps/%s/scif/runscript.help"
+	runHelpCommand   = "if [ ! -f \"%s\" ]\nthen\n    echo \"Container does not have a help file\"\nelse\n    /bin/cat %s\nfi"
 )
 
 func init() {
@@ -54,7 +55,7 @@ var RunHelpCmd = &cobra.Command{
 		}
 		name := filepath.Base(abspath)
 
-		a := []string{"/bin/cat", getHelpPath(cmd)}
+		a := []string{"/bin/sh", "-c", getCommand(getHelpPath(cmd))}
 		starter := buildcfg.LIBEXECDIR + "/singularity/bin/starter-suid"
 		procname := "Singularity help"
 		Env := []string{sylog.GetEnvVar()}
@@ -88,6 +89,10 @@ var RunHelpCmd = &cobra.Command{
 	Short:   docs.RunHelpShort,
 	Long:    docs.RunHelpLong,
 	Example: docs.RunHelpExample,
+}
+
+func getCommand(helpFile string) string {
+	return fmt.Sprintf(runHelpCommand, helpFile, helpFile)
 }
 
 func getHelpPath(cmd *cobra.Command) string {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Prints a nice pretty message when there is no help file present in the container.

**This fixes or addresses the following GitHub issues:**

- Fixes #2648 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
