### PR TITLE
Switch DOI to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We also have a Zenodo citation:
 Kurtzer, Gregory M.. (2016). Singularity 2.1.2 - Linux application and environment
 containers for science. 10.5281/zenodo.60736
 
-http://dx.doi.org/10.5281/zenodo.60736
+https://doi.org/10.5281/zenodo.60736
 ```
 
 ## License


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- ~~Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)~~
- ~~Added tests to validate this PR and tested this PR locally with a `make testall`~~
- ~~Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)~~
- ~~Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)~~

I'm guessing that for a simply link update, this is not necessary. Please let me know if yes and I'll update the PR accordingly.

Attn: @singularity-maintainers
