### PR TITLE
Mark TestEnsureDirPrivate as failed if it passed unexpectedly

### DIFF
--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -249,7 +249,7 @@ func TestEnsureDirPrivate(t *testing.T) {
 			t.Errorf("Expecting failure when calling ensureDirPrivate(%q), but got none", testEntry)
 
 		case tc.expectError && err != nil:
-			t.Logf("Expecting failure when calling ensureDirPrivate(%q), got: %+v", testEntry, err)
+			t.Errorf("Expecting failure when calling ensureDirPrivate(%q), got: %+v", testEntry, err)
 			continue
 
 		case !tc.expectError && err == nil:


### PR DESCRIPTION
When TestEnsureDirPrivate passes unexpectedly, the test is logging this
fact but not marking the failure.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>