### PR TITLE
Deprecate Sylabs Tokenfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.1.0
 
+## New Commands
+- Introduced the `remote` command group to support management of SCS endpoints:
+    - `add`     Create a new SCS remote endpoint
+    - `list`    List all remote endpoints that are configured
+    - `login`   Log into a remote endpoint using an authentication token
+    - `remove`  Remove an existing SCS remote endpoint
+    - `status`  Check the status of the services at an endpoint
+    - `use`     Set a remote endpoint to be used by default
+
+## New features / functionalities
   - Fixed usage docstrings for OCI - was missing "oci" in command examples.
   - Added --nocolor flag to Singularity client to disable color in logging
   - Repeated binds does not exit and fail, just issues warning

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -78,6 +78,7 @@ func init() {
 	SingularityCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress normal output")
 	SingularityCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print additional information")
 	SingularityCmd.Flags().StringVarP(&tokenFile, "tokenfile", "t", defaultTokenFile, "path to the file holding your sylabs authentication token")
+	SingularityCmd.Flags().MarkDeprecated("tokenfile", "Use 'singularity remote' to manage remote endpoints and tokens.")
 
 	VersionCmd.Flags().SetInterspersed(false)
 	SingularityCmd.AddCommand(VersionCmd)
@@ -203,8 +204,8 @@ func sylabsToken(cmd *cobra.Command, args []string) {
 	if authToken == "" {
 		authToken, authWarning = auth.ReadToken(defaultTokenFile)
 	}
-	if authToken == "" && authWarning == auth.WarningTokenFileNotFound {
-		sylog.Warningf("%v : Only pulls of public images will succeed", authWarning)
+	if authToken != "" {
+		sylog.Warningf("sylabs-token files are deprecated. Use 'singularity remote' to manage remote endpoints and tokens.")
 	}
 }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Adds message to `--tokenfile` flag
- Adds a warning when a `tokenfile` is used, including one at the default location.
- Adds `remotes` command to change log

**This fixes or addresses the following GitHub issues:**

- Related to #2774


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
