### PR TITLE
Fix starter environment variable cleanup

### DIFF
--- a/cmd/starter/c/include/message.h
+++ b/cmd/starter/c/include/message.h
@@ -47,6 +47,8 @@
 #define ANSI_COLOR_LIGHTCYAN    "\x1b[96m"
 #define ANSI_COLOR_RESET        "\x1b[0m"
 
+#define MSGLVL_ENV              "SINGULARITY_MESSAGELEVEL"
+
 void _print(int level, const char *function, const char *file, char *format, ...) __attribute__ ((__format__(printf, 4, 5)));
 
 #define singularity_message(a,b...) _print(a, __func__, __FILE__, b)

--- a/cmd/starter/c/message.c
+++ b/cmd/starter/c/message.c
@@ -53,11 +53,11 @@ void _print(int level, const char *function, const char *file_in, char *format, 
     va_list args;
 
     if ( messagelevel == -99 ) {
-        char *messagelevel_string = getenv("SINGULARITY_MESSAGELEVEL");
+        char *messagelevel_string = getenv(MSGLVL_ENV);
 
         if ( messagelevel_string == NULL ) {
             messagelevel = 5;
-            singularity_message(DEBUG, "SINGULARITY_MESSAGELEVEL undefined, setting level 5 (debug)\n");
+            singularity_message(DEBUG, MSGLVL_ENV " undefined, setting level 5 (debug)\n");
         } else {
             messagelevel = atoi(messagelevel_string);
             if ( messagelevel > 9 ) {

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -813,18 +813,6 @@ static void fix_streams(void) {
     }
 }
 
-static char *dupenv(const char *env) {
-    char *var = getenv(env);
-
-    if ( var != NULL ) {
-        return strdup(var);
-    } else {
-        fatalf("%s environment variable isn't set\n", env);
-    }
-
-    return NULL;
-}
-
 static void exit_with_status(const char *name, int status) {
     if ( WIFEXITED(status) ) {
         verbosef("%s exited with status %d\n", name, WEXITSTATUS(status));
@@ -843,28 +831,54 @@ void do_exit(int sig) {
     exit(1);
 }
 
+/*
+ * cleanenv set environ pointer to NULL, while it works
+ * in C context, it doesn't have any effect with the Go
+ * runtime using the real pointer, so we need to work
+ * directly with environ array.
+ */
+static void cleanenv(void) {
+    extern char **environ;
+    char **e;
+    char *p = NULL;
+
+    if ( environ == NULL || *environ == NULL ) {
+        fatalf("no environment variables set\n");
+    }
+
+    /* keep only SINGULARITY_MESSAGELEVEL for GO runtime */
+    for (e = environ; *e != NULL; e++) {
+        if ( strncmp(MSGLVL_ENV "=", *e, sizeof(MSGLVL_ENV)) == 0 ) {
+            p = *e;
+        } else {
+            *e = NULL;
+        }
+    }
+
+    if ( p != NULL ) {
+        *environ = p;
+    }
+}
+
 __attribute__((constructor)) static void init(void) {
     uid_t uid = getuid();
     gid_t gid = getgid();
     sigset_t mask;
     pid_t stage_pid;
-    char *loglevel;
     char *pipe_fd_env;
     int status;
     int forkfd = -1;
     int pipe_fd = -1;
     int fork_flags = 0;
-    int join_chroot = 0;
     int sync_pipe[2];
-    struct pollfd fds[2];
     struct fdlist *fd_before;
     struct fdlist *fd_after;
+
+    verbosef("Starter initialization\n");
 
 #ifndef SINGULARITY_NO_NEW_PRIVS
     fatalf("Host kernel is outdated and does not support PR_SET_NO_NEW_PRIVS!\n");
 #endif
-
-    loglevel = dupenv("SINGULARITY_MESSAGELEVEL");
 
     pipe_fd_env = getenv("PIPE_EXEC_FD");
     if ( pipe_fd_env != NULL ) {
@@ -879,7 +893,8 @@ __attribute__((constructor)) static void init(void) {
         fatalf("PIPE_EXEC_FD environment variable isn't set\n");
     }
 
-    verbosef("Container runtime\n");
+    /* cleanup environment variables */
+    cleanenv();
 
     // initialize starter configuration and share it with child processes
     config = (struct cConfig *)mmap(NULL, sizeof(struct cConfig), PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
@@ -905,14 +920,6 @@ __attribute__((constructor)) static void init(void) {
         if ( setegid(gid) < 0 || seteuid(uid) < 0 ) {
             fatalf("Failed to drop privileges: %s\n", strerror(errno));
         }
-    }
-
-    /* reset environment variables */
-    clearenv();
-
-    if ( loglevel != NULL ) {
-        setenv("SINGULARITY_MESSAGELEVEL", loglevel, 1);
-        free(loglevel);
     }
 
     /* read json configuration from stdin */

--- a/cmd/starter/main_linux.go
+++ b/cmd/starter/main_linux.go
@@ -14,7 +14,6 @@ package main
 import "C"
 
 import (
-	"os"
 	"runtime"
 	"unsafe"
 
@@ -35,14 +34,6 @@ func getEngine(jsonConfig []byte) *engines.Engine {
 }
 
 func startup() {
-	loglevel := os.Getenv("SINGULARITY_MESSAGELEVEL")
-	os.Clearenv()
-	if loglevel != "" {
-		if os.Setenv("SINGULARITY_MESSAGELEVEL", loglevel) != nil {
-			sylog.Warningf("can't restore SINGULARITY_MESSAGELEVEL environment variable")
-		}
-	}
-
 	cconf := unsafe.Pointer(C.config)
 	sconfig := starterConfig.NewConfig(starterConfig.CConfig(cconf))
 	jsonConfig := sconfig.GetJSONConfig()


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR removes unecessary Go environment cleanup and handle that in starter C code.


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
