### PR TITLE
Fakeroot feature

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -311,8 +311,7 @@ var actionFakerootFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "fakeroot",
 	ShortHand:    "f",
-	Hidden:       true,
-	Usage:        "run container in new user namespace as uid 0 (experimental)",
+	Usage:        "run container in new user namespace as uid 0",
 	EnvKeys:      []string{"FAKEROOT"},
 	ExcludedOS:   []string{cmdline.Darwin},
 }

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -40,6 +40,7 @@ var (
 	dockerPassword string
 	dockerLogin    bool
 	noCleanUp      bool
+	fakeroot       bool
 )
 
 // -s|--sandbox
@@ -178,6 +179,17 @@ var buildNoCleanupFlag = cmdline.Flag{
 	EnvKeys:      []string{"NO_CLEANUP"},
 }
 
+// --fakeroot
+var buildFakerootFlag = cmdline.Flag{
+	ID:           "buildFakerootFlag",
+	Value:        &fakeroot,
+	DefaultValue: false,
+	Name:         "fakeroot",
+	ShortHand:    "f",
+	Usage:        "build using user namespace to fake root user (requires a privileged installation)",
+	EnvKeys:      []string{"FAKEROOT"},
+}
+
 func init() {
 	cmdManager.RegisterCmd(BuildCmd)
 
@@ -194,6 +206,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&buildSectionFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildTmpdirFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildUpdateFlag, BuildCmd)
+	cmdManager.RegisterFlagForCmd(&buildFakerootFlag, BuildCmd)
 
 	cmdManager.RegisterFlagForCmd(&actionDockerUsernameFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&actionDockerPasswordFlag, BuildCmd)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"syscall"
+
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/internal/pkg/build"
@@ -97,6 +100,10 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While performing build: %v", err)
 		}
 	} else {
+		if syscall.Getuid() != 0 && !fakeroot && fs.IsFile(spec) {
+			sylog.Fatalf("You must be the root user, however you can use --remote or --fakeroot to build from a Singularity recipe file")
+		}
+
 		err := checkSections()
 		if err != nil {
 			sylog.Fatalf(err.Error())
@@ -108,7 +115,7 @@ func run(cmd *cobra.Command, args []string) {
 		}
 
 		// parse definition to determine build source
-		defs, err := build.MakeAllDefs(spec, false)
+		defs, err := build.MakeAllDefs(spec)
 		if err != nil {
 			sylog.Fatalf("Unable to build from %s: %v", spec, err)
 		}
@@ -137,6 +144,7 @@ func run(cmd *cobra.Command, args []string) {
 					LibraryURL:       libraryURL,
 					LibraryAuthToken: authToken,
 					DockerAuthConfig: authConf,
+					Fakeroot:         fakeroot,
 				},
 			})
 		if err != nil {

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -1184,17 +1184,6 @@ __attribute__((constructor)) static void init(void) {
                 fatalf("Failed to enter in shared mount namespace: %s\n", strerror(errno));
             }
             send_event(master_socket[0]);
-
-            /* force kernel to load overlay module to ease detection later */
-            if ( sconfig->starter.isSuid || uid == 0 ) {
-                if ( mount("none", "/", "overlay", MS_SILENT, "") < 0 ) {
-                    if ( errno != EINVAL ) {
-                        debugf("Overlay seems not supported by kernel\n");
-                    } else {
-                        debugf("Overlay seems supported by kernel\n");
-                    }
-                }
-            }
         }
 
         /* staying in /proc/pid could lead to "no such process" error, go to previous working directory */

