### PR TITLE
fixing docstrings for oci usage, missing "oci" in several

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,11 +12,11 @@ fixing or enhancing.
 
 **Before submitting a PR, make sure you have done the following:**
 
-- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
-- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
+- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
+- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
 - Added tests to validate this PR and tested this PR locally with a `make testall`
-- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
-- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)
+- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
+- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
 
 
 Attn: @singularity-maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.1.0
 
+  - Fixed usage docstrings for OCI - was missing "oci" in command examples.
+
 # v3.1.0 - [2019.02.22]
 
 ## New Commands

--- a/docs/content.go
+++ b/docs/content.go
@@ -803,50 +803,50 @@ found at:
 	OciCreateLong  string = `
   Create invoke create operation to create a container instance from an OCI bundle directory`
 	OciCreateExample string = `
-  $ singularity create -b ~/bundle mycontainer`
+  $ singularity oci create -b ~/bundle mycontainer`
 
 	OciStartUse   string = `start <container_ID>`
 	OciStartShort string = `Start container process (root user only)`
 	OciStartLong  string = `
   Start invoke start operation to start a previously created container identified by container ID.`
 	OciStartExample string = `
-  $ singularity start mycontainer`
+  $ singularity oci start mycontainer`
 
 	OciStateUse   string = `state <container_ID>`
 	OciStateShort string = `Query state of a container (root user only)`
 	OciStateLong  string = `
   State invoke state operation to query state of a created/running/stopped container identified by container ID.`
 	OciStateExample string = `
-  $ singularity state mycontainer`
+  $ singularity oci state mycontainer`
 
 	OciKillUse   string = `kill <container_ID> [-s] signal`
 	OciKillShort string = `Kill a container (root user only)`
 	OciKillLong  string = `
   Kill invoke kill operation to kill processes running within container identified by container ID.`
 	OciKillExample string = `
-  $ singularity kill mycontainer INT
-  $ singularity kill mycontainer -s INT`
+  $ singularity oci kill mycontainer INT
+  $ singularity oci kill mycontainer -s INT`
 
 	OciDeleteUse   string = `delete <container_ID>`
 	OciDeleteShort string = `Delete container (root user only)`
 	OciDeleteLong  string = `
   Delete invoke delete operation to delete resources that were created for container identified by container ID.`
 	OciDeleteExample string = `
-  $ singularity delete mycontainer`
+  $ singularity oci delete mycontainer`
 
 	OciAttachUse   string = `attach <container_ID>`
 	OciAttachShort string = `Attach console to a running container process (root user only)`
 	OciAttachLong  string = `
   Attach will attach console to a running container process running within container identified by container ID.`
 	OciAttachExample string = `
-  $ singularity attach mycontainer`
+  $ singularity oci attach mycontainer`
 
 	OciExecUse   string = `exec <container_ID> <command> <args>`
 	OciExecShort string = `Execute a command within container (root user only)`
 	OciExecLong  string = `
   Exec will execute the provided command/arguments within container identified by container ID.`
 	OciExecExample string = `
-  $ singularity exec mycontainer id`
+  $ singularity oci exec mycontainer id`
 
 	OciRunUse   string = `run [run options...] <container_ID>`
 	OciRunShort string = `Create/start/attach/delete a container from a bundle directory (root user only)`


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

This is a tiny fix to add "oci" to several of the Example docstrings - they are just missing! Opening a PR to fix it is much more useful (and almost takes the same time) as writing up an issue.  I also noticed that the links to the contributing and changelog files (in the pull request template) were 404, so I updated those (I guess nobody has clicked on them in a long time!) 

Attn: @singularity-maintainers
