### PR TITLE
Prevent session final directory to be overridden by user binds.

### DIFF
--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -732,7 +732,7 @@ func (e *EngineOperations) loadImages() error {
 		if img.Path == "/" {
 			return fmt.Errorf("/ as sandbox is not authorized")
 		}
-		if err := mainthread.Chdir(img.Source); err != nil {
+		if err := mainthread.Fchdir(int(img.Fd)); err != nil {
 			return err
 		}
 		cwd, err := os.Getwd()

--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -58,3 +58,8 @@ type SetFsIDArgs struct {
 	UID int
 	GID int
 }
+
+// ChdirArgs defines the arguments to chdir.
+type ChdirArgs struct {
+	Dir string
+}

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -106,3 +106,13 @@ func (t *RPC) SetFsID(uid int, gid int) (int, error) {
 	err := t.Client.Call(t.Name+".SetFsID", arguments, &reply)
 	return reply, err
 }
+
+// Chdir calls the chdir RPC using the supplied arguments.
+func (t *RPC) Chdir(dir string) (int, error) {
+	arguments := &args.ChdirArgs{
+		Dir: dir,
+	}
+	var reply int
+	err := t.Client.Call(t.Name+".Chdir", arguments, &reply)
+	return reply, err
+}

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -48,9 +48,16 @@ func (t *Methods) Mkdir(arguments *args.MkdirArgs, reply *int) (err error) {
 func (t *Methods) Chroot(arguments *args.ChrootArgs, reply *int) error {
 	root := arguments.Root
 
-	sylog.Debugf("Change current directory to %s", root)
-	if err := syscall.Chdir(root); err != nil {
-		return fmt.Errorf("failed to change directory to %s", root)
+	if root != "." {
+		sylog.Debugf("Change current directory to %s", root)
+		if err := syscall.Chdir(root); err != nil {
+			return fmt.Errorf("failed to change directory to %s", root)
+		}
+	} else {
+		cwd, err := os.Getwd()
+		if err == nil {
+			root = cwd
+		}
 	}
 
 	switch arguments.Method {
@@ -181,4 +188,9 @@ func (t *Methods) SetFsID(arguments *args.SetFsIDArgs, reply *int) error {
 		syscall.Setfsgid(arguments.GID)
 	})
 	return nil
+}
+
+// Chdir changes current working directory to path.
+func (t *Methods) Chdir(arguments *args.ChdirArgs, reply *int) error {
+	return mainthread.Chdir(arguments.Dir)
 }

--- a/internal/pkg/util/mainthread/mainthread.go
+++ b/internal/pkg/util/mainthread/mainthread.go
@@ -8,6 +8,7 @@ package mainthread
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // FuncChannel passes functions executed in main thread
@@ -47,10 +48,18 @@ func EvalSymlinks(path string) (rpath string, err error) {
 	return
 }
 
-// Chdir changes and returns current working directory from main thread
-func Chdir(path string) (err error) {
+// Chdir changes current working directory to the provided directory
+func Chdir(dir string) (err error) {
 	Execute(func() {
-		err = os.Chdir(path)
+		err = os.Chdir(dir)
+	})
+	return
+}
+
+// Fchdir changes current working directory to the directory pointed
+func Fchdir(fd int) (err error) {
+	Execute(func() {
+		err = syscall.Fchdir(fd)
 	})
 	return
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR prevents session final directory to be overridden by user binds. This is achieved by changing RPC server current directory in order to go into final directory just after layer setup, so the chroot will always occur in this directory even if final directory is overridden.

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
