### PR TITLE
Clean up imports using goimports

### DIFF
--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/sylabs/singularity/cmd/internal/cli"

--- a/cmd/internal/cli/cache_linux.go
+++ b/cmd/internal/cli/cache_linux.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 )

--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/client/library"
+	client "github.com/sylabs/singularity/pkg/client/library"
 )
 
 var (

--- a/internal/pkg/build/remotebuilder/remotebuilder.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder.go
@@ -18,11 +18,11 @@ import (
 	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
-	"github.com/sylabs/json-resp"
+	jsonresp "github.com/sylabs/json-resp"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
-	"github.com/sylabs/singularity/pkg/client/library"
-	"github.com/sylabs/singularity/pkg/util/user-agent"
+	client "github.com/sylabs/singularity/pkg/client/library"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 // CloudURI holds the URI of the Library web front-end.

--- a/internal/pkg/build/remotebuilder/remotebuilder_test.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder_test.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/websocket"
-	"github.com/sylabs/json-resp"
+	jsonresp "github.com/sylabs/json-resp"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/pkg/build/types"
-	"github.com/sylabs/singularity/pkg/util/user-agent"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 const (

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
-	"github.com/sylabs/singularity/pkg/client/shub"
+	shub "github.com/sylabs/singularity/pkg/client/shub"
 )
 
 // ShubConveyorPacker only needs to hold the conveyor to have the needed data to pack
@@ -40,7 +40,7 @@ func (cp *ShubConveyorPacker) Get(b *types.Bundle) (err error) {
 	cp.b.FSObjects["shubImg"] = f.Name()
 
 	// get image from singularity hub
-	if err = client.DownloadImage(cp.b.FSObjects["shubImg"], src, true, cp.b.Opts.NoHTTPS); err != nil {
+	if err = shub.DownloadImage(cp.b.FSObjects["shubImg"], src, true, cp.b.Opts.NoHTTPS); err != nil {
 		sylog.Fatalf("failed to Get from %s: %v\n", src, err)
 	}
 

--- a/pkg/client/library/api.go
+++ b/pkg/client/library/api.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/util/user-agent"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 // HTTP timeout in seconds

--- a/pkg/client/library/push.go
+++ b/pkg/client/library/push.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/util/user-agent"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 	"gopkg.in/cheggaaa/pb.v1"
 )
 

--- a/pkg/client/net/pull.go
+++ b/pkg/client/net/pull.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/util/user-agent"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 	"gopkg.in/cheggaaa/pb.v1"
 )
 

--- a/pkg/client/shub/api.go
+++ b/pkg/client/shub/api.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/util/user-agent"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 const (


### PR DESCRIPTION
goimports will rewrite some imports to conform to recommended style. In
this cases a couple kicked in (std library first, followed by a blank
line; explicitly naming imports if the package name does not match the
last element of the import path).

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>