### PR TITLE
Improve e2e driver error reporting

### DIFF
--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"syscall"
 	"testing"
 
@@ -35,29 +36,32 @@ func Run(t *testing.T) {
 	useragent.InitValue(buildcfg.PACKAGE_NAME, buildcfg.PACKAGE_VERSION)
 
 	// Ensure binary is in $PATH
-	cmdPath, err := exec.LookPath("singularity")
-	if err != nil {
+	cmdPath := filepath.Join(buildcfg.BINDIR, "singularity")
+	if _, err := exec.LookPath(cmdPath); err != nil {
 		log.Fatalf("singularity is not installed on this system: %v", err)
 	}
+
 	os.Setenv("E2E_CMD_PATH", cmdPath)
 
-	// Ensure config files are installed
-	configFiles := []struct {
-		fileName string
-		filePath string
-	}{
-		{"singularity.conf", "/singularity/singularity.conf"},
-		{"ecl.toml", "/singularity/ecl.toml"},
-		{"capability.json", "/singularity/capability.json"},
-		{"nvliblist.conf", "/singularity/nvliblist.conf"},
+	sysconfdir := func(fn string) string {
+		return filepath.Join(buildcfg.SYSCONFDIR, "singularity", fn)
 	}
+
+	// Ensure config files are installed
+	configFiles := []string{
+		sysconfdir("singularity.conf"),
+		sysconfdir("ecl.toml"),
+		sysconfdir("capability.json"),
+		sysconfdir("nvliblist.conf"),
+	}
+
 	for _, cf := range configFiles {
-		if fi, err := os.Stat(buildcfg.SYSCONFDIR + cf.filePath); err != nil {
-			log.Fatalf("%s is not installed on this system: %v", cf.fileName, err)
+		if fi, err := os.Stat(cf); err != nil {
+			log.Fatalf("%s is not installed on this system: %v", cf, err)
 		} else if !fi.Mode().IsRegular() {
-			log.Fatalf("%s is not a regular file", cf.fileName)
+			log.Fatalf("%s is not a regular file", cf)
 		} else if fi.Sys().(*syscall.Stat_t).Uid != 0 {
-			log.Fatalf("%s must be owned by root", cf.fileName)
+			log.Fatalf("%s must be owned by root", cf)
 		}
 	}
 


### PR DESCRIPTION
Use singularity's binary derived from compilation configuration to make
sure we are testing the binary that matches the source tree.

Use full paths when reporting errors so that the user knows what needs
to be fixed.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>