### PR TITLE
OCI engine: empty mount destination file

### DIFF
--- a/internal/pkg/runtime/engines/oci/create_linux.go
+++ b/internal/pkg/runtime/engines/oci/create_linux.go
@@ -925,7 +925,11 @@ func (c *container) mount(point *mount.Point) error {
 							return err
 						}
 					}
-				case syscall.S_IFREG:
+				case syscall.S_IFREG,
+					syscall.S_IFBLK,
+					syscall.S_IFCHR,
+					syscall.S_IFIFO,
+					syscall.S_IFSOCK:
 					sylog.Debugf("Creating file %s", filepath.Base(procDest))
 					if c.userNS {
 						if _, err := c.rpcOps.Touch(dest); err != nil {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR creates empty destination file in OCI engine when mount source is a block, character, fifo or a socket file

**This fixes or addresses the following GitHub issues:**

- Fixes #3373 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
