### PR TITLE
Improving error message when app doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _The old changelog can be found in the `release-2.6` branch_
   - Fixed usage docstrings for OCI - was missing "oci" in command examples.
   - Added --nocolor flag to Singularity client to disable color in logging
   - Repeated binds does not exit and fail, just issues warning
+  - Scientific Filesystem app, when doesn't exist, exits with clear message. 
 
 # v3.1.0 - [2019.02.22]
 

--- a/cmd/internal/cli/inspect_linux.go
+++ b/cmd/internal/cli/inspect_linux.go
@@ -276,7 +276,7 @@ func getFileContent(abspath, name string, args []string) (string, error) {
 
 	cmd, err := exec.PipeCommand(starter, []string{procname}, Env, configData)
 	if err != nil {
-		sylog.Fatalf("%s: %s", err, cmd)
+		sylog.Fatalf("%s: %s", err, cmd.Args)
 	}
 
 	b, err := cmd.Output()

--- a/cmd/internal/cli/inspect_linux.go
+++ b/cmd/internal/cli/inspect_linux.go
@@ -139,10 +139,8 @@ var InspectCmd = &cobra.Command{
 		delimiter := "@@@end"
 
 		// If AppName is given fail quickly (exit) if it doesn't exist
-
 		if AppName != "" {
 			sylog.Debugf("Inspection of App %s Selected.", AppName)
-
 			a[2] += getAppCheck(AppName)
 		}
 

--- a/cmd/internal/cli/inspect_linux.go
+++ b/cmd/internal/cli/inspect_linux.go
@@ -105,6 +105,10 @@ func getHelpFile(appName string) string {
 	return fmt.Sprintf("/scif/apps/%s/scif/runscript.help", appName)
 }
 
+func getAppCheck(appName string) string {
+	return fmt.Sprintf("if ! [ -d \"/scif/apps/%s\" ]; then echo \"App %s does not exist.\"; exit 2; fi;", appName, appName)
+}
+
 // InspectCmd represents the build command
 var InspectCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
@@ -133,6 +137,14 @@ var InspectCmd = &cobra.Command{
 		a := []string{"/bin/sh", "-c", ""}
 		prefix := "@@@start"
 		delimiter := "@@@end"
+
+		// If AppName is given fail quickly (exit) if it doesn't exist
+
+		if AppName != "" {
+			sylog.Debugf("Inspection of App %s Selected.", AppName)
+
+			a[2] += getAppCheck(AppName)
+		}
 
 		if helpfile {
 			sylog.Debugf("Inspection of helpfile selected.")
@@ -266,12 +278,12 @@ func getFileContent(abspath, name string, args []string) (string, error) {
 
 	cmd, err := exec.PipeCommand(starter, []string{procname}, Env, configData)
 	if err != nil {
-		sylog.Fatalf("%s", err)
+		sylog.Fatalf("%s: %s", err, cmd)
 	}
 
 	b, err := cmd.Output()
 	if err != nil {
-		sylog.Fatalf("%s", err)
+		sylog.Fatalf("%s: %s", err, b)
 	}
 
 	return string(b), nil


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

**Description of the Pull Request (PR):**

This pull request will adjust the inspect command, ensuring that it exits with a clear message if the app the user asked for does not exist. Here is a quick example - we pull a container that doesn't have any apps, and ask for one that doesn't exist:

```bash
$ singularity pull docker://busybox
$ singularity inspect --app bob busybox_latest.sif 
FATAL:   exit status 2: App bob does not exist.
```
It's still fatal because we exit out, but minimally the user knows what is going on.

The container works with inspect as expected:

```bash
$ singularity inspect busybox_latest.sif 

{
	"org.label-schema.build-date": "Friday_22_March_2019_16:52:46_EDT",
	"org.label-schema.schema-version": "1.0",
	"org.label-schema.usage.singularity.deffile.bootstrap": "docker",
	"org.label-schema.usage.singularity.deffile.from": "busybox",
	"org.label-schema.usage.singularity.version": "3.1.0-rc2.505.g3dd8344.dirty"
}
```
Here is a recipe that has a simple app:

```
Bootstrap: docker
From: busybox:latest

%apprun jujuboo
    echo "JOOOO!"
```

Building, and inspecting an app that doesn't exist:

```bash
$ sudo singularity build joo.sif Singularity
$ singularity inspect --app doesntexist joo.sif 
FATAL:   exit status 2: App doesntexist does not exist
```

I chose an [error code](https://mariadb.com/kb/en/library/operating-system-error-codes/) of 2 to indicate it doesn't exist.

Here is does exist:

```bash
$ singularity inspect --app jujuboo --labels joo.sif

{
	"SCIF_APP_NAME": "jujuboo"
}
```
There is still a bit of weirdness going on with what is given for default labels, that can be addressed in another PR.

**This fixes or addresses the following GitHub issues:**

- Fixes #3052 

Attn: @singularity-maintainers
