### PR TITLE
Remove duplicate KeysCmd code and use Aliases instead

### DIFF
--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -21,7 +21,6 @@ var (
 )
 
 func init() {
-	SingularityCmd.AddCommand(KeysCmd)
 	SingularityCmd.AddCommand(KeyCmd)
 
 	// key commands
@@ -31,29 +30,6 @@ func init() {
 	KeyCmd.AddCommand(KeyPullCmd)
 	KeyCmd.AddCommand(KeyPushCmd)
 	KeyCmd.AddCommand(KeyImportCmd)
-
-	// keys commands
-	KeysCmd.AddCommand(KeyNewPairCmd)
-	KeysCmd.AddCommand(KeyListCmd)
-	KeysCmd.AddCommand(KeySearchCmd)
-	KeysCmd.AddCommand(KeyPullCmd)
-	KeysCmd.AddCommand(KeyPushCmd)
-	KeysCmd.AddCommand(KeyImportCmd)
-}
-
-// KeysCmd is the 'keys' command that allows management of key stores
-var KeysCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.New("Invalid command")
-	},
-	DisableFlagsInUseLine: true,
-	Hidden:                true,
-
-	Use:           docs.KeysUse,
-	Short:         docs.KeyShort,
-	Long:          docs.KeyLong,
-	Example:       docs.KeyExample,
-	SilenceErrors: true,
 }
 
 // KeyCmd is the 'key' command that allows management of key stores
@@ -62,6 +38,7 @@ var KeyCmd = &cobra.Command{
 		return errors.New("Invalid command")
 	},
 	DisableFlagsInUseLine: true,
+	Aliases:               []string{"keys"},
 
 	Use:           docs.KeyUse,
 	Short:         docs.KeyShort,

--- a/docs/content.go
+++ b/docs/content.go
@@ -204,10 +204,7 @@ Enterprise Performance Computing (EPC)`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// key
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	KeyUse string = `key [key options...] <subcommand>`
-
-	// keys : for the hidden `keys` command
-	KeysUse  string = `keys [keys options...] <subcommand>`
+	KeyUse   string = `key [key options...] <subcommand>`
 	KeyShort string = `Manage OpenPGP key stores`
 	KeyLong  string = `
   The 'key' command allows you to manage local OpenPGP key stores by creating


### PR DESCRIPTION
In cmd/internal/cli/key.go, we were previously adding an entire
second cobra.Command object, KeysCmd, to add support for the
hidden alias singularity keys. Instead, we can just use
the (cobra.Command).Aliases field to support this behavior
without code duplication.

Signed-off-by: Michael Bauer <michael@bauer.dev>

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
