### PR TITLE
Allow arbitrary locations when pushing to oras

### DIFF
--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -360,14 +360,13 @@ func orasImagePush(t *testing.T, imgURI, imagePath string) (string, []byte, erro
 	argv := []string{"push"}
 
 	if imagePath != "" {
-		argv = append(argv, filepath.Base(imagePath))
+		argv = append(argv, imagePath)
 	}
 
 	argv = append(argv, imgURI)
 
 	cmd := fmt.Sprintf("%s %s", testenv.CmdPath, strings.Join(argv, " "))
 	pushCmd := exec.Command(testenv.CmdPath, argv...)
-	pushCmd.Dir = filepath.Dir(imagePath)
 	out, err := pushCmd.CombinedOutput()
 	return cmd, out, err
 }

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/containerd/containerd/reference"
@@ -119,9 +120,9 @@ func LibraryPush(file, dest, authToken, libraryURI, keyServerURL, remoteWarning 
 	return libraryClient.UploadImage(context.Background(), f, r.Host+r.Path, r.Tags, "No Description", &progressCallback{})
 }
 
-// OrasPush uploads the image specified by file and pushes it to the provided oci reference,
+// OrasPush uploads the image specified by path and pushes it to the provided oci reference,
 // it will use credentials if supplied
-func OrasPush(file, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
+func OrasPush(path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	ref = strings.TrimPrefix(ref, "//")
 
 	spec, err := reference.Parse(ref)
@@ -157,7 +158,10 @@ func OrasPush(file, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	}
 	conf.Annotations = nil
 
-	desc, err := store.Add(file, SifLayerMediaType, file)
+	// Get the filename from path and use it as the name in the file store
+	name := filepath.Base(path)
+
+	desc, err := store.Add(name, SifLayerMediaType, path)
 	if err != nil {
 		return fmt.Errorf("unable to add SIF file to FileStore: %s", err)
 	}


### PR DESCRIPTION
The current implementation requires the user to do something like this:

	cd /some/path
	singularity push file.sif oras://localhost:5000/test:latest

and does not support this:

	singularity push /some/path/file.sif oras://localhost:5000/test:latest

in other words, the local file must be in the current working directory.

Fix the call to:

	store.Add(name, mediaType, path)

so that the first argument is simply a filename (without a directory),
while the third argument is the path specified by the user.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
