### PR TITLE
Update the message shown when oci kill is run on a container without a state of created or running

### DIFF
--- a/internal/app/singularity/oci_kill_linux.go
+++ b/internal/app/singularity/oci_kill_linux.go
@@ -25,7 +25,7 @@ func OciKill(containerID string, killSignal string, killTimeout int) error {
 	}
 
 	if state.Status != ociruntime.Created && state.Status != ociruntime.Running {
-		return fmt.Errorf("container %s is nor created nor running", containerID)
+		return fmt.Errorf("cannot kill '%s', the state of the container must be created or running", containerID)
 	}
 
 	sig := syscall.SIGTERM


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Update the message shown when `oci kill` is run on a container without a state of `created` or `running`.

Attn: @sylabs/singularity-maintainers 
