### PR TITLE
Support for Shub caching when using 'pull'

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -217,7 +217,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While pulling library image: %v", err)
 		}
 	case ShubProtocol:
-		err := shub.DownloadImage(name, args[i], force, noHTTPS)
+		err := shub.PullShubImage(name, args[i], force, noHTTPS)
 		if err != nil {
 			sylog.Fatalf("While pulling shub image: %v\n", err)
 		}

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -216,7 +216,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While pulling library image: %v", err)
 		}
 	case ShubProtocol:
-		err := singularity.PullShubImage(name, args[i], force, noHTTPS)
+		err := singularity.PullShub(name, args[i], force, noHTTPS)
 		if err != nil {
 			sylog.Fatalf("While pulling shub image: %v\n", err)
 		}

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/uri"
 	net "github.com/sylabs/singularity/pkg/client/net"
-	shub "github.com/sylabs/singularity/pkg/client/shub"
 	"github.com/sylabs/singularity/pkg/cmdline"
 )
 
@@ -217,7 +216,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While pulling library image: %v", err)
 		}
 	case ShubProtocol:
-		err := shub.PullShubImage(name, args[i], force, noHTTPS)
+		err := singularity.PullShubImage(name, args[i], force, noHTTPS)
 		if err != nil {
 			sylog.Fatalf("While pulling shub image: %v\n", err)
 		}

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -152,9 +152,9 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 	return retErr
 }
 
-// PullShubImage will download a image from shub, and cache it. Next time
+// PullShub will download a image from shub, and cache it. Next time
 // that container is downloaded this will just use that cached image.
