### PR TITLE
Split the e2e-test makefile target into two targets so either set of tests can be run by themselves.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
           name: Run E2E tests
           command: |-
             cd $HOME/go/singularity
-            make -C ./builddir e2e-test
+            make -C ./builddir integration-test e2e-test
 
 workflows:
   version: 2

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -40,15 +40,17 @@ unit-test:
 
 .PHONY: e2e-test
 e2e-test:
-	@echo " TEST sudo go test [integration]"
-	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race \
-		./cmd/singularity ./pkg/network
-	@echo "       PASS"
 	@echo " TEST sudo go test [e2e]"
 	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race \
 		./e2e
 	@echo "       PASS"
 
+.PHONY: integration-test
+integration-test:
+	@echo " TEST sudo go test [integration]"
+	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race \
+		./cmd/singularity ./pkg/network
+	@echo "       PASS"
 
 .PHONY: test
 test:


### PR DESCRIPTION
Split the e2e-test makefile target into two targets so either set of tests can be run by themselves.

Attn: @singularity-maintainers
