### PR TITLE
Fix oci kill command

### DIFF
--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -42,7 +42,7 @@ func init() {
 	OciStateCmd.Flags().SetAnnotation("sync-socket", "argtag", []string{"<path>"})
 
 	OciKillCmd.Flags().SetInterspersed(false)
-	OciKillCmd.Flags().StringVarP(&ociArgs.KillSignal, "signal", "s", "", "signal sent to the container (default SIGTERM)")
+	OciKillCmd.Flags().StringVarP(&ociArgs.KillSignal, "signal", "s", "SIGTERM", "signal sent to the container (default SIGTERM)")
 
 	OciRunCmd.Flags().SetInterspersed(false)
 	OciRunCmd.Flags().StringVarP(&ociArgs.BundlePath, "bundle", "b", "", "specify the OCI bundle path")
@@ -140,6 +140,8 @@ var OciKillCmd = &cobra.Command{
 		killSignal := ""
 		if len(args) > 1 && args[1] != "" {
 			killSignal = args[1]
+		} else {
+			killSignal = ociArgs.KillSignal
 		}
 		if err := singularity.OciKill(args[0], killSignal, 0); err != nil {
 			sylog.Fatalf("%s", err)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a regression with oci kill command, actually :

 `singularity oci kill containerID SIGKILL` works

but not

`singularity oci kill -s SIGKILL containerID`


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
