### PR TITLE
Remove deprecated plugin hooks

### DIFF
--- a/internal/pkg/plugin/command.go
+++ b/internal/pkg/plugin/command.go
@@ -23,31 +23,3 @@ func AddCommands(rootCmd *cobra.Command) error {
 
 	return nil
 }
-
-// AddRootFlags calls all RootFlagAdder plugins and adds the returned flags
-// to the rootCmd
-func AddRootFlags(rootCmd *cobra.Command) error {
-	for _, pl := range loadedPlugins {
-		if _pl, ok := (pl.Initializer).(pluginapi.RootFlagAdder); ok {
-			for _, f := range _pl.RootFlagAdd() {
-				rootCmd.Flags().AddFlag(f)
-			}
-		}
-	}
-
-	return nil
-}
-
-// AddActionFlags calls all ActionFlagAdder plugins and adds the returned flags
-// to the actionCmd
-func AddActionFlags(actionCmd *cobra.Command) error {
-	for _, pl := range loadedPlugins {
-		if _pl, ok := (pl.Initializer).(pluginapi.ActionFlagAdder); ok {
-			for _, f := range _pl.ActionFlagAdd() {
-				actionCmd.Flags().AddFlag(f)
-			}
-		}
-	}
-
-	return nil
-}

--- a/pkg/plugin/command.go
+++ b/pkg/plugin/command.go
@@ -7,22 +7,9 @@ package plugin
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // CommandAdder allows a plugin to add new command(s) to the singularity binary
 type CommandAdder interface {
 	CommandAdd() []*cobra.Command
-}
-
-// RootFlagAdder is the interface for a plugin which wishes to add a flag to the
-// root singularity command
-type RootFlagAdder interface {
-	RootFlagAdd() []*pflag.Flag
-}
-
-// ActionFlagAdder is the interface for a plugin which wishes to add a flag to the
-// action command group (run, exec, shell, instance)
-type ActionFlagAdder interface {
-	ActionFlagAdd() []*pflag.Flag
 }


### PR DESCRIPTION
Signed-off-by: Michael Bauer <michael@bauer.dev>

**Description of the Pull Request (PR):**

Removes the older deprecated plugin hooks:

- `RootFlagAdder`
- `ActionFlagAdder`

