### PR TITLE
Throw a warning if seccomp is used and not enabled

### DIFF
--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -167,7 +167,7 @@ func startInstance(image string, instance string, portOffset int, opts startOpts
 	}
 	args = append(args, image, instance, strconv.Itoa(instanceStartPort+portOffset))
 	cmd := exec.Command(cmdPath, args...)
-	return cmd.CombinedOutput()
+	return cmd.Output()
 }
 
 func listInstance(opts listOpts) ([]byte, error) {
@@ -182,7 +182,7 @@ func listInstance(opts listOpts) ([]byte, error) {
 		args = append(args, opts.container)
 	}
 	cmd := exec.Command(cmdPath, args...)
-	return cmd.CombinedOutput()
+	return cmd.Output()
 }
 
 func stopInstance(opts stopOpts) ([]byte, error) {
@@ -206,14 +206,14 @@ func stopInstance(opts stopOpts) ([]byte, error) {
 		args = append(args, opts.instance)
 	}
 	cmd := exec.Command(cmdPath, args...)
-	return cmd.CombinedOutput()
+	return cmd.Output()
 }
 
 func execInstance(instance string, execCmd ...string) ([]byte, error) {
 	args := []string{"exec", "instance://" + instance}
 	args = append(args, execCmd...)
 	cmd := exec.Command(cmdPath, args...)
-	return cmd.CombinedOutput()
+	return cmd.Output()
 }
 
 // Sends a deterministic message to an echo server and expects the same message

--- a/internal/pkg/security/security.go
+++ b/internal/pkg/security/security.go
@@ -40,13 +40,15 @@ func Configure(config *specs.Spec) error {
 			}
 		}
 	}
-	if config.Linux != nil && config.Linux.Seccomp != nil {
+	if config.Linux != nil {
 		if seccomp.Enabled() {
-			if err := seccomp.LoadSeccompConfig(config.Linux.Seccomp, config.Process.NoNewPrivileges); err != nil {
-				return err
+			if config.Linux.Seccomp != nil {
+				if err := seccomp.LoadSeccompConfig(config.Linux.Seccomp, config.Process.NoNewPrivileges); err != nil {
+					return err
+				}
 			}
 		} else {
-			sylog.Warningf("seccomp requested but not enabled")
+			sylog.Warningf("seccomp requested but not enabled, seccomp library is missing or too old")
 		}
 	}
 	return nil


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR displays a warning when seccomp is used and not enabled

**This fixes or addresses the following GitHub issues:**

- Fixes #3292 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
