### PR TITLE
Add golangci-lint to travis as a replacement for `go lint`

### DIFF
--- a/.travis/before_install
+++ b/.travis/before_install
@@ -4,7 +4,6 @@ if [ -z "$OS_TYPE" ]; then
     # default is ubuntu
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
-    go get -u golang.org/x/lint/golint
     exit
 fi
 

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -2,8 +2,8 @@
 
 if [ -z "$OS_TYPE" ]; then
     # default is ubuntu
-    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | /bin/sh
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | /bin/sh -s -- -b $(go env GOPATH)/bin v1.15.0
     exit
 fi
 

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -3,6 +3,7 @@
 if [ -z "$OS_TYPE" ]; then
     # default is ubuntu
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
     go get -u golang.org/x/lint/golint
     exit
 fi


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add golangci-lint to Travis CI builds as a replacement for `go lint`