### PR TITLE
Work around MacOS build failure when downloading golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       - run:
           name: Check code
           command: |-
-            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | TMPDIR=$(mktemp -d) sh -s -- -b $(go env GOPATH)/bin v1.15.0
             make -j$(sysctl -n hw.physicalcpu) -C ./builddir check
 
   unit_tests:


### PR DESCRIPTION
Something changed recently (it doesn't seem to be godownloader; CircleCI
maybe?) and it's causing a failure when trying to delete the temporary
directory that's pointed to by TMPDIR.

Create another temporary directory to be used when running the shell
script used to download golangci-lint.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>