### PR TITLE
Double quote environment variable values in `10-docker2singularity.sh`

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -390,9 +390,9 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 			export = fmt.Sprintf("export %s=${%s:-}\n", envParts[0], envParts[0])
 		} else {
 			if envParts[0] == "PATH" {
-				export = fmt.Sprintf("export %s=\"%s\"\n", envParts[0], shell.Escape(envParts[1]))
+				export = fmt.Sprintf("export %s=%q\n", envParts[0], shell.Escape(envParts[1]))
 			} else {
-				export = fmt.Sprintf("export %s=${%s:-%s}\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
+				export = fmt.Sprintf("export %s=${%s:-%q}\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
 			}
 		}
 		_, err = f.WriteString(export)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Image like `docker://httpd` run dash as default shell and fail during `10-docker2singularity.sh` parsing. Other shell like busybox, bash, zsh parse file correctly. Fix this by adding double quote for default environment variable values.

**This fixes or addresses the following GitHub issues:**

- Fixes #2750 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
