### PR TITLE
RPMPREFIX fix

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -602,7 +602,6 @@ PSDIR := $psdir
 LIBDIR := $libdir
 LOCALEDIR := $localedir
 MANDIR := $mandir
-RPMPREFIX:=
 
 NAME := $package_name
 SHORT_VERSION := $short_version


### PR DESCRIPTION
**Description of the Pull Request (PR):**
Having RPMPREFIX defined where it was in mconfig, was overwriting the
value given on the command line. Remove the mconfig define, and just
accept if from the CLI if given.

Attn: @singularity-maintainers
