### PR TITLE
fix remote login

### DIFF
--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -25,8 +25,9 @@ const (
 )
 
 var (
-	remoteConfig string
-	global       bool
+	loginTokenFile string
+	remoteConfig   string
+	global         bool
 )
 
 var (
@@ -51,7 +52,7 @@ func init() {
 	// default location of the remote.yaml file is the user directory
 	RemoteCmd.Flags().StringVarP(&remoteConfig, "config", "c", remoteConfigUser, "path to the file holding remote endpoint configurations")
 	// use tokenfile to log in to a remote
-	RemoteLoginCmd.Flags().StringVar(&tokenFile, "tokenfile", "", "path to the file holding token")
+	RemoteLoginCmd.Flags().StringVar(&loginTokenFile, "tokenfile", "", "path to the file holding token")
 
 	// add --global flag to remote add/remove commands
 	addGlobalFlag(RemoteAddCmd)
@@ -157,7 +158,7 @@ var RemoteListCmd = &cobra.Command{
 var RemoteLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteLogin(remoteConfig, remoteConfigSys, args[0], tokenFile); err != nil {
+		if err := singularity.RemoteLogin(remoteConfig, remoteConfigSys, args[0], loginTokenFile); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes issue where `remote login` command will always try to use the default tokenfile to log into the remote.


**This fixes or addresses the following GitHub issues:**

- Fixes none


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
