### PR TITLE
Correctly handle incorrect short global flags

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -81,9 +81,13 @@ func checkForInvalidSingularityShortFlags() {
 			name := os.Args[i][1:len(os.Args[i])]
 			_, ok := supportedShortFlags[name]
 			if !ok {
-				fmt.Printf("Invalid flag \"%s\" for command \"singularity\"\n", os.Args[i])
-				SingularityCmd.Printf("Run 'singularity --help' for more detailed usage information.\n")
-				os.Exit(1)
+				// Testing tools tend to add short flags and we should accept them
+				// so we don't break CI
+				if !strings.HasPrefix(name, "test.count") {
+					fmt.Printf("Invalid flag \"%s\" for command \"singularity\"\n", os.Args[i])
+					SingularityCmd.Printf("Run 'singularity --help' for more detailed usage information.\n")
+					os.Exit(1)
+				}
 			}
 		}
 	}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -83,7 +83,7 @@ func checkForInvalidSingularityShortFlags() {
 			if !ok {
 				// Testing tools tend to add short flags and we should accept them
 				// so we don't break CI
-				if !strings.HasPrefix(name, "test.count") {
+				if !strings.HasPrefix(name, "test.") {
 					fmt.Printf("Invalid flag \"%s\" for command \"singularity\"\n", os.Args[i])
 					SingularityCmd.Printf("Run 'singularity --help' for more detailed usage information.\n")
 					os.Exit(1)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Correctly handle incorrect short global flags.


**This fixes or addresses the following GitHub issues:**

- Fixes #3176 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers