### PR TITLE
Wait for dpkg lock on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,10 @@ jobs:
             sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
             sudo chown -R circleci:circleci ~/go
       - run:
+         name: Wait until apt completion
+         command: |-
+           i=0 ; while fuser /var/lib/dpkg/lock > /dev/null 2>&1 ; do echo 'Waiting for dpkg lock...' ; let i=i+1 ; if test $i -ge 30 ; then echo 'Waiting for too long. Abort.' ; exit 1 ; fi ; sleep 1 ; done
+      - run:
           name: Fetch deps
           working_directory: /tmp
           command: |-
@@ -151,6 +155,10 @@ jobs:
             sudo tar -C /usr/local -xzf go1.11.linux-amd64.tar.gz
             sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
             sudo chown -R circleci:circleci ~/go
+      - run:
+         name: Wait until apt completion
+         command: |-
+           i=0 ; while fuser /var/lib/dpkg/lock > /dev/null 2>&1 ; do echo 'Waiting for dpkg lock...' ; let i=i+1 ; if test $i -ge 30 ; then echo 'Waiting for too long. Abort.' ; exit 1 ; fi ; sleep 1 ; done
       - run:
           name: Fetch deps
           working_directory: /tmp


### PR DESCRIPTION
It seems that when the VM boots, it runs `apt-get update` (or something
similar) and this prevents `apt-get install ...` from working.

Wait until that lock is released. Since the VM is using a somewhat old
version of Ubuntu, other (less racy) methods to handle this are not
available.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>