### PR TITLE
Support SCS system-wide endpoint config

### DIFF
--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -124,7 +124,7 @@ var RemoteRemoveCmd = &cobra.Command{
 var RemoteUseCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteUse(remoteConfig, args[0]); err != nil {
+		if err := singularity.RemoteUse(remoteConfig, remoteConfigSys, args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -139,7 +139,7 @@ var RemoteUseCmd = &cobra.Command{
 var RemoteListCmd = &cobra.Command{
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteList(remoteConfig); err != nil {
+		if err := singularity.RemoteList(remoteConfig, remoteConfigSys); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -154,7 +154,7 @@ var RemoteListCmd = &cobra.Command{
 var RemoteLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteLogin(remoteConfig, args[0]); err != nil {
+		if err := singularity.RemoteLogin(remoteConfig, remoteConfigSys, args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -169,7 +169,7 @@ var RemoteLoginCmd = &cobra.Command{
 var RemoteStatusCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteStatus(remoteConfig, args[0]); err != nil {
+		if err := singularity.RemoteStatus(remoteConfig, remoteConfigSys, args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -6,26 +6,53 @@
 package cli
 
 import (
+	"os"
 	"os/user"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+)
+
+const (
+	fileName = "remote.yaml"
+	userDir  = ".singularity"
+	sysDir   = "singularity"
 )
 
 var (
 	remoteConfig string
+	global       bool
 )
+
+var (
+	remoteConfigUser string
+	remoteConfigSys  string
+)
+
+func addGlobalFlag(c *cobra.Command) {
+	c.Flags().BoolVarP(&global, "global", "g", false, "edit the list of globally configured remote endpoints")
+}
 
 func init() {
 	usr, err := user.Current()
 	if err != nil {
 		sylog.Fatalf("Couldn't determine user home directory: %v", err)
 	}
-	remoteConfig = filepath.Join(usr.HomeDir, ".singularity", "remote.yaml")
-	RemoteCmd.Flags().StringVarP(&remoteConfig, "config", "c", remoteConfig, "path to the file holding remote endpoint configurations")
+
+	// assemble values of remoteConfig for user/sys locations
+	remoteConfigUser = filepath.Join(usr.HomeDir, userDir, fileName)
+	remoteConfigSys = filepath.Join(buildcfg.SYSCONFDIR, sysDir, fileName)
+
+	// default location of the remote.yaml file is the user directory
+	RemoteCmd.Flags().StringVarP(&remoteConfig, "config", "c", remoteConfigUser, "path to the file holding remote endpoint configurations")
+
+	// add --global flag to remote add/remove commands
+	addGlobalFlag(RemoteAddCmd)
+	addGlobalFlag(RemoteRemoveCmd)
 
 	SingularityCmd.AddCommand(RemoteCmd)
 	RemoteCmd.AddCommand(RemoteAddCmd)
@@ -36,7 +63,7 @@ func init() {
 	RemoteCmd.AddCommand(RemoteStatusCmd)
 }
 
-// RemoteCmd singularity remote ...
+// RemoteCmd singularity remote [...]
 var RemoteCmd = &cobra.Command{
 	Run: nil,
 
@@ -46,9 +73,25 @@ var RemoteCmd = &cobra.Command{
 	Example: docs.RemoteExample,
 }
 
+// setGlobalRemoteConfig will assign the appropriate value to remoteConfig if the global flag is set
+func setGlobalRemoteConfig(_ *cobra.Command, _ []string) {
+	if !global {
+		return
+	}
+
+	uid := uint32(os.Getuid())
+	if uid != 0 {
+		sylog.Fatalf("Unable to modify global endpoint configuration file: not root user")
+	}
+
+	// set remoteConfig value to the location of the global remote.yaml file
+	remoteConfig = remoteConfigSys
+}
+
 // RemoteAddCmd singularity remote add [remoteName] [remoteURI]
 var RemoteAddCmd = &cobra.Command{
-	Args: cobra.ExactArgs(2),
+	Args:   cobra.ExactArgs(2),
+	PreRun: setGlobalRemoteConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.RemoteAdd(remoteConfig, args[0], args[1]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -63,7 +106,8 @@ var RemoteAddCmd = &cobra.Command{
 
 // RemoteRemoveCmd singularity remote remove [remoteName]
 var RemoteRemoveCmd = &cobra.Command{
-	Args: cobra.ExactArgs(1),
+	Args:   cobra.ExactArgs(1),
+	PreRun: setGlobalRemoteConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.RemoteRemove(remoteConfig, args[0]); err != nil {
 			sylog.Fatalf("%s", err)

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -17,11 +17,11 @@ import (
 const listLine = "%s\t%s\n"
 
 // RemoteList prints information about remote configurations
-func RemoteList(configFile string) (err error) {
+func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(configFile, os.O_RDONLY|os.O_CREATE, 0600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no remote configurations")
@@ -34,6 +34,10 @@ func RemoteList(configFile string) (err error) {
 	c, err = remote.ReadFrom(file)
 	if err != nil {
 		return fmt.Errorf("while parsing remote config data: %s", err)
+	}
+
+	if err := syncSysConfig(c, sysConfigFile); err != nil {
+		return err
 	}
 
 	// list in alphanumeric order

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/remote"
 )
 
-const listLine = "%s\t%s\n"
+const listLine = "%s\t%s\t%s\n"
 
 // RemoteList prints information about remote configurations
 func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
@@ -45,16 +45,33 @@ func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
 	for n := range c.Remotes {
 		names = append(names, n)
 	}
+	sort.Slice(names, func(i, j int) bool {
+		iName, jName := names[i], names[j]
+
+		if c.Remotes[iName].System && !c.Remotes[jName].System {
+			return true
+		} else if !c.Remotes[iName].System && c.Remotes[jName].System {
+			return false
+		}
+
+		return names[i] < names[j]
+	})
 	sort.Strings(names)
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "NAME", "URI")
+	fmt.Fprintf(tw, listLine, "NAME", "URI", "SYS")
 	for _, n := range names {
 		uri := c.Remotes[n].URI
 		if c.DefaultRemote != "" && c.DefaultRemote == n {
 			n = fmt.Sprintf("[%s]", n)
 		}
-		fmt.Fprintf(tw, listLine, n, uri)
+
+		sys := "NO"
+		if c.Remotes[n].System {
+			sys = "YES"
+		}
+
+		fmt.Fprintf(tw, listLine, n, uri, sys)
 	}
 	tw.Flush()
 	return nil

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -15,11 +15,11 @@ import (
 )
 
 // RemoteLogin logs in remote by setting API token
-func RemoteLogin(configFile, name string) (err error) {
+func RemoteLogin(usrConfigFile, sysConfigFile, name string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}
@@ -29,6 +29,10 @@ func RemoteLogin(configFile, name string) (err error) {
 	c, err = remote.ReadFrom(file)
 	if err != nil {
 		return fmt.Errorf("while parsing remote config data: %s", err)
+	}
+
+	if err := syncSysConfig(c, sysConfigFile); err != nil {
+		return err
 	}
 
 	r, err := c.GetRemote(name)

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -29,11 +29,11 @@ type status struct {
 }
 
 // RemoteStatus checks status of services related to an endpoint
-func RemoteStatus(configFile, name string) (err error) {
+func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(configFile, os.O_RDONLY|os.O_CREATE, 0600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("No Remote configurations")
@@ -46,6 +46,10 @@ func RemoteStatus(configFile, name string) (err error) {
 	c, err = remote.ReadFrom(file)
 	if err != nil {
 		return fmt.Errorf("while parsing remote config data: %s", err)
+	}
+
+	if err := syncSysConfig(c, sysConfigFile); err != nil {
+		return err
 	}
 
 	e, err := c.GetRemote(name)

--- a/internal/app/singularity/remote_use.go
+++ b/internal/app/singularity/remote_use.go
@@ -15,7 +15,9 @@ import (
 func syncSysConfig(cUsr *remote.Config, sysConfigFile string) error {
 	// opening system config file
 	f, err := os.OpenFile(sysConfigFile, os.O_RDONLY, 0600)
-	if err != nil {
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}
 	defer f.Close()


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Introduce support for system-wide remote endpoint configuration file, giving users access to a set of pre-configured endpoints to choose from by default.

**This fixes or addresses the following GitHub issues:**

- Fixes #2894 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
