### PR TITLE
Ignore the e2e directory when doing unit tests

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -34,7 +34,7 @@ dist:
 unit-test:
 	@echo " TEST sudo go test [unit]"
 	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race \
-		`$(GO) list ./... | grep -v "cmd/singularity\|pkg/network"`
+		`$(GO) list ./... | grep -v "cmd/singularity\|pkg/network\|e2e"`
 	@echo "       PASS"
 
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

`make unit-test` was accidentally including the `e2e` directory when being executed.

```
?       github.com/sylabs/singularity/docs      [no test files]
ok      github.com/sylabs/singularity/e2e       1.008s  coverage: 5.1% of statements
?       github.com/sylabs/singularity/e2e/actions       [no test files]
?       github.com/sylabs/singularity/e2e/imgbuild      [no test files]
?       github.com/sylabs/singularity/e2e/pull  [no test files]
ok      github.com/sylabs/singularity/etc/conf  1.035s  coverage: 36.0% of statements
```

This should make sure that does not happen anymore.

```
?       github.com/sylabs/singularity/docs      [no test files]
ok      github.com/sylabs/singularity/etc/conf  1.034s  coverage: 36.0% of statements
```
Attn: @jmstover @mem @ArangoGutierrez 