### PR TITLE
Update the message shown when oci delete is run on a container without a state of created or stopped

### DIFF
--- a/internal/app/singularity/oci_delete_linux.go
+++ b/internal/app/singularity/oci_delete_linux.go
@@ -23,7 +23,7 @@ func OciDelete(containerID string) error {
 
 	switch engineConfig.State.Status {
 	case ociruntime.Running:
-		return fmt.Errorf("container is not stopped: running")
+		return fmt.Errorf("cannot delete '%s', the state of the container must be created or stopped", containerID)
 	case ociruntime.Stopped:
 	case ociruntime.Created:
 		if err := OciKill(containerID, "SIGTERM", 2); err != nil {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Update the message shown when `oci delete` is run on a container without a state of `created` or `stopped`

Attn: @singularity-maintainers
