### PR TITLE
Avoid panic with "key pull"

### DIFF
--- a/cmd/internal/cli/keys_pull.go
+++ b/cmd/internal/cli/keys_pull.go
@@ -62,12 +62,14 @@ func doKeysPullCmd(fingerprint string, url string) error {
 	defer fp.Close()
 
 	for _, e := range el {
+		storeKey := true
 		for _, estore := range elstore {
 			if e.PrimaryKey.KeyId == estore.PrimaryKey.KeyId {
-				e = nil // Entity is already in key store
+				storeKey = false // Entity is already in key store
+				break
 			}
 		}
-		if e != nil {
+		if storeKey {
 			if err = e.Serialize(fp); err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes a nil dereference in "key pull" when key is already stored locally.

**This fixes or addresses the following GitHub issues:**

- Fixes #2655 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
