### PR TITLE
Fix panic caused by `remote list ...` command

### DIFF
--- a/cmd/singularity/remote_test.go
+++ b/cmd/singularity/remote_test.go
@@ -338,4 +338,39 @@ func TestRemoteList(t *testing.T) {
 			}
 		}))
 	}
+
+	// Prep config by selecting a remote to default to
+	use := []struct {
+		name   string
+		remote string
+	}{
+		{"useCloud", "cloud"},
+	}
+
+	for _, tt := range use {
+		argv := []string{"remote", "--config", config.Name(), "use"}
+		argv = append(argv, tt.remote)
+		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
+			if b, err := exec.Command(cmdPath, argv...).CombinedOutput(); err != nil {
+				t.Log(string(b))
+				t.Fatalf("unexpected failure: %v", err)
+			}
+		}))
+	}
+
+	testPass = []struct {
+		name string
+	}{
+		{"PopulatedConfigWithDefault"},
+	}
+
+	for _, tt := range testPass {
+		argv := []string{"remote", "--config", config.Name(), "list"}
+		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
+			if b, err := exec.Command(cmdPath, argv...).CombinedOutput(); err != nil {
+				t.Log(string(b))
+				t.Fatalf("unexpected failure: %v", err)
+			}
+		}))
+	}
 }

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -15,6 +15,7 @@ import (
 )
 
 const listLine = "%s\t%s\t%s\n"
+const listLineDefault = "[%s]\t%s\t%s\n"
 
 // RemoteList prints information about remote configurations
 func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
@@ -61,17 +62,17 @@ func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(tw, listLine, "NAME", "URI", "SYS")
 	for _, n := range names {
-		uri := c.Remotes[n].URI
-		if c.DefaultRemote != "" && c.DefaultRemote == n {
-			n = fmt.Sprintf("[%s]", n)
-		}
-
 		sys := "NO"
 		if c.Remotes[n].System {
 			sys = "YES"
 		}
 
-		fmt.Fprintf(tw, listLine, n, uri, sys)
+		uri := c.Remotes[n].URI
+		if c.DefaultRemote != "" && c.DefaultRemote == n {
+			fmt.Fprintf(tw, listLineDefault, n, uri, sys)
+		} else {
+			fmt.Fprintf(tw, listLine, n, uri, sys)
+		}
 	}
 	tw.Flush()
 	return nil


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Caused by modifying the key to a map and the using it in a lookup causing a `nil` value to be returned. Added test case to catch future regressions.


**This fixes or addresses the following GitHub issues:**

- Fixes #3108


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
