### PR TITLE
Move icmd wrapper to internal/pkg/test/exec

### DIFF
--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -6,9 +6,9 @@
 package e2e
 
 import (
-	"os/exec"
-	"strings"
 	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/test/exec"
 )
 
 func PrepRegistry(t *testing.T) {
@@ -21,9 +21,8 @@ func PrepRegistry(t *testing.T) {
 
 	for _, command := range commands {
 		cmd := exec.Command("docker", command...)
-		if b, err := cmd.CombinedOutput(); err != nil {
-			t.Logf(string(b))
-			t.Fatalf("command failed: %v", strings.Join(command, " "))
+		if res := cmd.Run(t); res.Error != nil {
+			t.Fatalf("Command failed.\n%s", res)
 		}
 	}
 }
@@ -36,9 +35,8 @@ func KillRegistry(t *testing.T) {
 
 	for _, command := range commands {
 		cmd := exec.Command("docker", command...)
-		if b, err := cmd.CombinedOutput(); err != nil {
-			t.Logf(string(b))
-			t.Fatalf("command failed: %v", strings.Join(command, " "))
+		if res := cmd.Run(t); res.Error != nil {
+			t.Fatalf("Command failed.\n%s", res)
 		}
 	}
 }

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/test/exec"
 )
 
 // ImageVerify checks for an image integrity
@@ -330,12 +330,13 @@ func verifyEnv(t *testing.T, cmdPath, imagePath string, env []string, flags []st
 	args = append(args, imagePath, "env")
 
 	cmd := exec.Command(cmdPath, args...)
-	b, err := cmd.CombinedOutput()
+	res := cmd.Run(t)
 
-	out := string(b)
-	if err != nil {
-		t.Fatalf("Error running command: %v", err)
+	if res.Error != nil {
+		t.Fatalf("Error running command.\n%s", res)
 	}
+
+	out := res.Stdout()
 
 	for _, e := range env {
 		if !strings.Contains(out, e) {

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -10,11 +10,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/test/exec"
 )
 
 type testingEnv struct {
@@ -51,9 +51,8 @@ func remoteAdd(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "add"}
 		argv = append(argv, tt.remote, tt.uri)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -71,9 +70,8 @@ func remoteAdd(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "add"}
 		argv = append(argv, tt.remote, tt.uri)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err == nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected success: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error == nil {
+				t.Fatalf("Unexpected success.\n%s", res)
 			}
 		}))
 	}
@@ -107,9 +105,8 @@ func remoteRemove(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "add"}
 		argv = append(argv, tt.remote, tt.uri)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -126,9 +123,8 @@ func remoteRemove(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "remove"}
 		argv = append(argv, tt.remote)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -144,9 +140,8 @@ func remoteRemove(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "remove"}
 		argv = append(argv, tt.remote)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err == nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected success: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error == nil {
+				t.Fatalf("Unexpected success.\n%s", res)
 			}
 		}))
 	}
@@ -176,9 +171,8 @@ func remoteUse(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "use"}
 		argv = append(argv, tt.remote)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err == nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected success: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error == nil {
+				t.Fatalf("Unexpected success.\n%s", res)
 			}
 		}))
 	}
@@ -197,9 +191,8 @@ func remoteUse(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "add"}
 		argv = append(argv, tt.remote, tt.uri)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -216,9 +209,8 @@ func remoteUse(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "use"}
 		argv = append(argv, tt.remote)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -252,9 +244,8 @@ func remoteStatus(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "add"}
 		argv = append(argv, tt.remote, tt.uri)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -270,9 +261,8 @@ func remoteStatus(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "status"}
 		argv = append(argv, tt.remote)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -289,9 +279,8 @@ func remoteStatus(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "status"}
 		argv = append(argv, tt.remote)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err == nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected success: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error == nil {
+				t.Fatalf("Unexpected success.\n%s", res)
 			}
 		}))
 	}
@@ -318,9 +307,8 @@ func remoteList(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "list"}
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
 			fmt.Println("config.name is ", config.Name())
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -339,9 +327,8 @@ func remoteList(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "add"}
 		argv = append(argv, tt.remote, tt.uri)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -355,9 +342,8 @@ func remoteList(t *testing.T) {
 	for _, tt := range testPass {
 		argv := []string{"remote", "--config", config.Name(), "list"}
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -374,9 +360,8 @@ func remoteList(t *testing.T) {
 		argv := []string{"remote", "--config", config.Name(), "use"}
 		argv = append(argv, tt.remote)
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}
@@ -390,9 +375,8 @@ func remoteList(t *testing.T) {
 	for _, tt := range testPass {
 		argv := []string{"remote", "--config", config.Name(), "list"}
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
-			if b, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput(); err != nil {
-				t.Log(string(b))
-				t.Fatalf("unexpected failure: %v", err)
+			if res := exec.Command(testenv.CmdPath, argv...).Run(t); res.Error != nil {
+				t.Fatalf("Unexpected failure.\n%s", res)
 			}
 		}))
 	}

--- a/internal/pkg/test/exec/exec.go
+++ b/internal/pkg/test/exec/exec.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package test
+package exec
 
 import (
 	"testing"
@@ -13,20 +13,21 @@ import (
 
 type Cmd struct {
 	path string
+	args []string
 }
 
 type Result struct {
 	*icmd.Result
 }
 
-func NewCmd(path string) *Cmd {
-	return &Cmd{path: path}
+func Command(path string, args ...string) *Cmd {
+	return &Cmd{path: path, args: args}
 }
 
-func (c *Cmd) Run(t *testing.T, args ...string) *Result {
-	t.Logf("Running cmd %q with args %q", c.path, args)
+func (c *Cmd) Run(t *testing.T) *Result {
+	t.Logf("Running cmd %q with args %q", c.path, c.args)
 
-	result := icmd.RunCommand(c.path, args...)
+	result := icmd.RunCommand(c.path, c.args...)
 
 	return &Result{result}
 }


### PR DESCRIPTION
Rework some of the code to make it more similar to exec.Command, so that
moving from exec.Command to this version is simpler.

Rework some of the code already using this.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>