### PR TITLE
CLI Log Level Fix

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -94,12 +94,13 @@ var singQuietFlag = cmdline.Flag{
 	Usage:        "suppress normal output",
 }
 
-// --verbose
+// -v|--verbose
 var singVerboseFlag = cmdline.Flag{
 	ID:           "singVerboseFlag",
 	Value:        &verbose,
 	DefaultValue: false,
 	Name:         "verbose",
+	ShortHand:    "v",
 	Usage:        "print additional information",
 }
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -191,6 +191,7 @@ func setSylogColor() {
 var SingularityCmd = &cobra.Command{
 	TraverseChildren:      true,
 	DisableFlagsInUseLine: true,
+	PersistentPreRun:      persistentPreRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmdline.CommandError("invalid command")
 	},
@@ -204,13 +205,15 @@ var SingularityCmd = &cobra.Command{
 	SilenceUsage:  true,
 }
 
+func persistentPreRun(_ *cobra.Command, _ []string) {
+	setSylogMessageLevel()
+	setSylogColor()
+}
+
 // ExecuteSingularity adds all child commands to the root command and sets
 // flags appropriately. This is called by main.main(). It only needs to happen
 // once to the root command (singularity).
 func ExecuteSingularity() {
-	setSylogMessageLevel()
-	setSylogColor()
-
 	cmdManager.UpdateCmdFlagFromEnv(envPrefix)
 
 	for _, e := range cmdManager.GetError() {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Adds `-v` shorthand for `--verbose` flag
- Reintruduces `persistentPreRun` for singularity cobra command in order to properly set loglevel and color


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
