### PR TITLE
Add the vendor-check target to our code checking steps in the circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Check code
           command: |-
-            make -j$(nproc) -C ./builddir check
+            make -j$(nproc) -C ./builddir vendor-check check
 
   go1.11-alpine:
     <<: *defaults
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Check code
           command: |-
-            make -j$(nproc) -C ./builddir check
+            make -j$(nproc) -C ./builddir vendor-check check
 
   go1.11-macos:
     macos:
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: Check code
           command: |-
-            make -j$(sysctl -n hw.physicalcpu) -C ./builddir check
+            make -j$(sysctl -n hw.physicalcpu) -C ./builddir vendor-check check
 
   unit_tests:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,11 @@ jobs:
           name: Build Singularity
           command: |-
             ./mconfig -v -p /usr/local
-            make -j$(sysctl -n hw.physicalcpu) -C ./builddir all
+            make -j$(sysctl -n hw.logicalcpu) -C ./builddir all
       - run:
           name: Check code
           command: |-
-            make -j$(sysctl -n hw.physicalcpu) -C ./builddir vendor-check check
+            make -j$(sysctl -n hw.logicalcpu) -C ./builddir vendor-check check
 
   unit_tests:
     machine: true


### PR DESCRIPTION
Verify that the vendor libraries have not been modified outside of the `go mod` workflow (ie, manually edited). This is already done in travis.

Attn: @jmstover @singularity-maintainers
