### PR TITLE
Fix shared mount for %setup %files during build

### DIFF
--- a/internal/pkg/runtime/engines/imgbuild/create.go
+++ b/internal/pkg/runtime/engines/imgbuild/create.go
@@ -127,6 +127,12 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 		return fmt.Errorf("change directory failed: %s", err)
 	}
 
+	sylog.Debugf("Set RPC mount propagation flag to PRIVATE")
+	_, err = rpcOps.Mount("", "/", "", syscall.MS_PRIVATE, "")
+	if err != nil {
+		return err
+	}
+
 	sylog.Debugf("Chroot into %s\n", buildcfg.SESSIONDIR)
 	_, err = rpcOps.Chroot(buildcfg.SESSIONDIR, "pivot")
 	if err != nil {
@@ -161,9 +167,9 @@ func (engine *EngineOperations) copyFiles() error {
 		if transfer.Dst == "" {
 			transfer.Dst = transfer.Src
 		}
-		sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
 		// copy each file into bundle rootfs
 		transfer.Dst = filepath.Join(engine.EngineConfig.Rootfs(), transfer.Dst)
+		sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
 		copy := exec.Command("/bin/cp", "-fLr", transfer.Src, transfer.Dst)
 		if err := copy.Run(); err != nil {
 			return fmt.Errorf("While copying %v to %v: %v", transfer.Src, transfer.Dst, err)

--- a/internal/pkg/runtime/engines/imgbuild/engine.go
+++ b/internal/pkg/runtime/engines/imgbuild/engine.go
@@ -63,6 +63,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	}
 
 	starterConfig.SetMountPropagation("rslave")
+	starterConfig.SetSharedMount(true)
 
 	return nil
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes regression in build engine dropping shared feature affecting `%setup` and `%files` sections during build

**This fixes or addresses the following GitHub issues:**

- Fixes #2707 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
