### PR TITLE
SCS Remote Management

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/sylabs/singularity/docs"
+	scs "github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/build/types/parser"
@@ -223,4 +224,54 @@ func makeDockerCredentials(cmd *cobra.Command) (authConf *ocitypes.DockerAuthCon
 	}
 
 	return
+}
+
+// remote builds need to fail if we cannot resolve remote URLS
+func handleRemoteBuildFlags(cmd *cobra.Command) {
+	// if we can load config and if default endpoint is set, use that
+	// otherwise fall back on regular authtoken and URI behavior
+	e, err := sylabsRemote(remoteConfig)
+	if err == nil {
+		authToken = e.Token
+		if !cmd.Flags().Lookup("builder").Changed {
+			uri, err := e.GetServiceURI("builder")
+			if err != nil {
+				sylog.Fatalf("Unable to get build service URI: %v", err)
+			}
+			builderURL = uri
+		}
+		if !cmd.Flags().Lookup("library").Changed {
+			uri, err := e.GetServiceURI("library")
+			if err != nil {
+				sylog.Fatalf("Unable to get library service URI: %v", err)
+			}
+			libraryURL = uri
+		}
+	} else if err == scs.ErrNoDefault {
+		sylog.Warningf("No default remote in use, falling back to CLI defaults")
+	} else {
+		sylog.Debugf("Unable to load remote configuration: %v", err)
+	}
+}
+
+// standard builds should just warn and fall back to CLI default if we cannot resolve library URL
+func handleBuildFlags(cmd *cobra.Command) {
+	// if we can load config and if default endpoint is set, use that
+	// otherwise fall back on regular authtoken and URI behavior
+	e, err := sylabsRemote(remoteConfig)
+	if err == nil {
+		authToken = e.Token
+		if !cmd.Flags().Lookup("library").Changed {
+			uri, err := e.GetServiceURI("library")
+			if err == nil {
+				libraryURL = uri
+			} else {
+				sylog.Warningf("Unable to get library service URI: %v", err)
+			}
+		}
+	} else if err == scs.ErrNoDefault {
+		sylog.Warningf("No default remote in use, falling back to %v", libraryURL)
+	} else {
+		sylog.Debugf("Unable to load remote configuration: %v", err)
+	}
 }

