### PR TITLE
Fix RPM spec building on SLES 11

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -23,9 +23,6 @@
 
 %define singgopath src/github.com/sylabs/singularity
 
-# set sver for suse_version ... or 0 if not set
-%{!?sver:%{expand:%%global sles_version 0}}
-
 # Disable debugsource packages; otherwise it ends up with an empty %files
 #   file in debugsourcefiles.list on Fedora
 %undefine _debugsource_packages
@@ -40,7 +37,7 @@ URL: https://www.sylabs.io/singularity/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 %if "%{_target_vendor}" == "suse"
-%if %{sver} != 11
+%if "%{sles_version}" != "11"
 BuildRequires: go
 %endif
 %else
@@ -52,7 +49,7 @@ BuildRequires: make
 BuildRequires: libuuid-devel
 BuildRequires: openssl-devel
 %if ! 0%{?el6}
-%if %{sver} != 11
+%if "%{sles_version}" != "11"
 BuildRequires: libseccomp-devel
 %endif
 %endif

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -37,7 +37,9 @@ URL: https://www.sylabs.io/singularity/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 %if "%{_target_vendor}" == "suse"
+%if %{sles_version} != 11
 BuildRequires: go
+%endif
 %else
 BuildRequires: golang
 %endif
@@ -47,7 +49,9 @@ BuildRequires: make
 BuildRequires: libuuid-devel
 BuildRequires: openssl-devel
 %if ! 0%{?el6}
+%if %{sles_version} != 11
 BuildRequires: libseccomp-devel
+%endif
 %endif
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -23,6 +23,9 @@
 
 %define singgopath src/github.com/sylabs/singularity
 
+# set sver for suse_version ... or 0 if not set
+%{!?sver:%{expand:%%global sles_version 0}}
+
 # Disable debugsource packages; otherwise it ends up with an empty %files
 #   file in debugsourcefiles.list on Fedora
 %undefine _debugsource_packages
@@ -37,7 +40,7 @@ URL: https://www.sylabs.io/singularity/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 %if "%{_target_vendor}" == "suse"
-%if %{?sles_version} != 11
+%if %{sver} != 11
 BuildRequires: go
 %endif
 %else
@@ -49,7 +52,7 @@ BuildRequires: make
 BuildRequires: libuuid-devel
 BuildRequires: openssl-devel
 %if ! 0%{?el6}
-%if %{?sles_version} != 11
+%if %{sver} != 11
 BuildRequires: libseccomp-devel
 %endif
 %endif

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -37,7 +37,7 @@ URL: https://www.sylabs.io/singularity/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 %if "%{_target_vendor}" == "suse"
-%if %{sles_version} != 11
+%if %{?sles_version} != 11
 BuildRequires: go
 %endif
 %else
@@ -49,7 +49,7 @@ BuildRequires: make
 BuildRequires: libuuid-devel
 BuildRequires: openssl-devel
 %if ! 0%{?el6}
-%if %{sles_version} != 11
+%if %{?sles_version} != 11
 BuildRequires: libseccomp-devel
 %endif
 %endif


### PR DESCRIPTION
Go 1.8.3 is the newest Go version availible in the repositories so
we remove Go as a BuildRequire and expect it to be in the PATH
when rpmbuild is ran

libseccomp1 is to old to be used. It actually cannot be installed
as currently makeit will pick it up as existing and try using it.
Remove is as a BuildRequire as well.

Attn: @singularity-maintainers
