### PR TITLE
Armor flag support on key export command

### DIFF
--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -22,12 +22,13 @@ func init() {
 	KeyExportCmd.Flags().SetInterspersed(false)
 
 	KeyExportCmd.Flags().BoolVarP(&secretExport, "secret", "s", false, "export a secret key")
+	KeyExportCmd.Flags().BoolVarP(&armor, "armor", "a", false, "key armored format")
 }
 
 // KeyExportCmd is `singularity key export` and exports a public or secret
 // key from local keyring.
 var KeyExportCmd = &cobra.Command{
-	Args:                  cobra.ExactArgs(1),
+	Args: cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                sylabsToken,
 	Run:                   exportRun,
@@ -40,13 +41,13 @@ var KeyExportCmd = &cobra.Command{
 
 func exportRun(cmd *cobra.Command, args []string) {
 	if secretExport {
-		err := sypgp.ExportPrivateKey(args[0])
+		err := sypgp.ExportPrivateKey(args[0], armor)
 		if err != nil {
 			sylog.Errorf("key export command failed: %s", err)
 			os.Exit(10)
 		}
 	} else {
-		err := sypgp.ExportPubKey(args[0])
+		err := sypgp.ExportPubKey(args[0], armor)
 		if err != nil {
 			sylog.Errorf("key export command failed: %s", err)
 			os.Exit(10)

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -28,7 +28,7 @@ func init() {
 // KeyExportCmd is `singularity key export` and exports a public or secret
 // key from local keyring.
 var KeyExportCmd = &cobra.Command{
-	Args: cobra.ExactArgs(1),
+	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                sylabsToken,
 	Run:                   exportRun,

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -14,9 +14,8 @@ import (
 	"github.com/sylabs/singularity/pkg/sypgp"
 )
 
-var (
-	secretExport bool
-)
+var secretExport bool
+var armor bool
 
 func init() {
 	KeyExportCmd.Flags().SetInterspersed(false)
@@ -28,7 +27,7 @@ func init() {
 // KeyExportCmd is `singularity key export` and exports a public or secret
 // key from local keyring.
 var KeyExportCmd = &cobra.Command{
-	Args:                  cobra.ExactArgs(1),
+	Args: cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                sylabsToken,
 	Run:                   exportRun,

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -27,7 +27,7 @@ func init() {
 // KeyExportCmd is `singularity key export` and exports a public or secret
 // key from local keyring.
 var KeyExportCmd = &cobra.Command{
-	Args: cobra.ExactArgs(1),
+	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                sylabsToken,
 	Run:                   exportRun,

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -21,13 +21,13 @@ func init() {
 	KeyExportCmd.Flags().SetInterspersed(false)
 
 	KeyExportCmd.Flags().BoolVarP(&secretExport, "secret", "s", false, "export a secret key")
-	KeyExportCmd.Flags().BoolVarP(&armor, "armor", "a", false, "key armored format")
+	KeyExportCmd.Flags().BoolVarP(&armor, "armor", "a", false, "ascii armored format")
 }
 
 // KeyExportCmd is `singularity key export` and exports a public or secret
 // key from local keyring.
 var KeyExportCmd = &cobra.Command{
-	Args:                  cobra.ExactArgs(1),
+	Args: cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                sylabsToken,
 	Run:                   exportRun,

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -694,7 +694,7 @@ func ExportPrivateKey(kpath string, armor bool) error {
 		keyText, err = serializeEntity(entityToExport, openpgp.PrivateKeyType)
 		file.WriteString(keyText)
 	}
-
+	defer file.Close()
 	fmt.Printf("Private key with fingerprint %X correctly exported to file: %s\n", entityToExport.PrimaryKey.Fingerprint, kpath)
 
 	return nil

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -686,15 +686,16 @@ func ExportPrivateKey(kpath string, armor bool) error {
 	if !armor {
 		// Export the key to the file
 		err = entityToExport.SerializePrivate(file, nil)
-		if err != nil {
-			return err
-		}
 	} else {
 		var keyText string
 		keyText, err = serializeEntity(entityToExport, openpgp.PrivateKeyType)
 		file.WriteString(keyText)
 	}
 	defer file.Close()
+
+	if err != nil {
+		return fmt.Errorf("unable to serialize private key: %v", err)
+	}
 	fmt.Printf("Private key with fingerprint %X correctly exported to file: %s\n", entityToExport.PrimaryKey.Fingerprint, kpath)
 
 	return nil

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -653,7 +653,7 @@ func LoadKeyringFromFile(path string) (openpgp.EntityList, error) {
 }
 
 // ExportPrivateKey Will export a private key into a file (kpath).
-func ExportPrivateKey(kpath string) error {
+func ExportPrivateKey(kpath string, armor bool) error {
 
 	f, err := os.OpenFile(SecretPath(), os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
@@ -683,18 +683,25 @@ func ExportPrivateKey(kpath string) error {
 		return err
 	}
 
-	// Export the key to the file
-	err = entityToExport.SerializePrivate(file, nil)
-	if err != nil {
-		return err
+	if !armor {
+		// Export the key to the file
+		err = entityToExport.SerializePrivate(file, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		var keyText string
+		keyText, err = serializeEntity(entityToExport, openpgp.PrivateKeyType)
+		file.WriteString(keyText)
 	}
+
 	fmt.Printf("Private key with fingerprint %X correctly exported to file: %s\n", entityToExport.PrimaryKey.Fingerprint, kpath)
 
 	return nil
 }
 
 // ExportPubKey Will export a public key into a file (kpath).
-func ExportPubKey(kpath string) error {
+func ExportPubKey(kpath string, armor bool) error {
 	file, err := os.Create(kpath)
 	if err != nil {
 		return fmt.Errorf("unable to create file: %v", err)
@@ -715,7 +722,13 @@ func ExportPubKey(kpath string) error {
 		return err
 	}
 
-	err = entityToExport.Serialize(file)
+	if !armor {
+		err = entityToExport.Serialize(file)
+	} else {
+		var keyText string
+		keyText, err = serializeEntity(entityToExport, openpgp.PublicKeyType)
+		file.WriteString(keyText)
+	}
 
 	if err != nil {
 		return fmt.Errorf("unable to serialize public key: %v", err)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Support for armor flag on key export command.

**This fixes or addresses the following GitHub issues:**

- Fixes #3279 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
