### PR TITLE
Remote Login and Status Improvement

### DIFF
--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -170,9 +170,18 @@ var RemoteListCmd = &cobra.Command{
 
 // RemoteLoginCmd singularity remote login [remoteName]
 var RemoteLoginCmd = &cobra.Command{
-	Args: cobra.ExactArgs(1),
+	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteLogin(remoteConfig, remoteConfigSys, args[0], loginTokenFile); err != nil {
+		// default to empty string to signal to RemoteLogin to use default remote
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+			sylog.Infof("Authenticating with remote: %s", name)
+		} else {
+			sylog.Infof("Authenticating with default remote.")
+		}
+
+		if err := singularity.RemoteLogin(remoteConfig, remoteConfigSys, name, loginTokenFile); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -185,9 +194,18 @@ var RemoteLoginCmd = &cobra.Command{
 
 // RemoteStatusCmd singularity remote status [remoteName]
 var RemoteStatusCmd = &cobra.Command{
-	Args: cobra.ExactArgs(1),
+	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteStatus(remoteConfig, remoteConfigSys, args[0]); err != nil {
+		// default to empty string to signal to RemoteStatus to use default remote
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+			sylog.Infof("Checking status of remote: %s", name)
+		} else {
+			sylog.Infof("Checking status of default remote.")
+		}
+
+		if err := singularity.RemoteStatus(remoteConfig, remoteConfigSys, name); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -69,7 +69,8 @@ const (
 	RemoteLoginLong  string = `
 	The 'remote login' command allows you to set an authentication token for a
 	specific endpoint. This command will produce a link directing you to the token
-	service you can use to generate a valid token.`
+	service you can use to generate a valid token. If no endpoint is specified,
+	it will try the default remote.`
 	RemoteLoginExample string = `
 	$ singularity remote login SylabsCloud`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -79,7 +80,8 @@ const (
 	RemoteStatusShort string = `Check the status of the singularity services at an endpoint`
 	RemoteStatusLong  string = `
 	the 'remote status' command checks the status of the specified remote endpoint
-	and reports the availibility of services and their versions.`
+	and reports the availibility of services and their versions. If no endpoint is
+	specified, it will check the status of the default remote.`
 	RemoteStatusExample string = `
 	$ singularity remote status SylabsCloud`
 )

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -16,6 +16,8 @@ import (
 )
 
 // RemoteLogin logs in remote by setting API token
+// If the supplied remote name is an empty string, it will attempt
+// to use the default remote.
 func RemoteLogin(usrConfigFile, sysConfigFile, name, tokenfile string) (err error) {
 	c := &remote.Config{}
 
@@ -36,7 +38,13 @@ func RemoteLogin(usrConfigFile, sysConfigFile, name, tokenfile string) (err erro
 		return err
 	}
 
-	r, err := c.GetRemote(name)
+	var r *remote.EndPoint
+	if name == "" {
+		r, err = c.GetDefault()
+	} else {
+		r, err = c.GetRemote(name)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -29,6 +29,8 @@ type status struct {
 }
 
 // RemoteStatus checks status of services related to an endpoint
+// If the supplied remote name is an empty string, it will attempt
+// to use the default remote.
 func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 	c := &remote.Config{}
 
@@ -52,7 +54,13 @@ func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 		return err
 	}
 
-	e, err := c.GetRemote(name)
+	var e *remote.EndPoint
+	if name == "" {
+		e, err = c.GetDefault()
+	} else {
+		e, err = c.GetRemote(name)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remote `login` and `status` commands now will try to use the default remote if a remote name is not supplied.

E.g. If `SylabsCloud` is the default
`singularity remote status` will ping `SylabsCloud`
`singularity remote status staging` will ping the `staging` remote


**This fixes or addresses the following GitHub issues:**

- Fixes #3544


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
