### PR TITLE
Check the Go compiler during mconfig

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -19,6 +19,9 @@ hstar=
 hstld=
 hstranlib=
 hstobjcopy=
+hstgo=
+hstgo_version="go1.11"
+hstgo_opts="go"
 
 tgtcc=
 tgtcc_opts=$hstcc_opts
@@ -640,6 +643,8 @@ ARCH := $tgt_arch
 
 CFLAGS := $cflags
 
+GO := $hstgo
+
 CGO_CFLAGS := -include $builddir/config.h $CGO_CFLAGS
 CGO_LDFLAGS := $CGO_LDFLAGS
 CGO_CPPFLAGS := $CGO_CPPFLAGS
@@ -841,6 +846,9 @@ echo "=> project $package_name setup with :"
 echo "    - host arch: $hst_arch"
 echo "    - host wordsize: ${hst_word}-bit"
 echo "    - host C compiler: $hstcc"
+if test "${lang_go}" -eq 1 ; then
+	echo "    - host Go compiler: $hstgo"
+fi
 echo "    - host system: $host"
 echo "      ---"
 echo "    - target arch: $tgt_arch"

--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -74,7 +74,7 @@ else
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
 	if $hstgo run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
 		hstgo=`command -v $go`
-		echo $hostgo
+		echo $hstgo
 	else
 		echo "$hstgo cannot compile test code!"
 		usage

--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -55,6 +55,33 @@ else
 	fi
 fi
 
+if [ "$hstgo" = "" ]; then
+	printf " checking: host Go compiler (at least version $hstgo_version)... "
+	for go in $hstgo_opts; do
+		if $go run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
+			hstgo=`command -v $go`
+			break
+		fi
+	done
+	if [ "$hstgo" != "" ]; then
+		echo $hstgo
+	else
+		echo "not found!"
+		usage
+		exit 1
+	fi
+else
+	printf " checking: host Go compiler (at least version $hstgo_version)... "
+	if $hstgo run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
+		hstgo=`command -v $go`
+		echo $hostgo
+	else
+		echo "$hstgo cannot compile test code!"
+		usage
+		exit 1
+	fi
+fi
+
 ########################
 # host compilers options
 ########################

--- a/mlocal/checks/version.go
+++ b/mlocal/checks/version.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Printf("E: missing target Go version\n")
+		os.Exit(128)
+	}
+
+	for _, tag := range build.Default.ReleaseTags {
+		if tag == os.Args[1] {
+			return
+		}
+	}
+
+	os.Exit(1)
+}

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -9,5 +9,3 @@ GO_MODFLAGS :=
 GOFLAGS := -mod=vendor
 
 export GOFLAGS GO111MODULE
-
-GO := $(shell which go)


### PR DESCRIPTION
- Check that there's a Go compiler
- Check that the version of that compiler is at least what we need (1.11
  as of this writing)

Fixes: #3376

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>