### PR TITLE
fixing bind warning / fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _The old changelog can be found in the `release-2.6` branch_
 
   - Fixed usage docstrings for OCI - was missing "oci" in command examples.
   - Added --nocolor flag to Singularity client to disable color in logging
+  - Repeated binds does not exit and fail, just issues warning
 
 # v3.1.0 - [2019.02.22]
 

--- a/internal/pkg/runtime/engines/singularity/container.go
+++ b/internal/pkg/runtime/engines/singularity/container.go
@@ -1332,11 +1332,14 @@ func (c *container) addUserbindsMount(system *mount.System) error {
 
 		sylog.Debugf("Adding %s to mount list\n", src)
 
-		if err := system.Points.AddBind(mount.UserbindsTag, src, dst, flags); err != nil {
+		if err := system.Points.AddBind(mount.UserbindsTag, src, dst, flags); err != nil && err == mount.ErrMountExists {
+			sylog.Warningf("destination %s already in mount list: %s", src, err)
+		} else if err != nil {
 			return fmt.Errorf("unable to add %s to mount list: %s", src, err)
+		} else {
+			system.Points.AddRemount(mount.UserbindsTag, dst, flags)
+			flags &^= syscall.MS_RDONLY
 		}
-		system.Points.AddRemount(mount.UserbindsTag, dst, flags)
-		flags &^= syscall.MS_RDONLY
 	}
 
 	sylog.Debugf("Checking for 'user bind control' in configuration file")

--- a/internal/pkg/util/fs/mount/mount.go
+++ b/internal/pkg/util/fs/mount/mount.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -339,7 +340,9 @@ func (p *Points) add(tag AuthorizedTag, source string, dest string, fstype strin
 			}
 		}
 		if present {
-			return fmt.Errorf("destination %s is already in the mount point list", dest)
+			sylog.Warningf("destination %s is already in the mount point list", dest)
+			return nil
+
 		}
 		if len(p.points[tag]) == 1 && !authorizedTags[tag].multiPoint {
 			return fmt.Errorf("tag %s allow only one mount point", tag)

--- a/internal/pkg/util/fs/mount/mount.go
+++ b/internal/pkg/util/fs/mount/mount.go
@@ -349,8 +349,8 @@ func (p *Points) add(tag AuthorizedTag, source string, dest string, fstype strin
 		}
 		if present {
 			return ErrMountExists
-
 		}
+
 		if len(p.points[tag]) == 1 && !authorizedTags[tag].multiPoint {
 			return fmt.Errorf("tag %s allow only one mount point", tag)
 		}

--- a/internal/pkg/util/fs/mount/mount.go
+++ b/internal/pkg/util/fs/mount/mount.go
@@ -11,10 +11,18 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type mountError string
+
+func (e mountError) Error() string { return string(e) }
+
+const (
+	// ErrMountExists indicates a duplicated mount being asked for
+	ErrMountExists = mountError("destination is already in the mount point list")
 )
 
 var mountFlags = []struct {
@@ -340,8 +348,7 @@ func (p *Points) add(tag AuthorizedTag, source string, dest string, fstype strin
 			}
 		}
 		if present {
-			sylog.Warningf("destination %s is already in the mount point list", dest)
-			return nil
+			return ErrMountExists
 
 		}
 		if len(p.points[tag]) == 1 && !authorizedTags[tag].multiPoint {
@@ -520,6 +527,7 @@ func (p *Points) Import(points map[AuthorizedTag][]Point) error {
 			if err = p.AddImage(tag, point.Source, point.Destination, point.Type, flags, offset, sizelimit); err == nil {
 				continue
 			}
+
 			// check if this is a filesystem or overlay mount point
 			if point.Type != "overlay" {
 				if err = p.AddFSWithSource(tag, point.Source, point.Destination, point.Type, flags, strings.Join(options, ",")); err == nil {

--- a/internal/pkg/util/fs/mount/mount_test.go
+++ b/internal/pkg/util/fs/mount/mount_test.go
@@ -59,8 +59,10 @@ func TestImage(t *testing.T) {
 	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", 0, 0, 0); err == nil {
 		t.Errorf("should have failed with 0 size limit")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10); err != nil {
-		t.Errorf("should have issued warning with destination already in list")
+	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10); err == nil {
+		t.Errorf("nil error returned, should have returned non-nil mount.ErrMountExists")
+	} else if err != nil && err != mount.ErrMountExists {
+		t.Errorf("non-nil error should have been mount.ErrMountExists")
 	}
 	points.RemoveAll()
 

--- a/internal/pkg/util/fs/mount/mount_test.go
+++ b/internal/pkg/util/fs/mount/mount_test.go
@@ -61,7 +61,7 @@ func TestImage(t *testing.T) {
 	}
 	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10); err == nil {
 		t.Errorf("nil error returned, should have returned non-nil mount.ErrMountExists")
-	} else if err != nil && err != mount.ErrMountExists {
+	} else if err != nil && err != ErrMountExists {
 		t.Errorf("non-nil error should have been mount.ErrMountExists")
 	}
 	points.RemoveAll()

--- a/internal/pkg/util/fs/mount/mount_test.go
+++ b/internal/pkg/util/fs/mount/mount_test.go
@@ -59,8 +59,8 @@ func TestImage(t *testing.T) {
 	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", 0, 0, 0); err == nil {
 		t.Errorf("should have failed with 0 size limit")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10); err == nil {
-		t.Errorf("should have failed with destination already in list")
+	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10); err != nil {
+		t.Errorf("should have issued warning with destination already in list")
 	}
 	points.RemoveAll()
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This pull request will address the issue that if a user defines the same bind point twice, the (current) implementation will fail. Instead, we can skip and give the user a warning of a repeated bind:

```bash
$ singularity shell --bind /tmp --bind /tmp docker://busybox
WARNING: destination /tmp is already in the mount point list
Singularity> 
```

**This fixes or addresses the following GitHub issues:**

- Fixes #1469 


Attn: @singularity-maintainers
