### PR TITLE
Change directory from main thread with sandbox images (2978)

### DIFF
--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -539,7 +539,7 @@ func (e *EngineOperations) loadImages() error {
 		if img.Path == "/" {
 			return fmt.Errorf("/ as sandbox is not authorized")
 		}
-		if err := os.Chdir(img.Source); err != nil {
+		if err := mainthread.Chdir(img.Source); err != nil {
 			return err
 		}
 		cwd, err := os.Getwd()

--- a/internal/pkg/util/mainthread/mainthread.go
+++ b/internal/pkg/util/mainthread/mainthread.go
@@ -46,3 +46,11 @@ func EvalSymlinks(path string) (rpath string, err error) {
 	})
 	return
 }
+
+// Chdir changes and returns current working directory from main thread
+func Chdir(path string) (err error) {
+	Execute(func() {
+		err = os.Chdir(path)
+	})
+	return
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes `permission denied` when using sandbox image on SLES 11

**This fixes or addresses the following GitHub issues:**

- Fixes #2978 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
