### PR TITLE
Fix golintci-lint installation on macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
       - run:
           name: Check code
           command: |-
+            unset TMPDIR
             curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
             make -j$(sysctl -n hw.physicalcpu) -C ./builddir check
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

All macos CI jobs end with:

```
golangci/golangci-lint info found version: 1.15.0 for v1.15.0/darwin/amd64
golangci/golangci-lint info installed /Users/distiller/go/bin/golangci-lint
rm: /var/folders/1b/gl7yt7ds26vcyr1pkgld6l040000gn/T/: Operation not permitted
Exited with code 1
```


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
