### PR TITLE
Update ReadFrom() to properly handle invalid YAML files

### DIFF
--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -56,8 +56,10 @@ func ReadFrom(r io.Reader) (*Config, error) {
 	}
 
 	if len(b) > 0 {
-		// if we had data to read in io.Reader, attempt to unmarshal as YAML
-		if err := yaml.Unmarshal(b, c); err != nil {
+		// If we had data to read in io.Reader, attempt to unmarshal as YAML.
+		// Also, it will fail if the YAML file does not have the expected
+		// structure.
+		if err := yaml.UnmarshalStrict(b, c); err != nil {
 			return nil, fmt.Errorf("failed to decode YAML data from io.Reader: %s", err)
 		}
 	}

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -8,7 +8,6 @@ package remote
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -90,31 +89,19 @@ func TestWriteToReadFrom(t *testing.T) {
 
 	for _, test := range testsFail {
 		t.Run(test.name, func(t *testing.T) {
+			var r bytes.Buffer
+
 			yaml, err := yaml.Marshal(test.data)
 			if err != nil {
 				t.Fatalf("cannot mashal YAML: %s\n", err)
 			}
 
-			// We manually create the file to test ReadFrom()
-			tempFile, err := ioutil.TempFile("", "")
+			_, err = r.Write(yaml)
 			if err != nil {
-				t.Fatalf("cannot create temporary file: %s\n", err)
-			}
-			path := tempFile.Name()
-
-			_, err = tempFile.Write(yaml)
-			defer os.Remove(path)
-			tempFile.Close()
-			if err != nil {
-				t.Fatalf("cannot write to file: %s\n", err)
+				t.Fatalf("failed to write YAML data")
 			}
 
-			file, err := os.Open(path)
-			if err != nil {
-				t.Fatalf("cannot open file: %s\n", err)
-			}
-			defer file.Close()
-			_, err = ReadFrom(file)
+			_, err = ReadFrom(&r)
 			if err == nil {
 				t.Fatal("reading an invalid YAML file succeeded")
 			}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Update the ReadFrom() code and the associated test to correctly handle invalid YAML files. It now returns an error, as expected. Modifications based on the suggestion from Ian Kaneshiro.


**This fixes or addresses the following GitHub issues:**

- Fixes #3398 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers