### PR TITLE
Create clean & unique caches for unit tests

### DIFF
--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -237,20 +237,65 @@ func testSTDINPipe(t *testing.T) {
 		argv    []string
 		exit    int
 	}{
-		{"sh", "trueSTDIN", []string{"-c", fmt.Sprintf("echo hi | singularity exec %s grep hi", imagePath)}, 0},
-		{"sh", "falseSTDIN", []string{"-c", fmt.Sprintf("echo bye | singularity exec %s grep hi", imagePath)}, 1},
+		{
+			binName: "sh",
+			name:    "trueSTDIN",
+			argv:    []string{"-c", fmt.Sprintf("echo hi | singularity exec %s grep hi", imagePath)},
+			exit:    0,
+		},
+		{
+			binName: "sh",
+			name:    "falseSTDIN",
+			argv:    []string{"-c", fmt.Sprintf("echo bye | singularity exec %s grep hi", imagePath)},
+			exit:    1,
+		},
 		// Checking permissions
-		{"sh", "permissions", []string{"-c", fmt.Sprintf("singularity exec %s id -u | grep `id -u`", imagePath)}, 0},
+		{
+			binName: "sh",
+			name:    "permissions",
+			argv:    []string{"-c", fmt.Sprintf("singularity exec %s id -u | grep `id -u`", imagePath)},
+			exit:    0,
+		},
 		// testing run command properly hands arguments
-		{"sh", "arguments", []string{"-c", fmt.Sprintf("singularity run %s foo | grep foo", imagePath)}, 0},
+		{
+			binName: "sh",
+			name:    "arguments",
+			argv:    []string{"-c", fmt.Sprintf("singularity run %s foo | grep foo", imagePath)},
+			exit:    0,
+		},
 		// Stdin to URI based image
-		{"sh", "library", []string{"-c", "echo true | singularity shell library://busybox"}, 0},
-		{"sh", "docker", []string{"-c", "echo true | singularity shell docker://busybox"}, 0},
-		{"sh", "shub", []string{"-c", "echo true | singularity shell shub://singularityhub/busybox"}, 0},
+		{
+			binName: "sh",
+			name:    "library",
+			argv:    []string{"-c", "echo true | singularity shell library://busybox"},
+			exit:    0,
+		},
+		{
+			binName: "sh",
+			name:    "docker",
+			argv:    []string{"-c", "echo true | singularity shell docker://busybox"},
+			exit:    0,
+		},
+		{
+			binName: "sh",
+			name:    "shub",
+			argv:    []string{"-c", "echo true | singularity shell shub://singularityhub/busybox"},
+			exit:    0,
+		},
 		// Test apps
-		{"sh", "appsFoo", []string{"-c", fmt.Sprintf("singularity run --app foo %s | grep 'FOO'", appsImage)}, 0},
+		{
+			binName: "sh",
+			name:    "appsFoo",
+			argv:    []string{"-c", fmt.Sprintf("singularity run --app foo %s | grep 'FOO'", appsImage)},
+			exit:    0,
+		},
 		// Test target pwd
-		{"sh", "pwdPath", []string{"-c", fmt.Sprintf("singularity exec --pwd /etc %s pwd | egrep '^/etc'", imagePath)}, 0},
+		{
+			binName: "sh",
+			name:    "pwdPath",
+			argv:    []string{"-c", fmt.Sprintf("singularity exec --pwd /etc %s pwd | egrep '^/etc'", imagePath)},
+			exit:    0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -475,6 +520,10 @@ func testPersistentOverlay(t *testing.T) {
 
 func TestSingularityActions(t *testing.T) {
 	test.EnsurePrivilege(t)
+
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	opts := buildOpts{
 		force:   true,
 		sandbox: false,

--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -129,8 +130,14 @@ func testSingularityRun(t *testing.T) {
 			// Because we drop the privileges during a test, we set a new image cache
 			// otherwise the test would try to use the cache from the privileged user,
 			// creating failures.
-			test.SetCacheDir(t)
-			defer test.CleanCacheDir(t)
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, cacheDir)
+			}
+
 			_, stderr, exitCode, err := imageExec(t, tt.action, tt.opts, tt.image, tt.argv)
 			if tt.expectSuccess && (exitCode != 0) {
 				t.Log(stderr)
@@ -207,8 +214,14 @@ func testSingularityExec(t *testing.T) {
 			// Because we drop the privileges during a test, we set a new image cache
 			// otherwise the test would try to use the cache from the privileged user,
 			// creating failures.
-			test.SetCacheDir(t)
-			defer test.CleanCacheDir(t)
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("cannot set %s environment variable: %s", cache.DirEnv, err)
+			}
+
 			_, stderr, exitCode, err := imageExec(t, tt.action, tt.opts, tt.image, tt.argv)
 			if tt.expectSuccess && (exitCode != 0) {
 				t.Log(stderr)
@@ -229,8 +242,14 @@ func testSingularityExec(t *testing.T) {
 		// Because we drop the privileges during a test, we set a new image cache
 		// otherwise the test would try to use the cache from the privileged user,
 		// creating failures.
-		test.SetCacheDir(t)
-		defer test.CleanCacheDir(t)
+		cacheDir := test.SetCacheDir(t, "")
+		defer test.CleanCacheDir(t, cacheDir)
+
+		err := os.Setenv(cache.DirEnv, cacheDir)
+		if err != nil {
+			t.Fatalf("cannot set %s environment variable: %s", cache.DirEnv, err)
+		}
+
 		_, stderr, exitCode, err := imageExec(t, "exec", opts{noHome: true}, pwd+"/container.img", []string{"ls", "-ld", "$HOME"})
 		if exitCode != 1 {
 			t.Log(stderr, err)
@@ -318,8 +337,14 @@ func testSTDINPipe(t *testing.T) {
 			// Because we drop the privileges during a test, we set a new image cache
 			// otherwise the test would try to use the cache from the privileged user,
 			// creating failures.
-			test.SetCacheDir(t)
-			defer test.CleanCacheDir(t)
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("cannot set %s environment variable: %s", cache.DirEnv, err)
+			}
+
 			cmd := exec.Command(tt.binName, tt.argv...)
 			if err := cmd.Start(); err != nil {
 				t.Fatalf("cmd.Start: %v", err)
@@ -390,8 +415,14 @@ func testRunFromURI(t *testing.T) {
 			// Because we drop the privileges during a test, we set a new image cache
 			// otherwise the test would try to use the cache from the privileged user,
 			// creating failures.
-			test.SetCacheDir(t)
-			defer test.CleanCacheDir(t)
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("cannot set %s envionment variable: %s", cache.DirEnv, err)
+			}
+
 			_, stderr, exitCode, err := imageExec(t, tt.action, tt.opts, tt.image, tt.argv)
 			if tt.expectSuccess && (exitCode != 0) {
 				t.Log(stderr)
@@ -530,8 +561,14 @@ func testPersistentOverlay(t *testing.T) {
 		// Because we drop the privileges during a test, we set a new image cache
 		// otherwise the test would try to use the cache from the privileged user,
 		// creating failures.
-		test.SetCacheDir(t)
-		defer test.CleanCacheDir(t)
+		cacheDir := test.SetCacheDir(t, "")
+		defer test.CleanCacheDir(t, cacheDir)
+
+		err := os.Setenv(cache.DirEnv, cacheDir)
+		if err != nil {
+			t.Fatalf("cannot set %s environment variable: %s", cache.DirEnv, err)
+		}
+
 		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{dir}}, imagePath, []string{"test", "-f", "/foo_overlay"})
 		if exitCode != 1 {
 			t.Log(stderr, err)
@@ -550,8 +587,13 @@ func testPersistentOverlay(t *testing.T) {
 
 func TestSingularityActions(t *testing.T) {
 	test.EnsurePrivilege(t)
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cacheDir, err)
+	}
 
 	opts := buildOpts{
 		force:   true,

--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -126,6 +126,11 @@ func testSingularityRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
+			// Because we drop the privileges during a test, we set a new image cache
+			// otherwise the test would try to use the cache from the privileged user,
+			// creating failures.
+			test.SetCacheDir(t)
+			defer test.CleanCacheDir(t)
 			_, stderr, exitCode, err := imageExec(t, tt.action, tt.opts, tt.image, tt.argv)
 			if tt.expectSuccess && (exitCode != 0) {
 				t.Log(stderr)
@@ -199,6 +204,11 @@ func testSingularityExec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
+			// Because we drop the privileges during a test, we set a new image cache
+			// otherwise the test would try to use the cache from the privileged user,
+			// creating failures.
+			test.SetCacheDir(t)
+			defer test.CleanCacheDir(t)
 			_, stderr, exitCode, err := imageExec(t, tt.action, tt.opts, tt.image, tt.argv)
 			if tt.expectSuccess && (exitCode != 0) {
 				t.Log(stderr)
@@ -216,6 +226,11 @@ func testSingularityExec(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Run("noHome", test.WithoutPrivilege(func(t *testing.T) {
+		// Because we drop the privileges during a test, we set a new image cache
+		// otherwise the test would try to use the cache from the privileged user,
+		// creating failures.
+		test.SetCacheDir(t)
+		defer test.CleanCacheDir(t)
 		_, stderr, exitCode, err := imageExec(t, "exec", opts{noHome: true}, pwd+"/container.img", []string{"ls", "-ld", "$HOME"})
 		if exitCode != 1 {
 			t.Log(stderr, err)
@@ -300,6 +315,11 @@ func testSTDINPipe(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
+			// Because we drop the privileges during a test, we set a new image cache
+			// otherwise the test would try to use the cache from the privileged user,
+			// creating failures.
+			test.SetCacheDir(t)
+			defer test.CleanCacheDir(t)
 			cmd := exec.Command(tt.binName, tt.argv...)
 			if err := cmd.Start(); err != nil {
 				t.Fatalf("cmd.Start: %v", err)
@@ -367,6 +387,11 @@ func testRunFromURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
+			// Because we drop the privileges during a test, we set a new image cache
+			// otherwise the test would try to use the cache from the privileged user,
+			// creating failures.
+			test.SetCacheDir(t)
+			defer test.CleanCacheDir(t)
 			_, stderr, exitCode, err := imageExec(t, tt.action, tt.opts, tt.image, tt.argv)
 			if tt.expectSuccess && (exitCode != 0) {
 				t.Log(stderr)
@@ -502,6 +527,11 @@ func testPersistentOverlay(t *testing.T) {
 	}))
 	// look for the file without root privs
 	t.Run("overlay_noroot", test.WithoutPrivilege(func(t *testing.T) {
+		// Because we drop the privileges during a test, we set a new image cache
+		// otherwise the test would try to use the cache from the privileged user,
+		// creating failures.
+		test.SetCacheDir(t)
+		defer test.CleanCacheDir(t)
 		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{dir}}, imagePath, []string{"test", "-f", "/foo_overlay"})
 		if exitCode != 1 {
 			t.Log(stderr, err)
@@ -520,7 +550,6 @@ func testPersistentOverlay(t *testing.T) {
 
 func TestSingularityActions(t *testing.T) {
 	test.EnsurePrivilege(t)
-
 	test.SetCacheDir(t)
 	defer test.CleanCacheDir(t)
 

--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -110,6 +111,14 @@ func TestBuild(t *testing.T) {
 				}
 			}
 
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+			}
+
 			opts := buildOpts{
 				sandbox: tt.sandbox,
 			}
@@ -191,6 +200,14 @@ func TestMultipleBuilds(t *testing.T) {
 						sandbox: ts.sandbox,
 					}
 
+					cacheDir := test.SetCacheDir(t, "")
+					defer test.CleanCacheDir(t, cacheDir)
+
+					err := os.Setenv(cache.DirEnv, cacheDir)
+					if err != nil {
+						t.Fatalf("cannot set %s environment variable: %s", cache.DirEnv, err)
+					}
+
 					if b, err := imageBuild(opts, ts.imagePath, ts.buildSpec); err != nil {
 						t.Log(string(b))
 						t.Fatalf("unexpected failure: %v", err)
@@ -207,6 +224,14 @@ func TestBadPath(t *testing.T) {
 
 	imagePath := path.Join(testDir, "container")
 	defer os.RemoveAll(imagePath)
+
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	if b, err := imageBuild(buildOpts{}, imagePath, "/some/dumb/path"); err == nil {
 		t.Log(string(b))
@@ -408,6 +433,14 @@ func TestMultiStageDefinition(t *testing.T) {
 
 			imagePath := path.Join(testDir, "container")
 			defer os.RemoveAll(imagePath)
+
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+			}
 
 			if b, err := imageBuild(opts, imagePath, defFile); err != nil {
 				t.Log(string(b))
@@ -709,6 +742,14 @@ func TestBuildDefinition(t *testing.T) {
 
 			imagePath := path.Join(testDir, "container")
 			defer os.RemoveAll(imagePath)
+
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+			}
 
 			if b, err := imageBuild(opts, imagePath, defFile); err != nil {
 				t.Log(string(b))

--- a/cmd/singularity/docker_test.go
+++ b/cmd/singularity/docker_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"golang.org/x/sys/unix"
 )
@@ -90,6 +91,14 @@ func TestDockerAUFS(t *testing.T) {
 func TestDockerPermissions(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s envionment variable: %s", cacheDir, err)
+	}
 
 	imagePath := path.Join(testDir, "container")
 	defer os.Remove(imagePath)

--- a/cmd/singularity/docker_test.go
+++ b/cmd/singularity/docker_test.go
@@ -36,6 +36,14 @@ func TestDocker(t *testing.T) {
 			imagePath := path.Join(testDir, "container")
 			defer os.Remove(imagePath)
 
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+			}
+
 			b, err := imageBuild(buildOpts{}, imagePath, tt.imagePath)
 			if tt.expectSuccess {
 				if err != nil {
@@ -57,6 +65,14 @@ func TestDockerAUFS(t *testing.T) {
 
 	imagePath := path.Join(testDir, "container")
 	defer os.Remove(imagePath)
+
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	b, err := imageBuild(buildOpts{}, imagePath, "docker://dctrud/docker-aufs-sanity")
 	if err != nil {
@@ -136,6 +152,14 @@ func TestDockerWhiteoutSymlink(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
+
 	imagePath := path.Join(testDir, "container")
 	defer os.Remove(imagePath)
 
@@ -179,6 +203,14 @@ func TestDockerDefFile(t *testing.T) {
 
 			imagePath := path.Join(testDir, "container")
 			defer os.Remove(imagePath)
+
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+			}
 
 			deffile := prepareDefFile(DefFileDetail{
 				Bootstrap: "docker",
@@ -266,6 +298,14 @@ func TestDockerRegistry(t *testing.T) {
 			}
 			imagePath := path.Join(testDir, "container")
 			defer os.Remove(imagePath)
+
+			cacheDir := test.SetCacheDir(t, "")
+			defer test.CleanCacheDir(t, cacheDir)
+
+			err := os.Setenv(cache.DirEnv, cacheDir)
+			if err != nil {
+				t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+			}
 
 			defFile := prepareDefFile(tt.dfd)
 

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -430,6 +431,14 @@ func testInstanceFromURI(t *testing.T) {
 
 // Bootstrap to run all instance tests.
 func TestInstance(t *testing.T) {
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
+
 	// Build a basic Singularity image to test instances.
 	if b, err := imageBuild(buildOpts{force: true, sandbox: false}, instanceImagePath, instanceDefinition); err != nil {
 		t.Log(string(b))

--- a/cmd/singularity/security_test.go
+++ b/cmd/singularity/security_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -116,6 +117,15 @@ func testSecurityConfOwnership(t *testing.T) {
 
 func TestSecurity(t *testing.T) {
 	test.EnsurePrivilege(t)
+
+	cacheDir := test.SetCacheDir(t, "")
+	test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
+
 	opts := buildOpts{
 		force:   true,
 		sandbox: false,

--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -25,6 +25,9 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	b, err := types.NewBundle("", "sbuild-sandboxAssembler")
 	if err != nil {
 		return

--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/build/assemblers"
 	"github.com/sylabs/singularity/internal/pkg/build/sources"
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/pkg/build/types"
 )
@@ -25,8 +26,13 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	b, err := types.NewBundle("", "sbuild-sandboxAssembler")
 	if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -6,9 +6,11 @@
 package sources_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/build/sources"
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/pkg/build/types"
 )
@@ -26,8 +28,13 @@ func TestLibraryConveyor(t *testing.T) {
 
 	test.EnsurePrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	b, err := types.NewBundle("", "sbuild-library")
 	if err != nil {
@@ -54,8 +61,13 @@ func TestLibraryConveyor(t *testing.T) {
 // TestLibraryPacker checks if we can create a Bundle from the pulled image
 func TestLibraryPacker(t *testing.T) {
 	test.EnsurePrivilege(t)
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	b, err := types.NewBundle("", "sbuild-library")
 	if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -26,6 +26,9 @@ func TestLibraryConveyor(t *testing.T) {
 
 	test.EnsurePrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	b, err := types.NewBundle("", "sbuild-library")
 	if err != nil {
 		return
@@ -51,6 +54,8 @@ func TestLibraryConveyor(t *testing.T) {
 // TestLibraryPacker checks if we can create a Bundle from the pulled image
 func TestLibraryPacker(t *testing.T) {
 	test.EnsurePrivilege(t)
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	b, err := types.NewBundle("", "sbuild-library")
 	if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/build/sources"
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/pkg/build/types"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
@@ -38,8 +39,13 @@ func TestOCIConveyorDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cacheDir, err)
+	}
 
 	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
@@ -68,8 +74,13 @@ func TestOCIConveyorDockerArchive(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	// Since we manipulate archives/images, we make sure to have a clean image cache
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	archive, err := getTestTar(dockerArchiveURI)
 	if err != nil {
@@ -145,8 +156,13 @@ func TestOCIConveyorOCIArchive(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	archive, err := getTestTar(ociArchiveURI)
 	if err != nil {
@@ -181,8 +197,13 @@ func TestOCIConveyorOCILayout(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	archive, err := getTestTar(ociArchiveURI)
 	if err != nil {
@@ -229,8 +250,13 @@ func TestOCIPacker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -38,6 +38,9 @@ func TestOCIConveyorDocker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {
 		return
@@ -63,6 +66,10 @@ func TestOCIConveyorDocker(t *testing.T) {
 func TestOCIConveyorDockerArchive(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	// Since we manipulate archives/images, we make sure to have a clean image cache
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	archive, err := getTestTar(dockerArchiveURI)
 	if err != nil {
@@ -138,6 +145,9 @@ func TestOCIConveyorOCIArchive(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	archive, err := getTestTar(ociArchiveURI)
 	if err != nil {
 		t.Fatalf("Could not download oci archive test file: %v", err)
@@ -170,6 +180,9 @@ func TestOCIConveyorOCIArchive(t *testing.T) {
 func TestOCIConveyorOCILayout(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	archive, err := getTestTar(ociArchiveURI)
 	if err != nil {
@@ -215,6 +228,9 @@ func TestOCIConveyorOCILayout(t *testing.T) {
 func TestOCIPacker(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	b, err := types.NewBundle("", "sbuild-oci")
 	if err != nil {

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -56,6 +56,9 @@ func TestLibraryImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	// LibraryImage just return a string and there is no definition of what
 	// could be a bad string.
 	tests := []struct {
@@ -85,6 +88,9 @@ func TestLibraryImage(t *testing.T) {
 func TestLibraryImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	// Invalid cases
 	_, err := LibraryImageExists("", "")
@@ -123,7 +129,7 @@ func TestLibraryImageExists(t *testing.T) {
 		t.Fatalf("image reported as non-existing: %s\n", err)
 	}
 
-	// Valid case with a valid image, the get the hash from the
+	// Valid case with a valid image, we get the hash from the
 	// file we just created and check whether it matches with what
 	// we have in the cache
 	hash, err := client.ImageHash(name)

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	client "github.com/sylabs/scs-library-client/client"
-	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -60,7 +59,7 @@ func TestLibraryImage(t *testing.T) {
 	cacheDir := test.SetCacheDir(t, "")
 	defer test.CleanCacheDir(t, cacheDir)
 
-	err := os.Setenv(cache.DirEnv, cacheDir)
+	err := os.Setenv(DirEnv, cacheDir)
 	if err != nil {
 		t.Fatalf("failed to set %s environment variable: %s", cacheDir, err)
 	}
@@ -98,13 +97,13 @@ func TestLibraryImageExists(t *testing.T) {
 	cacheDir := test.SetCacheDir(t, "")
 	defer test.CleanCacheDir(t, cacheDir)
 
-	err := os.Setenv(cache.DirEnv, cacheDir)
+	err := os.Setenv(DirEnv, cacheDir)
 	if err != nil {
-		t.Fatalf("failed to set %s environmemt variable: %s", cache.DirEnv, err)
+		t.Fatalf("failed to set %s environmemt variable: %s", DirEnv, err)
 	}
 
 	// Invalid cases
-	_, err := LibraryImageExists("", "")
+	_, err = LibraryImageExists("", "")
 	if err == nil {
 		t.Fatalf("LibraryImageExists() returned true for invalid data:  %s\n", err)
 	}

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	client "github.com/sylabs/scs-library-client/client"
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -56,8 +57,13 @@ func TestLibraryImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cacheDir, err)
+	}
 
 	// LibraryImage just return a string and there is no definition of what
 	// could be a bad string.
@@ -89,8 +95,13 @@ func TestLibraryImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environmemt variable: %s", cache.DirEnv, err)
+	}
 
 	// Invalid cases
 	_, err := LibraryImageExists("", "")

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -56,9 +55,9 @@ func TestNetImageExists(t *testing.T) {
 	cacheDir := test.SetCacheDir(t, "")
 	defer test.CleanCacheDir(t, cacheDir)
 
-	err := os.Setenv(cache.DirEnv, cacheDir)
+	err := os.Setenv(DirEnv, cacheDir)
 	if err != nil {
-		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+		t.Fatalf("failed to set %s environment variable: %s", DirEnv, err)
 	}
 
 	tests := []struct {

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -52,6 +52,9 @@ func TestNetImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	tests := []struct {
 		name     string
 		sum      string

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -52,8 +53,13 @@ func TestNetImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	tests := []struct {
 		name     string

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -91,9 +90,9 @@ func TestOciTempExists(t *testing.T) {
 	cacheDir := test.SetCacheDir(t, "")
 	defer test.CleanCacheDir(t, cacheDir)
 
-	err := os.Setenv(cache.DirEnv, cacheDir)
+	err := os.Setenv(DirEnv, cacheDir)
 	if err != nil {
-		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+		t.Fatalf("failed to set %s environment variable: %s", DirEnv, err)
 	}
 
 	tests := []struct {

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -87,6 +87,9 @@ func TestOciTempExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	tests := []struct {
 		name     string
 		sum      string

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -87,8 +88,13 @@ func TestOciTempExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	tests := []struct {
 		name     string

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -52,8 +53,13 @@ func TestShubImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	tests := []struct {
 		name     string

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
@@ -56,9 +55,9 @@ func TestShubImageExists(t *testing.T) {
 	cacheDir := test.SetCacheDir(t, "")
 	defer test.CleanCacheDir(t, cacheDir)
 
-	err := os.Setenv(cache.DirEnv, cacheDir)
+	err := os.Setenv(DirEnv, cacheDir)
 	if err != nil {
-		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+		t.Fatalf("failed to set %s environment variable: %s", DirEnv, err)
 	}
 
 	tests := []struct {

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -52,6 +52,9 @@ func TestShubImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	tests := []struct {
 		name     string
 		sum      string

--- a/internal/pkg/client/oci/oci_test.go
+++ b/internal/pkg/client/oci/oci_test.go
@@ -17,6 +17,7 @@ import (
 
 	oci "github.com/containers/image/oci/layout"
 	"github.com/containers/image/types"
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	buildTypes "github.com/sylabs/singularity/pkg/build/types"
 )
@@ -365,8 +366,13 @@ func TestNewImageSource(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	// Because of the nature of the context.Context type, there is really
 	// not any invalid case.

--- a/internal/pkg/client/oci/oci_test.go
+++ b/internal/pkg/client/oci/oci_test.go
@@ -365,6 +365,9 @@ func TestNewImageSource(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	// Because of the nature of the context.Context type, there is really
 	// not any invalid case.
 	var validCtx context.Context

--- a/internal/pkg/test/cache.go
+++ b/internal/pkg/test/cache.go
@@ -8,36 +8,44 @@ package test
 import (
 	"io/ioutil"
 	"os"
+	"syscall"
 	"testing"
 )
 
-// SetCacheDir creates a new image cache in the context of testing
-// and set the appropriate environment variable to ensure that the
-// temporary cache is used by the caller. Note that the context of
-// the directory that is passed in will be deleted when calling
-// CleanCacheDir().
+// SetCacheDir creates a new temporary image cache directory in the
+// directory basedir and returns the path of the new directory. If
+// basedir is an empty string, SetCacheDir uses the default directory
+// for temporary files (see os.TempDir). It is the caller's responsibility
+// to remove the directory when no longer needed, which can be accomplished
+// by calling CleanCacheDir
 func SetCacheDir(t *testing.T, basedir string) string {
-	if basedir == "" {
-		// We create a unique temporary directory for the image cache since Go run
-		// tests concurrently and since SINGULARITY_TESTBASEDIR is a static directory.
-		dir, err := ioutil.TempDir("", "image_cache-")
-		if err != nil {
-			t.Fatalf("failed to create temporary directory: %s", err)
-		}
-
-		return dir
+	// We create a unique temporary directory for the image cache since Go run
+	// tests concurrently.
+	dir, err := ioutil.TempDir(basedir, "image_cache-")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory: %s", err)
 	}
 
-	return basedir
+	// Update the access mode to the directory since ioutil.TempDir()
+	// creates a new directory with a different access mode than the
+	// one we want here.
+	oldmask := syscall.Umask(0)
+	defer syscall.Umask(oldmask)
+	err = os.Chmod(dir, 0755)
+	if err != nil {
+		t.Fatalf("failed to change permission of %s: %s", dir, err)
+	}
+
+	return dir
 }
 
-// CleanCacheDir deleted the temporary cache that was created for
-// testing purposes.
-func CleanCacheDir(t *testing.T, basedir string) {
-	// We clean the image cache only if we are not using the
-	// default cache; we do not want to clean the developer's
-	// default cache.
-	if basedir != "" {
-		os.RemoveAll(basedir)
+// CleanCacheDir deleted the temporary image cache that was created for
+// testing purposes. CleanCacheDir will fail the test if an error occurs
+// during its execution.
+func CleanCacheDir(t *testing.T, path string) {
+	// Note: if path is empty os.RemoveAll() will fail
+	err := os.RemoveAll(path)
+	if err != nil {
+		t.Fatalf("failed to remove directory %s: %s", path, err)
 	}
 }

--- a/internal/pkg/test/cache.go
+++ b/internal/pkg/test/cache.go
@@ -6,59 +6,38 @@
 package test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
-	"syscall"
 	"testing"
 )
 
 // SetCacheDir creates a new image cache in the context of testing
 // and set the appropriate environment variable to ensure that the
-// temporary cache is used by the caller.
-func SetCacheDir(t *testing.T) {
-	basedir := os.Getenv("SINGULARITY_TESTBASEDIR")
-
-	if basedir != "" {
-		// We make sure the base directory for the test is created.
-		// we rely only on package from Golang to avoid dependency cycles
-		oldmask := syscall.Umask(0)
-		defer syscall.Umask(oldmask)
-		err := os.MkdirAll(basedir, 0755)
-		// This is an error only outside of the case where the directory already exists
-		if err != nil && !os.IsExist(err) {
-			t.Fatalf("failed to create test base directory %s: %s", basedir, err)
+// temporary cache is used by the caller. Note that the context of
+// the directory that is passed in will be deleted when calling
+// CleanCacheDir().
+func SetCacheDir(t *testing.T, basedir string) string {
+	if basedir == "" {
+		// We create a unique temporary directory for the image cache since Go run
+		// tests concurrently and since SINGULARITY_TESTBASEDIR is a static directory.
+		dir, err := ioutil.TempDir("", "image_cache-")
+		if err != nil {
+			t.Fatalf("failed to create temporary directory: %s", err)
 		}
-	} else {
-		t.Fatal("SINGULARITY_TESTBASEDIR not set")
+
+		return dir
 	}
 
-	// We create a unique temporary directory for the image cache since Go run
-	// tests concurrently and since SINGULARITY_TESTBASEDIR is a static directory.
-	dir, err := ioutil.TempDir(basedir, "image_cache-")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
-	}
-
-	// We do not use cache.DirEnv to avoid a dependency cycle
-	err = os.Setenv("SINGULARITY_CACHEDIR", dir)
-	if err != nil {
-		t.Fatalf("failed to set SINGULARITY_CACHEDIR")
-	}
+	return basedir
 }
 
 // CleanCacheDir deleted the temporary cache that was created for
 // testing purposes.
-func CleanCacheDir(t *testing.T) {
-	// We do not use cache.DirEnv to avoid a dependency cycle
-	cacheDir := os.Getenv("SINGULARITY_CACHEDIR")
-
+func CleanCacheDir(t *testing.T, basedir string) {
 	// We clean the image cache only if we are not using the
 	// default cache; we do not want to clean the developer's
 	// default cache.
-	if cacheDir != "" {
-		os.RemoveAll(cacheDir)
-	} else {
-		fmt.Println("WARNING! the test is using the default image cache")
+	if basedir != "" {
+		os.RemoveAll(basedir)
 	}
 }

--- a/internal/pkg/test/cache.go
+++ b/internal/pkg/test/cache.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// SetCacheDir creates a new image cache in the context of testing
+// and set the appropriate environment variable to ensure that the
+// temporary cache is used by the caller.
+func SetCacheDir(t *testing.T) {
+	basedir := os.Getenv("SINGULARITY_TESTBASEDIR")
+
+	if basedir != "" {
+		// We make sure the base directory for the test is created.
+		// we rely only on package from Golang to avoid dependency cycles
+		oldmask := syscall.Umask(0)
+		defer syscall.Umask(oldmask)
+		err := os.MkdirAll(basedir, 0755)
+		// This is an error only outside of the case where the directory already exists
+		if err != nil && !os.IsExist(err) {
+			t.Fatalf("failed to create test base directory %s: %s", basedir, err)
+		}
+	} else {
+		t.Fatal("SINGULARITY_TESTBASEDIR not set")
+	}
+
+	// We create a unique temporary directory for the image cache since Go run
+	// tests concurrently and since SINGULARITY_TESTBASEDIR is a static directory.
+	dir, err := ioutil.TempDir(basedir, "image_cache-")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory: %s", err)
+	}
+
+	// We do not use cache.DirEnv to avoid a dependency cycle
+	err = os.Setenv("SINGULARITY_CACHEDIR", dir)
+	if err != nil {
+		t.Fatalf("failed to set SINGULARITY_CACHEDIR")
+	}
+}
+
+// CleanCacheDir deleted the temporary cache that was created for
+// testing purposes.
+func CleanCacheDir(t *testing.T) {
+	// We do not use cache.DirEnv to avoid a dependency cycle
+	cacheDir := os.Getenv("SINGULARITY_CACHEDIR")
+
+	// We clean the image cache only if we are not using the
+	// default cache; we do not want to clean the developer's
+	// default cache.
+	if cacheDir != "" {
+		os.RemoveAll(cacheDir)
+	} else {
+		fmt.Println("WARNING! the test is using the default image cache")
+	}
+}

--- a/internal/pkg/test/privilege_darwin.go
+++ b/internal/pkg/test/privilege_darwin.go
@@ -18,13 +18,6 @@ import (
 var origUID, origGID, unprivUID, unprivGID int
 var origHome, unprivHome string
 
-const (
-	// CacheDirPriv is the directory the cachedir gets set to when running privileged
-	CacheDirPriv = "/tmp/WithPrivilege"
-	// CacheDirUnpriv is the directory the cachedir gets set to when running unprivileged
-	CacheDirUnpriv = "/tmp/WithoutPrivilege"
-)
-
 // EnsurePrivilege ensures elevated privileges are available during a test.
 func EnsurePrivilege(t *testing.T) {
 	uid := os.Getuid()
@@ -50,9 +43,6 @@ func ResetPrivilege(t *testing.T) {
 func WithPrivilege(f func(t *testing.T)) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
-
-		// set SINGULARITY_CACHEDIR
-		os.Setenv("SINGULARITY_CACHEDIR", CacheDirPriv)
 
 		EnsurePrivilege(t)
 

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -20,21 +20,12 @@ import (
 var origUID, origGID, unprivUID, unprivGID int
 var origHome, unprivHome string
 
-const (
-	// BaseDirPriv is the directory used by tests when running privileged
-	BaseDirPriv = "/tmp/WithPrivilege"
-	// BaseDirUnpriv is the directory used by tests when running unprivileged
-	BaseDirUnpriv = "/tmp/WithoutPrivilege"
-)
-
 // EnsurePrivilege ensures elevated privileges are available during a test.
 func EnsurePrivilege(t *testing.T) {
 	uid := os.Getuid()
 	if uid != 0 {
 		t.Fatal("test must be run with privilege")
 	}
-
-	os.Setenv("SINGULARITY_TESTBASEDIR", BaseDirPriv)
 }
 
 // DropPrivilege drops privilege. Use this at the start of a test that does
@@ -60,9 +51,6 @@ func DropPrivilege(t *testing.T) {
 			t.Fatalf("failed to set HOME environment variable: %v", err)
 		}
 	}
-
-	// set SINGULARITY_CACHEDIR; we do not refer to cache.DirEnv to avoid dependency cycles.
-	os.Setenv("SINGULARITY_TESTBASEDIR", BaseDirUnpriv)
 }
 
 // ResetPrivilege returns effective privilege to the original user.
@@ -78,8 +66,6 @@ func ResetPrivilege(t *testing.T) {
 	}
 
 	runtime.UnlockOSThread()
-
-	os.Setenv("SINGULARITY_TESTBASEDIR", BaseDirPriv)
 }
 
 // WithPrivilege wraps the supplied test function with calls to ensure
@@ -87,8 +73,6 @@ func ResetPrivilege(t *testing.T) {
 func WithPrivilege(f func(t *testing.T)) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
-
-		os.Setenv("SINGULARITY_TESTBASEDIR", BaseDirPriv)
 
 		EnsurePrivilege(t)
 
@@ -104,8 +88,6 @@ func WithoutPrivilege(f func(t *testing.T)) func(t *testing.T) {
 
 		DropPrivilege(t)
 		defer ResetPrivilege(t)
-
-		os.Setenv("SINGULARITY_TESTBASEDIR", BaseDirUnpriv)
 
 		f(t)
 	}

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -102,6 +102,9 @@ func TestReader(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	filename := downloadImage(t)
 	defer os.Remove(filename)
 
@@ -180,6 +183,9 @@ func TestReader(t *testing.T) {
 func TestAuthorizedPath(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	tests := []struct {
 		name       string
@@ -264,6 +270,9 @@ func TestRootAuthorizedOwner(t *testing.T) {
 	// Function focusing only on executing the privileged case
 	test.EnsurePrivilege(t)
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	tests := []ownerGroupTest{
 		/* This test fails with CircleCI because of weird user management that
 		   would lead to crazy code so we deactivate it for now
@@ -297,6 +306,9 @@ func TestAuthorizedOwner(t *testing.T) {
 	// this not a privileged test
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	// Note that we do not test the "root" case; the privileged cases are
 	// tested in a separate function.
@@ -364,6 +376,9 @@ func runAuthorizedGroupTest(t *testing.T, tt groupTest, img *Image) {
 func TestPrivilegedAuthorizedGroup(t *testing.T) {
 	test.EnsurePrivilege(t) // to make sure we create the image under the correct user
 
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
+
 	tests := []groupTest{
 		{
 			name:       "root - empty group list",
@@ -392,6 +407,9 @@ func TestPrivilegedAuthorizedGroup(t *testing.T) {
 func TestAuthorizedGroup(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	test.SetCacheDir(t)
+	defer test.CleanCacheDir(t)
 
 	// Note that we do not test the "root" case here, privileged cases are
 	// performed in a separate function.

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 
@@ -102,8 +103,13 @@ func TestReader(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cacheDir, err)
+	}
 
 	filename := downloadImage(t)
 	defer os.Remove(filename)
@@ -184,8 +190,13 @@ func TestAuthorizedPath(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	tests := []struct {
 		name       string
@@ -270,8 +281,13 @@ func TestRootAuthorizedOwner(t *testing.T) {
 	// Function focusing only on executing the privileged case
 	test.EnsurePrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	tests := []ownerGroupTest{
 		/* This test fails with CircleCI because of weird user management that
@@ -307,8 +323,13 @@ func TestAuthorizedOwner(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	// Note that we do not test the "root" case; the privileged cases are
 	// tested in a separate function.
@@ -376,8 +397,13 @@ func runAuthorizedGroupTest(t *testing.T, tt groupTest, img *Image) {
 func TestPrivilegedAuthorizedGroup(t *testing.T) {
 	test.EnsurePrivilege(t) // to make sure we create the image under the correct user
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	tests := []groupTest{
 		{
@@ -408,8 +434,13 @@ func TestAuthorizedGroup(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	test.SetCacheDir(t)
-	defer test.CleanCacheDir(t)
+	cacheDir := test.SetCacheDir(t, "")
+	defer test.CleanCacheDir(t, cacheDir)
+
+	err := os.Setenv(cache.DirEnv, cacheDir)
+	if err != nil {
+		t.Fatalf("failed to set %s environment variable: %s", cache.DirEnv, err)
+	}
 
 	// Note that we do not test the "root" case here, privileged cases are
 	// performed in a separate function.


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds a new testing function that enables the creation of a unique image cache for unit tests. This avoids the problem of unit tests sharing cache from one test to another.

The typical usage is:
```
test.EnsurePrivilege(t)
test.SetCacheDir(t)
defer test.CleanCacheDir(t)
```

Overview:
- This PR introduces a new environment variable: `SINGULARITY_TESTBASEDIR` that is set either to `/tmp/WithPrivilege` or `/tmp/WithoutPrivilege`; this allows us to separate privilege management and cache management but let the code managing the cache know where the cache should be created.
- `SetCacheDIr(t)` creates a temporary directory and set `SINGULARITY_CACHEDIR` to point at the temporary directory.
- `CleanCacheDir()` will delete the temporary directory used as image cache.

Note: this PR is based on the idea of limiting changes to the existing code so the `/tmp/WithPrivilege` and `/tmp/WithoutPrivilege` are kept and unique temporary image caches are created within these directories. It would be possible to not have these two directories and just create temporary directories since these two directories are currently only used for image caches.

**This fixes or addresses the following GitHub issues:**

- Fixes #3592 
- Addresses #3525 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers