### PR TITLE
Introduce trusted containers to allow nested execution of singularity containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.1.0
+  - Added `trusted container path` setting in `singularity.conf` to allow setuid binaries in designated containers to be run by non-root users
+  - Added `forbidden bind trusted` setting in `singularity.conf` to disallow some paths from user binds in trusted container to prevent exploits
+  - Added `--run-untrusted` flag to run trusted container in untrusted mode (disallowing setuid binaries but removing bind restrictions)
+  - Added `bounding capability trusted` setting in `singularity.conf` to retain some bounding capabilities in trusted container execution.
 
 # v3.1.0 - [2019.02.08]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,6 +52,7 @@
     - Michael Milton <ttmigueltt@gmail.com>
     - Nathan Lin <nathan.lin@yale.edu>
     - Oleksandr Moskalenko <om@rc.ufl.edu>
+    - Oliver Breitwieser <obreitwi@kip.uni-heidelberg.de>, <oliver@breitwieser.eu>
     - Oliver Freyermuth <freyermuth@physik.uni-bonn.de>
     - Olivier Sallou <olivier.sallou@irisa.fr>
     - Peter Steinbach <steinbach@scionics.de>

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -49,11 +49,12 @@ var (
 	PidNamespace  bool
 	IpcNamespace  bool
 
-	AllowSUID bool
-	KeepPrivs bool
-	NoPrivs   bool
-	AddCaps   string
-	DropCaps  string
+	AllowSUID    bool
+	KeepPrivs    bool
+	NoPrivs      bool
+	AddCaps      string
+	DropCaps     string
+	RunUntrusted bool
 )
 
 var actionFlags = pflag.NewFlagSet("ActionFlags", pflag.ExitOnError)
