### PR TITLE
Make sure Go modules are disabled when checking Go version

### DIFF
--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -58,7 +58,7 @@ fi
 if [ "$hstgo" = "" ]; then
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
 	for go in $hstgo_opts; do
-		if $go run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
+		if env GO111MODULE=off $go run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
 			hstgo=`command -v $go`
 			break
 		fi
@@ -72,7 +72,7 @@ if [ "$hstgo" = "" ]; then
 	fi
 else
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
-	if $hstgo run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
+	if env GO111MODULE=off $hstgo run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
 		hstgo=`command -v $go`
 		echo $hstgo
 	else

--- a/mlocal/checks/version.go
+++ b/mlocal/checks/version.go
@@ -14,9 +14,12 @@ func main() {
 
 	for _, tag := range build.Default.ReleaseTags {
 		if tag == os.Args[1] {
+			fmt.Printf("Found Go release tag %s.\n", tag)
 			return
 		}
 	}
+
+	fmt.Printf("Go release tag %s not found.\n", os.Args[1])
 
 	os.Exit(1)
 }


### PR DESCRIPTION
Since we are running a simple program to check that the Go version
meets the minimum requirements, we should not need any modules listed in
go.mod.

This takes care of a problem in CentOS 6 where, seemingly, the git
version that ships with it does not work well with the Go version that
ships with it _when modules are enabled_ (then the go tool tries to go
to the network to donwload modules).

The rest of the code should be fine as it's using the vendor directory
(by way of passing -mod=vendor to the go tool).

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>