### PR TITLE
Change default log level to info

### DIFF
--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -68,11 +68,11 @@ var loggerLevel messageLevel
 func init() {
 	_level, ok := os.LookupEnv("SINGULARITY_MESSAGELEVEL")
 	if !ok {
-		loggerLevel = debug
+		loggerLevel = info
 	} else {
 		_levelint, err := strconv.Atoi(_level)
 		if err != nil {
-			loggerLevel = debug
+			loggerLevel = info
 		} else {
 			loggerLevel = messageLevel(_levelint)
 		}


### PR DESCRIPTION
Parts of the code that do early logging (like those called before main
via init functions or variable initialization) are seeing a default log
level of debug and therefore logging at that level even if -d wasn't
specified.

Change this to info, which is the default using by the CLI during flag
processing.

If you need to see those early debug messages, you cannot use -d, you
MUST use SINGULARITY_MESSAGELEVEL=5.

Fixes: #3569

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>