### PR TITLE
Document blobSum type cache option

### DIFF
--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -23,7 +23,7 @@ func init() {
 	CacheListCmd.Flags().SetInterspersed(false)
 
 	CacheListCmd.Flags().StringSliceVarP(&cacheListTypes, "type", "T", []string{"library", "oci", "blobSum"},
-	"a list of cache types to display, possible entries: library, oci, blob(s), blobSum, all")
+		"a list of cache types to display, possible entries: library, oci, blob(s), blobSum, all")
 	CacheListCmd.Flags().SetAnnotation("type", "envkey", []string{"TYPE"})
 
 	CacheListCmd.Flags().BoolVarP(&allList, "all", "a", false, "list all cache types")

--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -22,7 +22,8 @@ var (
 func init() {
 	CacheListCmd.Flags().SetInterspersed(false)
 
-	CacheListCmd.Flags().StringSliceVarP(&cacheListTypes, "type", "T", []string{"library", "oci", "blobSum"}, "list cache type, choose between: library, oci, and blob")
+	CacheListCmd.Flags().StringSliceVarP(&cacheListTypes, "type", "T", []string{"library", "oci", "blobSum"},
+	"a list of cache types to display, possible entries: library, oci, blob(s), blobSum, all")
 	CacheListCmd.Flags().SetAnnotation("type", "envkey", []string{"TYPE"})
 
 	CacheListCmd.Flags().BoolVarP(&allList, "all", "a", false, "list all cache types")

--- a/docs/content.go
+++ b/docs/content.go
@@ -162,8 +162,7 @@ Enterprise Performance Computing (EPC)`
 	CacheUse   string = `cache <subcommand>`
 	CacheShort string = `Manage the local cache`
 	CacheLong  string = `
-  Manage your local singularity cache. There are 3 types of cache; library, oci, and blob.
-  You can list/clean using the specific types.`
+  Manage your local singularity cache. You can list/clean using the specific types.`
 	CacheExample string = `
   All group commands have their own help output:
 
@@ -176,9 +175,8 @@ Enterprise Performance Computing (EPC)`
 	CacheCleanUse   string = `clean [clean options...]`
 	CacheCleanShort string = `Clean your local Singularity cache`
 	CacheCleanLong  string = `
-  This will clean you local cache: "${HOME}/.singularity/cache". The available cache
-  types are: library, oci, and blob. By default cache clean will only clean blob cache,
-  use: '--all' to clean all cache.`
+  This will clean you local cache stored at $HOME/.singularity/cache.
+  By default only blob cache is cleaned, use '--all' to clean all cache.`
 	CacheCleanExample string = `
   All group commands have their own help output:
 
@@ -192,8 +190,7 @@ Enterprise Performance Computing (EPC)`
 	CacheListUse   string = `list [list options...]`
 	CacheListShort string = `List your local Singularity cache`
 	CacheListLong  string = `
-  This will list you local cache: "${HOME}/.singularity/cache". The available cache
-  types are: library, oci, and blob.`
+  This will list you local cache stored at $HOME/.singularity/cache.`
 	CacheListExample string = `
   All group commands have their own help output:
 

--- a/docs/content.go
+++ b/docs/content.go
@@ -190,7 +190,7 @@ Enterprise Performance Computing (EPC)`
 	CacheListUse   string = `list [list options...]`
 	CacheListShort string = `List your local Singularity cache`
 	CacheListLong  string = `
-  This will list you local cache stored at $HOME/.singularity/cache.`
+  This will list your local cache (stored at $HOME/.singularity/cache if SINGULARITY_CACHEDIR is not set).
 	CacheListExample string = `
   All group commands have their own help output:
 

--- a/docs/content.go
+++ b/docs/content.go
@@ -175,7 +175,7 @@ Enterprise Performance Computing (EPC)`
 	CacheCleanUse   string = `clean [clean options...]`
 	CacheCleanShort string = `Clean your local Singularity cache`
 	CacheCleanLong  string = `
-  This will clean you local cache stored at $HOME/.singularity/cache.
+  This will clean your local cache (stored at $HOME/.singularity/cache if SINGULARITY_CACHEDIR is not set).
   By default only blob cache is cleaned, use '--all' to clean all cache.`
 	CacheCleanExample string = `
   All group commands have their own help output:

--- a/docs/content.go
+++ b/docs/content.go
@@ -176,7 +176,7 @@ Enterprise Performance Computing (EPC)`
 	CacheCleanShort string = `Clean your local Singularity cache`
 	CacheCleanLong  string = `
   This will clean your local cache (stored at $HOME/.singularity/cache if SINGULARITY_CACHEDIR is not set).
-  By default only blob cache is cleaned, use '--all' to clean all cache.`
+  By default only blob cache is cleaned, use '--all' to clean the entire cache.`
 	CacheCleanExample string = `
   All group commands have their own help output:
 

--- a/docs/content.go
+++ b/docs/content.go
@@ -190,7 +190,7 @@ Enterprise Performance Computing (EPC)`
 	CacheListUse   string = `list [list options...]`
 	CacheListShort string = `List your local Singularity cache`
 	CacheListLong  string = `
-  This will list your local cache (stored at $HOME/.singularity/cache if SINGULARITY_CACHEDIR is not set).
+  This will list your local cache (stored at $HOME/.singularity/cache if SINGULARITY_CACHEDIR is not set).`
 	CacheListExample string = `
   All group commands have their own help output:
 


### PR DESCRIPTION
Also cache type listing removed from description so we won't need to update it in two places if cache type is added. All cache types are listed in --type option decsription and there is no need to duplicate it in command description as well.

Closes #3012