### PR TITLE
Add scripts/check-vendor and update .circleci/config.yml to use it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,42 @@
 version: 2.0
 
 defaults: &defaults
-  working_directory: /go/src/github.com/sylabs/singularity
+  working_directory: /go/singularity
 
 jobs:
   get_source:
     <<: *defaults
     docker:
-      - image: sylabsio/golang:1.11-stretch
+      - image: sylabsio/golang:1.11.9-stretch
     steps:
       - checkout
       - persist_to_workspace:
           root: /go
           paths:
-            - src/github.com/sylabs/singularity
+            - singularity
 
-  go1.11-stretch:
+  cache_go_mod:
     <<: *defaults
     docker:
-      - image: sylabsio/golang:1.11-stretch
+      - image: sylabsio/golang:1.11.9-stretch
+    steps:
+      - attach_workspace:
+          at: /go
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
+      - run:
+          name: Check vendor/ module is up-to-date
+          command: scripts/check-vendor
+      - save_cache:
+          key: go-mod-{{ checksum "go.sum" }}
+          paths:
+            - '/go/pkg/mod'
+
+  go1.11.9-stretch:
+    <<: *defaults
+    docker:
+      - image: sylabsio/golang:1.11.9-stretch
     steps:
       - attach_workspace:
           at: /go
@@ -30,12 +48,12 @@ jobs:
       - run:
           name: Check code
           command: |-
-            make -j$(nproc) -C ./builddir vendor-check check
+            make -j$(nproc) -C ./builddir check
 
-  go1.11-alpine:
+  go1.11.9-alpine:
     <<: *defaults
     docker:
-      - image: sylabsio/golang:1.11-alpine
+      - image: sylabsio/golang:1.11.9-alpine
     steps:
       - attach_workspace:
           at: /go
@@ -47,7 +65,7 @@ jobs:
       - run:
           name: Check code
           command: |-
-            make -j$(nproc) -C ./builddir vendor-check check
+            make -j$(nproc) -C ./builddir check
 
   go1.11-macos:
     macos:
@@ -71,7 +89,7 @@ jobs:
       - run:
           name: Check code
           command: |-
-            make -j$(sysctl -n hw.logicalcpu) -C ./builddir vendor-check check
+            make -j$(sysctl -n hw.logicalcpu) -C ./builddir check
 
   unit_tests:
     machine: true
@@ -107,14 +125,14 @@ jobs:
       - run:
           name: Build and Install Singularity
           command: |-
-            cd $HOME/go/src/github.com/sylabs/singularity
+            cd $HOME/go/singularity
             ./mconfig -v -p /usr/local --without-network
             make -j$(nproc) -C ./builddir all
             sudo make -C ./builddir install
       - run:
           name: Run unit tests
           command: |-
-            cd $HOME/go/src/github.com/sylabs/singularity
+            cd $HOME/go/singularity
             make -j$(nproc) -C ./builddir unit-test
 
   e2e_tests:
@@ -152,14 +170,14 @@ jobs:
       - run:
           name: Build and Install singularity
           command: |-
-            cd $HOME/go/src/github.com/sylabs/singularity
+            cd $HOME/go/singularity
             ./mconfig -v -p /usr/local
             make -j$(nproc) -C ./builddir all
             sudo make -C ./builddir install
       - run:
           name: Run E2E tests
           command: |-
-            cd $HOME/go/src/github.com/sylabs/singularity
+            cd $HOME/go/singularity
             make -C ./builddir e2e-tests
 
 workflows:
@@ -167,12 +185,15 @@ workflows:
   build_and_test:
     jobs:
       - get_source
-      - go1.11-stretch:
+      - cache_go_mod:
           requires:
             - get_source
-      - go1.11-alpine:
+      - go1.11.9-stretch:
           requires:
-            - get_source
+            - cache_go_mod
+      - go1.11.9-alpine:
+          requires:
+            - cache_go_mod
       - go1.11-macos:
           requires:
             - get_source

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/globalsign/mgo v0.0.0-20180615134936-113d3961e731
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/gogo/protobuf v1.0.0 // indirect
-	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/gorilla/websocket v1.2.0
@@ -89,7 +88,7 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.25
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/yaml.v2 v2.2.2
-	gotest.tools v2.2.0+incompatible // indirect
+	gotest.tools v2.3.0+incompatible // indirect
 	k8s.io/client-go v11.0.0+incompatible // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpbl
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20180810170437-e96c4e24768d/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -231,7 +232,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
-gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools v2.3.0+incompatible h1:oTCKjb7ZuVfn37AQodk7UysjQQL/S5Dep3pzi59u1NQ=
+gotest.tools v2.3.0+incompatible/go.mod h1:R//lfYlUuTOTfblYI3lGoAAAebUdzjvbmQsuB7Ykd90=
 k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -57,7 +57,7 @@ test:
 	@echo "       PASS"
 
 .PHONY: testall
-testall: vendor-check check test
+testall: check test
 
 .PHONY: rpm
 rpm: dist
@@ -95,10 +95,5 @@ install: $(INSTALLFILES)
 vendor:
 	@echo " VENDOR"
 	$(V)$(GO) mod vendor >/dev/null
-
-.PHONY: vendor-check
-vendor-check:
-	@echo " VENDOR CHECK"
-	$(V)$(GO) mod verify
 
 -include $(BUILDDIR)/mergeddeps

--- a/scripts/check-vendor
+++ b/scripts/check-vendor
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+
+if test ! -e go.mod ; then
+	echo "E: $PWD/go.mod not found. Abort."
+	exit 1
+fi
+
+export GO111MODULE=on
+
+# Make sure the index is updated
+git update-index --refresh
+
+if ! git diff-index --raw --exit-code HEAD ; then
+	echo "E: Workspace is unexpectly dirty. Abort."
+	exit 2
+fi
+
+if ! go mod download ; then
+	echo "E: Failed to download Go modules. Abort"
+	exit 3
+fi
+
+if ! go mod verify > /dev/null ; then
+	echo "E: Invalid Go module state. Abort."
+	exit 4
+fi
+
+if ! go mod vendor ; then
+	echo "E: Failed to update vendor/ directory. Abort."
+	exit 5
+fi
+
+# the go mod vendor command above might have opened files in vendor, and
+# this tells git that things _might_ have been modified so it should
+# check that.
+git update-index --refresh
+
+if ! git diff-index --raw --exit-code HEAD ; then
+	echo "E: Workspace became dirty after runnig 'go mod vendor'. Abort."
+	exit 6
+fi
+
+echo "I: Vendor directory OK."
+exit 0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,12 +258,12 @@ github.com/xeipuuv/gojsonschema
 # go4.org v0.0.0-20180417224846-9599cf28b011
 go4.org/errorutil
 # golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 => github.com/sylabs/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9
-golang.org/x/crypto/openpgp/armor
-golang.org/x/crypto/openpgp/errors
 golang.org/x/crypto/ssh/terminal
 golang.org/x/crypto/openpgp
 golang.org/x/crypto/openpgp/clearsign
+golang.org/x/crypto/openpgp/armor
 golang.org/x/crypto/openpgp/packet
+golang.org/x/crypto/openpgp/errors
 golang.org/x/crypto/openpgp/s2k
 golang.org/x/crypto/cast5
 golang.org/x/crypto/openpgp/elgamal


### PR DESCRIPTION
scripts/check-vendor makes sure that the contents of the vendor/
directory match the modules specified in go.mod. This prevents changes
that accidentally modify go.mod without updating vendor from merging. It
also prevents accidental modifications to vendor.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>
