### PR TITLE
Use PACKAGE_NAME in Long-form Version

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -64,6 +64,9 @@ func init() {
 	SingularityCmd.SetHelpTemplate(docs.HelpTemplate)
 	SingularityCmd.SetUsageTemplate(docs.UseTemplate)
 
+	vt := fmt.Sprintf("%s version {{printf \"%%s\" .Version}}\n", buildcfg.PACKAGE_NAME)
+	SingularityCmd.SetVersionTemplate(vt)
+
 	usr, err := user.Current()
 	if err != nil {
 		sylog.Fatalf("Couldn't determine user home directory: %v", err)


### PR DESCRIPTION
Use `PACKAGE_NAME` in `--version` output.

Closes #2988