### PR TITLE
Fix URI usage with user namespace

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -63,6 +63,9 @@ func convertImage(filename string, unsquashfsPath string) (string, error) {
 	// keep compatibility with v2
 	tmpdir := os.Getenv("SINGULARITY_LOCALCACHEDIR")
 	if tmpdir == "" {
+		tmpdir = os.Getenv("SINGULARITY_CACHEDIR")
+	}
+	if tmpdir == "" {
 		pw, err := user.GetPwUID(uint32(os.Getuid()))
 		if err != nil {
 			return "", fmt.Errorf("could not find current user information: %s", err)

--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -77,7 +77,7 @@ func imageExec(t *testing.T, action string, opts opts, imagePath string, command
 		argv = append(argv, "--app", opts.app)
 	}
 	if opts.userns {
-		argv = append(args, "-u")
+		argv = append(argv, "-u")
 	}
 	argv = append(argv, imagePath)
 	argv = append(argv, command...)

--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -35,6 +35,7 @@ type opts struct {
 	pwd       string
 	app       string
 	overlay   []string
+	userns    bool
 }
 
 // imageExec can be used to run/exec/shell a Singularity image
@@ -74,6 +75,9 @@ func imageExec(t *testing.T, action string, opts opts, imagePath string, command
 	}
 	if opts.app != "" {
 		argv = append(argv, "--app", opts.app)
+	}
+	if opts.userns {
+		argv = append(args, "-u")
 	}
 	argv = append(argv, imagePath)
 	argv = append(argv, command...)
@@ -307,6 +311,13 @@ func testRunFromURI(t *testing.T) {
 		{"falseDocker", "docker://busybox:latest", "exec", []string{"false"}, opts{}, false},
 		{"falselibrary", "library://busybox:latest", "exec", []string{"false"}, opts{}, false},
 		{"falseShub", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{}, false},
+		// exec from URI with user namespace enabled
+		{"trueDockerUserns", "docker://busybox:latest", "exec", []string{"true"}, opts{userns: true}, true},
+		{"trueLibraryUserns", "library://busybox:latest", "exec", []string{"true"}, opts{userns: true}, true},
+		{"trueShubUserns", "shub://singularityhub/busybox", "exec", []string{"true"}, opts{userns: true}, true},
+		{"falseDockerUserns", "docker://busybox:latest", "exec", []string{"false"}, opts{userns: true}, false},
+		{"falselibraryUserns", "library://busybox:latest", "exec", []string{"false"}, opts{userns: true}, false},
+		{"falseShubUserns", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{userns: true}, false},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/engines/singularity/cleanup.go
+++ b/internal/pkg/runtime/engines/singularity/cleanup.go
@@ -25,6 +25,13 @@ import (
 func (engine *EngineOperations) CleanupContainer(fatal error, status syscall.WaitStatus) error {
 	sylog.Debugf("Cleanup container")
 
+	if engine.EngineConfig.GetDeleteImage() {
+		image := engine.EngineConfig.GetImage()
+		if err := os.RemoveAll(image); err != nil {
+			sylog.Errorf("failed to delete container image %s: %s", image, err)
+		}
+	}
+
 	if engine.EngineConfig.Network != nil {
 		if err := engine.EngineConfig.Network.DelNetworks(); err != nil {
 			sylog.Errorf("%s", err)

--- a/internal/pkg/runtime/engines/singularity/config/config.go
+++ b/internal/pkg/runtime/engines/singularity/config/config.go
@@ -90,6 +90,7 @@ type JSONConfig struct {
 	TargetUID     int           `json:"targetUID,omitempty"`
 	TargetGID     []int         `json:"targetGID,omitempty"`
 	LibrariesPath []string      `json:"librariesPath,omitempty"`
+	DeleteImage   bool          `json:"deleteImage,omitempty"`
 }
 
 // NewConfig returns singularity.EngineConfig with a parsed FileConfig
@@ -473,4 +474,14 @@ func (e *EngineConfig) SetLibrariesPath(libraries []string) {
 // /.singularity.d/libs directory
 func (e *EngineConfig) GetLibrariesPath() []string {
 	return e.JSON.LibrariesPath
+}
+
+// GetDeleteImage returns if container image must be deleted after use
+func (e *EngineConfig) GetDeleteImage() bool {
+	return e.JSON.DeleteImage
+}
+
+// SetDeleteImage sets if container image must be deleted after use
+func (e *EngineConfig) SetDeleteImage(delete bool) {
+	e.JSON.DeleteImage = delete
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a regression from v2 allowing user namespace to execute container directly from URI like :

```
singularity shell -u docker://busybox
```

**This fixes or addresses the following GitHub issues:**

- Fixes #2588

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
