### PR TITLE
Fix docker pull overwrite

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -174,6 +174,12 @@ func pullRun(cmd *cobra.Command, args []string) {
 	case HTTPProtocol, HTTPSProtocol:
 		libexec.PullNetImage(name, args[i], force)
 	default:
+		if !force {
+			if _, err := os.Stat(name); err == nil {
+				sylog.Fatalf("image file already exists - will not overwrite")
+			}
+		}
+
 		authConf, err := makeDockerCredentials(cmd)
 		if err != nil {
 			sylog.Fatalf("While creating Docker credentials: %v", err)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Checks for an existing file before building a container to that location. Force option circumvents this check and a build will overwrite the location.


**This fixes or addresses the following GitHub issues:**

- Fixes #2939 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
