### PR TITLE
Fix panic with empty passwd/group file in container image

### DIFF
--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -7,6 +7,7 @@ package files
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,6 +29,19 @@ func TestGroup(t *testing.T) {
 	if err != nil {
 		t.Errorf("should have passed with correct group file")
 	}
+	// with an empty file
+	f, err := ioutil.TempFile("", "empty-group-")
+	if err != nil {
+		t.Error(err)
+	}
+	emptyGroup := f.Name()
+	defer os.Remove(emptyGroup)
+	f.Close()
+
+	_, err = Group(emptyGroup, uid, gids)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestPasswd(t *testing.T) {
@@ -43,6 +57,19 @@ func TestPasswd(t *testing.T) {
 	_, err = Passwd("/etc/passwd", "/home", uid)
 	if err != nil {
 		t.Errorf("should have passed with correct passwd file")
+	}
+	// with an empty file
+	f, err := ioutil.TempFile("", "empty-passwd-")
+	if err != nil {
+		t.Error(err)
+	}
+	emptyPasswd := f.Name()
+	defer os.Remove(emptyPasswd)
+	f.Close()
+
+	_, err = Passwd(emptyPasswd, "/home", uid)
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/internal/pkg/util/fs/files/group.go
+++ b/internal/pkg/util/fs/files/group.go
@@ -65,8 +65,8 @@ func Group(path string, uid int, gids []int) (content []byte, err error) {
 		return content, fmt.Errorf("failed to read group file content in container: %s", err)
 	}
 
-	if content[len(content)-1] != '\n' {
-		content = append(content, byte('\n'))
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		content = append(content, '\n')
 	}
 
 	for _, gid := range groups {

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -46,8 +46,8 @@ func Passwd(path string, home string, uid int) (content []byte, err error) {
 	}
 	userInfo := fmt.Sprintf("%s:x:%d:%d:%s:%s:%s\n", pwInfo.Name, pwInfo.UID, pwInfo.GID, pwInfo.Gecos, homeDir, pwInfo.Shell)
 
-	if content[len(content)-1] != '\n' {
-		content = append(content, byte('\n'))
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		content = append(content, '\n')
 	}
 
 	sylog.Verbosef("Creating template passwd file and appending user data: %s\n", path)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a panic when `/etc/passwd` and/or `/etc/group` are present but empty

**This fixes or addresses the following GitHub issues:**

- Fixes #2737


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
