### PR TITLE
Remove warning when CWD doesn't exist on host

### DIFF
--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -1541,7 +1541,11 @@ func (c *container) addCwdMount(system *mount.System) error {
 	}
 	cwd = c.engine.EngineConfig.OciConfig.Process.Cwd
 	if err := os.Chdir(cwd); err != nil {
-		sylog.Warningf("Could not set container working directory %s: %s", cwd, err)
+		if os.IsNotExist(err) {
+			sylog.Debugf("Container working directory %s doesn't exist, will retry after chroot", cwd)
+		} else {
+			sylog.Warningf("Could not set container working directory %s: %s", cwd, err)
+		}
 		return nil
 	}
 	current, err := os.Getwd()


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes false error warning message when using `--pwd` with a path not present on host

**This fixes or addresses the following GitHub issues:**

- Fixes #2778 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](../CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](../CHANGELOG.md) if necessary according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](../CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](../CONTRIBUTORS.md)


Attn: @singularity-maintainers
