### PR TITLE
create ~/.singularity if it doesn't exist

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -189,16 +189,6 @@ func setSylogColor() {
 	}
 }
 
-// getConfDir queries ConfigDirForUsername() and stops execution if there is an
-// error
-func getConfDir(usr string) string {
-	confDir, err := syfs.ConfigDirForUsername(usr)
-	if err != nil {
-		sylog.Fatalf("Error attempting to determine user's config directory: %s\n", err)
-	}
-	return confDir
-}
-
 // createConfDir tries to create the user's configuration directory and handles
 // messages and/or errors
 func createConfDir(d string) {
@@ -233,8 +223,7 @@ var SingularityCmd = &cobra.Command{
 func persistentPreRunE(cmd *cobra.Command, _ []string) error {
 	setSylogMessageLevel()
 	setSylogColor()
-	confDir := getConfDir(CurrentUser.Username)
-	createConfDir(confDir)
+	createConfDir(syfs.ConfigDir())
 	return cmdManager.UpdateCmdFlagFromEnv(cmd, envPrefix)
 }
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -188,6 +188,22 @@ func setSylogColor() {
 	}
 }
 
+// createDataDir will create ~/.singularity if it does not already exist
+func createDataDir(usr *user.User) {
+	data_dir := path.Join(usr.HomeDir, ".singularity")
+
+	if _, err := os.Stat(data_dir); err != nil {
+		if os.IsNotExist(err) {
+			sylog.Verbosef("%s does not exist. Creating.", data_dir)
+			os.Mkdir(data_dir, os.ModePerm)
+		} else {
+			sylog.Fatalf("Error attempting to stat %s: %s\n", data_dir, err)
+		}
+	} else {
+		sylog.Verbosef("%s already exits. Not creating.", data_dir)
+	}
+}
+
 // SingularityCmd is the base command when called without any subcommands
 var SingularityCmd = &cobra.Command{
 	TraverseChildren:      true,
@@ -208,6 +224,7 @@ var SingularityCmd = &cobra.Command{
 func persistentPreRunE(cmd *cobra.Command, _ []string) error {
 	setSylogMessageLevel()
 	setSylogColor()
+	createDataDir(CurrentUser)
 	return cmdManager.UpdateCmdFlagFromEnv(cmd, envPrefix)
 }
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -209,7 +209,7 @@ func createConfDir(d string) {
 			sylog.Fatalf("Error attempting to create %s: %s", d, err)
 		}
 	} else {
-		sylog.Debugf("Created %s.", d)
+		sylog.Debugf("Created %s", d)
 	}
 }
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -190,17 +190,17 @@ func setSylogColor() {
 
 // createDataDir will create ~/.singularity if it does not already exist
 func createDataDir(usr *user.User) {
-	data_dir := path.Join(usr.HomeDir, ".singularity")
+	dataDir := path.Join(usr.HomeDir, ".singularity")
 
-	if _, err := os.Stat(data_dir); err != nil {
+	if _, err := os.Stat(dataDir); err != nil {
 		if os.IsNotExist(err) {
-			sylog.Verbosef("%s does not exist. Creating.", data_dir)
-			os.Mkdir(data_dir, os.ModePerm)
+			sylog.Verbosef("%s does not exist. Creating.", dataDir)
+			os.Mkdir(dataDir, os.ModePerm)
 		} else {
-			sylog.Fatalf("Error attempting to stat %s: %s\n", data_dir, err)
+			sylog.Fatalf("Error attempting to stat %s: %s\n", dataDir, err)
 		}
 	} else {
-		sylog.Verbosef("%s already exits. Not creating.", data_dir)
+		sylog.Verbosef("%s already exits. Not creating.", dataDir)
 	}
 }
 

--- a/cmd/internal/cli/singularity_test.go
+++ b/cmd/internal/cli/singularity_test.go
@@ -17,7 +17,7 @@ import (
 func TestGetConfDir(t *testing.T) {
 	usr, _ := user.Current()
 	confDir := getConfDir(usr.Username)
-	hd, _ := os.UserHomeDir()
+	hd := usr.HomeDir
 	exptDir := hd + "/.singularity" // test currently assumes ~/.singularity
 	if confDir != exptDir {
 		t.Errorf("expected %s, got %s", exptDir, confDir)

--- a/cmd/internal/cli/singularity_test.go
+++ b/cmd/internal/cli/singularity_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/user"
+	"testing"
+	"time"
+)
+
+func TestGetConfDir(t *testing.T) {
+	usr, _ := user.Current()
+	confDir := getConfDir(usr.Username)
+	hd, _ := os.UserHomeDir()
+	exptDir := hd + "/.singularity" // test currently assumes ~/.singularity
+	if confDir != exptDir {
+		t.Errorf("expected %s, got %s", exptDir, confDir)
+	}
+}
+
+func TestCreateConfDir(t *testing.T) {
+	// create a random name for a directory
+	rand.Seed(time.Now().UnixNano())
+	bytes := make([]byte, 8)
+	for i := 0; i < 8; i++ {
+		bytes[i] = byte(65 + rand.Intn(25))
+	}
+	dir := "/tmp/" + string(bytes)
+
+	// create the directory and check that it exists
+	createConfDir(dir)
+	defer os.RemoveAll(dir)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Errorf("failed to create directory %s", dir)
+	} else {
+		// stick something in the directory and make sure it isn't deleted
+		ioutil.WriteFile(dir+"/foo", []byte(""), 655)
+		createConfDir(dir)
+		if _, err := os.Stat(dir + "/foo"); os.IsNotExist(err) {
+			t.Errorf("inadvertantly overwrote existing directory %s", dir)
+		}
+	}
+}

--- a/cmd/internal/cli/singularity_test.go
+++ b/cmd/internal/cli/singularity_test.go
@@ -9,20 +9,9 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"os/user"
 	"testing"
 	"time"
 )
-
-func TestGetConfDir(t *testing.T) {
-	usr, _ := user.Current()
-	confDir := getConfDir(usr.Username)
-	hd := usr.HomeDir
-	exptDir := hd + "/.singularity" // test currently assumes ~/.singularity
-	if confDir != exptDir {
-		t.Errorf("expected %s, got %s", exptDir, confDir)
-	}
-}
 
 func TestCreateConfDir(t *testing.T) {
 	// create a random name for a directory


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The main `singularity` command will now create `~/.singularity` if it does not already exist.

**This fixes or addresses the following GitHub issues:**

- Fixes #3472 
- Fixes #3591


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
