### PR TITLE
Fix status report in OCI engine

### DIFF
--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -272,7 +272,7 @@ var OciMountCmd = &cobra.Command{
 			sylog.Fatalf("%s", err)
 		}
 	},
-	Use:     "mount",
+	Use:     docs.OciMountUse,
 	Short:   docs.OciMountShort,
 	Long:    docs.OciMountLong,
 	Example: docs.OciMountExample,
@@ -288,7 +288,7 @@ var OciUmountCmd = &cobra.Command{
 			sylog.Fatalf("%s", err)
 		}
 	},
-	Use:     "umount",
+	Use:     docs.OciUmountUse,
 	Short:   docs.OciUmountShort,
 	Long:    docs.OciUmountLong,
 	Example: docs.OciUmountExample,

--- a/internal/app/starter/stage.go
+++ b/internal/app/starter/stage.go
@@ -43,6 +43,11 @@ func Stage(stage, masterSocket int, sconfig *sarterConfig.Config, engine *engine
 	} else {
 		sylog.Debugf("Entering stage 2\n")
 		if err := engine.StartProcess(conn); err != nil {
+			// write data to just tell master to not execute PostStartProcess
+			// in case of failure
+			if _, err := conn.Write([]byte("t")); err != nil {
+				sylog.Errorf("fail to send data to master: %s", err)
+			}
 			sylog.Fatalf("%s\n", err)
 		}
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes issue on status report, currently OCI socket return both running/stopped state in right order when it should return only one of those status. Also fixes `instance start` `no such process` issue. And fix oversight with help of `oci mount` and `oci umount`.

Fixes #2735 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