--- a/cmd/internal/cli/build_darwin.go
+++ b/cmd/internal/cli/build_darwin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -21,6 +21,8 @@ func preRun(cmd *cobra.Command, args []string) {
 func run(cmd *cobra.Command, args []string) {
 	dest := args[0]
 	spec := args[1]
+
+	handleRemoteBuildFlags(cmd)
 
 	// check if target collides with existing file
 	if ok := checkBuildTarget(dest, false); !ok {

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -35,6 +35,8 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	if remote {
+		handleRemoteBuildFlags(cmd)
+
 		// Submiting a remote build requires a valid authToken
 		if authToken == "" {
 			sylog.Fatalf("Unable to submit build job: %v", authWarning)
@@ -54,7 +56,6 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While performing build: %v", err)
 		}
 	} else {
-
 		err := checkSections()
 		if err != nil {
 			sylog.Fatalf(err.Error())
@@ -65,6 +66,7 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While creating Docker credentials: %v", err)
 		}
 
+		handleBuildFlags(cmd)
 		b, err := build.NewBuild(
 			spec,
 			dest,

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -8,6 +8,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
+	scs "github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	client "github.com/sylabs/singularity/pkg/client/library"
 )
@@ -32,6 +33,25 @@ var PushCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(2),
 	PreRun:                sylabsToken,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		// if we can load config and if default endpoint is set, use that
+		// otherwise fall back on regular authtoken and URI behavior
+		e, err := sylabsRemote(remoteConfig)
+		if err == nil {
+			authToken = e.Token
+			if !cmd.Flags().Lookup("library").Changed {
+				uri, err := e.GetServiceURI("library")
+				if err != nil {
+					sylog.Fatalf("Unable to get library service URI: %v", err)
+				}
+				PushLibraryURI = uri
+			}
+		} else if err == scs.ErrNoDefault {
+			sylog.Warningf("No default remote in use, falling back to: %v", PushLibraryURI)
+		} else {
+			sylog.Debugf("Unable to load remote configuration: %v", err)
+		}
+
 		// Push to library requires a valid authToken
 		if authToken != "" {
 			err := client.UploadImage(args[0], args[1], PushLibraryURI, authToken, "No Description")

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"os/user"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+)
+
+var (
+	remoteConfig string
+)
+
+func init() {
+	usr, err := user.Current()
+	if err != nil {
+		sylog.Fatalf("Couldn't determine user home directory: %v", err)
+	}
+	remoteConfig = filepath.Join(usr.HomeDir, ".singularity", "remote.yaml")
+	SingularityCmd.AddCommand(RemoteCmd)
+	RemoteCmd.AddCommand(RemoteAddCmd)
+	RemoteCmd.AddCommand(RemoteRemoveCmd)
+	RemoteCmd.AddCommand(RemoteUseCmd)
+	RemoteCmd.AddCommand(RemoteListCmd)
+	RemoteCmd.AddCommand(RemoteLoginCmd)
+	RemoteCmd.AddCommand(RemoteStatusCmd)
+}
+
+// RemoteCmd singularity remote ...
+var RemoteCmd = &cobra.Command{
+	Run: nil,
+
+	Use: docs.RemoteUse,
+	// Short:                 docs.RemoteShort,
+	// Long:                  docs.RemoteLong,
+	// Example:               docs.RemoteExample,
+}
+
+// RemoteAddCmd singularity remote add [remoteName] [remoteURI]
+var RemoteAddCmd = &cobra.Command{
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := singularity.RemoteAdd(remoteConfig, args[0], args[1]); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use: docs.RemoteAddUse,
+	// Short:                 docs.RemoteAddShort,
+	// Long:                  docs.RemoteAddLong,
+	// Example:               docs.RemoteAddExample,
+}
+
+// RemoteRemoveCmd singularity remote remove [remoteName]
+var RemoteRemoveCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := singularity.RemoteRemove(remoteConfig, args[0]); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use: docs.RemoteRemoveUse,
+	// Short:                 docs.RemoteAddShort,
+	// Long:                  docs.RemoteAddLong,
+	// Example:               docs.RemoteAddExample,
+}
+
+// RemoteUseCmd singularity remote use [remoteName]
+var RemoteUseCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := singularity.RemoteUse(remoteConfig, args[0]); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use: docs.RemoteUseUse,
+	// Short:                 docs.RemoteAddShort,
+	// Long:                  docs.RemoteAddLong,
+	// Example:               docs.RemoteAddExample,
+}
+
+// RemoteListCmd singularity remote list
+var RemoteListCmd = &cobra.Command{
+	Args: cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := singularity.RemoteList(remoteConfig); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use: docs.RemoteListUse,
+	// Short:                 docs.RemoteAddShort,
+	// Long:                  docs.RemoteAddLong,
+	// Example:               docs.RemoteAddExample,
+}
+
+// RemoteLoginCmd singularity remote login [remoteName]
+var RemoteLoginCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := singularity.RemoteLogin(remoteConfig, args[0]); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use: docs.RemoteLoginUse,
+	// Short:                 docs.RemoteAddShort,
+	// Long:                  docs.RemoteAddLong,
+	// Example:               docs.RemoteAddExample,
+}
+
+// RemoteStatusCmd singularity remote status [remoteName]
+var RemoteStatusCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := singularity.RemoteStatus(remoteConfig, args[0]); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use: docs.RemoteStatusUse,
+	// Short:                 docs.RemoteAddShort,
+	// Long:                  docs.RemoteAddLong,
+	// Example:               docs.RemoteAddExample,
+}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/plugin"
+	scs "github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/auth"
 )
