### PR TITLE
Check container state during oci attach

### DIFF
--- a/internal/app/singularity/oci_attach_linux.go
+++ b/internal/app/singularity/oci_attach_linux.go
@@ -144,6 +144,9 @@ func OciAttach(containerID string) error {
 	if err != nil {
 		return err
 	}
+	if engineConfig.GetState().Status != ociruntime.Running {
+		return fmt.Errorf("could not attach to %s: not in running state", containerID)
+	}
 
 	defer exitContainer(containerID, false)
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Attach to a container process only in a running state

**This fixes or addresses the following GitHub issues:**

- Fixes #3100 
- Fixes #3101 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
