### PR TITLE
Fix incorrect OCI cred mapping

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -274,7 +274,7 @@ var actionDockerUsernameFlag = cmdline.Flag{
 // --docker-password
 var actionDockerPasswordFlag = cmdline.Flag{
 	ID:           "actionDockerPasswordFlag",
-	Value:        &dockerUsername,
+	Value:        &dockerPassword,
 	DefaultValue: "",
 	Name:         "docker-password",
 	Usage:        "specify a password for docker authentication",

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -191,7 +191,11 @@ func OrasPull(name, ref string, force bool, ociAuth *ocitypes.DockerAuthConfig) 
 	}
 
 	credFn := func(_ string) (string, string, error) {
-		return ociAuth.Username, ociAuth.Password, nil
+		if ociAuth != nil {
+			return ociAuth.Username, ociAuth.Password, nil
+		}
+
+		return "", "", nil
 	}
 	resolver := docker.NewResolver(docker.ResolverOptions{Credentials: credFn})
 

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -148,9 +148,12 @@ func OrasPush(path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	}
 
 	credFn := func(_ string) (string, string, error) {
-		return ociAuth.Username, ociAuth.Password, nil
-	}
+		if ociAuth != nil {
+			return ociAuth.Username, ociAuth.Password, nil
+		}
 
+		return "", "", nil
+	}
 	resolver := docker.NewResolver(docker.ResolverOptions{Credentials: credFn})
 
 	store := content.NewFileStore("")


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Fixes incorrect mapping of CLI credential vars
- Prevent potential nil pointer dereference panic


**This fixes or addresses the following GitHub issues:**

- Fixes #3616 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
