### PR TITLE
Read link from main thread (2967)

### DIFF
--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sylabs/singularity/internal/pkg/util/mainthread"
+
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/cgroups"
@@ -1008,7 +1010,7 @@ func (c *container) addDevMount(system *mount.System) error {
 			//  and also check the device that docker uses,
 			//  /dev/console.
 			procfd := fmt.Sprintf("/proc/self/fd/%d", fd)
-			ttylink, err := os.Readlink(procfd)
+			ttylink, err := mainthread.Readlink(procfd)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Attempt to fix `permission denied` while reading link `/proc/self/fd/0` while using `--contain` option on SLES 11


**This fixes or addresses the following GitHub issues:**

- Fixes #2967


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
