### PR TITLE
Update default key server url on verify help command

### DIFF
--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultKeyServer = "https://keys.sylabs.io"
+	defaultKeyServer = "https://cloud.sylabs.io/keystore"
 )
 
 var (


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Updates default key server url

#3182 

**This fixes or addresses the following GitHub issues:**

- Fixes #3182


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
