### PR TITLE
Add syfs.ConfigDir() to obtain singularity's config directory

### DIFF
--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -15,11 +15,11 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/cmdline"
+	"github.com/sylabs/singularity/pkg/syfs"
 )
 
 const (
 	fileName      = "remote.yaml"
-	userDir       = ".singularity"
 	sysDir        = "singularity"
 	remoteWarning = "no authentication token, log in with 'singularity remote` commands"
 )
@@ -31,7 +31,7 @@ var (
 )
 
 // assemble values of remoteConfig for user/sys locations
-var remoteConfigUser = filepath.Join(CurrentUser.HomeDir, userDir, fileName)
+var remoteConfigUser = filepath.Join(syfs.ConfigDir(), fileName)
 var remoteConfigSys = filepath.Join(buildcfg.SYSCONFDIR, sysDir, fileName)
 
 // -g|--global

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/auth"
 	"github.com/sylabs/singularity/pkg/cmdline"
+	"github.com/sylabs/singularity/pkg/syfs"
 )
 
 var cmdManager = cmdline.NewCommandManager(SingularityCmd)
@@ -123,7 +124,7 @@ func getCurrentUser() *user.User {
 }
 
 func getDefaultTokenFile() string {
-	return path.Join(CurrentUser.HomeDir, ".singularity", "sylabs-token")
+	return path.Join(syfs.ConfigDir(), "sylabs-token")
 }
 
 // initializePlugins should be called in any init() function which needs to interact with the plugin

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -9,12 +9,12 @@ package cache
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path"
 	"path/filepath"
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/pkg/syfs"
 )
 
 const (
@@ -22,11 +22,12 @@ const (
 	// for image downloads to be cached in
 	DirEnv = "SINGULARITY_CACHEDIR"
 
-	// RootDefault specifies the directory inside of ${HOME} that images are
-	// cached in by default.
+	// cacheDir specifies the name of the directory relative to the
+	// singularity data directory where images are cached in by
+	// default.
 	// Uses "~/.singularity/cache" which will not clash with any 2.x cache
 	// directory.
-	RootDefault = ".singularity/cache"
+	cacheDir = "cache"
 )
 
 var root string
@@ -53,15 +54,10 @@ func Clean() error {
 }
 
 func updateCacheRoot() {
-	usr, err := user.Current()
-	if err != nil {
-		sylog.Fatalf("Couldn't determine user home directory: %v", err)
-	}
-
 	if d := os.Getenv(DirEnv); d != "" {
 		root = d
 	} else {
-		root = path.Join(usr.HomeDir, RootDefault)
+		root = path.Join(syfs.ConfigDir(), cacheDir)
 	}
 
 	if err := initCacheDir(root); err != nil {

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -7,28 +7,16 @@ package cache
 
 import (
 	"os"
-	"os/user"
-	"path"
+	"path/filepath"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/pkg/syfs"
 )
 
-var cacheDefault string
+var cacheDefault = filepath.Join(syfs.ConfigDir(), cacheDir)
 
 const cacheCustom = "/tmp/customcachedir"
-
-func TestMain(m *testing.M) {
-	usr, err := user.Current()
-	if err != nil {
-		sylog.Errorf("Couldn't determine user home directory: %v", err)
-		os.Exit(1)
-	}
-	cacheDefault = path.Join(usr.HomeDir, RootDefault)
-
-	os.Exit(m.Run())
-}
 
 func TestRoot(t *testing.T) {
 	test.DropPrivilege(t)

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// Package syfs provides functions to access singularity's file system
+// layout.
+package syfs
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"sync"
+
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+)
+
+const singularityDir = ".singularity"
+
+// cache contains the information for the current user
+var cache struct {
+	sync.Once
+	configDir string // singularity user configuration directory
+}
+
+// ConfigDir returns the directory where the singularity user
+// configuration and data is located.
+func ConfigDir() string {
+	cache.Do(func() {
+		cache.configDir = configDir()
+		sylog.Debugf("Using singularity directory %q", cache.configDir)
+	})
+
+	return cache.configDir
+}
+
+func configDir() string {
+	user, err := user.Current()
+
+	if err != nil {
+		sylog.Warningf("Could not lookup the current user's information: %s", err)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			sylog.Warningf("Could not get current working directory: %s", err)
+			return singularityDir
+		}
+
+		return filepath.Join(cwd, singularityDir)
+	}
+
+	return filepath.Join(user.HomeDir, singularityDir)
+}
+
+// ConfigDirForUsername returns the directory where the singularity
+// configuration and data for the specified username is located.
+func ConfigDirForUsername(username string) (string, error) {
+	u, err := user.Lookup(username)
+
+	if err != nil {
+		return "", err
+	}
+
+	if cu, err := user.Current(); err == nil && u.Username == cu.Username {
+		return ConfigDir(), nil
+	}
+
+	return filepath.Join(u.HomeDir, singularityDir), nil
+}

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -25,7 +25,7 @@ import (
 	jsonresp "github.com/sylabs/json-resp"
 	"github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/internal/pkg/util/user"
+	"github.com/sylabs/singularity/pkg/syfs"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
 	"golang.org/x/crypto/openpgp/packet"
@@ -96,35 +96,14 @@ func AskQuestionNoEcho(format string, a ...interface{}) (string, error) {
 	return string(response), nil
 }
 
-// getSingularityDir returns the directory where the user's singularity
-// configuration and data is located.
-func getSingularityDir() string {
-	user, err := user.GetPwUID(uint32(os.Getuid()))
-	if err != nil {
-		sylog.Warningf("Could not lookup user's real home directory: %s", err)
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			sylog.Warningf("Could not get current working directory: %s", err)
-			return ".singularity"
-		}
-
-		dir := filepath.Join(cwd, ".singularity")
-		sylog.Warningf("Using current directory: %s", dir)
-		return dir
-	}
-
-	return filepath.Join(user.Dir, ".singularity")
-}
-
 // GetTokenFile returns a string describing the path to the stored token file
 func GetTokenFile() string {
-	return filepath.Join(getSingularityDir(), "sylabs-token")
+	return filepath.Join(syfs.ConfigDir(), "sylabs-token")
 }
 
 // DirPath returns a string describing the path to the sypgp home folder
 func DirPath() string {
-	return filepath.Join(getSingularityDir(), "sypgp")
+	return filepath.Join(syfs.ConfigDir(), "sypgp")
 }
 
 // SecretPath returns a string describing the path to the private keys store


### PR DESCRIPTION
There are multiple locations in the code that have their own method to
define where the singulary configuration directory exists, all trying to
do more or less the same thing.

Move that code to a single location that can be reused by the rest of
the code. Call the package "syfs" to express that this represents
singularity's file system layout.

Change direct references to .singularity to syfs.ConfigDir().

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>