### PR TITLE
Change plugin API CommandAdder -> CommandHook

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -92,7 +92,7 @@ func init() {
 	SingularityCmd.AddCommand(VersionCmd)
 
 	initializePlugins()
-	plugin.AddCommands(SingularityCmd)
+	SingularityCmd.AddCommand(plugin.AllCommands()...)
 }
 
 func setSylogMessageLevel(cmd *cobra.Command, args []string) {

--- a/examples/plugins/test-plugin/main.go
+++ b/examples/plugins/test-plugin/main.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	singularity "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 	pluginapi "github.com/sylabs/singularity/pkg/plugin"
+	singularity "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 )
 
 // Plugin is the only variable which a plugin MUST export. This symbol is accessed
@@ -33,6 +33,7 @@ type pluginImplementation struct {
 var impl = pluginImplementation{}
 
 func (p pluginImplementation) Initialize(r pluginapi.HookRegistration) {
+	// Adding a custom flag to the action commands
 	flag := pluginapi.StringFlagHook{
 		Flag: pflag.Flag{
 			Name:      "test-flag",
@@ -47,23 +48,22 @@ func (p pluginImplementation) Initialize(r pluginapi.HookRegistration) {
 	}
 
 	r.RegisterStringFlag(flag)
-}
 
-func (p pluginImplementation) CommandAdd() []*cobra.Command {
-	ret := []*cobra.Command{}
-
-	ret = append(ret, &cobra.Command{
-		DisableFlagsInUseLine: true,
-		Args:                  cobra.MinimumNArgs(1),
-		Use:                   "test-cmd [args ...]",
-		Short:                 "Test test test",
-		Long:                  "Long test long test long test",
-		Example:               "singularity test-cmd my test",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("test-cmd is printing args:", args)
+	// Adding a custom command to the root command
+	cmd := pluginapi.CommandHook{
+		Command: &cobra.Command{
+			DisableFlagsInUseLine: true,
+			Args:                  cobra.MinimumNArgs(1),
+			Use:                   "test-cmd [args ...]",
+			Short:                 "Test test test",
+			Long:                  "Long test long test long test",
+			Example:               "singularity test-cmd my test",
+			Run: func(cmd *cobra.Command, args []string) {
+				fmt.Println("test-cmd is printing args:", args)
+			},
+			TraverseChildren: true,
 		},
-		TraverseChildren: true,
-	})
+	}
 
-	return ret
+	r.RegisterCommand(cmd)
 }

--- a/internal/pkg/plugin/command.go
+++ b/internal/pkg/plugin/command.go
@@ -10,16 +10,21 @@ import (
 	pluginapi "github.com/sylabs/singularity/pkg/plugin"
 )
 
-// AddCommands calls all CommandAdder plugins and adds the commands to the
-// roootCmd
-func AddCommands(rootCmd *cobra.Command) error {
-	for _, pl := range loadedPlugins {
-		if _pl, ok := (pl.Initializer).(pluginapi.CommandAdder); ok {
-			for _, cmd := range _pl.CommandAdd() {
-				rootCmd.AddCommand(cmd)
-			}
-		}
-	}
+type commandRegistry struct {
+	Commands []*cobra.Command
+}
+
+// RegisterCommand registers a CommandHook for adding a new command to the singularity
+// binary
+func (r *commandRegistry) RegisterCommand(hook pluginapi.CommandHook) error {
+	r.Commands = append(r.Commands, hook.Command)
 
 	return nil
+}
+
+// AllCommands returns a slice of commands registered by plugins which need to be
+// added to the main SingularityCmd. By simply returning the slice of objects, it's
+// trivial to handle this from the CLI.
+func AllCommands() []*cobra.Command {
+	return reg.commandRegistry.Commands
 }

--- a/internal/pkg/plugin/flag.go
+++ b/internal/pkg/plugin/flag.go
@@ -59,7 +59,7 @@ func AddFlagHooks(flagSet *pflag.FlagSet) {
 func FlagHookCallbacks(c *singularity.EngineConfig) {
 	assertInitialized()
 
-	for _, hook := range reg.Hooks {
+	for _, hook := range reg.flagRegistry.Hooks {
 		hook.callback(hook.flag, c)
 	}
 }

--- a/internal/pkg/plugin/registry.go
+++ b/internal/pkg/plugin/registry.go
@@ -5,10 +5,14 @@
 
 package plugin
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
 
 type registry struct {
 	*flagRegistry
+	*commandRegistry
 }
 
 var reg registry
@@ -18,6 +22,9 @@ func init() {
 		flagRegistry: &flagRegistry{
 			FlagSet: pflag.NewFlagSet("flagRegistrySet", pflag.ExitOnError),
 			Hooks:   []flagHook{},
+		},
+		commandRegistry: &commandRegistry{
+			Commands: []*cobra.Command{},
 		},
 	}
 }

--- a/pkg/plugin/command.go
+++ b/pkg/plugin/command.go
@@ -9,7 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CommandAdder allows a plugin to add new command(s) to the singularity binary
-type CommandAdder interface {
-	CommandAdd() []*cobra.Command
+// CommandHook allows a plugin to add new command(s) to singularity by
+// defining custom cobra.Command objects.
+type CommandHook struct {
+	Command *cobra.Command
 }

--- a/pkg/plugin/register.go
+++ b/pkg/plugin/register.go
@@ -10,4 +10,5 @@ package plugin
 type HookRegistration interface {
 	RegisterStringFlag(StringFlagHook) error
 	RegisterBoolFlag(BoolFlagHook) error
+	RegisterCommand(CommandHook) error
 }


### PR DESCRIPTION
In order to be more consistent with how we are defining the
plugin API, the CommandAdder interface was changed to use
the new design pattern which FlagHooks already use. This
establishes a commandRegistry in the internal plugin package
which tracks all CommandHooks registered by all plugins.

Signed-off-by: Michael Bauer <michael@bauer.dev>

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
