### PR TITLE
Remove the `GOCACHE` environment variable from the circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,3 +185,6 @@ workflows:
       - integration_tests:
           requires:
             - get_source
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,3 @@ workflows:
       - integration_tests:
           requires:
             - get_source
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ jobs:
             echo 'export  GOPATH=$HOME/go' >> $BASH_ENV
             echo 'export  GOROOT=/usr/local/go' >> $BASH_ENV
             echo 'export  GOBIN=$HOME/go/bin' >> $BASH_ENV
-            echo 'export  GOCACHE=off' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$GOBIN:$GOROOT/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin' >> $BASH_ENV
       - run:
           name: Update Go to 1.11.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,9 @@ jobs:
       - run:
           name: Setup environment
           command: |-
-            echo 'export  GOPATH=$HOME/go' >> $BASH_ENV
-            echo 'export  GOROOT=/usr/local/go' >> $BASH_ENV
-            echo 'export  GOBIN=$HOME/go/bin' >> $BASH_ENV
+            echo 'export GOPATH=$HOME/go' >> $BASH_ENV
+            echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
+            echo 'export GOBIN=$HOME/go/bin' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$GOBIN:$GOROOT/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin' >> $BASH_ENV
       - run:
           name: Update Go to 1.11.6
@@ -128,9 +128,9 @@ jobs:
       - run:
           name: Setup environment
           command: |-
-            echo 'export  GOPATH=$HOME/go' >> $BASH_ENV
-            echo 'export  GOROOT=/usr/local/go' >> $BASH_ENV
-            echo 'export  GOBIN=$HOME/go/bin' >> $BASH_ENV
+            echo 'export GOPATH=$HOME/go' >> $BASH_ENV
+            echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
+            echo 'export GOBIN=$HOME/go/bin' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$GOBIN:$GOROOT/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin' >> $BASH_ENV
       - run:
           name: Update Go to 1.11.6


### PR DESCRIPTION
Setting `GOCACHE=off` is deprecated when using go modules.

See: https://golang.org/doc/go1.12#gocache

- Fixes #3259 

Attn: @singularity-maintainers