### PR TITLE
Escape '%' with double '%%'

### DIFF
--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -82,8 +82,8 @@ func scanDefinitionFile(data []byte, atEOF bool) (advance int, token []byte, err
 			return 0, nil, err
 		}
 
-		// Check if the first word starts with % sign
-		if word != nil && word[0] == '%' && word[1] != '%' {
+		// Check if the first word starts with % sign. But if theres two ('%%'); then escape
+		if word != nil && word[0] == '%' && len(word) >= 2 && word[1] != '%' {
 			// If the word starts with %, it's a section identifier
 
 			// We no longer check if the word is a valid section identifier here, since we want to move to
@@ -105,12 +105,15 @@ func scanDefinitionFile(data []byte, atEOF bool) (advance int, token []byte, err
 			}
 		} else {
 			// This line is not a section identifier
-			if word != nil {
-				if line[1] == '%' {
+			// Check if theres two '%%', if there is; remove the first one
+			if len(line) >= 2 {
+				if line[0] == '%' && line[1] == '%' {
 					retbuf.Write([]byte(strings.TrimPrefix(string(line), "%")))
 				} else {
 					retbuf.Write(line)
 				}
+			} else {
+				retbuf.Write(line)
 			}
 			retbuf.WriteString("\n")			
 		}

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -17,8 +17,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/build/types"
 )
 
 var (
@@ -115,7 +115,7 @@ func scanDefinitionFile(data []byte, atEOF bool) (advance int, token []byte, err
 			} else {
 				retbuf.Write(line)
 			}
-			retbuf.WriteString("\n")			
+			retbuf.WriteString("\n")
 		}
 
 		// Shift the advance retval to the next line


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR will add a escape for `%`, by using two `%%`.

## Example:

```
$ cat test.def
bootstrap: library
from: alpine:3.8

%runscript
cat /hello-world

%post
cat << EOF > /hello-world

USAGE:
    ./somthing.sh %{option}... %bar

%%{hello world}
%%hello world

%%post

EOF
```

*Notice we are only escaping if the word start with `%`.*

Build the container:

```
$ sudo singularity build test.sif test.def 
# build succeeds
```

Testing it:

```
$ ./test.sif 

USAGE:
    ./somthing.sh %{option}... %bar

%{hello world}
%hello world

%post

```

<br>

If you tried to build the container before this PR, this will happen:

```
$ sudo singularity build test.sif test.def 
WARNING: Authentication token file not found : Only pulls of public images will succeed
FATAL:   Unable to create build: unable to parse spec bar.def: While parsing definition: bar.def: invalid section(s) specified: {hello, hello
```

<br>

### This fixes or addresses the following GitHub issues:

- Fixes #2646 


<br>
