### PR TITLE
Add 'shub' to cache list/clean + improved '--name' handling

### DIFF
--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -48,7 +48,7 @@ var cacheCleanTypesFlag = cmdline.Flag{
 var cacheCleanNameFlag = cmdline.Flag{
 	ID:           "cacheCleanNameFlag",
 	Value:        &cacheName,
-	DefaultValue: []string{""},
+	DefaultValue: []string{},
 	Name:         "name",
 	ShortHand:    "N",
 	Usage:        "specify a container cache to clean (will clear all cache with the same name)",

--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -19,7 +19,7 @@ import (
 var (
 	cleanAll        bool
 	cacheCleanTypes []string
-	cacheName       string
+	cacheName       []string
 )
 
 // -a|--all
@@ -40,7 +40,7 @@ var cacheCleanTypesFlag = cmdline.Flag{
 	DefaultValue: []string{"blob"},
 	Name:         "type",
 	ShortHand:    "T",
-	Usage:        "clean cache type, choose between: library, oci, and blob",
+	Usage:        "clean cache type, choose between: library, oci, shub, and blob",
 	EnvKeys:      []string{"TYPE"},
 }
 
@@ -48,7 +48,7 @@ var cacheCleanTypesFlag = cmdline.Flag{
 var cacheCleanNameFlag = cmdline.Flag{
 	ID:           "cacheCleanNameFlag",
 	Value:        &cacheName,
-	DefaultValue: "",
+	DefaultValue: []string{""},
 	Name:         "name",
 	ShortHand:    "N",
 	Usage:        "specify a container cache to clean (will clear all cache with the same name)",
@@ -61,7 +61,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&cacheCleanNameFlag, CacheCleanCmd)
 }
 
-// CacheCleanCmd : is `singularity cache clean' and will clear your local singularity cache
+// CacheCleanCmd is 'singularity cache clean' and will clear your local singularity cache
 var CacheCleanCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -25,10 +25,10 @@ var (
 var cacheListTypesFlag = cmdline.Flag{
 	ID:           "cacheListTypes",
 	Value:        &cacheListTypes,
-	DefaultValue: []string{"library", "oci", "blobSum"},
+	DefaultValue: []string{"library", "oci", "shub", "blobSum"},
 	Name:         "type",
 	ShortHand:    "T",
-	Usage:        "a list of cache types to display, possible entries: library, oci, blob(s), blobSum, all",
+	Usage:        "a list of cache types to display, possible entries: library, oci, shub, blob(s), blobSum, all",
 	EnvKeys:      []string{"TYPE"},
 }
 
@@ -77,8 +77,8 @@ var CacheListCmd = &cobra.Command{
 func cacheListCmd() error {
 	err := singularity.ListSingularityCache(cacheListTypes, allList, cacheListSummary)
 	if err != nil {
-		sylog.Fatalf("Not listing cache; an error occurred: %v", err)
+		sylog.Fatalf("An error occurred while listing cache: %v", err)
 		return err
 	}
-	return err
+	return nil
 }

--- a/internal/app/singularity/cache_clean_linux.go
+++ b/internal/app/singularity/cache_clean_linux.go
@@ -37,6 +37,17 @@ func cleanOciCache() error {
 	return nil
 }
 
+func cleanShubCache() error {
+	sylog.Debugf("Removing: %v", cache.Shub())
+
+	err := os.RemoveAll(cache.Shub())
+	if err != nil {
+		return fmt.Errorf("unable to clean shub cache: %v", err)
+	}
+
+	return nil
+}
+
 func cleanBlobCache() error {
 	sylog.Debugf("Removing: %v", cache.OciBlob())
 
@@ -46,28 +57,28 @@ func cleanBlobCache() error {
 	}
 
 	return nil
-
 }
 
-// CleanCache : clean a type of cache (cacheType string). will return a error if one occurs.
-func CleanCache(cacheType string) error {
-	switch cacheType {
-	case "library":
-		err := cleanLibraryCache()
-		return err
-	case "oci":
-		err := cleanOciCache()
-		return err
-	case "blob", "blobs":
-		err := cleanBlobCache()
-		return err
-	case "all":
-		err := cache.Clean()
-		return err
-	default:
-		// The caller checks the returned error and will exit as required
-		return fmt.Errorf("not a valid type: %s", cacheType)
+// CleanCache will clean a type of cache (cacheType string). will return a error if one occurs.
+func CleanCache(cacheType []string) error {
+	for _, c := range cacheType {
+		switch c {
+		case "library":
+			return cleanLibraryCache()
+		case "oci":
+			return cleanOciCache()
+		case "shub":
+			return cleanShubCache()
+		case "blob", "blobs":
+			return cleanBlobCache()
+		case "all":
+			return cache.Clean()
+		default:
+			// The caller checks the returned error and will exit as required
+			return fmt.Errorf("not a valid type: %s", cacheType)
+		}
 	}
+	return fmt.Errorf("no cache to clean; non specified")
 }
 
 func cleanLibraryCacheName(cacheName string) (bool, error) {
@@ -120,11 +131,36 @@ func cleanOciCacheName(cacheName string) (bool, error) {
 	return foundMatch, nil
 }
 
-// CleanCacheName : will clean a container with the same name as cacheName (in the cache directory).
+func cleanShubCacheName(cacheName string) (bool, error) {
+	foundMatch := false
+	blobs, err := ioutil.ReadDir(cache.Shub())
+	if err != nil {
+		return false, fmt.Errorf("unable to opening shub cache folder: %v", err)
+	}
+	for _, f := range blobs {
+		blob, err := ioutil.ReadDir(filepath.Join(cache.Shub(), f.Name()))
+		if err != nil {
+			return false, fmt.Errorf("unable to look in shub cache folder: %v", err)
+		}
+		for _, b := range blob {
+			if b.Name() == cacheName {
+				sylog.Debugf("Removing: %v", filepath.Join(cache.Shub(), f.Name(), b.Name()))
+				err = os.RemoveAll(filepath.Join(cache.Shub(), f.Name(), b.Name()))
+				if err != nil {
+					return false, fmt.Errorf("unable to remove shub cache: %v", err)
+				}
+				foundMatch = true
+			}
+		}
+	}
+	return foundMatch, nil
+}
+
+// CleanCacheName will clean a container with the same name as cacheName (in the cache directory).
 // if libraryCache is true; only search thrught library cache. if ociCache is true; only search the
 // oci-tmp cache. if both are false; search all cache, and if both are true; again, search all cache.
-func CleanCacheName(cacheName string, libraryCache, ociCache bool) (bool, error) {
-	if libraryCache == ociCache {
+func CleanCacheName(cacheName string, libraryCache, ociCache, shubCache bool) (bool, error) {
+	if libraryCache == ociCache && libraryCache == shubCache {
 		matchLibrary, err := cleanLibraryCacheName(cacheName)
 		if err != nil {
 			return false, err
@@ -133,7 +169,11 @@ func CleanCacheName(cacheName string, libraryCache, ociCache bool) (bool, error)
 		if err != nil {
 			return false, err
 		}
-		if matchLibrary || matchOci {
+		matchShub, err := cleanShubCacheName(cacheName)
+		if err != nil {
+			return false, err
+		}
+		if matchLibrary || matchOci || matchShub {
 			return true, nil
 		}
 		return false, nil
@@ -156,12 +196,13 @@ func CleanCacheName(cacheName string, libraryCache, ociCache bool) (bool, error)
 	return match, nil
 }
 
-// CleanSingularityCache : the main function that drives all these other functions, if allClean is true; clean
+// CleanSingularityCache is the main function that drives all these other functions, if allClean is true; clean
 // all cache. if typeNameClean contains somthing; only clean that type. if cacheName contains somthing; clean only
 // cache with that name.
-func CleanSingularityCache(cleanAll bool, cacheCleanTypes []string, cacheName string) error {
+func CleanSingularityCache(cleanAll bool, cacheCleanTypes []string, cacheName []string) error {
 	libraryClean := false
 	ociClean := false
+	shubClean := false
 	blobClean := false
 
 	for _, t := range cacheCleanTypes {
@@ -170,6 +211,8 @@ func CleanSingularityCache(cleanAll bool, cacheCleanTypes []string, cacheName st
 			libraryClean = true
 		case "oci":
 			ociClean = true
+		case "shub":
+			shubClean = true
 		case "blob", "blobs":
 			blobClean = true
 		case "all":
@@ -180,35 +223,42 @@ func CleanSingularityCache(cleanAll bool, cacheCleanTypes []string, cacheName st
 		}
 	}
 
-	if len(cacheName) >= 1 && !cleanAll {
-		foundMatch, err := CleanCacheName(cacheName, libraryClean, ociClean)
-		if err != nil {
-			return err
-		}
-		if !foundMatch {
-			sylog.Warningf("No cache found with given name: %s", cacheName)
+	if len(cacheName) >= 2 && !cleanAll {
+		for _, n := range cacheName {
+			foundMatch, err := CleanCacheName(n, libraryClean, ociClean, shubClean)
+			if err != nil {
+				return err
+			}
+			if !foundMatch {
+				sylog.Warningf("No cache found with given name: %s", n)
+			}
 		}
 		return nil
 	}
 
 	if cleanAll {
-		if err := CleanCache("all"); err != nil {
+		if err := CleanCache([]string{"all"}); err != nil {
 			return err
 		}
 	}
 
 	if libraryClean {
-		if err := CleanCache("library"); err != nil {
+		if err := CleanCache([]string{"library"}); err != nil {
 			return err
 		}
 	}
 	if ociClean {
-		if err := CleanCache("oci"); err != nil {
+		if err := CleanCache([]string{"oci"}); err != nil {
+			return err
+		}
+	}
+	if shubClean {
+		if err := CleanCache([]string{"shub"}); err != nil {
 			return err
 		}
 	}
 	if blobClean {
-		if err := CleanCache("blob"); err != nil {
+		if err := CleanCache([]string{"blob"}); err != nil {
 			return err
 		}
 	}

--- a/internal/app/singularity/cache_clean_linux.go
+++ b/internal/app/singularity/cache_clean_linux.go
@@ -29,7 +29,10 @@ func CleanCache(cacheType []string) error {
 		case "blob", "blobs":
 			cacheToRemove = cache.OciBlob()
 		case "all":
-			cacheToRemove = cache.Root()
+			if err := cache.Clean(); err != nil {
+				return err
+			}
+			break
 		default:
 			return fmt.Errorf("not a valid type: %s", c)
 		}

--- a/internal/app/singularity/cache_list_linux.go
+++ b/internal/app/singularity/cache_list_linux.go
@@ -52,6 +52,8 @@ func listTypeCache(printList bool, cacheType string) (int, int64, error) {
 		cachePath = cache.Library()
 	case "oci":
 		cachePath = cache.OciTemp()
+	case "shub":
+		cachePath = cache.Shub()
 	case "":
 		return 0, 0, fmt.Errorf("no cache type specifyed")
 	default:
@@ -139,6 +141,7 @@ func listBlobCache(printList bool) (int, int64, error) {
 func ListSingularityCache(cacheListTypes []string, listAll, cacheListSummary bool) error {
 	libraryList := false
 	ociList := false
+	shubList := false
 	blobList := false
 	blobSum := false
 
@@ -148,6 +151,8 @@ func ListSingularityCache(cacheListTypes []string, listAll, cacheListSummary boo
 			libraryList = true
 		case "oci":
 			ociList = true
+		case "shub":
+			shubList = true
 		case "blob", "blobs":
 			blobList = true
 		case "blobSum":
@@ -208,6 +213,22 @@ func ListSingularityCache(cacheListTypes []string, listAll, cacheListSummary boo
 		}
 		containerCount += ociCount
 		containerSpace += ociSize
+	}
+
+	if listAll {
+		shubCount, shubSize, err := listTypeCache(true, "shub")
+		if err != nil {
+			return err
+		}
+		containerCount += shubCount
+		containerSpace += shubSize
+	} else if shubList {
+		shubCount, shubSize, err := listTypeCache(!cacheListSummary, "shub")
+		if err != nil {
+			return err
+		}
+		containerCount += shubCount
+		containerSpace += shubSize
 	}
 
 	if listAll {


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds support for `cache list/clean` for `shub`. And improves the `--name` handling.

#### Example:

You cant do this before:

```bash
$ singularity cache clean -Nalpine_latest.sif -Nalpine_3.8.sif -Ndebian_latest.sif
```

_Before it would only clean `debian_latest.sif`, but now it will clean all that are specified._

#### Shub cache example:

```bash
$ singularity exec shub://GodloveD/busybox true
INFO:    Downloading shub image
[...]

$ singularity cache list 
NAME                     DATE CREATED           SIZE             TYPE
busybox_latest.sif       2019-05-31 12:19:49    618.53 kB        shub

There 1 containers using: 618.53 kB, 0 oci blob file(s) using 0.00 kB of space.
Total space used: 618.53 kB
```


## This fixes or addresses the following GitHub issues:

- Related to #3660 

<br>
