### PR TITLE
OCI Config Embedding In SIF

### DIFF
--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -59,6 +59,7 @@ func createSIF(path string, definition, ociConf []byte, squashfile string) (err 
 			Groupid:  sif.DescrDefaultGroup,
 			Link:     sif.DescrUnusedLink,
 			Data:     ociConf,
+			Fname:    "oci-config.json",
 		}
 		ociInput.Size = int64(binary.Size(ociInput.Data))
 

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -334,18 +334,6 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 		}
 	}
 
-	if len(cp.imgConfig.WorkingDir) > 0 {
-		_, err = f.WriteString("OCI_WORKDIR='" + cp.imgConfig.WorkingDir + "'\n")
-		if err != nil {
-			return
-		}
-	} else {
-		_, err = f.WriteString("OCI_WORKDIR=''\n")
-		if err != nil {
-			return
-		}
-	}
-
 	_, err = f.WriteString(`CMDLINE_ARGS=""
 # prepare command line arguments for evaluation
 for arg in "$@"; do
@@ -376,11 +364,6 @@ if [ $# -gt 0 ]; then
     SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${CMDLINE_ARGS}"
 else
     SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
-fi
-
-# WORKDIR - if set change directory to this location before executing CMD/ENTRYPOINT
-if [ -n "$OCI_WORKDIR" ]; then
-    cd ${OCI_WORKDIR}
 fi
 
 # Evaluate shell expressions first and set arguments accordingly,

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -63,6 +63,7 @@ type Options struct {
 // NewBundle creates a Bundle environment
 func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
 	b = &Bundle{}
+	b.JSONObjects = make(map[string][]byte)
 
 	if bundlePrefix == "" {
 		bundlePrefix = "sbuild-"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Adds a generic `JSON` partition to `SIF` image containing OCI configuration when building from an OCI source.

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
