### PR TITLE
Removed Extra TIP pointing to 'sylabs.io/docs' when pushing a unsigned container

### DIFF
--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -88,7 +88,6 @@ func LibraryPush(file, dest, authToken, libraryURI, keyServerURL, remoteWarning 
 
 		// if its not signed, print a warning
 		if !imageSigned {
-			sylog.Infof("TIP: Learn how to sign your own containers here : https://www.sylabs.io/docs/")
 			return ErrLibraryUnsigned
 		}
 	} else {


### PR DESCRIPTION
## Description of the Pull Request (PR):

In PR https://github.com/sylabs/singularity/pull/3522, it was decided to not point to our online documents. Instead, point to `singularity help sign`. 

<br>
