### PR TITLE
Document fact that --contain ignores bind paths

### DIFF
--- a/pkg/runtime/engines/singularity/config/data/singularity.conf
+++ b/pkg/runtime/engines/singularity/config/data/singularity.conf
@@ -101,6 +101,7 @@ mount hostfs = {{ if eq .MountHostfs true }}yes{{ else }}no{{ end }}
 # the container. The file or directory must exist within the container on
 # which to attach to. you can specify a different source and destination
 # path (respectively) with a colon; otherwise source and dest are the same.
+# NOTE: these are ignored if singularity is invoked with --contain.
 #bind path = /etc/singularity/default-nsswitch.conf:/etc/nsswitch.conf
 #bind path = /opt
 #bind path = /scratch


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add a comment in singularity.conf that --contain causes bind paths to be ignored.  This was already done for singularity-2 in #1212 but didn't get ported forward to singularity-3.


**This fixes or addresses the following GitHub issues:**

- mentioned in #1707 but does not fully address it


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
