### PR TITLE
Update the message shown when oci start is run on a container without a state of created

### DIFF
--- a/internal/app/singularity/oci_start_linux.go
+++ b/internal/app/singularity/oci_start_linux.go
@@ -22,7 +22,7 @@ func OciStart(containerID string) error {
 	}
 
 	if state.Status != ociruntime.Created {
-		return fmt.Errorf("container %s is not created", containerID)
+		return fmt.Errorf("cannot start '%s', the state of the container must be %s", containerID, ociruntime.Created)
 	}
 
 	if state.ControlSocket == "" {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Update the message shown when `oci start` is run on a container without a state of `created`

Attn: @singularity-maintainers
