### PR TITLE
Increase test coverage in pkg/sypgp

### DIFF
--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -414,9 +414,9 @@ func storePubKeyring(keys openpgp.EntityList) error {
 	return nil
 }
 
-// CompareKeyEntity compares a key ID with a string, returning true if the
+// compareKeyEntity compares a key ID with a string, returning true if the
 // key and oldToken match.
-func CompareKeyEntity(e *openpgp.Entity, oldToken string) bool {
+func compareKeyEntity(e *openpgp.Entity, oldToken string) bool {
 	// TODO: there must be a better way to do this...
 	return fmt.Sprintf("%X", e.PrimaryKey.Fingerprint) == oldToken
 }
@@ -435,7 +435,7 @@ func CheckLocalPubKey(ckey string) (bool, error) {
 	}
 
 	for i := range elist {
-		if CompareKeyEntity(elist[i], ckey) {
+		if compareKeyEntity(elist[i], ckey) {
 			return true, nil
 		}
 	}
@@ -461,7 +461,7 @@ func RemovePubKey(toDelete string) error {
 	// sort through them, and remove any that match toDelete
 	for i := range elist {
 		// if the elist[i] dose not match toDelete, then add it to newKeyList
-		if !CompareKeyEntity(elist[i], toDelete) {
+		if !compareKeyEntity(elist[i], toDelete) {
 			newKeyList = append(newKeyList, elist[i])
 		} else {
 			matchKey = true

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -477,6 +477,24 @@ func CheckLocalPubKey(ckey string) (bool, error) {
 	return findKeyByFingerprint(elist, ckey) != nil, nil
 }
 
+// removeKey removes one key identified by fingerprint from list.
+//
+// removeKey returns a new list with the key removed, or nil if the key
+// was not found. The elements of the new list are the _same_ pointers
+// found in the original list.
+func removeKey(list openpgp.EntityList, fingerprint string) openpgp.EntityList {
+	for idx, e := range list {
+		if compareKeyEntity(e, fingerprint) {
+			newList := make(openpgp.EntityList, len(list)-1)
+			copy(newList, list[:idx])
+			copy(newList[idx:], list[idx+1:])
+			return newList
+		}
+	}
+
+	return nil
+}
+
 // RemovePubKey will delete a public key matching toDelete
 func RemovePubKey(toDelete string) error {
 	// read all the local public keys

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -421,6 +421,16 @@ func compareKeyEntity(e *openpgp.Entity, oldToken string) bool {
 	return fmt.Sprintf("%X", e.PrimaryKey.Fingerprint) == oldToken
 }
 
+func findKeyByFingerprint(entities openpgp.EntityList, fingerprint string) *openpgp.Entity {
+	for _, e := range entities {
+		if compareKeyEntity(e, fingerprint) {
+			return e
+		}
+	}
+
+	return nil
+}
+
 // CheckLocalPubKey will check if we have a local public key matching ckey string
 // returns true if there's a match.
 func CheckLocalPubKey(ckey string) (bool, error) {
@@ -434,12 +444,7 @@ func CheckLocalPubKey(ckey string) (bool, error) {
 		return false, fmt.Errorf("unable to load local keyring: %v", err)
 	}
 
-	for i := range elist {
-		if compareKeyEntity(elist[i], ckey) {
-			return true, nil
-		}
-	}
-	return false, nil
+	return findKeyByFingerprint(elist, ckey) != nil, nil
 }
 
 // RemovePubKey will delete a public key matching toDelete

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -876,6 +876,7 @@ func ExportPrivateKey(kpath string, armor bool) error {
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	if !armor {
 		// Export the key to the file
@@ -888,7 +889,6 @@ func ExportPrivateKey(kpath string, armor bool) error {
 		}
 		file.WriteString(keyText)
 	}
-	defer file.Close()
 
 	if err != nil {
 		return fmt.Errorf("unable to serialize private key: %v", err)

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -507,21 +507,8 @@ func RemovePubKey(toDelete string) error {
 		return fmt.Errorf("unable to list local keyring: %v", err)
 	}
 
-	var newKeyList openpgp.EntityList
-
-	matchKey := false
-
-	// sort through them, and remove any that match toDelete
-	for i := range elist {
-		// if the elist[i] dose not match toDelete, then add it to newKeyList
-		if !compareKeyEntity(elist[i], toDelete) {
-			newKeyList = append(newKeyList, elist[i])
-		} else {
-			matchKey = true
-		}
-	}
-
-	if !matchKey {
+	newKeyList := removeKey(elist, toDelete)
+	if newKeyList == nil {
 		return fmt.Errorf("no key matching given fingerprint found")
 	}
 

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -383,6 +383,17 @@ func PrintPrivKeyring() error {
 	return nil
 }
 
+// storePrivKeys writes all the private keys in list to the writer w.
+func storePrivKeys(w io.Writer, list openpgp.EntityList) error {
+	for _, e := range list {
+		if err := e.SerializePrivate(w, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // appendPrivateKey appends a private key entity to the local keyring
 func appendPrivateKey(e *openpgp.Entity) error {
 	f, err := createOrAppendPrivateFile(SecretPath())
@@ -391,7 +402,18 @@ func appendPrivateKey(e *openpgp.Entity) error {
 	}
 	defer f.Close()
 
-	return e.SerializePrivate(f, nil)
+	return storePrivKeys(f, openpgp.EntityList{e})
+}
+
+// storePubKeys writes all the public keys in list to the writer w.
+func storePubKeys(w io.Writer, list openpgp.EntityList) error {
+	for _, e := range list {
+		if err := e.Serialize(w); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // appendPubKey appends a public key entity to the local keyring
@@ -402,7 +424,7 @@ func appendPubKey(e *openpgp.Entity) error {
 	}
 	defer f.Close()
 
-	return e.Serialize(f)
+	return storePubKeys(f, openpgp.EntityList{e})
 }
 
 // storePubKeyring overwrites the public keyring with the listed keys

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -218,6 +218,14 @@ func ensureDirPrivate(dn string) error {
 	return nil
 }
 
+// createOrAppendPrivateFile creates the named filename, making sure
+// it's only accessible to the current user.
+//
+// TODO(mem): move this function to a common location
+func createOrAppendPrivateFile(fn string) (*os.File, error) {
+	return os.OpenFile(fn, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+}
+
 // ensureFilePrivate makes sure that the file system mode for the named
 // file does not allow other users access to it (neither read nor
 // write).
@@ -377,7 +385,7 @@ func PrintPrivKeyring() error {
 
 // appendPrivateKey appends a private key entity to the local keyring
 func appendPrivateKey(e *openpgp.Entity) error {
-	f, err := os.OpenFile(SecretPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	f, err := createOrAppendPrivateFile(SecretPath())
 	if err != nil {
 		return err
 	}
@@ -388,7 +396,7 @@ func appendPrivateKey(e *openpgp.Entity) error {
 
 // appendPubKey appends a public key entity to the local keyring
 func appendPubKey(e *openpgp.Entity) error {
-	f, err := os.OpenFile(PublicPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	f, err := createOrAppendPrivateFile(PublicPath())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Break up PathsCheck so that the individual pieces can be tested
- Add ensureDirPrivate and ensureFilePrivate which are testable using
  temporary directories
- Add tests for ensureDirPrivate and ensureFilePrivate
- Add PrintEntity test

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>