### PR TITLE
Fix panic for builds using invalid library source

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -58,9 +58,15 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 
 	imageRef := library.NormalizeLibraryRef(b.Recipe.Header["from"])
 
-	libraryImage, _, err := libraryClient.GetImage(context.TODO(), imageRef)
+	libraryImage, existOk, err := libraryClient.GetImage(context.TODO(), imageRef)
 	if err != nil {
-		return err
+		return fmt.Errorf("while getting image info: %v", err)
+	}
+	if !existOk {
+		return fmt.Errorf("image does not exist in the library")
+	}
+	if libraryImage == nil {
+		return fmt.Errorf("failed getting image from the library")
 	}
 
 	imageName := uri.GetName("library://" + imageRef)


### PR DESCRIPTION
Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

**This fixes or addresses the following GitHub issues:**

- Fixes #3620


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
