### PR TITLE
'key remove --secret' Remove a secret key from your local keyring

### DIFF
--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -9,8 +9,39 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sypgp"
 )
+
+var (
+	secretKeyRemove   bool
+	secretForceRemove bool
+)
+
+var keyRemoveSecretFlag = cmdline.Flag{
+	ID:           "keyRemoveSecretFlag",
+	Value:        &secretKeyRemove,
+	DefaultValue: false,
+	Name:         "secret",
+	ShortHand:    "s",
+	Usage:        "remove a secret key",
+}
+
+var keyRemoveForceFlag = cmdline.Flag{
+	ID:           "keyRemoveForceFlag",
+	Value:        &secretForceRemove,
+	DefaultValue: false,
+	Name:         "force",
+	ShortHand:    "f",
+	Usage:        "remove a secret key without prompting",
+}
+
+func init() {
+	//	cmdManager.RegisterCmd(KeyRemoveCmd)
+
+	cmdManager.RegisterFlagForCmd(&keyRemoveSecretFlag, KeyRemoveCmd)
+	cmdManager.RegisterFlagForCmd(&keyRemoveForceFlag, KeyRemoveCmd)
+}
 
 // KeyRemoveCmd is `singularity key remove <fingerprint>' command
 var KeyRemoveCmd = &cobra.Command{
@@ -18,7 +49,7 @@ var KeyRemoveCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		err := sypgp.RemovePubKey(args[0])
+		err := sypgp.RemoveKey(secretKeyRemove, secretForceRemove, args[0])
 		if err != nil {
 			sylog.Fatalf("Unable to remove public key: %s", err)
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds the `--secret` flag to `key remove`, this will allow you to remove a secret, (or private) key from you local keyring. This is not the same as revoke, remove only remove a private key from you local keyring.

## This fixes or addresses the following GitHub issues:

- Fixes #3277 

<br>
