### PR TITLE
Remove reliance on basename command to generate environment headers.

### DIFF
--- a/cmd/internal/cli/inspect_linux.go
+++ b/cmd/internal/cli/inspect_linux.go
@@ -116,7 +116,7 @@ func getTestCommand(appName string) string {
 func getEnvironmentCommand(appName string) string {
 	var str strings.Builder
 	str.WriteString(" for env in %s/env/9*-environment.sh; do")
-	str.WriteString("     echo `basename -z $env`:`wc -c < $env`;")
+	str.WriteString("     echo ${env##*/}:`wc -c < $env`;")
 	str.WriteString("     cat $env;")
 	str.WriteString(" done;")
 	return fmt.Sprintf(str.String(), getPathPrefix(appName))


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR removes reliance on the `basename` command to generate headers for the `singularity inspect -e` command's multiple possible environments. I was using `-z` to keep newlines from being printed, but alpine's version of `basename` does not have `-z` and has slightly different semantics. This refactor uses shell variable substitution instead.

**This fixes or addresses the following GitHub issues:**

- Fixes #3054

Attn: @singularity-maintainers
