### PR TITLE
adding argument --nocolor to disable sylog printing of color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _The old changelog can be found in the `release-2.6` branch_
 # Changes Since v3.1.0
 
   - Fixed usage docstrings for OCI - was missing "oci" in command examples.
+  - Added --nocolor flag to Singularity client to disable color in logging
 
 # v3.1.0 - [2019.02.22]
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -104,7 +104,6 @@ func setSylogMessageLevel(cmd *cobra.Command, args []string) {
 }
 
 func setSylogColorOn(cmd *cobra.Command, args []string) {
-
 	if nocolor {
 		sylog.DisableColor()
 	}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -27,6 +27,7 @@ import (
 // Global variables for singularity CLI
 var (
 	debug   bool
+	nocolor bool
 	silent  bool
 	verbose bool
 	quiet   bool
@@ -71,6 +72,7 @@ func init() {
 	defaultTokenFile = path.Join(usr.HomeDir, ".singularity", "sylabs-token")
 
 	SingularityCmd.Flags().BoolVarP(&debug, "debug", "d", false, "print debugging information (highest verbosity)")
+	SingularityCmd.Flags().BoolVar(&nocolor, "nocolor", false, "print without color output (default False)")
 	SingularityCmd.Flags().BoolVarP(&silent, "silent", "s", false, "only print errors")
 	SingularityCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress normal output")
 	SingularityCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print additional information")
@@ -99,6 +101,13 @@ func setSylogMessageLevel(cmd *cobra.Command, args []string) {
 	}
 
 	sylog.SetLevel(level)
+}
+
+func setSylogColorOn(cmd *cobra.Command, args []string) {
+
+	if nocolor {
+		sylog.DisableColor()
+	}
 }
 
 // SingularityCmd is the base command when called without any subcommands
@@ -178,6 +187,7 @@ func handleEnv(flag *pflag.Flag) {
 
 func persistentPreRun(cmd *cobra.Command, args []string) {
 	setSylogMessageLevel(cmd, args)
+	setSylogColorOn(cmd, args)
 	updateFlagsFromEnv(cmd)
 }
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -103,7 +103,7 @@ func setSylogMessageLevel(cmd *cobra.Command, args []string) {
 	sylog.SetLevel(level)
 }
 
-func setSylogColorOn(cmd *cobra.Command, args []string) {
+func setSylogColor(cmd *cobra.Command, args []string) {
 	if nocolor {
 		sylog.DisableColor()
 	}
@@ -186,7 +186,7 @@ func handleEnv(flag *pflag.Flag) {
 
 func persistentPreRun(cmd *cobra.Command, args []string) {
 	setSylogMessageLevel(cmd, args)
-	setSylogColorOn(cmd, args)
+	setSylogColor(cmd, args)
 	updateFlagsFromEnv(cmd)
 }
 

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -61,12 +61,9 @@ var messageColors = map[messageLevel]string{
 	info:  "\x1b[34m",
 }
 
-const colorReset string = "\x1b[0m"
+var colorReset string = "\x1b[0m"
 
 var loggerLevel messageLevel
-
-// By default, color is enabled
-var disableColor = false
 
 func init() {
 	_level, ok := os.LookupEnv("SINGULARITY_MESSAGELEVEL")
@@ -90,11 +87,7 @@ func prefix(level messageLevel) string {
 
 	// This section builds and returns the prefix for levels < debug
 	if loggerLevel < debug {
-		if disableColor {
-			return fmt.Sprintf("%-8s ", level.String()+":")
-		}
 		return fmt.Sprintf("%s%-8s%s ", messageColor, level.String()+":", colorReset)
-
 	}
 
 	pc, _, _, ok := runtime.Caller(3)
@@ -113,9 +106,6 @@ func prefix(level messageLevel) string {
 	pid := os.Getpid()
 	uidStr := fmt.Sprintf("[U=%d,P=%d]", uid, pid)
 
-	if disableColor {
-		return fmt.Sprintf("%-8s%-19s%-30s", level, uidStr, funcName)
-	}
 	return fmt.Sprintf("%s%-8s%s%-19s%-30s", messageColor, level, colorReset, uidStr, funcName)
 }
 
@@ -172,7 +162,13 @@ func SetLevel(l int) {
 
 // DisableColor for the logger
 func DisableColor() {
-	disableColor = true
+	messageColors = map[messageLevel]string{
+		fatal: "",
+		error: "",
+		warn:  "",
+		info:  "",
+	}
+	colorReset = ""
 }
 
 // GetLevel returns the current log level as integer

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -66,7 +66,7 @@ const colorReset string = "\x1b[0m"
 var loggerLevel messageLevel
 
 // By default, color is enabled
-var disableColor bool = false
+var disableColor = false
 
 func init() {
 	_level, ok := os.LookupEnv("SINGULARITY_MESSAGELEVEL")
@@ -170,7 +170,7 @@ func SetLevel(l int) {
 	loggerLevel = messageLevel(l)
 }
 
-// Disable color for the logger
+// DisableColor for the logger
 func DisableColor() {
 	disableColor = true
 }

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -61,7 +61,7 @@ var messageColors = map[messageLevel]string{
 	info:  "\x1b[34m",
 }
 
-var colorReset string = "\x1b[0m"
+var colorReset = "\x1b[0m"
 
 var loggerLevel messageLevel
 

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -65,6 +65,9 @@ const colorReset string = "\x1b[0m"
 
 var loggerLevel messageLevel
 
+// By default, color is enabled
+var disableColor bool = false
+
 func init() {
 	_level, ok := os.LookupEnv("SINGULARITY_MESSAGELEVEL")
 	if !ok {
@@ -85,8 +88,13 @@ func prefix(level messageLevel) string {
 		messageColor = "\x1b[0m"
 	}
 
+	// This section builds and returns the prefix for levels < debug
 	if loggerLevel < debug {
+		if disableColor {
+			return fmt.Sprintf("%-8s ", level.String()+":")
+		}
 		return fmt.Sprintf("%s%-8s%s ", messageColor, level.String()+":", colorReset)
+
 	}
 
 	pc, _, _, ok := runtime.Caller(3)
@@ -105,6 +113,9 @@ func prefix(level messageLevel) string {
 	pid := os.Getpid()
 	uidStr := fmt.Sprintf("[U=%d,P=%d]", uid, pid)
 
+	if disableColor {
+		return fmt.Sprintf("%-8s%-19s%-30s", level, uidStr, funcName)
+	}
 	return fmt.Sprintf("%s%-8s%s%-19s%-30s", messageColor, level, colorReset, uidStr, funcName)
 }
 
@@ -157,6 +168,11 @@ func Debugf(format string, a ...interface{}) {
 // SetLevel explicitly sets the loggerLevel
 func SetLevel(l int) {
 	loggerLevel = messageLevel(l)
+}
+
+// Disable color for the logger
+func DisableColor() {
+	disableColor = true
 }
 
 // GetLevel returns the current log level as integer


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

**Description of the Pull Request (PR):**

This pull request will give the user the option to add `--nocolor` to the singularity command to disable color formatting of output. For example, here we can pull a container (without the flag):

```bash
$ singularity --debug pull docker://busybox >& container-color.log
```
The container-color.log is a mess: 

```
^[[0mDEBUG   ^[[0m[U=1000,P=355]     NewBundle()                   Created temporary directory for bundle /tmp/sbuild-878156988
^[[34mINFO    ^[[0m[U=1000,P=355]     Full()                        Starting build...
^[[0mDEBUG   ^[[0m[U=1000,P=355]     Get()                         Reference: busybox
^[[0mDEBUG   ^[[0m[U=1000,P=355]     updateCacheSubdir()           Caching directory set to /home/vanessa/.singularity/cache/oci
Getting image source signatures
Skipping fetch of repeat blob sha256:697743189b6d255069caf6c455be10c7f8cae8076c6f94d224ae15cd41420e87
Copying config sha256:85dcb8c21e86b3e01a3a45fc932b31f5194c174d0a5d8a993381cc1fca749f40
^M 0 B / 575 B [-----------------------------------------------------------------]^M 575 B / 575 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
^[[0mDEBUG   ^[[0m[U=1000,P=355]     Full()                        Inserting Metadata
^[[0mDEBUG   ^[[0m[U=1000,P=355]     Full()                        Calling assembler
^[[34mINFO    ^[[0m[U=1000,P=355]     Assemble()                    Creating SIF file...
^[[34mINFO    ^[[0m[U=1000,P=355]     Full()                        Build complete: busybox_latest.sif
^[[0mDEBUG   ^[[0m[U=1000,P=355]     cleanUp()                     Build bundle cleanup: /tmp/sbuild-878156988
```
When we add the flag

```bash
$ singularity --debug --nocolor pull docker://busybox >& container.log
```
It's much cleaner.

```
WARNING [U=1000,P=316]     sylabsToken()                 Authentication token file not found : Only pulls of public images will succeed
DEBUG   [U=1000,P=316]     NewBundle()                   Created temporary directory for bundle /tmp/sbuild-751271701
INFO    [U=1000,P=316]     Full()                        Starting build...
DEBUG   [U=1000,P=316]     Get()                         Reference: busybox
DEBUG   [U=1000,P=316]     updateCacheSubdir()           Caching directory set to /home/vanessa/.singularity/cache/oci
Getting image source signatures
Skipping fetch of repeat blob sha256:697743189b6d255069caf6c455be10c7f8cae8076c6f94d224ae15cd41420e87
Copying config sha256:85dcb8c21e86b3e01a3a45fc932b31f5194c174d0a5d8a993381cc1fca749f40
^M 0 B / 575 B [-----------------------------------------------------------------]^M 575 B / 575 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
DEBUG   [U=1000,P=316]     Full()                        Inserting Metadata
DEBUG   [U=1000,P=316]     Full()                        Calling assembler
INFO    [U=1000,P=316]     Assemble()                    Creating SIF file...
INFO    [U=1000,P=316]     Full()                        Build complete: busybox_latest.sif
DEBUG   [U=1000,P=316]     cleanUp()                     Build bundle cleanup: /tmp/sbuild-751271701

```

## Points for discussion:

 - Naming of variables
 - If a boolean is appropriate (or something more similar to color=always)
 - If there are other spots in the code that color output that I didn't see?

**This fixes or addresses the following GitHub issues:**

- Fixes #2832 

Attn: @singularity-maintainers
