### PR TITLE
Set 0755 permissions for upper dir

### DIFF
--- a/pkg/ocibundle/tools/overlay.go
+++ b/pkg/ocibundle/tools/overlay.go
@@ -48,7 +48,7 @@ func CreateOverlay(bundlePath string) error {
 	}
 
 	upperDir := filepath.Join(overlayDir, "upper")
-	if err = os.Mkdir(upperDir, 0700); err != nil {
+	if err = os.Mkdir(upperDir, 0755); err != nil {
 		return fmt.Errorf("failed to create %s: %s", upperDir, err)
 	}
 	workDir := filepath.Join(overlayDir, "work")


### PR DESCRIPTION
**Description of the Pull Request (PR):**

When creating OCI bundle based on SIF, need to create overlay upper directory with 0755 permissions instead of 0700. 

With 0700 containers with Uid set fail to start on Ubuntu 14.04, so we need to relax permissions a bit.


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
