### PR TITLE
Port remote_test.go test to E2E framework to fix #3350

### DIFF
--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sylabs/singularity/e2e/actions"
 	"github.com/sylabs/singularity/e2e/imgbuild"
 	"github.com/sylabs/singularity/e2e/pull"
+	"github.com/sylabs/singularity/e2e/remote"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
@@ -26,7 +27,7 @@ import (
 var runDisabled = flag.Bool("run_disabled", false, "run tests that have been temporarily disabled")
 
 // Run is the main func for the test framework, initializes the required vars
-// and set the environment for the RunE2ETests framework
+// and sets the environment for the RunE2ETests framework
 func Run(t *testing.T) {
 	flag.Parse()
 
@@ -86,4 +87,5 @@ func Run(t *testing.T) {
 	t.Run("BUILD", imgbuild.RunE2ETests)
 	t.Run("ACTIONS", actions.RunE2ETests)
 	t.Run("PULL", pull.RunE2ETests)
+	t.Run("REMOTE", remote.RunE2ETests)
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Port remote_test.go test to E2E framework

**This fixes or addresses the following GitHub issues:**

- Fixes #3350 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
