### PR TITLE
fixing logger, adding default to no color given not the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _The old changelog can be found in the `release-2.6` branch_
 
   - Fixed usage docstrings for OCI - was missing "oci" in command examples.
   - Added --nocolor flag to Singularity client to disable color in logging
+  - writing to (non terminal) for stderr automatically disables color
 
 # v3.1.0 - [2019.02.22]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ _The old changelog can be found in the `release-2.6` branch_
 
   - Fixed usage docstrings for OCI - was missing "oci" in command examples.
   - Added --nocolor flag to Singularity client to disable color in logging
-  - writing to (non terminal) for stderr automatically disables color
 
 # v3.1.0 - [2019.02.22]
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/plugin"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/auth"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Global variables for singularity CLI
@@ -104,7 +105,9 @@ func setSylogMessageLevel(cmd *cobra.Command, args []string) {
 }
 
 func setSylogColor(cmd *cobra.Command, args []string) {
-	if nocolor {
+	// Disable color if nocolor flag, or NOT writing to terminal
+	fd := int(os.Stderr.Fd())
+	if nocolor || !terminal.IsTerminal(fd) {
 		sylog.DisableColor()
 	}
 }

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -163,10 +163,14 @@ func SetLevel(l int) {
 // DisableColor for the logger
 func DisableColor() {
 	messageColors = map[messageLevel]string{
-		fatal: "",
-		error: "",
-		warn:  "",
-		info:  "",
+		fatal:    "",
+		error:    "",
+		warn:     "",
+		info:     "",
+		verbose:  "",
+		verbose2: "",
+		verbose3: "",
+		debug:    "",
 	}
 	colorReset = ""
 }

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -38,7 +38,6 @@ func (l messageLevel) String() string {
 	if !ok {
 		str = "????"
 	}
-
 	return str
 }
 
@@ -166,6 +165,7 @@ func DisableColor() {
 		fatal:    "",
 		error:    "",
 		warn:     "",
+		log:      "",
 		info:     "",
 		verbose:  "",
 		verbose2: "",

--- a/internal/pkg/sylog/sylog_test.go
+++ b/internal/pkg/sylog/sylog_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 )
 
-// TestSylogSetLevel to ensure the correct integer is returned
-func TestSylogSetLevel(t *testing.T) {
+// TestSetLevel to ensure the correct integer is returned
+func TestSetLevel(t *testing.T) {
 	var levelTests = []struct {
 		name  string
 		level int
@@ -32,9 +32,7 @@ func TestSylogSetLevel(t *testing.T) {
 	for _, tt := range levelTests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetLevel(tt.level)
-
 			l := GetLevel()
-
 			if l != tt.level {
 				t.Errorf("got %d, want %d", l, tt.level)
 			}
@@ -42,8 +40,7 @@ func TestSylogSetLevel(t *testing.T) {
 	}
 }
 
-func TestSylogPrefix(t *testing.T) {
-
+func TestPrefix(t *testing.T) {
 	var logSuffix = "\x1b[0m "
 	var levelTests = []struct {
 		name  string
@@ -80,8 +77,7 @@ func TestSylogPrefix(t *testing.T) {
 	}
 }
 
-func TestSylogDisableColor(t *testing.T) {
-
+func TestDisableColor(t *testing.T) {
 	var logSuffix = "\x1b[0m "
 	var levelTests = []struct {
 		name  string
@@ -101,19 +97,19 @@ func TestSylogDisableColor(t *testing.T) {
 	// Disable all color output, removing prefix and off suffix
 	DisableColor()
 
-	// Test that prefix is colored
+	// Test that prefix is not colored
 	for _, tt := range levelTests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			SetLevel(int(tt.level))
 			levelPrefix := prefix(tt.level)
 
-			// Check that we start with the color prefix
+			// Check that we don't start with the color prefix
 			if !strings.HasPrefix(levelPrefix, tt.name) {
 				t.Errorf("got prefix %s, want %s", levelPrefix, tt.name)
 			}
 
-			// The suffix should be consistently the "off" color string
+			// The suffix should not contain the the "off" color string
 			if strings.HasSuffix(levelPrefix, logSuffix) && tt.level != debug {
 				t.Errorf("%s does ends with %s", levelPrefix, logSuffix)
 			}

--- a/internal/pkg/sylog/sylog_test.go
+++ b/internal/pkg/sylog/sylog_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build sylog
+
+package sylog
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSylogSetLevel to ensure the correct integer is returned
+func TestSylogSetLevel(t *testing.T) {
+	var levelTests = []struct {
+		name  string
+		level int
+	}{
+		{"SetLevelFatal", int(fatal)},
+		{"SetLevelError", int(error)},
+		{"SetLevelWarn", int(warn)},
+		{"SetLevelLog", int(log)},
+		{"SetLevelInfo", int(info)},
+		{"SetLevelVerbose", int(verbose)},
+		{"SetLevelVerbose2", int(verbose2)},
+		{"SetLevelVerbose3", int(verbose3)},
+		{"SetLevelDebug", int(debug)},
+	}
+
+	for _, tt := range levelTests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetLevel(tt.level)
+
+			l := GetLevel()
+
+			if l != tt.level {
+				t.Errorf("got %d, want %d", l, tt.level)
+			}
+		})
+	}
+}
+
+func TestSylogPrefix(t *testing.T) {
+
+	var logSuffix = "\x1b[0m "
+	var levelTests = []struct {
+		name  string
+		level messageLevel
+	}{
+		{"\x1b[31mFATAL", fatal},
+		{"\x1b[31mERROR", error},
+		{"\x1b[33mWARNING", warn},
+		{"\x1b[0mLOG", log},
+		{"\x1b[34mINFO", info},
+		{"\x1b[0mVERBOSE", verbose},
+		{"\x1b[0mVERBOSE", verbose2},
+		{"\x1b[0mVERBOSE", verbose3},
+		{"\x1b[0mDEBUG", debug},
+	}
+
+	// Test that prefix is colored
+	for _, tt := range levelTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			SetLevel(int(tt.level))
+			levelPrefix := prefix(tt.level)
+
+			// Check that we start with the color prefix
+			if !strings.HasPrefix(levelPrefix, tt.name) {
+				t.Errorf("got prefix %s, want %s", levelPrefix, tt.name)
+			}
+
+			// The suffix should be consistently the "off" color string
+			if !strings.HasSuffix(levelPrefix, logSuffix) && tt.level != debug {
+				t.Errorf("%s does not end with %s", levelPrefix, logSuffix)
+			}
+		})
+	}
+}
+
+func TestSylogDisableColor(t *testing.T) {
+
+	var logSuffix = "\x1b[0m "
+	var levelTests = []struct {
+		name  string
+		level messageLevel
+	}{
+		{"FATAL", fatal},
+		{"ERROR", error},
+		{"WARNING", warn},
+		{"LOG", log},
+		{"INFO", info},
+		{"VERBOSE", verbose},
+		{"VERBOSE", verbose2},
+		{"VERBOSE", verbose3},
+		{"DEBUG", debug},
+	}
+
+	// Disable all color output, removing prefix and off suffix
+	DisableColor()
+
+	// Test that prefix is colored
+	for _, tt := range levelTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			SetLevel(int(tt.level))
+			levelPrefix := prefix(tt.level)
+
+			// Check that we start with the color prefix
+			if !strings.HasPrefix(levelPrefix, tt.name) {
+				t.Errorf("got prefix %s, want %s", levelPrefix, tt.name)
+			}
+
+			// The suffix should be consistently the "off" color string
+			if strings.HasSuffix(levelPrefix, logSuffix) && tt.level != debug {
+				t.Errorf("%s does ends with %s", levelPrefix, logSuffix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

**Description of the Pull Request (PR):**

This pull request will detect if the user is not directing output to the terminal, and if not, disable color automatically. It also fixes a bug that @bauerm97 and I overlooked of missing a few of the message levels! Specifically this part:

```go
// DisableColor for the logger
func DisableColor() {
	messageColors = map[messageLevel]string{
		fatal:    "",
		error:    "",
		warn:     "",
		info:     "",
	}
	colorReset = ""
}
```

was missing levels!

```go
// DisableColor for the logger
func DisableColor() {
	messageColors = map[messageLevel]string{
		fatal:    "",
		error:    "",
		warn:     "",
		info:     "",
		verbose:  "",
		verbose2: "",
		verbose3: "",
		debug:    "",
	}
	colorReset = ""
}
```

Thus the debug still had weird characters with the flag.

Attn: @singularity-maintainers
