### PR TITLE
Remove redundant file owner checks

### DIFF
--- a/internal/pkg/runtime/engines/singularity/prepare.go
+++ b/internal/pkg/runtime/engines/singularity/prepare.go
@@ -37,11 +37,6 @@ func (e *EngineOperations) prepareUserCaps() error {
 
 	e.EngineConfig.OciConfig.SetProcessNoNewPrivileges(true)
 
-	// ensure that capability config file is in fact root owned
-	if !fs.IsOwner(buildcfg.CAPABILITY_FILE, 0) {
-		return fmt.Errorf("while setting user capabilities: capability config file not owned by root")
-	}
-
 	file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
@@ -134,11 +129,6 @@ func (e *EngineOperations) prepareRootCaps() error {
 		e.EngineConfig.OciConfig.SetupPrivileged(true)
 		commonCaps = e.EngineConfig.OciConfig.Process.Capabilities.Permitted
 	case "file":
-		// ensure that capability config file is in fact root owned
-		if !fs.IsOwner(buildcfg.CAPABILITY_FILE, 0) {
-			return fmt.Errorf("while setting user capabilities: capability config file not owned by root")
-		}
-
 		file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0644)
 		if err != nil {
 			return fmt.Errorf("while opening capability config file: %s", err)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR removes redundant file owner check preventing user namespace to run correctly

**This fixes or addresses the following GitHub issues:**

- Fixes #2699


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
