### PR TITLE
Prealloc slices where possible

### DIFF
--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -42,7 +42,7 @@ func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
 	}
 
 	// list in alphanumeric order
-	var names []string
+	names := make([]string, 0, len(c.Remotes))
 	for n := range c.Remotes {
 		names = append(names, n)
 	}

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -75,7 +75,7 @@ func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 	}
 
 	// list in alphanumeric order
-	var names []string
+	names := make([]string, 0, len(smap))
 	for n := range smap {
 		names = append(names, n)
 	}

--- a/internal/pkg/runtime/engines/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engines/config/starter/starter_linux.go
@@ -197,7 +197,7 @@ func (c *Config) AddUIDMappings(uids []specs.LinuxIDMapping) error {
 
 // AddGIDMappings sets user namespace GID mapping
 func (c *Config) AddGIDMappings(gids []specs.LinuxIDMapping) error {
-	var targetGids []int
+	targetGids := make([]int, 0, len(gids))
 	gidMap := ""
 	for _, gid := range gids {
 		targetGids = append(targetGids, int(gid.ContainerID))

--- a/internal/pkg/runtime/engines/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engines/oci/prepare_linux.go
@@ -75,13 +75,14 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	// reset state config that could be passed to engine
 	e.EngineConfig.State = ociruntime.State{}
 
-	var gids []int
+	user := &e.EngineConfig.OciConfig.Process.User
+	gids := make([]int, 0, len(user.AdditionalGids)+1)
 
-	uid := int(e.EngineConfig.OciConfig.Process.User.UID)
-	gid := e.EngineConfig.OciConfig.Process.User.GID
+	uid := int(user.UID)
+	gid := user.GID
 
 	gids = append(gids, int(gid))
-	for _, g := range e.EngineConfig.OciConfig.Process.User.AdditionalGids {
+	for _, g := range user.AdditionalGids {
 		gids = append(gids, int(g))
 	}
 

--- a/internal/pkg/runtime/engines/oci/process_linux.go
+++ b/internal/pkg/runtime/engines/oci/process_linux.go
@@ -36,18 +36,16 @@ import (
 )
 
 func setRlimit(rlimits []specs.POSIXRlimit) error {
-	var resources []string
+	resources := make(map[string]struct{})
 
 	for _, rl := range rlimits {
 		if err := rlimit.Set(rl.Type, rl.Soft, rl.Hard); err != nil {
 			return err
 		}
-		for _, t := range resources {
-			if t == rl.Type {
-				return fmt.Errorf("%s was already set", t)
-			}
+		if _, found := resources[rl.Type]; found {
+			return fmt.Errorf("%s was already set", rl.Type)
 		}
-		resources = append(resources, rl.Type)
+		resources[rl.Type] = struct{}{}
 	}
 
 	return nil

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -362,7 +362,7 @@ func getSignEntities(fimg *sif.FileImage) ([]string, error) {
 		return nil, err
 	}
 
-	var entities []string
+	entities := make([]string, 0, len(signatures))
 	for _, v := range signatures {
 		fingerprint, err := v.GetEntityString()
 		if err != nil {

--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -434,6 +434,7 @@ func Normalize(capabilities []string) ([]string, []string) {
 
 	capabilities = normalize(capabilities)
 
+	// nolint:prealloc
 	var included []string
 	var excluded []string
 	for _, capb := range capabilities {


### PR DESCRIPTION
Code like this:

    var names []string
    for n := range c.Remotes {
        names = append(names, n)
    }

knows in advance the required capacity for the slice, so it's possible
to avoid trashing in the allocator by simply preallocating the slice,
like this:

    names := make([]string, 0, len(c.Remotes))
    for n := range c.Remotes {
        names = append(names, n)
    }

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>