### PR TITLE
Remove installing dep from ci configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,6 @@ jobs:
           working_directory: /tmp
           command: |-
             mkdir -p ${GOBIN}
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             sudo apt-get update -y && sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev
       - run:
           name: Build and Install singularity

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -2,7 +2,6 @@
 
 if [ -z "$OS_TYPE" ]; then
     # default is ubuntu
-    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | /bin/sh
     exit
 fi
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This removes installing the go module 'dep' from circle ci and travis ci.   The travis ci one was added in my PR #2953, I think because of a merge error.


**This fixes or addresses the following GitHub issues:**

- None


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
