### PR TITLE
Add a logger Close method and fix logger test sync issue

### DIFF
--- a/internal/pkg/instance/logger_test.go
+++ b/internal/pkg/instance/logger_test.go
@@ -85,7 +85,10 @@ func TestLogger(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to create new logger: %s", err)
 		}
-		writer := logger.NewWriter(f.stream, f.dropCRNL)
+		writer, err := logger.NewWriter(f.stream, f.dropCRNL)
+		if err != nil {
+			t.Errorf("failed to add new writer: %s", err)
+		}
 		writer.Write([]byte(f.write))
 
 		logger.Close()
@@ -104,7 +107,9 @@ func TestLogger(t *testing.T) {
 		}
 
 		// will recreate log file
-		logger.ReOpenFile()
+		if err := logger.ReOpenFile(); err != nil {
+			t.Errorf("failed to reopen log file: %s", err)
+		}
 		// we call it again to just close re-opened log file descriptor
 		logger.Close()
 

--- a/internal/pkg/instance/logger_test.go
+++ b/internal/pkg/instance/logger_test.go
@@ -105,7 +105,7 @@ func TestLogger(t *testing.T) {
 
 		// will recreate log file
 		logger.ReOpenFile()
-		// we call it again to just close re-opened log file
+		// we call it again to just close re-opened log file descriptor
 		logger.Close()
 
 		// delete it once again

--- a/internal/pkg/instance/logger_test.go
+++ b/internal/pkg/instance/logger_test.go
@@ -72,22 +72,25 @@ func TestLogger(t *testing.T) {
 			search:   "",
 		},
 	}
-	for _, f := range formatTest {
-		logfile, err := ioutil.TempFile("", "log-")
-		if err != nil {
-			t.Errorf("failed to create temporary log file: %s", err)
-		}
 
-		logger, err := NewLogger(logfile.Name(), f.formatter)
+	logfile, err := ioutil.TempFile("", "log-")
+	if err != nil {
+		t.Errorf("failed to create temporary log file: %s", err)
+	}
+	filename := logfile.Name()
+	logfile.Close()
+
+	for _, f := range formatTest {
+		logger, err := NewLogger(filename, f.formatter)
 		if err != nil {
 			t.Errorf("failed to create new logger: %s", err)
 		}
 		writer := logger.NewWriter(f.stream, f.dropCRNL)
 		writer.Write([]byte(f.write))
 
-		logfile.Sync()
+		logger.Close()
 
-		d, err := ioutil.ReadAll(logfile)
+		d, err := ioutil.ReadFile(filename)
 		if err != nil {
 			t.Errorf("failed to read log data: %s", err)
 		}
@@ -96,18 +99,18 @@ func TestLogger(t *testing.T) {
 			t.Errorf("failed to retrieve %s in %s", f.search, string(d))
 		}
 
-		if err := os.Remove(logfile.Name()); err != nil {
-			t.Errorf("failed while deleting log file %s: %s", logfile.Name(), err)
+		if err := os.Remove(filename); err != nil {
+			t.Errorf("failed while deleting log file %s: %s", filename, err)
 		}
 
 		// will recreate log file
 		logger.ReOpenFile()
+		// we call it again to just close re-opened log file
+		logger.Close()
 
 		// delete it once again
-		if err := os.Remove(logfile.Name()); err != nil {
-			t.Errorf("failed while deleting log file %s: %s", logfile.Name(), err)
+		if err := os.Remove(filename); err != nil {
+			t.Errorf("failed while deleting log file %s: %s", filename, err)
 		}
-
-		logfile.Close()
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Explicitly close logger to force a flush of data to the log file

**This fixes or addresses the following GitHub issues:**

- Duplicate fix of #3527 as suggested by @mem 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
