### PR TITLE
Pass -mod=vendor to go list to avoid downloading modules

### DIFF
--- a/makeit/gengodep
+++ b/makeit/gengodep
@@ -3,7 +3,7 @@
 srcdir=$1
 shift
 
-go list \
+go list -mod=vendor \
 	-deps \
 	-f '{{ with $d := . }}{{ range $d.GoFiles }}{{ $d.Dir }}/{{ . }} {{ end }}{{ end }}' \
 	"$@" |


### PR DESCRIPTION
Since we have vendored copies of the Go modules' code, we need to pass
-mod=vendor almost everywhere where we call go to prevent go from trying
to download them to the module cache.

makeit/gengodep is missing that.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>