### PR TITLE
Fix scratch issue

### DIFF
--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -1430,10 +1430,10 @@ func (c *container) addTmpMount(system *mount.System) error {
 			tmpSource = filepath.Join(workdir, tmpSource)
 			vartmpSource = filepath.Join(workdir, vartmpSource)
 
-			if err := fs.Mkdir(tmpSource, os.ModeSticky|0777); err != nil {
+			if err := fs.Mkdir(tmpSource, os.ModeSticky|0777); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("failed to create %s: %s", tmpSource, err)
 			}
-			if err := fs.Mkdir(vartmpSource, os.ModeSticky|0777); err != nil {
+			if err := fs.Mkdir(vartmpSource, os.ModeSticky|0777); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("failed to create %s: %s", vartmpSource, err)
 			}
 		} else {
@@ -1506,11 +1506,11 @@ func (c *container) addScratchMount(system *mount.System) error {
 
 		if hasWorkdir {
 			fullSourceDir = filepath.Join(sourceDir, filepath.Base(dir))
-			if err := fs.MkdirAll(fullSourceDir, 0750); err != nil {
+			if err := fs.MkdirAll(fullSourceDir, 0750); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("could not create scratch working directory %s: %s", sourceDir, err)
 			}
 		} else {
-			src := filepath.Join("/scratch", filepath.Base(dir))
+			src := filepath.Join("/scratch", dir)
 			if err := c.session.AddDir(src); err != nil {
 				return fmt.Errorf("could not create scratch working directory %s: %s", sourceDir, err)
 			}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes issues when multiple scratch directories finishing with same base name directory are provided. Also fix workdir reuse between run by ignoring `Mkdir` errors when directory already exists

**This fixes or addresses the following GitHub issues:**

- Fixes #2811 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
