### PR TITLE
Enable "gosimple" linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - gofmt
     - goimports
     - golint
+    - gosimple
     - govet
     - ineffassign
     - maligned

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -205,7 +205,6 @@ func replaceURIWithImage(cmd *cobra.Command, args []string) {
 	}
 
 	args[0] = image
-	return
 }
 
 // setVM will set the --vm option if needed by other options

--- a/cmd/internal/cli/key_list.go
+++ b/cmd/internal/cli/key_list.go
@@ -40,7 +40,7 @@ var KeyListCmd = &cobra.Command{
 }
 
 func doKeyListCmd(secret bool) error {
-	if secret == false {
+	if !secret {
 		fmt.Printf("Public key listing (%s):\n\n", sypgp.PublicPath())
 		sypgp.PrintPubKeyring()
 	} else {

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -235,7 +235,7 @@ func envAppend(flag *pflag.Flag, envvar string) {
 
 // envBool sets a bool flag if the CLI option is unset and env var is set
 func envBool(flag *pflag.Flag, envvar string) {
-	if flag.Changed == true || envvar == "" {
+	if flag.Changed || envvar == "" {
 		return
 	}
 
@@ -254,7 +254,7 @@ func envBool(flag *pflag.Flag, envvar string) {
 // envStringNSlice writes to a string or slice flag if CLI option/argument
 // string is unset and env var is set
 func envStringNSlice(flag *pflag.Flag, envvar string) {
-	if flag.Changed == true {
+	if flag.Changed {
 		return
 	}
 

--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -721,7 +721,7 @@ func verifyFile(t *testing.T, original, copy string) error {
 		t.Fatalf("While reading file: %v", err)
 	}
 
-	if bytes.Compare(o, c) != 0 {
+	if !bytes.Equal(o, c) {
 		return fmt.Errorf("Incorrect file content")
 	}
 

--- a/internal/app/singularity/cache_clean_linux.go
+++ b/internal/app/singularity/cache_clean_linux.go
@@ -122,7 +122,7 @@ func cleanOciCacheName(cacheName string) (bool, error) {
 }
 
 // CleanCacheName : will clean a container with the same name as cacheName (in the cache directory).
-// if libraryCache == true; only search thrught library cache. if ociCache == true; only search the
+// if libraryCache is true; only search thrught library cache. if ociCache is true; only search the
 // oci-tmp cache. if both are false; search all cache, and if both are true; again, search all cache.
 func CleanCacheName(cacheName string, libraryCache, ociCache bool) (bool, error) {
 	if libraryCache == ociCache {
@@ -134,20 +134,20 @@ func CleanCacheName(cacheName string, libraryCache, ociCache bool) (bool, error)
 		if err != nil {
 			return false, err
 		}
-		if matchLibrary == true || matchOci == true {
+		if matchLibrary || matchOci {
 			return true, nil
 		}
 		return false, nil
 	}
 
 	match := false
-	if libraryCache == true {
+	if libraryCache {
 		match, err := cleanLibraryCacheName(cacheName)
 		if err != nil {
 			return false, err
 		}
 		return match, nil
-	} else if ociCache == true {
+	} else if ociCache {
 		match, err := cleanOciCacheName(cacheName)
 		if err != nil {
 			return false, err
@@ -157,7 +157,7 @@ func CleanCacheName(cacheName string, libraryCache, ociCache bool) (bool, error)
 	return match, nil
 }
 
-// CleanSingularityCache : the main function that drives all these other functions, if allClean == true; clean
+// CleanSingularityCache : the main function that drives all these other functions, if allClean is true; clean
 // all cache. if typeNameClean contains somthing; only clean that type. if cacheName contains somthing; clean only
 // cache with that name.
 func CleanSingularityCache(cleanAll bool, cacheCleanTypes []string, cacheName string) error {
@@ -181,12 +181,12 @@ func CleanSingularityCache(cleanAll bool, cacheCleanTypes []string, cacheName st
 		}
 	}
 
-	if len(cacheName) >= 1 && cleanAll != true {
+	if len(cacheName) >= 1 && !cleanAll {
 		foundMatch, err := CleanCacheName(cacheName, libraryClean, ociClean)
 		if err != nil {
 			return err
 		}
-		if foundMatch != true {
+		if !foundMatch {
 			sylog.Warningf("No cache found with given name: %v", cacheName)
 			os.Exit(0)
 		}

--- a/internal/app/singularity/cache_list_linux.go
+++ b/internal/app/singularity/cache_list_linux.go
@@ -108,7 +108,7 @@ func listBlobCache(printList bool) error {
 			if err != nil {
 				return fmt.Errorf("unable to get stat for oci-blob cache: %v", err)
 			}
-			if printList == true {
+			if printList {
 				printFileSize, err := findSize(fileInfo.Size())
 				if err != nil {
 					// no need to describe the error, since it is already
@@ -120,7 +120,7 @@ func listBlobCache(printList bool) error {
 			totalSize += fileInfo.Size()
 		}
 	}
-	if printList != true && count >= 1 {
+	if !printList && count >= 1 {
 		printFileSize, err := findSize(totalSize)
 		if err != nil {
 			// no need to describe the error, since it is already

--- a/internal/app/singularity/capability_list_linux.go
+++ b/internal/app/singularity/capability_list_linux.go
@@ -27,7 +27,7 @@ func CapabilityList(capFile string, c CapListConfig) error {
 		return fmt.Errorf("while listing capabilities: only root user can list capabilities")
 	}
 
-	if c.User == "" && c.Group == "" && c.All == false {
+	if c.User == "" && c.Group == "" && !c.All {
 		return fmt.Errorf("while listing capabilities: must specify user, group, or listall")
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -92,7 +92,7 @@ func (cp *DebootstrapConveyorPacker) getRecipeHeaderInfo() (err error) {
 		return fmt.Errorf("Invalid debootstrap header, no OSVersion specified")
 	}
 
-	include, _ := cp.b.Recipe.Header["include"]
+	include := cp.b.Recipe.Header["include"]
 
 	//check for include environment variable and add it to requires string
 	include += ` ` + os.Getenv("INCLUDE")

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -169,7 +169,7 @@ func (c *YumConveyor) getBootstrapOptions() (err error) {
 		return fmt.Errorf("Invalid yum header, no MirrorURL specified")
 	}
 
-	c.updateurl, _ = c.b.Recipe.Header["updateurl"]
+	c.updateurl = c.b.Recipe.Header["updateurl"]
 
 	// look for an OS version if a mirror specifies it
 	regex := regexp.MustCompile(`(?i)%{OSVERSION}`)
@@ -182,7 +182,7 @@ func (c *YumConveyor) getBootstrapOptions() (err error) {
 		c.updateurl = regex.ReplaceAllString(c.updateurl, c.osversion)
 	}
 
-	include, _ := c.b.Recipe.Header["include"]
+	include := c.b.Recipe.Header["include"]
 
 	// check for include environment variable and add it to requires string
 	include += ` ` + os.Getenv("INCLUDE")
@@ -277,7 +277,7 @@ func (c *YumConveyor) importGPGKey() (err error) {
 	sylog.Infof("We have a GPG key!  Preparing RPM database.")
 
 	// make sure gpg is being imported over https
-	if strings.HasPrefix(c.gpg, "https://") == false {
+	if !strings.HasPrefix(c.gpg, "https://") {
 		return fmt.Errorf("GPG key must be fetched with https")
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -63,7 +63,7 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 		mirrorurl = regex.ReplaceAllString(mirrorurl, osversion)
 	}
 
-	include, _ := cp.b.Recipe.Header["include"]
+	include := cp.b.Recipe.Header["include"]
 
 	// check for include environment variable and add it to requires string
 	include += ` ` + os.Getenv("INCLUDE")

--- a/internal/pkg/build/sources/packer_ext3_linux.go
+++ b/internal/pkg/build/sources/packer_ext3_linux.go
@@ -72,8 +72,7 @@ func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs strin
 
 // getLoopDevice attaches a loop device with the specified arguments
 func getLoopDevice(arguments *args.LoopArgs) error {
-	var reply int
-	reply = 1
+	reply := 1
 	loopdev := new(loop.Device)
 	loopdev.MaxLoopDevices = 256
 	loopdev.Info = &arguments.Info

--- a/internal/pkg/build/sources/packer_sif_linux.go
+++ b/internal/pkg/build/sources/packer_sif_linux.go
@@ -80,9 +80,7 @@ func (p *SIFPacker) unpackSIF(b *types.Bundle, rootfs string) (err error) {
 
 // unpackImagePart temporarily mounts an image parition using a loop device and then copies its contents to the destination directory
 func unpackImagePartion(src, dest, mountType string, info *loop.Info64) (err error) {
-
-	var number int
-	number = 0
+	number := 0
 	loopdev := new(loop.Device)
 	loopdev.MaxLoopDevices = 256
 	loopdev.Info = info

--- a/internal/pkg/runtime/engines/config/parser.go
+++ b/internal/pkg/runtime/engines/config/parser.go
@@ -75,7 +75,7 @@ func Parser(filepath string, f interface{}) error {
 						break
 					}
 				}
-				if found == false {
+				if !found {
 					return fmt.Errorf("value authorized for directive '%s' are %s", dir, authorized)
 				}
 			} else {
@@ -128,7 +128,7 @@ func Parser(filepath string, f interface{}) error {
 						}
 					}
 				}
-				if found == false {
+				if !found {
 					return fmt.Errorf("value authorized for directive '%s' are %s", dir, authorized)
 				}
 			} else {

--- a/internal/pkg/runtime/engines/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engines/config/starter/starter_linux.go
@@ -43,10 +43,7 @@ func NewConfig(config CConfig) *Config {
 
 // GetIsSUID returns if SUID workflow is enabled or not
 func (c *Config) GetIsSUID() bool {
-	if c.config.container.isSuid == 1 {
-		return true
-	}
-	return false
+	return c.config.container.isSuid == 1
 }
 
 // GetContainerPid returns container process ID
@@ -65,10 +62,7 @@ func (c *Config) SetInstance(instance bool) {
 
 // GetInstance returns if container run as instance or not
 func (c *Config) GetInstance() bool {
-	if c.config.container.isInstance == 1 {
-		return true
-	}
-	return false
+	return c.config.container.isInstance == 1
 }
 
 // SetNoNewPrivs sets NO_NEW_PRIVS flag
@@ -82,10 +76,7 @@ func (c *Config) SetNoNewPrivs(noprivs bool) {
 
 // GetNoNewPrivs returns if NO_NEW_PRIVS flag is set or not
 func (c *Config) GetNoNewPrivs() bool {
-	if c.config.container.noNewPrivs == 1 {
-		return true
-	}
-	return false
+	return c.config.container.noNewPrivs == 1
 }
 
 // SetSharedMount sets if master/container shares mount point
@@ -99,10 +90,7 @@ func (c *Config) SetSharedMount(shared bool) {
 
 // GetSharedMount returns if master/container shares mount point or not
 func (c *Config) GetSharedMount() bool {
-	if c.config.container.sharedMount == 1 {
-		return true
-	}
-	return false
+	return c.config.container.sharedMount == 1
 }
 
 // SetJoinMount sets if container process join a mount namespace
@@ -116,10 +104,7 @@ func (c *Config) SetJoinMount(join bool) {
 
 // GetJoinMount returns if container process join a mount namespace
 func (c *Config) GetJoinMount() bool {
-	if c.config.container.joinMount == 1 {
-		return true
-	}
-	return false
+	return c.config.container.joinMount == 1
 }
 
 // SetBringLoopbackInterface sets if starter bring loopback network interface
@@ -133,10 +118,7 @@ func (c *Config) SetBringLoopbackInterface(bring bool) {
 
 // GetBringLoopbackInterface returns if starter bring loopback network interface
 func (c *Config) GetBringLoopbackInterface() bool {
-	if c.config.container.bringLoopbackInterface == 1 {
-		return true
-	}
-	return false
+	return c.config.container.bringLoopbackInterface == 1
 }
 
 // SetMountPropagation sets root filesystem mount propagation

--- a/internal/pkg/runtime/engines/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/create_linux.go
@@ -41,7 +41,7 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 		return fmt.Errorf("stat on %s failed", rootfs)
 	}
 
-	if st.IsDir() == false {
+	if !st.IsDir() {
 		return fmt.Errorf("%s is not a directory", rootfs)
 	}
 

--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -367,11 +367,7 @@ func (c *container) setupDefaultLayout(system *mount.System, sessionPath string)
 // is enabled
 func (c *container) isLayerEnabled() bool {
 	sylog.Debugf("Using Layer system: %v\n", c.sessionLayerType)
-	if c.sessionLayerType == "none" {
-		return false
-	}
-
-	return true
+	return c.sessionLayerType != "none"
 }
 
 func (c *container) mount(point *mount.Point) error {

--- a/internal/pkg/security/seccomp/seccomp_linux.go
+++ b/internal/pkg/security/seccomp/seccomp_linux.go
@@ -94,7 +94,7 @@ func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool) error {
 	}
 
 	supportCondition := hasConditionSupport()
-	if supportCondition == false {
+	if !supportCondition {
 		sylog.Warningf("seccomp rule conditions are not supported with libseccomp under 2.2.1")
 	}
 
@@ -145,7 +145,7 @@ func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool) error {
 				continue
 			}
 
-			if len(syscall.Args) == 0 || supportCondition == false {
+			if len(syscall.Args) == 0 || !supportCondition {
 				if err := filter.AddRule(sysNr, scmpAction); err != nil {
 					return fmt.Errorf("failed adding seccomp rule for syscall %s: %s", sysName, err)
 				}

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -143,7 +143,7 @@ func checkWhiteStrict(fp *os.File, egroup *execgroup) (ok bool, err error) {
 		}
 	}
 	for _, v := range m {
-		if v != true {
+		if !v {
 			return false, fmt.Errorf("%s is not signed by required entities", fp.Name())
 		}
 	}
@@ -209,7 +209,7 @@ func shouldRun(ecl *EclConfig, fp *os.File) (ok bool, err error) {
 // ShouldRun determines if a container should run according to its execgroup rules
 func (ecl *EclConfig) ShouldRun(cpath string) (ok bool, err error) {
 	// look if ECL rules are activated
-	if ecl.Activated == false {
+	if !ecl.Activated {
 		return true, nil
 	}
 
@@ -224,7 +224,7 @@ func (ecl *EclConfig) ShouldRun(cpath string) (ok bool, err error) {
 // ShouldRunFp determines if an already opened container should run according to its execgroup rules
 func (ecl *EclConfig) ShouldRunFp(fp *os.File) (ok bool, err error) {
 	// look if ECL rules are activated
-	if ecl.Activated == false {
+	if !ecl.Activated {
 		return true, nil
 	}
 

--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -85,7 +85,7 @@ func TestHostname(t *testing.T) {
 	if err != nil {
 		t.Errorf("should have passed with correct hostname")
 	}
-	if bytes.Compare(content, []byte("mycontainer\n")) != 0 {
+	if !bytes.Equal(content, []byte("mycontainer\n")) {
 		t.Errorf("Hostname returns a bad content")
 	}
 	_, err = Hostname("bad|hostname")
@@ -110,7 +110,7 @@ func TestResolvConf(t *testing.T) {
 	if err != nil {
 		t.Errorf("should have passed with valid dns")
 	}
-	if bytes.Compare(content, []byte("nameserver 8.8.8.8\n")) != 0 {
+	if !bytes.Equal(content, []byte("nameserver 8.8.8.8\n")) {
 		t.Errorf("ResolvConf returns a bad content")
 	}
 }

--- a/internal/pkg/util/fs/files/group.go
+++ b/internal/pkg/util/fs/files/group.go
@@ -22,7 +22,7 @@ func Group(path string, uid int, gids []int) (content []byte, err error) {
 	var groups []int
 
 	sylog.Verbosef("Checking for template group file: %s\n", path)
-	if fs.IsFile(path) == false {
+	if !fs.IsFile(path) {
 		return content, fmt.Errorf("group file doesn't exist in container, not updating")
 	}
 
@@ -55,7 +55,7 @@ func Group(path string, uid int, gids []int) (content []byte, err error) {
 			break
 		}
 	}
-	if duplicate == false {
+	if !duplicate {
 		if len(gids) == 0 {
 			groups = append(groups, int(pwInfo.GID))
 		}

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -19,7 +19,7 @@ import (
 // updates content with current user information and returns content
 func Passwd(path string, home string, uid int) (content []byte, err error) {
 	sylog.Verbosef("Checking for template passwd file: %s\n", path)
-	if fs.IsFile(path) == false {
+	if !fs.IsFile(path) {
 		return content, fmt.Errorf("passwd file doesn't exist in container, not updating")
 	}
 

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -247,9 +247,8 @@ func (m *Manager) sync() error {
 
 	for p, e := range m.entries {
 		path := m.rootPath + p
-		switch e.(type) {
+		switch entry := e.(type) {
 		case *file:
-			entry := e.(*file)
 			if entry.created {
 				continue
 			}
@@ -273,7 +272,6 @@ func (m *Manager) sync() error {
 			}
 			entry.created = true
 		case *symlink:
-			entry := e.(*symlink)
 			if entry.created {
 				continue
 			}

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -379,7 +379,7 @@ func (p *Points) add(tag AuthorizedTag, source string, dest string, fstype strin
 					isInternal = true
 				}
 			}
-			if isInternal == true {
+			if isInternal {
 				internalOpts = append(internalOpts, o)
 			} else {
 				mountOpts = append(mountOpts, o)

--- a/internal/pkg/util/fs/mount/system_linux.go
+++ b/internal/pkg/util/fs/mount/system_linux.go
@@ -28,10 +28,10 @@ type System struct {
 
 func (b *System) init() {
 	if b.beforeTagHooks == nil {
-		b.beforeTagHooks = make(map[AuthorizedTag][]hookFn, 0)
+		b.beforeTagHooks = make(map[AuthorizedTag][]hookFn)
 	}
 	if b.afterTagHooks == nil {
-		b.afterTagHooks = make(map[AuthorizedTag][]hookFn, 0)
+		b.afterTagHooks = make(map[AuthorizedTag][]hookFn)
 	}
 }
 

--- a/pkg/client/library/pull.go
+++ b/pkg/client/library/pull.go
@@ -37,7 +37,7 @@ func DownloadImage(filePath string, libraryRef string, libraryURL string, Force 
 
 	libraryRef = strings.TrimPrefix(libraryRef, "library://")
 
-	if strings.Index(libraryRef, ":") == -1 {
+	if !strings.Contains(libraryRef, ":") {
 		libraryRef += ":latest"
 	}
 

--- a/pkg/client/net/pull.go
+++ b/pkg/client/net/pull.go
@@ -39,7 +39,7 @@ func DownloadImage(filePath string, libraryURL string, Force bool) error {
 	}
 	if filePath == "" {
 		refParts := strings.Split(libraryURL, "/")
-		filePath = fmt.Sprintf("%s", refParts[len(refParts)-1])
+		filePath = refParts[len(refParts)-1]
 		sylog.Infof("Download filename not provided. Downloading to: %s\n", filePath)
 	}
 

--- a/pkg/client/shub/util.go
+++ b/pkg/client/shub/util.go
@@ -31,11 +31,7 @@ func isShubPullRef(shubRef string) bool {
 
 	// sanity check
 	// if found string is not equal to the input, input isn't a valid URI
-	if strings.Compare(shubRef, found) != 0 {
-		return false
-	}
-
-	return true
+	return shubRef == found
 }
 
 // shubParseReference accepts a valid Shub reference string and parses its content

--- a/pkg/image/ext3.go
+++ b/pkg/image/ext3.go
@@ -57,7 +57,7 @@ func CheckExt3Header(b []byte) (uint64, error) {
 	if err := binary.Read(buffer, binary.LittleEndian, einfo); err != nil {
 		return offset, fmt.Errorf("can't read the top of the image")
 	}
-	if bytes.Compare(einfo.Magic[:], []byte(extMagic)) != 0 {
+	if !bytes.Equal(einfo.Magic[:], []byte(extMagic)) {
 		return offset, fmt.Errorf(notValidExt3ImageMessage)
 	}
 	if einfo.Compat&compatHasJournal == 0 {

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -28,7 +28,7 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	if n, err := img.File.Read(b); err != nil || n != bufferSize {
 		return fmt.Errorf("can't read first %d bytes: %s", bufferSize, err)
 	}
-	if bytes.Index(b, []byte(sifMagic)) == -1 {
+	if !bytes.Contains(b, []byte(sifMagic)) {
 		return fmt.Errorf("SIF magic not found")
 	}
 
@@ -103,7 +103,7 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 
 	// UnloadContainer close image, just want to unmap image
 	// from memory
-	if fimg.Amodebuf == false {
+	if !fimg.Amodebuf {
 		if err := syscall.Munmap(fimg.Filedata); err != nil {
 			return fmt.Errorf("while calling unmapping SIF file")
 		}

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -55,7 +55,7 @@ func CheckSquashfsHeader(b []byte) (uint64, error) {
 	if err := binary.Read(buffer, binary.LittleEndian, sinfo); err != nil {
 		return offset, fmt.Errorf("can't read the top of the image")
 	}
-	if bytes.Compare(sinfo.Magic[:], []byte(squashfsMagic)) != 0 {
+	if !bytes.Equal(sinfo.Magic[:], []byte(squashfsMagic)) {
 		return offset, fmt.Errorf("not a valid squashfs image")
 	}
 

--- a/pkg/image/unpacker/squashfs.go
+++ b/pkg/image/unpacker/squashfs.go
@@ -59,9 +59,7 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) error 
 	}
 
 	args := []string{"-f", "-d", dest, filename}
-	for _, f := range files {
-		args = append(args, f)
-	}
+	args = append(args, files...)
 	cmd := exec.Command(s.UnsquashfsPath, args...)
 	if stdin {
 		cmd.Stdin = reader

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -153,7 +153,7 @@ func NewSetupFromConfig(networkConfList []*libcni.NetworkConfigList, containerID
 			ContainerID:    containerID,
 			NetNS:          netNS,
 			IfName:         fmt.Sprintf("eth%d", ifIndex),
-			CapabilityArgs: make(map[string]interface{}, 0),
+			CapabilityArgs: make(map[string]interface{}),
 			Args:           make([][2]string, 0),
 		}
 
@@ -204,18 +204,18 @@ func (m *Setup) SetCapability(network string, capName string, args interface{}) 
 				return fmt.Errorf("%s network doesn't have %s capability", network, capName)
 			}
 
-			switch args.(type) {
+			switch args := args.(type) {
 			case PortMapEntry:
 				if m.runtimeConf[i].CapabilityArgs[capName] == nil {
 					m.runtimeConf[i].CapabilityArgs[capName] = make([]PortMapEntry, 0)
 				}
 				m.runtimeConf[i].CapabilityArgs[capName] = append(
 					m.runtimeConf[i].CapabilityArgs[capName].([]PortMapEntry),
-					args.(PortMapEntry),
+					args,
 				)
 			case []allocator.Range:
 				if m.runtimeConf[i].CapabilityArgs[capName] == nil {
-					m.runtimeConf[i].CapabilityArgs[capName] = []allocator.RangeSet{args.([]allocator.Range)}
+					m.runtimeConf[i].CapabilityArgs[capName] = []allocator.RangeSet{args}
 				}
 			}
 		}

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -461,7 +461,7 @@ func GenKeyPair(keyServiceURI string, authToken string) (entity *openpgp.Entity,
 
 // DecryptKey decrypts a private key provided a pass phrase
 func DecryptKey(k *openpgp.Entity) error {
-	if k.PrivateKey.Encrypted == true {
+	if k.PrivateKey.Encrypted {
 		pass, err := AskQuestionNoEcho("Enter key passphrase: ")
 		if err != nil {
 			return err
@@ -476,7 +476,7 @@ func DecryptKey(k *openpgp.Entity) error {
 
 // EncryptKey encrypts a private key using a pass phrase
 func EncryptKey(k *openpgp.Entity, pass string) (err error) {
-	if k.PrivateKey.Encrypted == true {
+	if k.PrivateKey.Encrypted {
 		return fmt.Errorf("key already encrypted")
 	}
 	err = k.PrivateKey.Encrypt([]byte(pass))

--- a/pkg/util/capabilities/config.go
+++ b/pkg/util/capabilities/config.go
@@ -26,8 +26,8 @@ type Config struct {
 // config with the set of authorized user/group capabilities
 func ReadFrom(r io.Reader) (*Config, error) {
 	c := &Config{
-		Users:  make(Caplist, 0),
-		Groups: make(Caplist, 0),
+		Users:  make(Caplist),
+		Groups: make(Caplist),
 	}
 
 	// read all data from r into b

--- a/pkg/util/user-agent/agent_test.go
+++ b/pkg/util/user-agent/agent_test.go
@@ -13,7 +13,7 @@ import (
 func TestSingularityVersion(t *testing.T) {
 	InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")
 
-	re := regexp.MustCompile("Singularity/[[:digit:]]+(.[[:digit:]]+){2} \\(Linux [[:alnum:]]+\\) Go/[[:digit:]]+(.[[:digit:]]+){1,2}")
+	re := regexp.MustCompile(`Singularity/[[:digit:]]+(.[[:digit:]]+){2} \(Linux [[:alnum:]]+\) Go/[[:digit:]]+(.[[:digit:]]+){1,2}`)
 	if !re.MatchString(Value()) {
 		t.Fatalf("user agent did not match regexp")
 	}


### PR DESCRIPTION
gosimple checks for common constructs that can be written in simpler
forms (for example "boolVar" vs "boolVar == true").

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>