### PR TITLE
Add info messages when converting from SIF and removing temporary converted image

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -421,6 +421,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			unsquashfsPath = filepath.Join(d, "unsquashfs")
 		}
 		sylog.Verbosef("User namespace requested, convert image %s to sandbox", image)
+		sylog.Infof("Convert SIF file to sandbox...")
 		dir, err := convertImage(image, unsquashfsPath)
 		if err != nil {
 			sylog.Fatalf("while extracting %s: %s", image, err)

--- a/internal/pkg/runtime/engines/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engines/singularity/cleanup_linux.go
@@ -27,6 +27,8 @@ func (engine *EngineOperations) CleanupContainer(fatal error, status syscall.Wai
 
 	if engine.EngineConfig.GetDeleteImage() {
 		image := engine.EngineConfig.GetImage()
+		sylog.Verbosef("Removing image %s", image)
+		sylog.Infof("Cleaning up image...")
 		if err := os.RemoveAll(image); err != nil {
 			sylog.Errorf("failed to delete container image %s: %s", image, err)
 		}


### PR DESCRIPTION


**Description of the Pull Request (PR):**

Adds info messages to indicate what's happening when converting from SIF to sandbox and removing the sandbox.   This behavior was added in #2838.


**This fixes or addresses the following GitHub issues:**

- Partially fixes #2880


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
