### PR TITLE
Print Full Fingerprint When Verifying a Container

### DIFF
--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -348,7 +348,7 @@ func Verify(cpath, keyServiceURI string, id uint32, isGroup bool, authToken stri
 			name = i.Name
 			break
 		}
-		author += fmt.Sprintf("\t%s, KeyID %X\n", name, signer.PrimaryKey.KeyId)
+		author += fmt.Sprintf("\t%s, KeyID %X\n", name, signer.PrimaryKey.Fingerprint)
 	}
 	fmt.Printf("Data integrity checked, authentic and signed by:\n%v", author)
 

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -348,7 +348,7 @@ func Verify(cpath, keyServiceURI string, id uint32, isGroup bool, authToken stri
 			name = i.Name
 			break
 		}
-		author += fmt.Sprintf("\t%s, KeyID %X\n", name, signer.PrimaryKey.Fingerprint)
+		author += fmt.Sprintf("\t%s, Fingerprint %X\n", name, signer.PrimaryKey.Fingerprint)
 	}
 	fmt.Printf("Data integrity checked, authentic and signed by:\n%v", author)
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Example:

```bash
$ singularity verify alpine_latest.sif 
WARNING: sylabs-token files are deprecated. Use 'singularity remote' to manage remote endpoints and tokens.
Verifying image: alpine_latest.sif
Data integrity checked, authentic and signed by:
	Sylabs Admin <support@sylabs.io>, Fingerprint 8883491F4268F173C6E5DC49EDECE4F3F38D871E
```

<br>

@gmkurtzer Approves of this change.

<br>

## This fixes or addresses the following GitHub issues:

- Fixes # ?

<br>