-func PullShubImage(filePath string, shubRef string, force, noHTTPS bool) (err error) {
+func PullShub(filePath string, shubRef string, force, noHTTPS bool) (err error) {
 	if !force {
 		if _, err := os.Stat(filePath); err == nil {
 			return fmt.Errorf("image file already exists: %q - will not overwrite", filePath)

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/uri"
 	"github.com/sylabs/singularity/pkg/build/types"
+	shub "github.com/sylabs/singularity/pkg/client/shub"
 	"github.com/sylabs/singularity/pkg/signing"
 	"github.com/sylabs/singularity/pkg/sypgp"
 	pb "gopkg.in/cheggaaa/pb.v1"
@@ -149,6 +150,55 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 	sylog.Infof("Download complete: %s\n", name)
 
 	return retErr
+}
+
+// PullShubImage will download a image from shub, and cache it. Next time
+// that container is downloaded this will just use that cached image.
+func PullShubImage(filePath string, shubRef string, force, noHTTPS bool) (err error) {
+	if !force {
+		if _, err := os.Stat(filePath); err == nil {
+			return fmt.Errorf("image file already exists: %q - will not overwrite", filePath)
+		}
+	}
+
+	imageName := uri.GetName(shubRef)
+	imagePath := cache.ShubImage("hash", imageName)
+
+	exists, err := cache.ShubImageExists("hash", imageName)
+	if err != nil {
+		return fmt.Errorf("unable to check if %v exists: %v", imagePath, err)
+	}
+	if !exists {
+		sylog.Infof("Downloading shub image")
+		err := shub.DownloadImage(imagePath, shubRef, true, noHTTPS)
+		if err != nil {
+			return err
+		}
+	} else {
+		sylog.Infof("Use image from cache")
+	}
+
+	// Perms are 777 *prior* to umask in order to allow image to be
+	// executed with its leading shebang like a script
+	dstFile, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
+	if err != nil {
+		return fmt.Errorf("while opening destination file: %v", err)
+	}
+	defer dstFile.Close()
+
+	srcFile, err := os.Open(imagePath)
+	if err != nil {
+		return fmt.Errorf("while opening cached image: %v", err)
+	}
+	defer srcFile.Close()
+
+	// Copy image from cache
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return fmt.Errorf("while copying image from cache: %v", err)
+	}
+
+	return nil
 }
 
 // downloadImageCallback is called to display progress bar while downloading

--- a/pkg/client/shub/pull.go
+++ b/pkg/client/shub/pull.go
@@ -114,19 +114,22 @@ func downloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 	// Do the request, if status isn't success, return error
 	resp, err := httpc.Do(req)
 	if resp == nil {
-		return fmt.Errorf("No response received from singularity hub")
+		return fmt.Errorf("no response received from singularity hub")
+	}
+	if err != nil {
+		return err
 	}
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("The requested image was not found in singularity hub")
+		return fmt.Errorf("the requested image was not found in singularity hub")
 	}
 	sylog.Debugf("%s response received, beginning image download\n", resp.Status)
 
 	if resp.StatusCode != http.StatusOK {
 		err := jsonresp.ReadError(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Download did not succeed: %s", err.Error())
+			return fmt.Errorf("download did not succeed: %s", err.Error())
 		}
-		return fmt.Errorf("Download did not succeed: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return fmt.Errorf("download did not succeed: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	// Perms are 777 *prior* to umask

--- a/pkg/client/shub/pull.go
+++ b/pkg/client/shub/pull.go
@@ -25,6 +25,11 @@ const pullTimeout = 7200
 // to cache it, or use cache.
 func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 	sylog.Debugf("Downloading container from Shub")
+	if !force {
+		if _, err := os.Stat(filePath); err == nil {
+			return fmt.Errorf("image file already exists: %q - will not overwrite", filePath)
+		}
+	}
 
 	// use custom parser to make sure we have a valid shub URI
 	if ok := isShubPullRef(shubRef); !ok {

--- a/pkg/client/shub/pull.go
+++ b/pkg/client/shub/pull.go
@@ -23,12 +23,12 @@ import (
 // Timeout for an image pull in seconds (2 hours)
 const pullTimeout = 7200
 
-// DownloadImage will retrieve an image from the Container Singularityhub,
-// saving it into the specified file
-func DownloadImage(filePath string, shubRef string, force, noHTTPS bool) (err error) {
+// PullShubImage will download a image from shub, and cache it. Next time
+// that container is downloaded this will just use that cached image.
+func PullShubImage(filePath string, shubRef string, force, noHTTPS bool) (err error) {
 	if !force {
 		if _, err := os.Stat(filePath); err == nil {
-			return fmt.Errorf("image file already exists - will not overwrite")
+			return fmt.Errorf("image file already exists: %q - will not overwrite", filePath)
 		}
 	}
 
@@ -41,7 +41,7 @@ func DownloadImage(filePath string, shubRef string, force, noHTTPS bool) (err er
 	}
 	if !exists {
 		sylog.Infof("Downloading shub image")
-		err := downloadImage(imagePath, shubRef, true, noHTTPS)
+		err := DownloadImage(imagePath, shubRef, true, noHTTPS)
 		if err != nil {
 			return err
 		}
@@ -72,7 +72,9 @@ func DownloadImage(filePath string, shubRef string, force, noHTTPS bool) (err er
 	return nil
 }
 
-func downloadImage(filePath, shubRef string, force, noHTTPS bool) error {
+// Download image will download a shub image to a path. This will not try
+// to cache it, or use cache.
+func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 	sylog.Debugf("Downloading container from Shub")
 
 	// use custom parser to make sure we have a valid shub URI


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds the support for caching Shub images when using the `pull` command.

#### Example:

```bash
$ singularity pull shub://michael-tn/mpi-hello-world:latest
INFO:    Downloading shub image
 194.44 MiB / 194.44 MiB [========================================] 100.00% 4.12 TiB/s 0s

$ rm mpi-hello-world_latest.sif 
$ singularity pull shub://michael-tn/mpi-hello-world:latest
INFO:    Use image from cache
```

## This fixes or addresses the following GitHub issues:

- Fixes #3402 

- Related to #3659 

<br>
