### PR TITLE
Do not manipulate "environ" directly, use C API

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -832,31 +832,17 @@ void do_exit(int sig) {
 }
 
 /*
- * cleanenv set environ pointer to NULL, while it works
- * in C context, it doesn't have any effect with the Go
- * runtime using the real pointer, so we need to work
- * directly with environ array.
+ * cleanenv clears all the environment variables except for MSGLVL_ENV
  */
 static void cleanenv(void) {
-    extern char **environ;
-    char **e;
-    char *p = NULL;
-
-    if ( environ == NULL || *environ == NULL ) {
-        fatalf("no environment variables set\n");
+    char * cur = getenv(MSGLVL_ENV);
+    if (cur) {
+        cur = strdup(cur);
     }
-
-    /* keep only SINGULARITY_MESSAGELEVEL for GO runtime */
-    for (e = environ; *e != NULL; e++) {
-        if ( strncmp(MSGLVL_ENV "=", *e, sizeof(MSGLVL_ENV)) == 0 ) {
-            p = *e;
-        } else {
-            *e = NULL;
-        }
-    }
-
-    if ( p != NULL ) {
-        *environ = p;
+    clearenv();
+    if (cur) {
+        setenv(MSGLVL_ENV, cur, 1);
+        free(cur);
     }
 }
 


### PR DESCRIPTION
Reading thru the docs, it seems the environ variable is not meant to be
used to _remove_ or _change_ values in the environment, but only to
iterate over them.

A recent change introduced the "cleanenv" function, which deletes all
environment variables except SINGULARITY_MESSAGELEVEL. It does this by
setting the pointers in the environ array to NULL. While this seems to
work with some implementations of the C library, with others it's
causing a segmentation fault during the initialization of the C library.

To avoid assuming a particular behavir, change the cleanenv function so
that it obtains the current value of SINGULARITY_MESSAGELEVEL, clears
all the environment variables using the clearenv function and sets
SINGULARITY_MESSAGELEVEL back to its previous value using setenv.

Since the original change did not specify the conditions under which a
bug was observed, this has received only limited testing. All the
existing tests are passing with this change.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>