### PR TITLE
Converted the remote command status code to readable string

### DIFF
--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -24,6 +24,10 @@ var (
 	ErrNoDefault = errors.New("no default remote")
 )
 
+var errorCodeMap = map[int]string{
+	404: "Invalid Token",
+}
+
 // Config stores the state of remote endpoint configurations
 type Config struct {
 	DefaultRemote string               `yaml:"Active"`
@@ -212,7 +216,11 @@ func (e *EndPoint) VerifyToken() error {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("error response from server: %v", res.StatusCode)
+		convStatus := errorCodeMap[res.StatusCode]
+		if convStatus == "" {
+			convStatus = "Unknown"
+		}
+		return fmt.Errorf("error response from server: %v", convStatus)
 	}
 
 	return nil

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -26,6 +26,7 @@ var (
 
 var errorCodeMap = map[int]string{
 	404: "Invalid Token",
+	500: "Internal Server Error",
 }
 
 // Config stores the state of remote endpoint configurations
@@ -216,8 +217,8 @@ func (e *EndPoint) VerifyToken() error {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		convStatus := errorCodeMap[res.StatusCode]
-		if convStatus == "" {
+		convStatus, ok := errorCodeMap[res.StatusCode]
+		if !ok {
 			convStatus = "Unknown"
 		}
 		return fmt.Errorf("error response from server: %v", convStatus)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Converted the remote command status code to readable string

Output:
---------
vagrant@vagrant:~/go/src/github.com/sylabs/singularity$ singularity remote login sylabs
Generate an API Key at https://cloud.sylabs.io/auth/tokens, and paste here:
API Key: 
FATAL:   while verifying token: error response from server: Invalid Token

**This fixes or addresses the following GitHub issues:**

- Fixes #3000 

Attn: @singularity-maintainers