### PR TITLE
Fixed panic when pulling a container that does not exist

### DIFF
--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -69,7 +69,7 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 		return fmt.Errorf("while getting image info: %v", err)
 	}
 	if !existOk {
-		return fmt.Errorf("image does not exist in library")
+		return fmt.Errorf("image does not exist in the library")
 	}
 	if libraryImage == nil {
 		return fmt.Errorf("failed getting image from the library")

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -69,10 +69,10 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 		return fmt.Errorf("while getting image info: %v", err)
 	}
 	if !existOk {
-		return fmt.Errorf("image does not exist in remote library")
+		return fmt.Errorf("image does not exist in library")
 	}
 	if libraryImage == nil {
-		return fmt.Errorf("failed getting image from remote library")
+		return fmt.Errorf("failed getting image from the library")
 	}
 
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -68,6 +68,9 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 	if err != nil {
 		return fmt.Errorf("while getting image info: %v", err)
 	}
+	if libraryImage == nil {
+		return fmt.Errorf("image does not exist in remote library")
+	}
 
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)
 	exists, err := cache.LibraryImageExists(libraryImage.Hash, imageName)

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -64,12 +64,15 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 	imageName := uri.GetName("library://" + imageRef)
 
 	// check if image exists in library
-	libraryImage, _, err := libraryClient.GetImage(context.TODO(), imageRef)
+	libraryImage, existOk, err := libraryClient.GetImage(context.TODO(), imageRef)
 	if err != nil {
 		return fmt.Errorf("while getting image info: %v", err)
 	}
-	if libraryImage == nil {
+	if !existOk {
 		return fmt.Errorf("image does not exist in remote library")
+	}
+	if libraryImage == nil {
+		return fmt.Errorf("failed getting image from remote library")
 	}
 
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes a panic when pulling a image that does not exist.

Example:

```bash
# Before this PR:
$ singularity pull foobar
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb8 pc=0xf75540]

goroutine 1 [running]:
github.com/sylabs/singularity/internal/app/singularity.LibraryPull(0xc000226520, 0x11, 0x7ffc9b8ea25c, 0x6, 0x0, 0x0, 0x7ffc9b8ea25c, 0x6, 0xc000388740, 0x19, ...)
[...]

# After this PR:
$ singularity pull library://foobar
FATAL:   While pulling library image: image does not exist in the library
```

<br>