@@ -267,4 +268,8 @@ func initPrivilegeVars() {
 	// --allow-setuid
 	actionFlags.BoolVar(&AllowSUID, "allow-setuid", false, "allow setuid binaries in container (root only)")
 	actionFlags.SetAnnotation("allow-setuid", "envkey", []string{"ALLOW_SETUID"})
+
+	// --run-untrusted
+	actionFlags.BoolVar(&RunUntrusted, "run-untrusted", false, "run container in untrusted mode even if it is in a trusted location (allows for more user binds)")
+	actionFlags.SetAnnotation("run-untrusted", "envkey", []string{"RUN_UNTRUSTED"})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -72,6 +72,7 @@ func init() {
 		cmd.Flags().AddFlag(actionFlags.Lookup("docker-username"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("docker-password"))
 		cmd.Flags().AddFlag(actionFlags.Lookup("docker-login"))
+		cmd.Flags().AddFlag(actionFlags.Lookup("run-untrusted"))
 		if cmd == ShellCmd {
 			cmd.Flags().AddFlag(actionFlags.Lookup("shell"))
 		}

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -165,6 +165,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	engineConfig.SetSecurity(Security)
 	engineConfig.SetShell(ShellPath)
 	engineConfig.SetLibrariesPath(ContainLibsPath)
+	engineConfig.SetRunUntrusted(RunUntrusted)
 
 	if ShellPath != "" {
 		generator.AddProcessEnv("SINGULARITY_SHELL", ShellPath)

--- a/internal/pkg/runtime/engines/singularity/config/data/singularity.conf
+++ b/internal/pkg/runtime/engines/singularity/config/data/singularity.conf
@@ -241,3 +241,57 @@ memory fs type = {{ .MemoryFSType }}
 # Allow to share same images associated with loop devices to minimize loop
 # usage and optimize kernel cache (useful for MPI)
 shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }}
+
+# TRUSTED CONTAINER PATH: [STRING]
+# DEFAULT: NULL
+# Allow containers to be used with --allow-setuid by non-root users that are
+# located within an allowed path prefix. If this configuration is undefined
+# (commented or set to NULL), containers will be only be allowed to run in
+# SUID mode if the user is root and specifies --allow-setuid.
+# Note: Please make sure that the singularity config file in trusted containers
+# cannot be bind mounted by non-root user, otherwise this option poses a
+# security risk!
+# Be also sure to forbid all vulnerable paths from being bind mounted by users
+# via the "forbidden bind trusted settings.
+#trusted container path = /containers
+{{ range $path := .TrustedContainerPaths }}
+{{- if ne $path "" -}}
+trusted container path = {{$path}}
+{{ end -}}
+{{ end }}
+
+# FORBIDDEN BIND TRUSTED: [STRING]
+# DEFAULT: Undefined
+# When trusting containers (i.e., allowing non-root users to execute setuid
+# binaries in them), we open ourselves up to security vulnerabilities. Trusted
+# containers should only be used in an environment where non-root users have no
+# possibility to set the SUID flag on binaries. But there are other
+# attack-possibilities. For example, if sudo is present in the container, the
+# user could bind mount different config files granting him root rights.
+# A reasonable default is provided, however:
+# Prior to setting trusted container paths, be sure to check for
+# possible exploits in your containers!
+# Especially if singularity is present in the container, it is of utmost
+# importance to add its configuration directory (default: /etc/singularity) to
+# the list of forbidden binds!
+{{ range $path := .ForbiddenBindsTrusted }}
+{{- if ne $path "" -}}
+forbidden bind trusted = {{$path}}
+{{ end -}}
+{{ end }}
+
+# BOUNDING CAPABILITY TRUSTED: [STRING]
+# DEFAULT: Undefined
+# Bounding capabilities with which trusted container images are executed.
+# For nested containers, this list should at least contain CAP_SETPCAP and
+# CAP_SYS_ADMIN.
+# Please note the distinction between bounding and
+# permitted/effective/inheritable capabilities. Setting a capability here does
+# not automatically grant it to the process in which the new container is
+# spawned, but rather it allows setuid-binaries within such a container to
+# attain them (for instance when running another singularity image).
+{{ range $cap := .BoundingCapsTrusted }}
+{{- if ne $cap "" -}}
+bounding capability trusted = {{$cap}}
+{{ end -}}
+{{ end }}

--- a/internal/pkg/util/env/clean.go
+++ b/internal/pkg/util/env/clean.go
@@ -53,6 +53,10 @@ func SetContainerEnv(g *generate.Generator, env []string, cleanEnv bool, homeDes
 			sylog.Verbosef("Can't process environment variable %s", env)
 			continue
 		}
+		if strings.HasPrefix(e[0], "SINGULARITY_") {
+			sylog.Verbosef("Not forwarding %s from user to container environment", e[0])
+			continue
+		}
 
 		if e[0] == "SINGULARITYENV_PREPEND_PATH" ||
 			e[0] == "SINGULARITYENV_APPEND_PATH" ||

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -68,6 +68,29 @@ func TestIsSuid(t *testing.T) {
 	}
 }
 
+func TestIsUnder(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	dummyFolders := []string{
+		"/foo",
+		"/bar",
+		"/deadbeef/foobar",
+	}
+
+	if result, err := IsUnder("/bar", dummyFolders, false); err != nil {
+		t.Errorf("isUnder returns error: %s", err)
+	} else if !result {
+		t.Errorf("isUnder returns false for correct case.")
+	}
+
+	if result, err := IsUnder("/var/run", []string{"/run"}, true); err != nil {
+		t.Errorf("isUnder returns error: %s", err)
+	} else if !result {
+		t.Errorf("isUnder returns false for correct case using symlinks.")
+	}
+}
+
 func TestRootDir(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

In our group we are currently in the process of moving the complete user workflow into singularity containers which are rebuilt daily. Because we have several software environments which are incompatible with each others, we deploy several apps per container image. Since users are meant to do their complete development workflow inside some of the apps, being able to switch apps (and containers) within one session (or compute job) is a very desired feature. Sure, one can always leave the container and spawn a different one, but that would mean setting up the control infrastructure for every compute job in the minimal environment outside of containers.

This PR tries to solve the issues surrounding nested container execution.

It does so by introducing the concept of _trusted container images_ which have to reside under admin-chosen locations in the host's filesystem (i.e., per default users cannot provide their own images). Security measures on these images are less strict since they can only be deployed by a root-controlling user:
* The root filesystem is not mounted with `NOSUID`, hence execution of any setuid binary inside the container is possible (including ther `starter-suid` from `singularity`).
*  `PR_SET_NO_NEW_PRIVS` is not set which would prevent `singularity` inside the container from spawning another one.
* The bounding capabilities set is relaxed to a set of admin-chosen capabilities (for nested execution of containers these have to be at least `CAP_SETPCAP` and `CAP_SYS_ADMIN`).

With these measures in place, a singularity installation within a container is able to spawn another one, allowing for nested execution of containers as long as all of them reside under a trusted path.

Since we still want to allow non-root users to perform bind mounts on trusted images, some paths within the container have to be forbidden. Examples would be the path to `singularity.conf` or `/etc/{sudoers,group,passwd,shadow}` in a container that has `sudo` installed . Obviously, prior to enabling trusted containers, admins should check their container images for possible security vulnerabilities.

If users still want to bind mount a forbidden path, they have the option to execute with `--run-untrusted`. In this case the trusted image is executed in the default secure way without any user bind restrictions.

While the primary motivation for this PR is nested singularity execution, it might be useful in other situations where trusted container images should retain a different set of capabilities (for example to perform networking related tasks).

The changes in detail:
* Add `trusted container path` setting to singularity.conf:
  If the image to be loaded is under a path specified in trusted
  container path, then it is loaded in 'trusted' mode.
  This means that it is mounted without the `NOSUID` flag and that the
  process spawned inside the container does not have `PR_SET_NO_NEW_PRIVS`
  set. Hence non-root users are capable of executing setuid-binaries
  inside the trusted container (which is why extra care should be placed
  on ensuring they can do no harm).

* Add `forbidden bind trusted` setting to `singularity.conf`:
  If a container is run in 'trusted' mode by a non-root user, all paths
  specified as 'forbidden bind trusted' will not be available as bind
  mount target in order to prohibit exploits (for instance, by replacing
  the /etc/suoders file in a container with sudo installed).

* Add `--run-untrusted` flag to action commands:
  When `--run-untrusted` is specified, a trusted container is forcibly run
  in 'untrusted' mode, re-allowing all user binds while re-enabling
  PR_SET_NO_NEW_PRIVS.

* Add `bounding capability trusted` setting to `singularity.conf` that allows admins to
  specify a list of capabilities the bounding capabilities set should
  retain for processes spawned in trusted containers. This is useful to
  allow nested execution of singularity containers.

**This fixes or addresses the following GitHub issues:**
_None_

**Before submitting a PR, make sure you have done the following:**

- [x] Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] Added tests to validate this PR and tested this PR locally with a `make testall`
  - [x] Added one test for `IsUnder` - probably is not enough..
- [x] Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md) (in #2728)

Attn: @singularity-maintainers

Any feedback is greatly appreciated… :)