### PR TITLE
Fix ineffective assignments as reported by ineffassign

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -455,6 +455,10 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		}
 
 		cmd, err := exec.PipeCommand(starter, []string{procname}, Env, configData)
+		if err != nil {
+			sylog.Warningf("failed to prepare command: %s", err)
+		}
+
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -51,6 +51,10 @@ func doKeyImportCmd(path string) error {
 
 	// If the block does not correspond to any of public ot private type return error
 	block, err := armor.Decode(f)
+	if err != nil {
+		return err
+	}
+
 	if block.Type != PublicKeyType && block.Type != PrivateKeyType {
 		return errors.InvalidArgumentError("expected public or private key block, got: " + block.Type)
 	}

--- a/internal/app/singularity/oci_create_linux.go
+++ b/internal/app/singularity/oci_create_linux.go
@@ -83,6 +83,9 @@ func OciCreate(containerID string, args *OciArgs) error {
 
 	procName := fmt.Sprintf("Singularity OCI %s", containerID)
 	cmd, err := exec.PipeCommand(starter, []string{procName}, Env, configData)
+	if err != nil {
+		return err
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -521,6 +521,9 @@ func insertDefinition(b *types.Bundle) error {
 
 			// look at number of files in bootstrap_history to give correct file name
 			files, err := ioutil.ReadDir(filepath.Join(b.Rootfs(), "/.singularity.d/bootstrap_history"))
+			if err != nil {
+				return err
+			}
 
 			// name is "Singularity" concatenated with an index based on number of other files in bootstrap_history
 			len := strconv.Itoa(len(files))

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -106,6 +106,10 @@ func (cp *OCIConveyorPacker) Get(b *sytypes.Bundle) (err error) {
 			} else {
 				cp.srcRef, err = oci.ParseReference(tmpDir)
 			}
+
+			if err != nil {
+				return fmt.Errorf("error parsing reference: %v", err)
+			}
 		}
 
 	default:

--- a/internal/pkg/client/oci/oci.go
+++ b/internal/pkg/client/oci/oci.go
@@ -58,6 +58,9 @@ func (t *ImageReference) NewImageSource(ctx context.Context, sys *types.SystemCo
 func (t *ImageReference) newImageSource(ctx context.Context, sys *types.SystemContext, w io.Writer) (types.ImageSource, error) {
 	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
 	policyCtx, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return nil, err
+	}
 
 	// First we are fetching into the cache
 	err = copy.Image(context.Background(), policyCtx, t.ImageReference, t.source, &copy.Options{

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -94,7 +94,9 @@ func getPath(privileged bool, username string) (string, error) {
 	}
 
 	containerID, hostID, err := proc.ReadIDMap("/proc/self/uid_map")
-	if containerID == 0 && containerID != hostID {
+	if err != nil {
+		return path, err
+	} else if containerID == 0 && containerID != hostID {
 		if pw, err = user.GetPwUID(hostID); err != nil {
 			return path, err
 		}

--- a/internal/pkg/runtime/engines/oci/process_linux.go
+++ b/internal/pkg/runtime/engines/oci/process_linux.go
@@ -211,6 +211,9 @@ func (engine *EngineOperations) PreStartProcess(pid int, masterConn net.Conn, fa
 	}
 
 	file, err := instance.Get(engine.CommonConfig.ContainerID)
+	if err != nil {
+		return err
+	}
 	engine.EngineConfig.State.AttachSocket = filepath.Join(filepath.Dir(file.Path), "attach.sock")
 
 	attach, err := unix.CreateSocket(engine.EngineConfig.State.AttachSocket)

--- a/internal/pkg/runtime/engines/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engines/singularity/cleanup_linux.go
@@ -60,7 +60,7 @@ func (engine *EngineOperations) CleanupContainer(fatal error, status syscall.Wai
 			var err error
 
 			mainthread.Execute(func() {
-				if err := syscall.Setresuid(0, 0, uid); err != nil {
+				if err = syscall.Setresuid(0, 0, uid); err != nil {
 					err = fmt.Errorf("failed to escalate privileges")
 					return
 				}

--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -766,7 +766,6 @@ func (c *container) addOverlayMount(system *mount.System) error {
 			if err != nil {
 				return fmt.Errorf("while adding ext3 image: %s", err)
 			}
-			flags &^= syscall.MS_RDONLY
 		case image.SQUASHFS:
 			flags := uintptr(c.suidFlag | syscall.MS_NODEV | syscall.MS_RDONLY)
 			err = system.Points.AddImage(mount.PreLayerTag, src, dst, "squashfs", flags, offset, size)

--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -64,6 +64,10 @@ func (e *EngineOperations) prepareUserCaps() error {
 	}
 
 	groups, err := os.Getgroups()
+	if err != nil {
+		return err
+	}
+
 	for _, g := range groups {
 		gr, err := user.GetGrGID(uint32(g))
 		if err != nil {
@@ -141,7 +145,12 @@ func (e *EngineOperations) prepareRootCaps() error {
 		}
 
 		commonCaps = append(commonCaps, capConfig.ListUserCaps("root")...)
+
 		groups, err := os.Getgroups()
+		if err != nil {
+			return fmt.Errorf("while getting groups: %s", err)
+		}
+
 		for _, g := range groups {
 			gr, err := user.GetGrGID(uint32(g))
 			if err != nil {
@@ -587,6 +596,10 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 	}
 
 	link, err := mainthread.Readlink(imgObject.Source)
+	if err != nil {
+		return nil, err
+	}
+
 	if link != imgObject.Path {
 		return nil, fmt.Errorf("resolved path %s doesn't match with opened path %s", imgObject.Path, link)
 	}

--- a/internal/pkg/runtime/engines/singularity/process_linux.go
+++ b/internal/pkg/runtime/engines/singularity/process_linux.go
@@ -351,7 +351,7 @@ func (engine *EngineOperations) PostStartProcess(pid int) error {
 					err = fmt.Errorf("failed to escalate gid privileges")
 					return
 				}
-				if err := syscall.Setresuid(uid, uid, 0); err != nil {
+				if err = syscall.Setresuid(uid, uid, 0); err != nil {
 					err = fmt.Errorf("failed to escalate uid privileges")
 					return
 				}

--- a/internal/pkg/security/seccomp/seccomp_linux.go
+++ b/internal/pkg/security/seccomp/seccomp_linux.go
@@ -77,8 +77,6 @@ func Enabled() bool {
 
 // LoadSeccompConfig loads seccomp configuration filter for the current process
 func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool) error {
-	supportCondition := true
-
 	if err := prctl(syscall.PR_GET_SECCOMP, 0, 0, 0, 0); err == syscall.EINVAL {
 		return fmt.Errorf("can't load seccomp filter: not supported by kernel")
 	}
@@ -95,7 +93,7 @@ func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool) error {
 		return fmt.Errorf("a defaultAction must be provided")
 	}
 
-	supportCondition = hasConditionSupport()
+	supportCondition := hasConditionSupport()
 	if supportCondition == false {
 		sylog.Warningf("seccomp rule conditions are not supported with libseccomp under 2.2.1")
 	}

--- a/internal/pkg/util/auth/auth_test.go
+++ b/internal/pkg/util/auth/auth_test.go
@@ -21,12 +21,12 @@ func Test_ReadToken(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	result, w := ReadToken("/no/such/file")
+	result, _ := ReadToken("/no/such/file")
 	if result != "" {
 		t.Errorf("readToken from invalid file must give empty string")
 	}
 
-	result, w = ReadToken("test_data/test_token_toosmall")
+	_, w := ReadToken("test_data/test_token_toosmall")
 	if w != WarningTokenTooShort {
 		t.Errorf("readToken from file with bad (too small) token must give empty string")
 	}

--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -77,18 +77,18 @@ func TestHostname(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	content, err := Hostname("")
+	_, err := Hostname("")
 	if err == nil {
 		t.Errorf("should have failed with empty hostname")
 	}
-	content, err = Hostname("mycontainer")
+	content, err := Hostname("mycontainer")
 	if err != nil {
 		t.Errorf("should have passed with correct hostname")
 	}
 	if bytes.Compare(content, []byte("mycontainer\n")) != 0 {
 		t.Errorf("Hostname returns a bad content")
 	}
-	content, err = Hostname("bad|hostname")
+	_, err = Hostname("bad|hostname")
 	if err == nil {
 		t.Errorf("should have failed with non valid hostname")
 	}
@@ -98,15 +98,15 @@ func TestResolvConf(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	content, err := ResolvConf([]string{})
+	_, err := ResolvConf([]string{})
 	if err == nil {
 		t.Errorf("should have failed with empty dns")
 	}
-	content, err = ResolvConf([]string{"test"})
+	_, err = ResolvConf([]string{"test"})
 	if err == nil {
 		t.Errorf("should have failed with bad dns")
 	}
-	content, err = ResolvConf([]string{"8.8.8.8"})
+	content, err := ResolvConf([]string{"8.8.8.8"})
 	if err != nil {
 		t.Errorf("should have passed with valid dns")
 	}

--- a/internal/pkg/util/fs/files/group.go
+++ b/internal/pkg/util/fs/files/group.go
@@ -19,7 +19,7 @@ import (
 // updates content with current user information and returns content
 func Group(path string, uid int, gids []int) (content []byte, err error) {
 	duplicate := false
-	groups := make([]int, 0)
+	var groups []int
 
 	sylog.Verbosef("Checking for template group file: %s\n", path)
 	if fs.IsFile(path) == false {

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -191,17 +191,15 @@ func ConvertOptions(options []string) (uintptr, []string) {
 
 // ConvertSpec converts an OCI Mount spec into an importable mount points list
 func ConvertSpec(mounts []specs.Mount) (map[AuthorizedTag][]Point, error) {
-	var tag AuthorizedTag
-
 	points := make(map[AuthorizedTag][]Point)
 	for _, m := range mounts {
+		var tag AuthorizedTag
 		var options []string
 		var propagationOption string
 		var err error
 		source := m.Source
 		mountType := m.Type
 
-		tag = ""
 		if mountType != "" && mountType != "bind" && mountType != "none" {
 			if _, ok := authorizedFS[mountType]; !ok {
 				return points, fmt.Errorf("%s filesystem type is not authorized", mountType)

--- a/pkg/client/library/util_test.go
+++ b/pkg/client/library/util_test.go
@@ -288,12 +288,12 @@ func Test_imageHash(t *testing.T) {
 
 	expectedSha256 := "sha256.d7d356079af905c04e5ae10711ecf3f5b34385e9b143c5d9ddbf740665ce2fb7"
 
-	shasum, err := ImageHash("no_such_file.txt")
+	_, err := ImageHash("no_such_file.txt")
 	if err == nil {
 		t.Error("Invalid file must return an error")
 	}
 
-	shasum, err = ImageHash("test_data/test_sha256")
+	shasum, err := ImageHash("test_data/test_sha256")
 	if err != nil {
 		t.Errorf("ImageHash on valid file should not raise error: %v", err)
 	}
@@ -309,12 +309,12 @@ func Test_sha256sum(t *testing.T) {
 
 	expectedSha256 := "sha256.d7d356079af905c04e5ae10711ecf3f5b34385e9b143c5d9ddbf740665ce2fb7"
 
-	shasum, err := sha256sum("no_such_file.txt")
+	_, err := sha256sum("no_such_file.txt")
 	if err == nil {
 		t.Error("Invalid file must return an error")
 	}
 
-	shasum, err = sha256sum("test_data/test_sha256")
+	shasum, err := sha256sum("test_data/test_sha256")
 	if err != nil {
 		t.Errorf("sha256sum on valid file should not raise error: %v", err)
 	}

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -351,9 +351,8 @@ func (m *Setup) GetNetworkIP(network string, version string) (net.IP, error) {
 // with a network, if network is empty, the function returns interface
 // for the first configured network
 func (m *Setup) GetNetworkInterface(network string) (string, error) {
-	n := network
-	if n == "" && len(m.networkConfList) > 0 {
-		n = m.networkConfList[0].Name
+	if network == "" && len(m.runtimeConf) > 0 {
+		return m.runtimeConf[0].IfName, nil
 	}
 
 	for i := 0; i < len(m.networkConfList); i++ {

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -712,6 +712,9 @@ func serializeEntity(e *openpgp.Entity, blockType string) (string, error) {
 // PushPubkey pushes a public key to the Key Service.
 func PushPubkey(e *openpgp.Entity, keyserverURI, authToken string) error {
 	keyText, err := serializeEntity(e, openpgp.PublicKeyType)
+	if err != nil {
+		return err
+	}
 
 	// Get a Key Service client.
 	c, err := client.NewClient(&client.Config{

--- a/pkg/util/copy/buffer_test.go
+++ b/pkg/util/copy/buffer_test.go
@@ -33,7 +33,7 @@ func TestNewTerminalBuffer(t *testing.T) {
 	}
 
 	// Write content and end with a newline to clear buffer
-	n, err = ntb.Write([]byte("st\n"))
+	_, err = ntb.Write([]byte("st\n"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -159,7 +159,7 @@ func TestCountChilds(t *testing.T) {
 	if childs == 0 {
 		t.Fatal("init have no child processes")
 	}
-	childs, err = CountChilds(0)
+	_, err = CountChilds(0)
 	if err == nil {
 		t.Fatal("no error reported with PID 0")
 	}
@@ -271,7 +271,9 @@ func TestHasNamespace(t *testing.T) {
 	}
 
 	has, err = HasNamespace(cmd.Process.Pid, "pid")
-	if !has {
+	if err != nil {
+		t.Fatal(err)
+	} else if !has {
 		t.Errorf("pid namespace should be different")
 	}
 


### PR DESCRIPTION
There are assignments without any effect, for example:

	i := getValue(0)
	i = getValue(0)
	if i > 0 {
		// ...
	}

the first assignment has no effect because it's immediately overwritten
by the second assignment. In some cases this is done because there's a
side-effect to calling a function (in which case the value should be
discarded explictly), and in some cases it's an oversight.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>