### PR TITLE
Run gofmt -s on a few files that can be simplified

### DIFF
--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -250,11 +250,11 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Files: []FilePair{
-				FilePair{
+				{
 					Src: tmpfile.Name(),
 					Dst: "NewName2.txt",
 				},
-				FilePair{
+				{
 					Src: tmpfile.Name(),
 					Dst: "NewName.txt",
 				},
@@ -330,7 +330,7 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Apps: []AppDetail{
-				AppDetail{
+				{
 					Name: "foo",
 					Help: []string{
 						"foo help info line 1",
@@ -338,7 +338,7 @@ func TestBuildDefinition(t *testing.T) {
 						"foo help info line 3",
 					},
 				},
-				AppDetail{
+				{
 					Name: "bar",
 					Help: []string{
 						"bar help info line 1",
@@ -352,7 +352,7 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Apps: []AppDetail{
-				AppDetail{
+				{
 					Name: "foo",
 					Env: []string{
 						"testvar1=fooOne",
@@ -360,7 +360,7 @@ func TestBuildDefinition(t *testing.T) {
 						"testvar3=fooThree",
 					},
 				},
-				AppDetail{
+				{
 					Name: "bar",
 					Env: []string{
 						"testvar1=barOne",
@@ -374,7 +374,7 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Apps: []AppDetail{
-				AppDetail{
+				{
 					Name: "foo",
 					Labels: map[string]string{
 						"customLabel1": "fooOne",
@@ -382,7 +382,7 @@ func TestBuildDefinition(t *testing.T) {
 						"customLabel3": "fooThree",
 					},
 				},
-				AppDetail{
+				{
 					Name: "bar",
 					Labels: map[string]string{
 						"customLabel1": "barOne",
@@ -396,27 +396,27 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Apps: []AppDetail{
-				AppDetail{
+				{
 					Name: "foo",
 					Files: []FilePair{
-						FilePair{
+						{
 							Src: tmpfile.Name(),
 							Dst: "FooFile2.txt",
 						},
-						FilePair{
+						{
 							Src: tmpfile.Name(),
 							Dst: "FooFile.txt",
 						},
 					},
 				},
-				AppDetail{
+				{
 					Name: "bar",
 					Files: []FilePair{
-						FilePair{
+						{
 							Src: tmpfile.Name(),
 							Dst: "BarFile2.txt",
 						},
-						FilePair{
+						{
 							Src: tmpfile.Name(),
 							Dst: "BarFile.txt",
 						},
@@ -428,13 +428,13 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Apps: []AppDetail{
-				AppDetail{
+				{
 					Name: "foo",
 					Install: []string{
 						"FooInstallFile1",
 					},
 				},
-				AppDetail{
+				{
 					Name: "bar",
 					Install: []string{
 						"BarInstallFile1",
@@ -446,7 +446,7 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Apps: []AppDetail{
-				AppDetail{
+				{
 					Name: "foo",
 					Run: []string{
 						"echo foo runscript line 1",
@@ -454,7 +454,7 @@ func TestBuildDefinition(t *testing.T) {
 						"echo foo runscript line 3",
 					},
 				},
-				AppDetail{
+				{
 					Name: "bar",
 					Run: []string{
 						"echo bar runscript line 1",
@@ -468,7 +468,7 @@ func TestBuildDefinition(t *testing.T) {
 			Bootstrap: "docker",
 			From:      "alpine:latest",
 			Apps: []AppDetail{
-				AppDetail{
+				{
 					Name: "foo",
 					Test: []string{
 						"echo foo testscript line 1",
@@ -476,7 +476,7 @@ func TestBuildDefinition(t *testing.T) {
 						"echo foo testscript line 3",
 					},
 				},
-				AppDetail{
+				{
 					Name: "bar",
 					Test: []string{
 						"echo bar testscript line 1",

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -17,7 +17,7 @@ import (
 var remoteConfig = Config{
 	DefaultRemote: "",
 	Remotes: map[string]*EndPoint{
-		"cloud": &EndPoint{
+		"cloud": {
 			URI:   "cloud.sylabs.io",
 			Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 		},
@@ -39,23 +39,23 @@ type writeReadTest struct {
 
 func TestWriteToReadFrom(t *testing.T) {
 	testsPass := []writeReadTest{
-		writeReadTest{
+		{
 			name: "empty config",
 			c: Config{
 				DefaultRemote: "",
 				Remotes:       map[string]*EndPoint{},
 			},
 		},
-		writeReadTest{
+		{
 			name: "config with stuff",
 			c: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -105,7 +105,7 @@ type remoteTest struct {
 
 func TestAddRemote(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "add remote to empty config",
 			old: Config{
 				Remotes: map[string]*EndPoint{},
@@ -113,7 +113,7 @@ func TestAddRemote(t *testing.T) {
 			new: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -125,12 +125,12 @@ func TestAddRemote(t *testing.T) {
 				Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 			},
 		},
-		remoteTest{
+		{
 			name: "add remote to non-empty config",
 			old: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -139,11 +139,11 @@ func TestAddRemote(t *testing.T) {
 			new: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -174,7 +174,7 @@ func TestAddRemote(t *testing.T) {
 		old: Config{
 			DefaultRemote: "",
 			Remotes: map[string]*EndPoint{
-				"cloud": &EndPoint{
+				"cloud": {
 					URI:   "cloud.sylabs.io",
 					Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 				},
@@ -196,12 +196,12 @@ func TestAddRemote(t *testing.T) {
 
 func TestRemoveRemote(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "remove remote to make empty config",
 			old: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -212,16 +212,16 @@ func TestRemoveRemote(t *testing.T) {
 			},
 			id: "cloud",
 		},
-		remoteTest{
+		{
 			name: "remove remote to make non-empty config",
 			old: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -230,7 +230,7 @@ func TestRemoveRemote(t *testing.T) {
 			new: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -270,12 +270,12 @@ func TestRemoveRemote(t *testing.T) {
 
 func TestRenameRemote(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "rename remote not default",
 			old: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -284,7 +284,7 @@ func TestRenameRemote(t *testing.T) {
 			new: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"newCloud": &EndPoint{
+					"newCloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -293,16 +293,16 @@ func TestRenameRemote(t *testing.T) {
 			id:    "cloud",
 			newID: "newCloud",
 		},
-		remoteTest{
+		{
 			name: "rename remote when it's default",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -311,11 +311,11 @@ func TestRenameRemote(t *testing.T) {
 			new: Config{
 				DefaultRemote: "newCloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"newCloud": &EndPoint{
+					"newCloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -339,7 +339,7 @@ func TestRenameRemote(t *testing.T) {
 	}
 
 	testsFail := []remoteTest{
-		remoteTest{
+		{
 			name: "rename non-existent remote",
 			old: Config{
 				DefaultRemote: "",
@@ -349,7 +349,7 @@ func TestRenameRemote(t *testing.T) {
 			newID: "newCloud",
 		},
 
-		remoteTest{
+		{
 			name: "rename existing remote to existing remote",
 			old: Config{
 				DefaultRemote: "",
@@ -359,16 +359,16 @@ func TestRenameRemote(t *testing.T) {
 			newID: "newCloud",
 		},
 
-		remoteTest{
+		{
 			name: "default does not exist",
 			old: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -389,16 +389,16 @@ func TestRenameRemote(t *testing.T) {
 
 func TestGetRemote(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "get existing remote",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -427,12 +427,12 @@ func TestGetRemote(t *testing.T) {
 	}
 
 	testsFail := []remoteTest{
-		remoteTest{
+		{
 			name: "remote does not exist",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -452,16 +452,16 @@ func TestGetRemote(t *testing.T) {
 
 func TestGetDefaultRemote(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "get existing default remote",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -489,28 +489,28 @@ func TestGetDefaultRemote(t *testing.T) {
 	}
 
 	testsFail := []remoteTest{
-		remoteTest{
+		{
 			name: "no default set",
 			old: Config{
 				DefaultRemote: "",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
 				},
 			},
 		},
-		remoteTest{
+		{
 			name: "default does not exist",
 			old: Config{
 				DefaultRemote: "notaremote",
 				Remotes: map[string]*EndPoint{
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -529,16 +529,16 @@ func TestGetDefaultRemote(t *testing.T) {
 
 func TestSetDefaultRemote(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "set existing remote to default",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -547,11 +547,11 @@ func TestSetDefaultRemote(t *testing.T) {
 			new: Config{
 				DefaultRemote: "random",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -574,12 +574,12 @@ func TestSetDefaultRemote(t *testing.T) {
 	}
 
 	testsFail := []remoteTest{
-		remoteTest{
+		{
 			name: "default does not exist",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -599,16 +599,16 @@ func TestSetDefaultRemote(t *testing.T) {
 
 func TestGetServiceURI(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "get uri from real cloud remote",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -633,16 +633,16 @@ func TestGetServiceURI(t *testing.T) {
 	}
 
 	testsFail := []remoteTest{
-		remoteTest{
+		{
 			name: "get uri from non-existent remote",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"notaremote": &EndPoint{
+					"notaremote": {
 						URI:   "not.a.remote",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -669,16 +669,16 @@ func TestGetServiceURI(t *testing.T) {
 
 func TestGetAllServiceURIs(t *testing.T) {
 	testsPass := []remoteTest{
-		remoteTest{
+		{
 			name: "get uris from real cloud remote",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"random": &EndPoint{
+					"random": {
 						URI:   "cloud.random.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
@@ -703,16 +703,16 @@ func TestGetAllServiceURIs(t *testing.T) {
 	}
 
 	testsFail := []remoteTest{
-		remoteTest{
+		{
 			name: "get uri from non-existent remote",
 			old: Config{
 				DefaultRemote: "cloud",
 				Remotes: map[string]*EndPoint{
-					"notaremote": &EndPoint{
+					"notaremote": {
 						URI:   "not.a.remote",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},
-					"cloud": &EndPoint{
+					"cloud": {
 						URI:   "cloud.sylabs.io",
 						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
 					},

--- a/pkg/util/capabilities/config_test.go
+++ b/pkg/util/capabilities/config_test.go
@@ -23,23 +23,23 @@ type readWriteTest struct {
 
 func TestReadFromWriteTo(t *testing.T) {
 	testsPass := []readWriteTest{
-		readWriteTest{
+		{
 			name: "empty config",
 			c: Config{
 				Users:  map[string][]string{},
 				Groups: map[string][]string{},
 			},
 		},
-		readWriteTest{
+		{
 			name: "config with stuff",
 			c: Config{
 				Users: map[string][]string{
-					"user1": []string{"CAP_SYS_ADMIN"},
-					"user2": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+					"user1": {"CAP_SYS_ADMIN"},
+					"user2": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 				},
 				Groups: map[string][]string{
-					"user1": []string{"CAP_SYS_ADMIN"},
-					"user2": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+					"user1": {"CAP_SYS_ADMIN"},
+					"user2": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 				},
 			},
 		},
@@ -104,62 +104,62 @@ type capTest struct {
 
 func TestAddUserCaps(t *testing.T) {
 	testsPass := []capTest{
-		capTest{
+		{
 			name: "add existing user single cap",
 			old: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 				},
 			},
 			id:   "root",
 			caps: []string{"CAP_DAC_OVERRIDE"},
 		},
-		capTest{
+		{
 			name: "add existing user multiple caps",
 			old: Config{
 				Users: map[string][]string{
-					"user1": []string{"CAP_SYS_ADMIN"},
+					"user1": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"user1": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"user1": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			id:   "user1",
 			caps: []string{"CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 		},
-		capTest{
+		{
 			name: "add new user",
 			old: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"root":  []string{"CAP_SYS_ADMIN"},
-					"user1": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"root":  {"CAP_SYS_ADMIN"},
+					"user1": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			id:   "user1",
 			caps: []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 		},
-		capTest{
+		{
 			name: "add duplicate cap",
 			old: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			id:   "root",
@@ -183,12 +183,12 @@ func TestAddUserCaps(t *testing.T) {
 		name: "add bad cap fail",
 		old: Config{
 			Users: map[string][]string{
-				"root": []string{"CAP_SYS_ADMIN"},
+				"root": {"CAP_SYS_ADMIN"},
 			},
 		},
 		new: Config{
 			Users: map[string][]string{
-				"root": []string{"CAP_SYS_ADMIN"},
+				"root": {"CAP_SYS_ADMIN"},
 			},
 		},
 		id:   "root",
@@ -204,62 +204,62 @@ func TestAddUserCaps(t *testing.T) {
 
 func TestAddGroupCaps(t *testing.T) {
 	testsPass := []capTest{
-		capTest{
+		{
 			name: "add existing group single cap",
 			old: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 				},
 			},
 			id:   "root",
 			caps: []string{"CAP_DAC_OVERRIDE"},
 		},
-		capTest{
+		{
 			name: "add existing group multiple caps",
 			old: Config{
 				Groups: map[string][]string{
-					"group1": []string{"CAP_SYS_ADMIN"},
+					"group1": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"group1": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"group1": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			id:   "group1",
 			caps: []string{"CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 		},
-		capTest{
+		{
 			name: "add new group",
 			old: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"root":   []string{"CAP_SYS_ADMIN"},
-					"group1": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"root":   {"CAP_SYS_ADMIN"},
+					"group1": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			id:   "group1",
 			caps: []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 		},
-		capTest{
+		{
 			name: "add duplicate cap",
 			old: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			id:   "root",
@@ -283,12 +283,12 @@ func TestAddGroupCaps(t *testing.T) {
 		name: "add bad cap fail",
 		old: Config{
 			Groups: map[string][]string{
-				"root": []string{"CAP_SYS_ADMIN"},
+				"root": {"CAP_SYS_ADMIN"},
 			},
 		},
 		new: Config{
 			Groups: map[string][]string{
-				"root": []string{"CAP_SYS_ADMIN"},
+				"root": {"CAP_SYS_ADMIN"},
 			},
 		},
 		id:   "root",
@@ -304,46 +304,46 @@ func TestAddGroupCaps(t *testing.T) {
 
 func TestDropUserCaps(t *testing.T) {
 	testsPass := []capTest{
-		capTest{
+		{
 			name: "drop existing user single cap",
 			old: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "root",
 			caps: []string{"CAP_DAC_OVERRIDE"},
 		},
-		capTest{
+		{
 			name: "drop existing user multiple caps",
 			old: Config{
 				Users: map[string][]string{
-					"user1": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"user1": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"user1": []string{"CAP_SYS_ADMIN"},
+					"user1": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "user1",
 			caps: []string{"CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 		},
-		capTest{
+		{
 			name: "drop duplicate cap",
 			old: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"root": []string{},
+					"root": {},
 				},
 			},
 			id:   "root",
@@ -364,31 +364,31 @@ func TestDropUserCaps(t *testing.T) {
 	}
 
 	testsFail := []capTest{
-		capTest{
+		{
 			name: "drop bad cap fail",
 			old: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "root",
 			caps: []string{"CAP_BAD_WRONG_INCORRECT_BAD"},
 		},
-		capTest{
+		{
 			name: "drop bad user fail",
 			old: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Users: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "non_existent_user",
@@ -407,46 +407,46 @@ func TestDropUserCaps(t *testing.T) {
 
 func TestDropGroupCaps(t *testing.T) {
 	testsPass := []capTest{
-		capTest{
+		{
 			name: "drop existing group single cap",
 			old: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "root",
 			caps: []string{"CAP_DAC_OVERRIDE"},
 		},
-		capTest{
+		{
 			name: "drop existing group multiple caps",
 			old: Config{
 				Groups: map[string][]string{
-					"group1": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"group1": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"group1": []string{"CAP_SYS_ADMIN"},
+					"group1": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "group1",
 			caps: []string{"CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 		},
-		capTest{
+		{
 			name: "drop duplicate cap",
 			old: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
+					"root": {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"root": []string{},
+					"root": {},
 				},
 			},
 			id:   "root",
@@ -467,31 +467,31 @@ func TestDropGroupCaps(t *testing.T) {
 	}
 
 	testsFail := []capTest{
-		capTest{
+		{
 			name: "drop bad cap fail",
 			old: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "root",
 			caps: []string{"CAP_BAD_WRONG_INCORRECT_BAD"},
 		},
-		capTest{
+		{
 			name: "drop bad group fail",
 			old: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			new: Config{
 				Groups: map[string][]string{
-					"root": []string{"CAP_SYS_ADMIN"},
+					"root": {"CAP_SYS_ADMIN"},
 				},
 			},
 			id:   "non_existent_group",
@@ -511,12 +511,12 @@ func TestDropGroupCaps(t *testing.T) {
 func TestListCaps(t *testing.T) {
 	conf := Config{
 		Users: map[string][]string{
-			"root":  []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
-			"user1": []string{"CAP_CHOWN"},
+			"root":  {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+			"user1": {"CAP_CHOWN"},
 		},
 		Groups: map[string][]string{
-			"root":  []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
-			"user2": []string{"CAP_CHOWN"},
+			"root":  {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+			"user2": {"CAP_CHOWN"},
 		},
 	}
 
@@ -546,31 +546,31 @@ type capCheckTest struct {
 func TestCheckCaps(t *testing.T) {
 	conf := Config{
 		Users: map[string][]string{
-			"root":  []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
-			"user1": []string{"CAP_CHOWN", "CAP_SYS_ADMIN"},
-			"user2": []string{},
+			"root":  {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+			"user1": {"CAP_CHOWN", "CAP_SYS_ADMIN"},
+			"user2": {},
 		},
 		Groups: map[string][]string{
-			"root":  []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
-			"user1": []string{"CAP_CHOWN", "CAP_SYS_ADMIN"},
-			"user2": []string{},
+			"root":  {"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
+			"user1": {"CAP_CHOWN", "CAP_SYS_ADMIN"},
+			"user2": {},
 		},
 	}
 
 	testsPass := []capCheckTest{
-		capCheckTest{
+		{
 			name:       "check multiple authorized",
 			id:         "root",
 			caps:       []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 			authorized: []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 		},
-		capCheckTest{
+		{
 			name:         "check multiple unauthorized",
 			id:           "user2",
 			caps:         []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 			unauthorized: []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},
 		},
-		capCheckTest{
+		{
 			name:         "check multiple authorized & unauthorized",
 			id:           "user1",
 			caps:         []string{"CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE"},


### PR DESCRIPTION
The simplifications are all of the form:

	[]T{T{...}, T{...}, ...}

to

	[]T{{...}, {...}, ...}

In other words, when you have an array of a particular type, you don't
need to name the type for every single element of the array.

The resulting code is less cluttered and easier to read.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>