### PR TITLE
Fix use of imageName and uri.GetName when transport is empty

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -120,7 +120,12 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While getting image info: %v", err)
 		}
 
-		imageName := uri.GetName(args[i])
+		var imageName string
+		if transport == "" {
+			imageName = uri.GetName("library://" + args[i])
+		} else {
+			imageName = uri.GetName(args[i])
+		}
 		imagePath := cache.LibraryImage(libraryImage.Hash, imageName)
 		if exists, err := cache.LibraryImageExists(libraryImage.Hash, imageName); err != nil {
 			sylog.Fatalf("unable to check if %v exists: %v", imagePath, err)
@@ -138,7 +143,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 		}
 
 		// Perms are 777 *prior* to umask
-		dstFile, err := os.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
+		dstFile, err := os.OpenFile(imageName, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
 		if err != nil {
 			sylog.Fatalf("%v\n", err)
 		}

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -91,7 +91,11 @@ func pullRun(cmd *cobra.Command, args []string) {
 	if PullImageName == "" {
 		name = args[0]
 		if len(args) == 1 {
-			name = uri.GetName(args[i]) // TODO: If not library/shub & no name specified, simply put to cache
+			if transport == "" {
+				name = uri.GetName("library://" + args[i])
+			} else {
+				name = uri.GetName(args[i]) // TODO: If not library/shub & no name specified, simply put to cache
+			}
 		}
 	} else {
 		name = PullImageName
@@ -143,7 +147,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 		}
 
 		// Perms are 777 *prior* to umask
-		dstFile, err := os.OpenFile(imageName, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
+		dstFile, err := os.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
 		if err != nil {
 			sylog.Fatalf("%v\n", err)
 		}

--- a/cmd/singularity/pull_test.go
+++ b/cmd/singularity/pull_test.go
@@ -48,6 +48,7 @@ func TestPull(t *testing.T) {
 		{"Pull_Docker", "docker://alpine:3.7", true, "", imagePath, true},   // https://hub.docker.com/
 		{"Pull_Shub", "shub://GodloveD/busybox", true, "", imagePath, true}, // https://singularity-hub.org/
 		{"PullWithHash", "library://alpine:sha256.af5e6b93dcfd08b7b46d6158c31ae5b6c2b4241c169b65595659ad9feac6f761", true, "", imagePath, true},
+		{"PullWithoutTransportProtocol", "alpine:3.7", true, "", imagePath, true},
 	}
 	defer os.Remove(imagePath)
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #2681

Problem discussed in https://github.com/sylabs/singularity/issues/2681#issuecomment-462235773

> Still would like to add some tests covering the issue encountered

## Manual Testing
```sh
$ ./singularity -d pull alpine:latest
DEBUG   [U=502,P=69854]    apiGet()                      apiGet calling https://library.sylabs.io/v1/images///alpine:latest
DEBUG   [U=502,P=69854]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library/sha256.69ce2a3dcc6d3e559e20ced0df251046ee6ecff390a945d856fe0dcb3bcb3ce8
DEBUG   [U=502,P=69854]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library
DEBUG   [U=502,P=69854]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library/sha256.69ce2a3dcc6d3e559e20ced0df251046ee6ecff390a945d856fe0dcb3bcb3ce8
DEBUG   [U=502,P=69854]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library
```

identical to:
```sh
$ ./singularity -d pull library://alpine:latest
DEBUG   [U=502,P=69986]    apiGet()                      apiGet calling https://library.sylabs.io/v1/images///alpine:latest
DEBUG   [U=502,P=69986]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library/sha256.69ce2a3dcc6d3e559e20ced0df251046ee6ecff390a945d856fe0dcb3bcb3ce8
DEBUG   [U=502,P=69986]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library
DEBUG   [U=502,P=69986]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library/sha256.69ce2a3dcc6d3e559e20ced0df251046ee6ecff390a945d856fe0dcb3bcb3ce8
DEBUG   [U=502,P=69986]    updateCacheSubdir()           Caching directory set to /Users/andremarcelo-tanner/.singularity/cache/library
```