### PR TITLE
Compile only compatible engines for SUID binary 

### DIFF
--- a/internal/pkg/runtime/engines/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engines/config/starter/starter_linux.go
@@ -21,7 +21,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/opencontainers/runtime-spec/specs-go"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/capabilities"
 )

--- a/internal/pkg/runtime/engines/imgbuild/config/config.go
+++ b/internal/pkg/runtime/engines/imgbuild/config/config.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build build_engine
+
 package imgbuild
 
 import (

--- a/internal/pkg/runtime/engines/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/create_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build build_engine
+
 package imgbuild
 
 import (
@@ -18,7 +20,6 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/build/copy"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
-	imgbuildConfig "github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild/config"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/client"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
@@ -26,10 +27,6 @@ import (
 
 // CreateContainer creates a container
 func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error {
-	if engine.CommonConfig.EngineName != imgbuildConfig.Name {
-		return fmt.Errorf("engineName configuration doesn't match runtime name")
-	}
-
 	rpcOps := &client.RPC{
 		Client: rpc.NewClient(rpcConn),
 		Name:   engine.CommonConfig.EngineName,

--- a/internal/pkg/runtime/engines/imgbuild/engine_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/engine_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build build_engine
+
 package imgbuild
 
 import (
@@ -10,7 +12,6 @@ import (
 	"syscall"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/starter"
 	imgbuildConfig "github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild/config"
@@ -41,10 +42,6 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	if syscall.Getuid() != 0 {
 		return fmt.Errorf("unable to run imgbuild engine as non-root user")
-	}
-
-	if starterConfig.GetIsSUID() {
-		return fmt.Errorf("%s don't allow SUID workflow", e.CommonConfig.EngineName)
 	}
 
 	e.EngineConfig.OciConfig.SetupPrivileged(true)

--- a/internal/pkg/runtime/engines/imgbuild/init.go
+++ b/internal/pkg/runtime/engines/imgbuild/init.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !build_engine or !linux
+
+package imgbuild
+
+// Init registers runtime engine, this method is called
+// from cmd/starter/main_linux.go
+func Init(name string) error {
+	return nil
+}

--- a/internal/pkg/runtime/engines/imgbuild/init_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/init_linux.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build build_engine
+
+package imgbuild
+
+import (
+	"github.com/sylabs/singularity/internal/pkg/runtime/engines"
+	imgbuildConfig "github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild/config"
+	"github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/server"
+)
+
+// Init registers runtime engine, this method is called
+// from cmd/starter/main_linux.go
+func Init(name string) error {
+	if name != imgbuildConfig.Name {
+		return nil
+	}
+	eOp := &EngineOperations{EngineConfig: &imgbuildConfig.EngineConfig{}}
+	if err := engines.RegisterEngineOperations(imgbuildConfig.Name, eOp); err != nil {
+		return err
+	}
+	return engines.RegisterEngineRPCMethods(imgbuildConfig.Name, new(server.Methods))
+}

--- a/internal/pkg/runtime/engines/imgbuild/process_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/process_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build build_engine
+
 package imgbuild
 
 import (

--- a/internal/pkg/runtime/engines/oci/cleanup_linux.go
+++ b/internal/pkg/runtime/engines/oci/cleanup_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package oci
 
 import (

--- a/internal/pkg/runtime/engines/oci/config_linux.go
+++ b/internal/pkg/runtime/engines/oci/config_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package oci
 
 import (

--- a/internal/pkg/runtime/engines/oci/create_linux.go
+++ b/internal/pkg/runtime/engines/oci/create_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package oci
 
 import (

--- a/internal/pkg/runtime/engines/oci/engine_linux.go
+++ b/internal/pkg/runtime/engines/oci/engine_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package oci
 
 import (

--- a/internal/pkg/runtime/engines/oci/init.go
+++ b/internal/pkg/runtime/engines/oci/init.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !oci_engine or !linux
+
+package oci
+
+// Init registers runtime engine, this method is called
+// from cmd/starter/main_linux.go
+func Init(name string) error {
+	return nil
+}

--- a/internal/pkg/runtime/engines/oci/init_linux.go
+++ b/internal/pkg/runtime/engines/oci/init_linux.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build oci_engine
+
+package oci
+
+import (
+	"github.com/sylabs/singularity/internal/pkg/runtime/engines"
+	ociserver "github.com/sylabs/singularity/internal/pkg/runtime/engines/oci/rpc/server"
+	"github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/server"
+)
+
+// Init registers runtime engine, this method is called
+// from cmd/starter/main_linux.go
+func Init(name string) error {
+	if name != Name {
+		return nil
+	}
+	eOp := &EngineOperations{EngineConfig: &EngineConfig{}}
+	if err := engines.RegisterEngineOperations(Name, eOp); err != nil {
+		return err
+	}
+	ocimethods := new(ociserver.Methods)
+	ocimethods.Methods = new(server.Methods)
+	return engines.RegisterEngineRPCMethods(Name, ocimethods)
+}

--- a/internal/pkg/runtime/engines/oci/monitor_linux.go
+++ b/internal/pkg/runtime/engines/oci/monitor_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package oci
 
 import (

--- a/internal/pkg/runtime/engines/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engines/oci/prepare_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package oci
 
 import (
@@ -56,14 +58,6 @@ func (e *EngineOperations) checkCapabilities() error {
 
 // PrepareConfig checks and prepares the runtime engine config
 func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
-	if e.CommonConfig.EngineName != Name {
-		return fmt.Errorf("incorrect engine")
-	}
-
-	if starterConfig.GetIsSUID() {
-		return fmt.Errorf("SUID workflow disabled by administrator")
-	}
-
 	if e.EngineConfig.OciConfig.Process == nil {
 		return fmt.Errorf("empty OCI process configuration")
 	}

--- a/internal/pkg/runtime/engines/oci/process_linux.go
+++ b/internal/pkg/runtime/engines/oci/process_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package oci
 
 import (

--- a/internal/pkg/runtime/engines/oci/rpc/args.go
+++ b/internal/pkg/runtime/engines/oci/rpc/args.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package rpc
 
 // SymlinkArgs defines the arguments to symlink.

--- a/internal/pkg/runtime/engines/oci/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/oci/rpc/client/client.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package client
 
 import (

--- a/internal/pkg/runtime/engines/oci/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/oci/rpc/server/server_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build oci_engine
+
 package server
 
 import (

--- a/internal/pkg/runtime/engines/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engines/singularity/cleanup_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package singularity
 
 import (

--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package singularity
 
 import (

--- a/internal/pkg/runtime/engines/singularity/create_linux.go
+++ b/internal/pkg/runtime/engines/singularity/create_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package singularity
 
 import (
@@ -16,15 +18,10 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/client"
-	singularityConfig "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 )
 
 // CreateContainer creates a container
 func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error {
-	if engine.CommonConfig.EngineName != singularityConfig.Name {
-		return fmt.Errorf("engineName configuration doesn't match runtime name")
-	}
-
 	if engine.EngineConfig.GetInstanceJoin() {
 		return nil
 	}

--- a/internal/pkg/runtime/engines/singularity/engine.go
+++ b/internal/pkg/runtime/engines/singularity/engine.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package singularity
 
 import (

--- a/internal/pkg/runtime/engines/singularity/init.go
+++ b/internal/pkg/runtime/engines/singularity/init.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !singularity_engine or !linux
+
+package singularity
+
+// Init registers runtime engine, this method is called
+// from cmd/starter/main_linux.go
+func Init(name string) error {
+	return nil
+}

--- a/internal/pkg/runtime/engines/singularity/init_linux.go
+++ b/internal/pkg/runtime/engines/singularity/init_linux.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build singularity_engine
+
+package singularity
+
+import (
+	"github.com/sylabs/singularity/internal/pkg/runtime/engines"
+	"github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/server"
+	singularityConfig "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
+)
+
+// Init registers runtime engine, this method is called
+// from cmd/starter/main_linux.go
+func Init(name string) error {
+	if name != singularityConfig.Name {
+		return nil
+	}
+	eOp := &EngineOperations{EngineConfig: singularityConfig.NewConfig()}
+	if err := engines.RegisterEngineOperations(singularityConfig.Name, eOp); err != nil {
+		return err
+	}
+	return engines.RegisterEngineRPCMethods(singularityConfig.Name, new(server.Methods))
+}

--- a/internal/pkg/runtime/engines/singularity/monitor.go
+++ b/internal/pkg/runtime/engines/singularity/monitor.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package singularity
 
 import (

--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package singularity
 
 import (
@@ -453,10 +455,6 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 
 // PrepareConfig checks and prepares the runtime engine config
 func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
-	if e.CommonConfig.EngineName != singularityConfig.Name {
-		return fmt.Errorf("incorrect engine")
-	}
-
 	configurationFile := buildcfg.SYSCONFDIR + "/singularity/singularity.conf"
 	if err := config.Parser(configurationFile, e.EngineConfig.File); err != nil {
 		return fmt.Errorf("Unable to parse singularity.conf file: %s", err)

--- a/internal/pkg/runtime/engines/singularity/process_linux.go
+++ b/internal/pkg/runtime/engines/singularity/process_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package singularity
 
 import (

--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package rpc
 
 import (

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package client
 
 import (

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build singularity_engine
+
 package server
 
 import (

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -16,7 +16,7 @@ $(BUILDDIR)/.clean-starter: $(starter_CSOURCE)
 # starter
 starter := $(BUILDDIR)/cmd/starter/c/starter
 $(starter): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starter_SOURCE)
-	@echo " GO" $@
+	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS)\"
 	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go
 

--- a/mlocal/frags/build_runtime_suid.mk
+++ b/mlocal/frags/build_runtime_suid.mk
@@ -2,10 +2,19 @@
 #   include this file, Makefile_runtime.stub MUST first be included.
 
 # starter suid
+starter_suid := $(BUILDDIR)/cmd/starter/c/starter-suid
 starter_suid_INSTALL := $(DESTDIR)$(LIBEXECDIR)/singularity/bin/starter-suid
-$(starter_suid_INSTALL): $(starter)
+
+$(starter_suid): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starter_SOURCE)
+	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS_SUID)\"
+	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS_SUID)" $(GO_LDFLAGS) $(GO_GCFLAGS) $(GO_ASMFLAGS) \
+		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go
+
+$(starter_suid_INSTALL): $(starter_suid)
 	@echo " INSTALL SUID" $@
 	$(V)install -d $(@D)
-	$(V)install -m 4755 $(starter) $(starter_suid_INSTALL)
+	$(V)install -m 4755 $(starter_suid) $(starter_suid_INSTALL)
 
+CLEANFILES += $(starter_suid)
 INSTALLFILES += $(starter_suid_INSTALL)
+ALL += $(starter_suid)

--- a/mlocal/frags/go_appsec_opts.mk
+++ b/mlocal/frags/go_appsec_opts.mk
@@ -1,1 +1,2 @@
 GO_TAGS += seccomp
+GO_TAGS_SUID += seccomp

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -1,6 +1,7 @@
 # go tool default build options
 GO111MODULE := on
-GO_TAGS := containers_image_openpgp sylog
+GO_TAGS := containers_image_openpgp sylog build_engine oci_engine singularity_engine
+GO_TAGS_SUID := containers_image_openpgp sylog singularity_engine
 GO_LDFLAGS :=
 GO_BUILDMODE := -buildmode=default
 GO_GCFLAGS := -gcflags=all=-trimpath=$(SOURCEDIR)

--- a/mlocal/frags/go_unix_opts.mk
+++ b/mlocal/frags/go_unix_opts.mk
@@ -1,1 +1,2 @@
 GO_TAGS += apparmor selinux
+GO_TAGS_SUID += apparmor selinux


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR allow to filter (with Go build tags) runtime engines embedded within SUID binary

**This fixes or addresses the following GitHub issues:**

- Fixes #3380 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