@@ -196,6 +197,22 @@ func sylabsToken(cmd *cobra.Command, args []string) {
 	if authToken == "" && authWarning == auth.WarningTokenFileNotFound {
 		sylog.Warningf("%v : Only pulls of public images will succeed", authWarning)
 	}
+}
+
+// sylabsRemote returns the remote in use or an error
+func sylabsRemote(filepath string) (*scs.EndPoint, error) {
+	file, err := os.OpenFile(filepath, os.O_RDONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	c, err := scs.ReadFrom(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetDefault()
 }
 
 // envAppend combines command line and environment var into a single argument

--- a/docs/content.go
+++ b/docs/content.go
@@ -901,4 +901,15 @@ found at:
   Umount will umount an OCI bundle previously mounted with singularity oci mount.`
 	OciUmountExample string = `
   $ singularity oci umount /var/lib/singularity/bundles/example`
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// Remote
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RemoteUse       string = `remote <subcommand>`
+	RemoteAddUse    string = `add <remote_name> <remote_URI>`
+	RemoteRemoveUse string = `remove <remote_name>`
+	RemoteUseUse    string = `use <remote_name>`
+	RemoteListUse   string = `list`
+	RemoteLoginUse  string = `login <remote_name>`
+	RemoteStatusUse string = `status <remote_name>`
 )

--- a/internal/app/singularity/remote_add.go
+++ b/internal/app/singularity/remote_add.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sylabs/singularity/internal/pkg/remote"
+)
+
+// RemoteAdd adds remote to configuration
+func RemoteAdd(configFile, name, uri string) (err error) {
+	c := &remote.Config{}
+	e := remote.EndPoint{URI: uri}
+
+	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing capability config data: %s", err)
+	}
+
+	if err := c.Add(name, &e); err != nil {
+		return err
+	}
+
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("while truncating remote config file: %s", err)
+	}
+
+	if n, err := file.Seek(0, os.SEEK_SET); err != nil || n != 0 {
+		return fmt.Errorf("failed to reset %s cursor: %s", file.Name(), err)
+	}
+
+	if _, err := c.WriteTo(file); err != nil {
+		return fmt.Errorf("while writing remote config to file: %s", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+	}
+
+	return nil
+}

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/sylabs/singularity/internal/pkg/remote"
+)
+
+const listLine = "%s\t%s\n"
+
+// RemoteList prints information about remote configurations
+func RemoteList(configFile string) (err error) {
+
+	c := &remote.Config{}
+	file, err := os.OpenFile(configFile, os.O_RDONLY|os.O_CREATE, 0644)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("No Remote configurations")
+		}
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing capability config data: %s", err)
+	}
+
+	// list in alphanumeric order
+	var names []string
+	for n := range c.Remotes {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, listLine, "NAME", "URI")
+	for _, n := range names {
+		uri := c.Remotes[n].URI
+		if c.DefaultRemote != "" && c.DefaultRemote == n {
+			n = fmt.Sprintf("[%s]", n)
+		}
+		fmt.Fprintf(tw, listLine, n, uri)
+	}
+	tw.Flush()
+	return nil
+}

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+
+	"github.com/sylabs/singularity/internal/pkg/remote"
+	"github.com/sylabs/singularity/pkg/sypgp"
+)
+
+// RemoteLogin logs in remote by setting API token
+func RemoteLogin(configFile, name string) (err error) {
+	c := &remote.Config{}
+
+	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing capability config data: %s", err)
+	}
+
+	r, err := c.GetRemote(name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Generate an API Key at https://%s/auth/tokens, and paste here:\n", r.URI)
+	r.Token, err = sypgp.AskQuestionNoEcho("API Key: ")
+	if err != nil {
+		return err
+	}
+
+	if err := r.VerifyToken(); err != nil {
+		return fmt.Errorf("while verifying token: %v", err)
+	}
+
+	sylog.Infof("API Key Verified!")
+
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("while truncating remote config file: %s", err)
+	}
+
+	if n, err := file.Seek(0, os.SEEK_SET); err != nil || n != 0 {
+		return fmt.Errorf("failed to reset %s cursor: %s", file.Name(), err)
+	}
+
+	if _, err := c.WriteTo(file); err != nil {
+		return fmt.Errorf("while writing remote config to file: %s", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+	}
+
+	return nil
+}

--- a/internal/app/singularity/remote_remove.go
+++ b/internal/app/singularity/remote_remove.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sylabs/singularity/internal/pkg/remote"
+)
+
+// RemoteRemove deletes a remote remote from the configuration
+func RemoteRemove(configFile, name string) (err error) {
+	c := &remote.Config{}
+
+	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing capability config data: %s", err)
+	}
+
+	if err := c.Remove(name); err != nil {
+		return err
+	}
+
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("while truncating remote config file: %s", err)
+	}
+
+	if n, err := file.Seek(0, os.SEEK_SET); err != nil || n != 0 {
+		return fmt.Errorf("failed to reset %s cursor: %s", file.Name(), err)
+	}
+
+	if _, err := c.WriteTo(file); err != nil {
+		return fmt.Errorf("while writing remote config to file: %s", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+	}
+
+	return nil
+}

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	jsonresp "github.com/sylabs/json-resp"
+	"github.com/sylabs/singularity/internal/pkg/remote"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+)
+
+const statusLine = "%s\t%s\t%s\n"
+
+type status struct {
+	name    string
+	uri     string
+	status  string
+	version string
+}
+
+type scsAssets map[string]string
+
+// RemoteStatus checks status of services related to an endpoint
+func RemoteStatus(configFile, name string) (err error) {
+	c := &remote.Config{}
+	file, err := os.OpenFile(configFile, os.O_RDONLY|os.O_CREATE, 0644)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("No Remote configurations")
+		}
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing capability config data: %s", err)
+	}
+
+	e, err := c.GetRemote(name)
+	if err != nil {
+		return err
+	}
+
+	a, err := e.GetAllServiceURIs()
+	if err != nil {
+		return fmt.Errorf("while getting asset configuration: %s", err)
+	}
+
+	ch := make(chan status)
+	for name, uri := range a {
+		go doStatusCheck(name, uri, ch)
+	}
+
+	// map storing statuses by name
+	smap := make(map[string]status)
+	for range a {
+		s := <-ch
+		smap[s.name] = s
+	}
+
+	// list in alphanumeric order
+	var names []string
+	for n := range smap {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, statusLine, "SERVICE", "STATUS", "VERSION")
+	for _, n := range names {
+		s := smap[n]
+		fmt.Fprintf(tw, statusLine, strings.Title(s.name+" Service"), s.status, s.version)
+	}
+	tw.Flush()
+
+	return nil
+}
+
+// VersionResponse - Response form the API for a version request
+type VersionResponse struct {
+	Version string `json:"version"`
+}
+
+func getStatus(url string) (version string, err error) {
+	client := &http.Client{
+		Timeout: (30 * time.Second),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url+"/version", nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", useragent.Value())
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request to server:\n\t%v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("error response from server: %v", res.StatusCode)
+	}
+
+	var vRes VersionResponse
+	if err := jsonresp.ReadResponse(res.Body, &vRes); err != nil {
+		return "", err
+	}
+
+	return vRes.Version, nil
+}
+
+func doStatusCheck(name, uri string, ch chan<- status) {
+	stat, err := getStatus(uri)
+	if err != nil {
+		ch <- status{name: name, uri: uri, status: "N/A"}
+		return
+	}
+	ch <- status{name: name, uri: uri, status: "OK", version: stat}
+}

--- a/internal/app/singularity/remote_use.go
+++ b/internal/app/singularity/remote_use.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sylabs/singularity/internal/pkg/remote"
+)
+
+// RemoteUse sets remote to use
+func RemoteUse(configFile, name string) (err error) {
+	c := &remote.Config{}
+
+	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing capability config data: %s", err)
+	}
+
+	if err := c.SetDefault(name); err != nil {
+		return err
+	}
+
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("while truncating remote config file: %s", err)
+	}
+
+	if n, err := file.Seek(0, os.SEEK_SET); err != nil || n != 0 {
+		return fmt.Errorf("failed to reset %s cursor: %s", file.Name(), err)
+	}
+
+	if _, err := c.WriteTo(file); err != nil {
+		return fmt.Errorf("while writing remote config to file: %s", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+	}
+
+	return nil
+}

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package remote
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var (
+	// ErrNoDefault indicates no default remote being set
+	ErrNoDefault = errors.New("no default remote")
+)
+
+// Config stores the state of remote endpoint configurations
+type Config struct {
+	DefaultRemote string               `yaml:"Active"`
+	Remotes       map[string]*EndPoint `yaml:"Remotes"`
+}
+
+// EndPoint descriptes a single remote service
+type EndPoint struct {
+	URI   string `yaml:"URI,omitempty"`
+	Token string `yaml:"Token,omitempty"`
+}
+
+// ReadFrom reads remote configuration from io.Reader
+// returns Config populated with remotes
+func ReadFrom(r io.Reader) (*Config, error) {
+	c := &Config{
+		Remotes: make(map[string]*EndPoint),
+	}
+
+	// read all data from r into b
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from io.Reader: %s", err)
+	}
+
+	if len(b) > 0 {
+		// if we had data to read in io.Reader, attempt to unmarshal as YAML
+		if err := yaml.Unmarshal(b, c); err != nil {
+			return nil, fmt.Errorf("failed to decode YAML data from io.Reader: %s", err)
+		}
+	}
+	return c, nil
+}
+
+// WriteTo writes the configuration to the io.Writer
+// returns and error if write is incomplete
+func (c *Config) WriteTo(w io.Writer) (int64, error) {
+	yaml, err := yaml.Marshal(c)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshall remote config to yaml: %v", err)
+	}
+
+	n, err := w.Write(yaml)
+	if err != nil {
+		return 0, fmt.Errorf("failed to write remote config to io.Writer: %v", err)
+	}
+
+	return int64(n), err
+}
+
+// SetDefault sets default remote endpoint or returns an error if it does not exist
+func (c *Config) SetDefault(name string) error {
+	if _, ok := c.Remotes[name]; !ok {
+		return fmt.Errorf("%s is not a remote", name)
+	}
+
+	c.DefaultRemote = name
+	return nil
+}
+
+// GetDefault returns default remote endpoint or an error
+func (c *Config) GetDefault() (*EndPoint, error) {
+	if c.DefaultRemote == "" {
+		return nil, ErrNoDefault
+	}
+
+	if _, ok := c.Remotes[c.DefaultRemote]; !ok {
+		return nil, fmt.Errorf("%s is not a remote", c.DefaultRemote)
+	}
+
+	return c.Remotes[c.DefaultRemote], nil
+}
+
+// Add a new remote endpoint
+// returns an error if it already exists
+func (c *Config) Add(name string, e *EndPoint) error {
+	if _, ok := c.Remotes[name]; ok {
+		return fmt.Errorf("%s is already a remote", name)
+	}
+
+	c.Remotes[name] = e
+	return nil
+}
+
+// Remove a remote endpoint
+// returns an error if it does not exist
+func (c *Config) Remove(name string) error {
+	if _, ok := c.Remotes[name]; !ok {
+		return fmt.Errorf("%s is not a remote", name)
+	}
+
+	delete(c.Remotes, name)
+	return nil
+}
+
+// GetRemote returns a reference to an existing endpoint
+// returns error if remote does not exist
+func (c *Config) GetRemote(name string) (*EndPoint, error) {
+	r, ok := c.Remotes[name]
+	if !ok {
+		return nil, fmt.Errorf("%s is not a remote", name)
+	}
+	return r, nil
+}
+
+// Rename an existing remote
+// returns an error if it does not exist
+func (c *Config) Rename(name, newName string) error {
+	if _, ok := c.Remotes[name]; !ok {
+		return fmt.Errorf("%s is not a remote", name)
+	}
+
+	c.Remotes[newName] = c.Remotes[name]
+	delete(c.Remotes, name)
+	return nil
+}
+
+// returns an error if a token is not valid
+func (e *EndPoint) VerifyToken() error {
+
+	baseURL, err := e.GetServiceURI("token")
+	if err != nil {
+		return fmt.Errorf("While getting token service uri: %v", err)
+	}
+
+	client := &http.Client{
+		Timeout: (30 * time.Second),
+	}
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/token-status", nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", e.Token))
+	req.Header.Set("User-Agent", useragent.Value())
+
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request to server:\n\t%v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("error response from server: %v", res.StatusCode)
+	}
+
+	return nil
+}
+
+func getCloudConfig(uri string) ([]byte, error) {
+	client := &http.Client{
+		Timeout: (30 * time.Second),
+	}
+
+	url := "https://" + uri + "/assets/config/config.prod.json"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", useragent.Value())
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request to server:\n\t%v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error response from server: %v", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("while reading response body: %v", err)
+	}
+	return b, nil
+}
+
+// GetServiceURI returns the URI for the service at the specified SCS endpoint
+// Examples of services: consent, build, library, key, token
+func (e *EndPoint) GetServiceURI(service string) (string, error) {
+	b, err := getCloudConfig(e.URI)
+	if err != nil {
+		return "", err
+	}
+
+	var a map[string]map[string]interface{}
+	if err := json.Unmarshal(b, &a); err != nil {
+		return "", fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
+	}
+
+	val, ok := a[service+"API"]
+	if !ok {
+		return "", fmt.Errorf("%v is not a service at endpoint", service)
+	}
+
+	uri, ok := val["uri"].(string)
+	if !ok {
+		return "", fmt.Errorf("%v service at endpoint failed to provide URI in response", service)
+	}
+
+	return uri, nil
+}
+
+// GetAllServiceURIs returns all available service urls for a given endpoint in a map
+func (e *EndPoint) GetAllServiceURIs() (map[string]string, error) {
+	b, err := getCloudConfig(e.URI)
+	if err != nil {
+		return nil, err
+	}
+
+	var a map[string]map[string]interface{}
+	if err := json.Unmarshal(b, &a); err != nil {
+		return nil, fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
+	}
+
+	uris := make(map[string]string)
+	for k := range a {
+		if strings.HasSuffix(k, "API") {
+			if s, ok := a[k]["uri"].(string); ok {
+				uris[strings.TrimSuffix(k, "API")] = s
+			}
+		}
+	}
+
+	return uris, nil
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR introduces the `remote` command and package which are used to manage multiple SCS remote endpoints and tokens.

Having this work in conjunction with current `authtoken` behavior has been really tricky. I have opted for using `remotes` taking precedence if there is one set as default. Otherwise normal `authtoken` and CLI flag behavior remains. This will mean that there will be no change in CLI behavior(other than potentially some debug or warning messages) if remotes are never set. I would like to move away from current `authtoken` in the future and have expressed more thoughts on #2774  

What still needs to be done:
- Unit testing for `remote` package
- e2e testing for `remote` command
- Documentation of `remote` command


**This fixes or addresses the following GitHub issues:**

- Fixes #2687 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
