### PR TITLE
Return error with capability add/drop when no user/group specified

### DIFF
--- a/internal/app/singularity/capability_manage_linux.go
+++ b/internal/app/singularity/capability_manage_linux.go
@@ -86,6 +86,10 @@ func manageCaps(capFile string, c CapManageConfig, t manageType) error {
 		}
 	}
 
+	if c.User == "" && c.Group == "" {
+		return fmt.Errorf("no user or group specified")
+	}
+
 	if c.User != "" {
 		if !userExists(c.User) {
 			return fmt.Errorf("while setting capabilities for user %s: user does not exist", c.User)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Return an error when no user or group are specified for `singularity capability add/drop` commands

**This fixes or addresses the following GitHub issues:**

- Fixes #2723 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
