### PR TITLE
Remove `Y/n` When Searching for Keys

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -264,7 +264,7 @@ Enterprise Performance Computing (EPC)`
   The 'key search' command allows you to connect to a key server and look for
   public keys matching the argument passed to the command line. You can
   also search for a key by fingerprint or key ID by adding '0x' before the
-  fingerprint.`
+  fingerprint. (Maximum 100 search entities)`
 	KeySearchExample string = `
   $ singularity key search sylabs.io
 

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -559,8 +559,10 @@ func SearchPubkey(search, keyserverURI, authToken string) error {
 		return err
 	}
 
+	// the max entities to print.
 	pd := client.PageDetails{
-		Size: 10,
+		// still will only print 100 entities
+		Size: 256,
 	}
 
 	// Retrieve first page of search results from Key Service.
@@ -587,27 +589,7 @@ func SearchPubkey(search, keyserverURI, authToken string) error {
 		}
 	}
 
-	// Print first page of search results.
-	fmt.Print(keyText)
-
-	// Retrieve 2-N pages of search results from Key Service.
-	for pd.Token != "" {
-		resp, err := AskQuestion("\nDisplay more results? [Y/n] ")
-		if err != nil {
-			return err
-		}
-		if resp != "" && resp != "y" && resp != "Y" {
-			break
-		}
-
-		keyText, err := c.PKSLookup(context.TODO(), &pd, search, client.OperationIndex, true, false, nil)
-		if err != nil {
-			return err
-		}
-
-		// Print page of search results.
-		fmt.Print(keyText)
-	}
+	fmt.Printf("%v", keyText)
 
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

@gmkurtzer request to remove the `Y/n` when searching for keys.

<br>

## This fixes or addresses the following GitHub issues:

- Fixes # **`Makes @gmkurtzer Happy`**

<br>
