### PR TITLE
Add missing DisableColor when building without +sylog

### DIFF
--- a/internal/pkg/sylog/sylog_dummy.go
+++ b/internal/pkg/sylog/sylog_dummy.go
@@ -38,6 +38,9 @@ func Debugf(format string, a ...interface{}) {}
 // SetLevel is a dummy function doing nothing.
 func SetLevel(l int) {}
 
+// DisableColor for the logger
+func DisableColor() {}
+
 // GetLevel is a dummy function returning lowest message level.
 func GetLevel() int {
 	return int(-1)


### PR DESCRIPTION
When building without the sylog tag, the build is broken because the
sylog package is missing the new DisableColor color function. This
causes, among other things, guru to stop working.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>