--- a/etc/network/40_fakeroot.conflist
+++ b/etc/network/40_fakeroot.conflist
@@ -1,0 +1,22 @@
+{
+    "cniVersion": "0.3.1",
+    "name": "fakeroot",
+    "plugins": [
+        {
+            "type": "ptp",
+            "ipMasq": true,
+            "ipam": {
+                "type": "host-local",
+                "subnet": "10.23.0.0/16",
+                "routes": [
+                    { "dst": "0.0.0.0/0" }
+                ]
+            }
+        },
+        {
+            "type": "portmap",
+            "capabilities": {"portMappings": true},
+            "snat": true
+        }
+    ]
+}

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -60,7 +60,7 @@ type Config struct {
 
 // NewBuild creates a new Build struct from a spec (URI, definition file, etc...)
 func NewBuild(spec string, conf Config) (*Build, error) {
-	def, err := makeDef(spec, false)
+	def, err := MakeDef(spec)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse spec %v: %v", spec, err)
 	}
@@ -248,13 +248,19 @@ func engineRequired(def types.Definition) bool {
 
 // runBuildEngine creates an imgbuild engine and creates a container out of our bundle in order to execute %post %setup scripts in the bundle
 func runBuildEngine(b *types.Bundle) error {
-	if syscall.Getuid() != 0 {
-		return fmt.Errorf("Attempted to build with scripts as non-root user")
+	if syscall.Getuid() != 0 && !b.Opts.Fakeroot {
+		return fmt.Errorf("Attempted to build with scripts as non-root user or without --fakeroot")
 	}
 
 	sylog.Debugf("Starting build engine")
 	env := []string{sylog.GetEnvVar()}
 	starter := filepath.Join(buildcfg.LIBEXECDIR, "/singularity/bin/starter")
+	if b.Opts.Fakeroot {
+		starter = filepath.Join(buildcfg.LIBEXECDIR, "/singularity/bin/starter-suid")
+		if _, err := os.Stat(starter); os.IsNotExist(err) {
+			return fmt.Errorf("fakeroot feature requires to install Singularity as root")
+		}
+	}
 	progname := []string{"singularity image-build"}
 	ociConfig := &oci.Config{}
 
@@ -324,12 +330,7 @@ func getcp(def types.Definition, libraryURL, authToken string) (ConveyorPacker, 
 }
 
 // MakeDef gets a definition object from a spec
-func MakeDef(spec string, remote bool) (types.Definition, error) {
-	return makeDef(spec, remote)
-}
-
-// makeDef gets a definition object from a spec
-func makeDef(spec string, remote bool) (types.Definition, error) {
+func MakeDef(spec string) (types.Definition, error) {
 	if ok, err := uri.IsValid(spec); ok && err == nil {
 		// URI passed as spec
 		return types.NewDefinitionFromURI(spec)
@@ -347,11 +348,6 @@ func makeDef(spec string, remote bool) (types.Definition, error) {
 	}
 	defer defFile.Close()
 
-	// must be root to build from a definition
-	if os.Getuid() != 0 && !remote {
-		return types.Definition{}, fmt.Errorf("you must be the root user to build from a definition file")
-	}
-
 	d, err := parser.ParseDefinitionFile(defFile)
 	if err != nil {
 		return types.Definition{}, fmt.Errorf("while parsing definition: %s: %v", spec, err)
@@ -360,13 +356,8 @@ func makeDef(spec string, remote bool) (types.Definition, error) {
 	return d, nil
 }
 
-// MakeAllDefs gets a definition slice from a spec
-func MakeAllDefs(spec string, remote bool) ([]types.Definition, error) {
-	return makeAllDefs(spec, remote)
-}
-
-// makeAllDef gets a definition object from a spec
-func makeAllDefs(spec string, remote bool) ([]types.Definition, error) {
+// MakeAllDefs gets a definition object from a spec
+func MakeAllDefs(spec string) ([]types.Definition, error) {
 	if ok, err := uri.IsValid(spec); ok && err == nil {
 		// URI passed as spec
 		d, err := types.NewDefinitionFromURI(spec)
@@ -385,11 +376,6 @@ func makeAllDefs(spec string, remote bool) ([]types.Definition, error) {
 		return nil, fmt.Errorf("unable to open file %s: %v", spec, err)
 	}
 	defer defFile.Close()
-
-	// must be root to build from a definition
-	if os.Getuid() != 0 && !remote {
-		return nil, fmt.Errorf("you must be the root user to build from a definition file")
-	}
 
 	d, err := parser.All(defFile)
 	if err != nil {

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -35,8 +35,8 @@ func (s *stage) Assemble(path string) error {
 // runPreScript() executes the stages pre script on host
 func (s *stage) runPreScript() error {
 	if s.b.RunSection("pre") && s.b.Recipe.BuildData.Pre.Script != "" {
-		if syscall.Getuid() != 0 {
-			return fmt.Errorf("attempted to build with scripts as non-root user")
+		if syscall.Getuid() != 0 && !s.b.Opts.Fakeroot {
+			return fmt.Errorf("attempted to build with scripts as non-root user or without --fakeroot")
 		}
 
 		// Run %pre script here

--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package fakeroot
+
+import (
+	"fmt"
+	"os"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sylabs/singularity/internal/pkg/util/user"
+)
+
+// GetIDRange returns the allocated ID range based on base ID
+// and a list of allowed users
+func GetIDRange(base uint64, allowedUsers []string) (*specs.LinuxIDMapping, error) {
+	userinfo, err := user.GetPwUID(uint32(os.Getuid()))
+	if err != nil {
+		return nil, err
+	}
+	if base%65536 != 0 {
+		return nil, fmt.Errorf("fakeroot base id is not a multiple of 65536")
+	} else if base < 65536 || base > 4294901760 {
+		return nil, fmt.Errorf("fakeroot base id is not set between 65536 and 4294901760")
+	}
+
+	// root user is always authorized and has a 1:1 mapping
+	if userinfo.UID == 0 {
+		return &specs.LinuxIDMapping{
+			ContainerID: 1,
+			HostID:      1,
+			Size:        65535,
+		}, nil
+	}
+
+	for i, name := range allowedUsers {
+		if userinfo.Name == name {
+			return &specs.LinuxIDMapping{
+				ContainerID: 1,
+				HostID:      uint32(base) + uint32(i*65536),
+				Size:        65535,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("you are not allowed to use fakeroot")
+}

--- a/internal/pkg/fakeroot/fakeroot_test.go
+++ b/internal/pkg/fakeroot/fakeroot_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package fakeroot
+
+import (
+	"os"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/util/user"
+)
+
+type set struct {
+	name            string
+	base            uint64
+	allowedUsers    []string
+	expectedMapping *specs.LinuxIDMapping
+}
+
+func testGetIDRange(t *testing.T, s set) {
+	idRange, err := GetIDRange(s.base, s.allowedUsers)
+	if err != nil && s.expectedMapping != nil {
+		t.Errorf("unexpected error for %q: %s", s.name, err)
+	} else if err == nil && s.expectedMapping == nil {
+		t.Errorf("unexpected success for %q", s.name)
+	} else if err == nil && s.expectedMapping != nil {
+		if s.expectedMapping.ContainerID != idRange.ContainerID {
+			t.Errorf("bad container ID returned for %q: %d instead of %d", s.name, idRange.ContainerID, s.expectedMapping.ContainerID)
+		}
+		if s.expectedMapping.HostID != idRange.HostID {
+			t.Errorf("bad host ID returned for %q: %d instead of %d", s.name, idRange.HostID, s.expectedMapping.HostID)
+		}
+		if s.expectedMapping.Size != idRange.Size {
+			t.Errorf("bad size returned for %q: %d instead of %d", s.name, idRange.Size, s.expectedMapping.Size)
+		}
+	}
+}
+
+func TestGetIDRangeUser(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	userinfo, err := user.GetPwUID(uint32(os.Getuid()))
+	if err != nil {
+		t.Fatalf("failed to retrieve user information: %s", err)
+	}
+
+	tests := []set{
+		{
+			name: "empty",
+		},
+		{
+			name: "low base",
+			base: 65535,
+		},
+		{
+			name: "high base",
+			base: 65536 * 65536,
+		},
+		{
+			name: "base not multiple of 65536",
+			base: 65537,
+		},
+		{
+			name: "good base, no users",
+			base: 65536,
+		},
+		{
+			name:         "good base, current user",
+			base:         65536 * 1024,
+			allowedUsers: []string{userinfo.Name},
+			expectedMapping: &specs.LinuxIDMapping{
+				ContainerID: 1,
+				HostID:      65536 * 1024,
+				Size:        65535,
+			},
+		},
+	}
+	for _, test := range tests {
+		testGetIDRange(t, test)
+	}
+}
+
+func TestGetIDRangeRoot(t *testing.T) {
+	test.EnsurePrivilege(t)
+
+	tests := []set{
+		{
+			name: "empty",
+		},
+		{
+			name: "low base",
+			base: 65535,
+		},
+		{
+			name: "high base",
+			base: 65536 * 65536,
+		},
+		{
+			name: "base not multiple of 65536",
+			base: 65537,
+		},
+		{
+			name: "good base, root user",
+			base: 65536 * 1024,
+			expectedMapping: &specs.LinuxIDMapping{
+				ContainerID: 1,
+				HostID:      1,
+				Size:        65535,
+			},
+		},
+	}
+	for _, test := range tests {
+		testGetIDRange(t, test)
+	}
+}

--- a/internal/pkg/runtime/engines/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/create_linux.go
@@ -56,6 +56,9 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 
 	// sensible mount point options to avoid accidental system settings override
 	flags := uintptr(syscall.MS_BIND | syscall.MS_NOSUID | syscall.MS_NOEXEC | syscall.MS_NODEV | syscall.MS_RDONLY)
+	if engine.EngineConfig.Opts.Fakeroot {
+		flags = uintptr(syscall.MS_BIND | syscall.MS_REC)
+	}
 
 	sylog.Debugf("Mounting image directory %s\n", rootfs)
 	_, err = rpcOps.Mount(rootfs, sessionPath, "", syscall.MS_BIND, "errors=remount-ro")
@@ -96,9 +99,11 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 	if err != nil {
 		return fmt.Errorf("mount proc failed: %s", err)
 	}
-	_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-	if err != nil {
-		return fmt.Errorf("remount proc failed: %s", err)
+	if !engine.EngineConfig.Opts.Fakeroot {
+		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
+		if err != nil {
+			return fmt.Errorf("remount proc failed: %s", err)
+		}
 	}
 
 	dest = filepath.Join(sessionPath, "sys")
@@ -107,9 +112,11 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 	if err != nil {
 		return fmt.Errorf("mount sys failed: %s", err)
 	}
-	_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-	if err != nil {
-		return fmt.Errorf("remount sys failed: %s", err)
+	if !engine.EngineConfig.Opts.Fakeroot {
+		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
+		if err != nil {
+			return fmt.Errorf("remount sys failed: %s", err)
+		}
 	}
 
 	dest = filepath.Join(sessionPath, "dev")
@@ -125,9 +132,11 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 	if err != nil {
 		return fmt.Errorf("mount /etc/resolv.conf failed: %s", err)
 	}
-	_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-	if err != nil {
-		return fmt.Errorf("remount /etc/resolv.conf failed: %s", err)
+	if !engine.EngineConfig.Opts.Fakeroot {
+		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
+		if err != nil {
+			return fmt.Errorf("remount /etc/resolv.conf failed: %s", err)
+		}
 	}
 
 	dest = filepath.Join(sessionPath, "etc", "hosts")
@@ -136,9 +145,11 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 	if err != nil {
 		return fmt.Errorf("mount /etc/hosts failed: %s", err)
 	}
-	_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-	if err != nil {
-		return fmt.Errorf("remount /etc/hosts failed: %s", err)
+	if !engine.EngineConfig.Opts.Fakeroot {
+		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
+		if err != nil {
+			return fmt.Errorf("remount /etc/hosts failed: %s", err)
+		}
 	}
 
 	sylog.Debugf("Chdir into %s\n", sessionPath)

--- a/internal/pkg/runtime/engines/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engines/singularity/cleanup_linux.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/instance"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/internal/pkg/util/priv"
 )
 
 /*
@@ -32,8 +33,14 @@ func (engine *EngineOperations) CleanupContainer(fatal error, status syscall.Wai
 	}
 
 	if engine.EngineConfig.Network != nil {
+		if engine.EngineConfig.GetFakeroot() {
+			priv.Escalate()
+		}
 		if err := engine.EngineConfig.Network.DelNetworks(); err != nil {
 			sylog.Errorf("%s", err)
+		}
+		if engine.EngineConfig.GetFakeroot() {
+			priv.Drop()
 		}
 	}
 

--- a/internal/pkg/util/priv/priv_linux.go
+++ b/internal/pkg/util/priv/priv_linux.go
@@ -7,17 +7,20 @@ package priv
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 )
 
 // Escalate escalates thread privileges
 func Escalate() error {
+	runtime.LockOSThread()
 	uid := os.Getuid()
 	return syscall.Setresuid(uid, 0, uid)
 }
 
 // Drop drops thread privileges
 func Drop() error {
+	defer runtime.UnlockOSThread()
 	uid := os.Getuid()
 	return syscall.Setresuid(uid, uid, 0)
 }

--- a/mlocal/frags/build_network.mk
+++ b/mlocal/frags/build_network.mk
@@ -11,7 +11,8 @@ cni_plugins_INSTALL := $(addprefix $(cni_install_DIR)/, $(notdir $(cni_plugins))
 cni_config_LIST := $(SOURCEDIR)/etc/network/00_bridge.conflist \
                    $(SOURCEDIR)/etc/network/10_ptp.conflist \
                    $(SOURCEDIR)/etc/network/20_ipvlan.conflist \
-                   $(SOURCEDIR)/etc/network/30_macvlan.conflist
+                   $(SOURCEDIR)/etc/network/30_macvlan.conflist \
+                   $(SOURCEDIR)/etc/network/40_fakeroot.conflist
 cni_config_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/network
 
 .PHONY: cniplugins

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -62,6 +62,8 @@ type Options struct {
 	// NoCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
 	// useful for debugging
 	NoCleanUp bool `json:"noCleanUp"`
+	// fakeroot indicates if the build engine uses the fakeroot feature
+	Fakeroot bool `json:"fakeroot"`
 }
 
 // NewBundle creates a Bundle environment

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -36,6 +36,7 @@ type FileConfig struct {
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
 	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
 	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
+	FakerootBaseID          uint64   `default:"4227858432" directive:"fakeroot base id"`
 	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
 	EnableOverlay           string   `default:"try" authorized:"yes,no,try" directive:"enable overlay"`
 	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
@@ -43,6 +44,7 @@ type FileConfig struct {
 	LimitContainerGroups    []string `directive:"limit container groups"`
 	LimitContainerPaths     []string `directive:"limit container paths"`
 	AutofsBugPath           []string `directive:"autofs bug path"`
+	FakerootAllowedUsers    []string `directive:"fakeroot allowed users"`
 	RootDefaultCapabilities string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
 	MemoryFSType            string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
 	CniConfPath             string   `directive:"cni configuration path"`
@@ -52,6 +54,30 @@ type FileConfig struct {
 
 // JSONConfig stores engine specific confguration that is allowed to be set by the user
 type JSONConfig struct {
+	ScratchDir    []string      `json:"scratchdir,omitempty"`
+	OverlayImage  []string      `json:"overlayImage,omitempty"`
+	BindPath      []string      `json:"bindpath,omitempty"`
+	NetworkArgs   []string      `json:"networkArgs,omitempty"`
+	Security      []string      `json:"security,omitempty"`
+	LibrariesPath []string      `json:"librariesPath,omitempty"`
+	ImageList     []image.Image `json:"imageList,omitempty"`
+	OpenFd        []int         `json:"openFd,omitempty"`
+	TargetGID     []int         `json:"targetGID,omitempty"`
+	Image         string        `json:"image"`
+	Workdir       string        `json:"workdir,omitempty"`
+	CgroupsPath   string        `json:"cgroupsPath,omitempty"`
+	HomeSource    string        `json:"homedir,omitempty"`
+	HomeDest      string        `json:"homeDest,omitempty"`
+	Command       string        `json:"command,omitempty"`
+	Shell         string        `json:"shell,omitempty"`
+	TmpDir        string        `json:"tmpdir,omitempty"`
+	AddCaps       string        `json:"addCaps,omitempty"`
+	DropCaps      string        `json:"dropCaps,omitempty"`
+	Hostname      string        `json:"hostname,omitempty"`
+	Network       string        `json:"network,omitempty"`
+	DNS           string        `json:"dns,omitempty"`
+	Cwd           string        `json:"cwd,omitempty"`
+	TargetUID     int           `json:"targetUID,omitempty"`
 	WritableImage bool          `json:"writableImage,omitempty"`
 	WritableTmpfs bool          `json:"writableTmpfs,omitempty"`
 	Contain       bool          `json:"container,omitempty"`
@@ -67,30 +93,7 @@ type JSONConfig struct {
 	NoHome        bool          `json:"noHome,omitempty"`
 	NoInit        bool          `json:"noInit,omitempty"`
 	DeleteImage   bool          `json:"deleteImage,omitempty"`
-	Image         string        `json:"image"`
-	OverlayImage  []string      `json:"overlayImage,omitempty"`
-	Workdir       string        `json:"workdir,omitempty"`
-	ScratchDir    []string      `json:"scratchdir,omitempty"`
-	HomeSource    string        `json:"homedir,omitempty"`
-	HomeDest      string        `json:"homeDest,omitempty"`
-	BindPath      []string      `json:"bindpath,omitempty"`
-	Command       string        `json:"command,omitempty"`
-	Shell         string        `json:"shell,omitempty"`
-	TmpDir        string        `json:"tmpdir,omitempty"`
-	AddCaps       string        `json:"addCaps,omitempty"`
-	DropCaps      string        `json:"dropCaps,omitempty"`
-	Hostname      string        `json:"hostname,omitempty"`
-	ImageList     []image.Image `json:"imageList,omitempty"`
-	Network       string        `json:"network,omitempty"`
-	NetworkArgs   []string      `json:"networkArgs,omitempty"`
-	DNS           string        `json:"dns,omitempty"`
-	Cwd           string        `json:"cwd,omitempty"`
-	Security      []string      `json:"security,omitempty"`
-	OpenFd        []int         `json:"openFd,omitempty"`
-	CgroupsPath   string        `json:"cgroupsPath,omitempty"`
-	TargetUID     int           `json:"targetUID,omitempty"`
-	TargetGID     []int         `json:"targetGID,omitempty"`
-	LibrariesPath []string      `json:"librariesPath,omitempty"`
+	Fakeroot      bool          `json:"fakeroot,omitempty"`
 }
 
 // NewConfig returns singularity.EngineConfig with a parsed FileConfig
@@ -474,6 +477,16 @@ func (e *EngineConfig) SetLibrariesPath(libraries []string) {
 // /.singularity.d/libs directory
 func (e *EngineConfig) GetLibrariesPath() []string {
 	return e.JSON.LibrariesPath
+}
+
+// SetFakeroot sets fakeroot flag
+func (e *EngineConfig) SetFakeroot(fakeroot bool) {
+	e.JSON.Fakeroot = fakeroot
+}
+
+// GetFakeroot returns if fakeroot is set or not
+func (e *EngineConfig) GetFakeroot() bool {
+	return e.JSON.Fakeroot
 }
 
 // GetDeleteImage returns if container image must be deleted after use

--- a/pkg/runtime/engines/singularity/config/data/singularity.conf
+++ b/pkg/runtime/engines/singularity/config/data/singularity.conf
@@ -242,3 +242,34 @@ memory fs type = {{ .MemoryFSType }}
 # Allow to share same images associated with loop devices to minimize loop
 # usage and optimize kernel cache (useful for MPI)
 shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }}
+
+# FAKEROOT BASE ID: [INT] 65536 <= BASE <= 4294901760
+# DEFAULT: 4227858432
+# This is the start of allocatable UID/GID in containers for fakeroot users.
+# Each user will be allocated a range of 65535 UID/GID based on this base,
+# eg:
+# the first user in the list of allowed users will get a UID/GID range starting at:
+# (BASE_ID)+(65536*0) -> 4227858432:4227923967
+# the second user in the list of allowed users will get a UID/GID range starting at:
+# (BASE_ID)+(65536*1) -> 4227923968:4227989503
+#
+# The default value of 4227858432 should be fine with most environment and
+# only changed if some users UID/GID on your system may overlap with the
+# allocated ranges. DON'T CHANGE IT IF USERS ALREADY USE THE FEATURE.
+# The default value enables the configuration of up to 1024 users; if you need to
+# configure more users, you must decrease this value, basically by 65536 to
+# add one user and so on.
+# Additionally this value must be a multiple of 65536.
+fakeroot base id = {{ .FakerootBaseID }}
+
+# FAKEROOT ALLOWED USERS: [STRING]
+# DEFAULT: Undefined
+# This is the list of users allowed to use the fakeroot feature.
+# User position will determine the allocated ID range based on the
+# formula above, so you will need to be very careful when manipulating
+# the user list in order to not swap a range between users
+#fakeroot allowed users = foo, bar
+{{ range $index, $users := .FakerootAllowedUsers }}
+fakeroot allowed users = 
+{{ if $index }}, {{ end }}{{$users}}
+{{- end }}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR introduces fakeroot feature unlocking the possibility :
- to build an image as user, work only with the following bootstrap methods :
  - docker
  - library (if stored image format is SIF or squashfs)
  - shub (if stored image format is SIF or squashfs)
- execute container process as a fake root user able to switch to any UID/GID inside container (UID/GID are mapped to non-existent user/group outside of container)

Support :
- sandbox/squashfs/SIF images
- underlay
- network support with `--net` or `--net --network=fakeroot`
- usage is restricted by a whitelist, so user need to be added to `fakeroot allowed users` in `singularity.conf` in order to use fakeroot

As fakeroot use user namespace it has some user namespace limitations :
- no overlay support (`--overlay`, `--writable-tmpfs`)
- no cgroups support (`--apply-crgoups`)
- no `--security=uid` and `--security=gid` support (would make sense once filesystem issues adressed)
- `--drop-caps`, `--add-caps`, `--keep-privs`, `--no-privs` and `--allow-setuid` have no effect, fakeroot user has all capabilities by default and could manipulate those capabilities inside container
- **fakeroot users can't manipulate file owned by real root or system user**
- as real user UID/GID are mapped to root/root inside container, don't expect to change UID/GID to those you have outside container, they are mapped to non-existent user/group

Demo :
- build : https://asciinema.org/a/pSBeCEUNzoNCNhIIKHkO3sIkt
- exec : https://asciinema.org/a/ONi0fLRDFyDt71xq5IFrGnWJP

**Fakeroot requires:**
- **a privileged installation (with setuid binary)**
- **a kernel supporting user namespace (3.8 or later)**

**Issues related:**
- Fixes #1924
- Fixes #3207