### PR TITLE
Fix recorded version of github.com/opencontainers/image-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v0.0.0-20180411145040-e562b0440392
-	github.com/opencontainers/image-tools v0.0.0-00010101000000-000000000000
+	github.com/opencontainers/image-tools v0.0.0-20180129025323-c95f76cbae74
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/runtime-spec v0.0.0-20180913141938-5806c3563733
 	github.com/opencontainers/runtime-tools v0.6.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,7 +184,7 @@ github.com/opencontainers/go-digest
 github.com/opencontainers/image-spec/specs-go/v1
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/schema
-# github.com/opencontainers/image-tools v0.0.0-00010101000000-000000000000 => github.com/sylabs/image-tools v0.0.0-20181006203805-2814f4980568
+# github.com/opencontainers/image-tools v0.0.0-20180129025323-c95f76cbae74 => github.com/sylabs/image-tools v0.0.0-20181006203805-2814f4980568
 github.com/opencontainers/image-tools/image
 # github.com/opencontainers/runc v0.1.1
 github.com/opencontainers/runc/libcontainer/system


### PR DESCRIPTION
The timestamp and commit hash correspond to the most recent commit in 
github.com/opencontainers/image-tools right before our modifications.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>