### PR TITLE
always update base metadata when building

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -31,6 +31,10 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 
 	cp.b = b
 
+	if err = makeBaseEnv(cp.b.Rootfs()); err != nil {
+		return fmt.Errorf("While inserting base environment: %v", err)
+	}
+
 	// check for custom library from definition
 	customLib, ok := b.Recipe.Header["library"]
 	if ok {
@@ -63,6 +67,11 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 		} else if cacheFileHash != libraryImage.Hash {
 			return fmt.Errorf("Cached File Hash(%s) and Expected Hash(%s) does not match", cacheFileHash, libraryImage.Hash)
 		}
+	}
+
+	// insert base metadata before unpacking fs
+	if err = makeBaseEnv(cp.b.Rootfs()); err != nil {
+		return fmt.Errorf("While inserting base environment: %v", err)
 	}
 
 	cp.LocalPacker, err = GetLocalPacker(imagePath, cp.b)

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -86,6 +86,10 @@ func GetLocalPacker(src string, b *types.Bundle) (LocalPacker, error) {
 
 // Get just stores the source
 func (cp *LocalConveyorPacker) Get(b *types.Bundle) (err error) {
+	// insert base metadata before unpacking fs
+	if err = makeBaseEnv(b.Rootfs()); err != nil {
+		return fmt.Errorf("While inserting base environment: %v", err)
+	}
 
 	cp.src = filepath.Clean(b.Recipe.Header["from"])
 

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -6,6 +6,7 @@
 package sources
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -41,6 +42,11 @@ func (cp *ShubConveyorPacker) Get(b *types.Bundle) (err error) {
 	// get image from singularity hub
 	if err = client.DownloadImage(cp.b.FSObjects["shubImg"], src, true, cp.b.Opts.NoHTTPS); err != nil {
 		sylog.Fatalf("failed to Get from %s: %v\n", src, err)
+	}
+
+	// insert base metadata before unpacking fs
+	if err = makeBaseEnv(cp.b.Rootfs()); err != nil {
+		return fmt.Errorf("While inserting base environment: %v", err)
 	}
 
 	cp.LocalPacker, err = GetLocalPacker(cp.b.FSObjects["shubImg"], cp.b)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR changed builds from container image sources to extract content into a fs with `/.singularity.d` metadata already in place in case the image does not already contain it.


**This fixes or addresses the following GitHub issues:**

- Related to #2731 
- May fix issue #2589 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
