### PR TITLE
Add support for mounting FUSE filesystems in the container

### DIFF
--- a/internal/pkg/runtime/engines/config/config.go
+++ b/internal/pkg/runtime/engines/config/config.go
@@ -8,10 +8,9 @@ package config
 // Common provides the basis for all engine configs. Anything that can not be
 // properly described through the OCI config can be stored as generic JSON []byte
 type Common struct {
-	EngineName  string `json:"engineName"`
-	ContainerID string `json:"containerID"`
-	// EngineConfig is the raw JSON representation of the Engine's underlying config
-	EngineConfig EngineConfig `json:"engineConfig"`
+	EngineName   string       `json:"engineName"`
+	ContainerID  string       `json:"containerID"`
+	EngineConfig EngineConfig `json:"engineConfig"` // EngineConfig is the raw JSON representation of the Engine's underlying config
 }
 
 // EngineConfig is a generic interface to represent the implementations of an EngineConfig

--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/image"
 	"github.com/sylabs/singularity/pkg/network"
+	singularity "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 	"github.com/sylabs/singularity/pkg/util/loop"
 	"github.com/sylabs/singularity/pkg/util/namespaces"
@@ -169,6 +170,9 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 		return err
 	}
 	if err := c.addHostnameMount(system); err != nil {
+		return err
+	}
+	if err := c.addFuseMount(system); err != nil {
 		return err
 	}
 
@@ -1895,4 +1899,66 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func() e
 		c.engine.EngineConfig.Network = setup
 		return nil
 	}, nil
+}
+
+// addFuseMount transforms the plugin configuration into a series of
+// mount requests for FUSE filesystems
+func (c *container) addFuseMount(system *mount.System) error {
+	for i, name := range c.engine.EngineConfig.GetPluginFuseMounts() {
+		var cfg struct {
+			Fuse singularity.FuseInfo
+		}
+
+		if err := c.engine.EngineConfig.GetPluginConfig(name, &cfg); err != nil {
+			sylog.Debugf("Failed getting plugin config: %+v\n", err)
+			return err
+		}
+
+		// we cannot check this because the mount point might
+		// not exist outside the container with the name that
+		// it's going to have _inside_ the container, so we
+		// simply assume that it is a directory.
+		//
+		// In a normal situation we would stat the mount point
+		// to obtain the mode, and bitwise-and the result with
+		// S_IFMT.
+		rootmode := syscall.S_IFDIR & syscall.S_IFMT
+
+		// we assume that the file descriptor we obtained by
+		// opening /dev/fuse before is valid in the RPC server,
+		// where the actual mount operation is going to be
+		// executed.
+		opts := fmt.Sprintf("fd=%d,rootmode=%o,user_id=%d,group_id=%d",
+			cfg.Fuse.DevFuseFd,
+			rootmode,
+			os.Getuid(),
+			os.Getgid())
+
+		// mount file system in three steps: first create a
+		// dedicated session directory for each FUSE filesystem
+		// and use that as the mount point.
+		fuseDir := fmt.Sprintf("/fuse/%d", i)
+		if err := c.session.AddDir(fuseDir); err != nil {
+			return err
+		}
+		fuseDir, _ = c.session.GetPath(fuseDir)
+		sylog.Debugf("Add FUSE mount %s for %s with options %s", fuseDir, name, opts)
+		if err := system.Points.AddFS(
+			mount.BindsTag,
+			fuseDir,
+			"fuse",
+			syscall.MS_NOSUID|syscall.MS_NODEV,
+			opts); err != nil {
+			sylog.Debugf("Calling AddFS: %+v\n", err)
+			return err
+		}
+
+		// second, add a bind-mount the session directory into
+		// the destination mount point inside the container.
+		if err := system.Points.AddBind(mount.OtherTag, fuseDir, cfg.Fuse.MountPoint, 0); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -799,6 +799,42 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	// determine if engine need to propagate signals across processes
 	e.checkSignalPropagation()
 
+	// We must call this here because at this point we haven't
+	// spawned the master process nor the RPC server. The assumption
+	// is that this function runs in stage 1 and that even if it's a
+	// separate process, it's created in such a way that it's
+	// sharing its file descriptor table with the wrapper / stage 2.
+	//
+	// At this point we do not have elevated privileges. We assume
+	// that the user running singularity has access to /dev/fuse
+	// (typically it's 0666, or 0660 belonging to a group that
+	// allows the user to read and write to it).
+	if err := openDevFuse(e, starterConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// openDevFuse is a helper function that opens /dev/fuse once for each
+// plugin that wants to mount a FUSE filesystem.
+func openDevFuse(e *EngineOperations, starterConfig *starter.Config) error {
+	for _, name := range e.EngineConfig.GetPluginFuseMounts() {
+		fd, err := syscall.Open("/dev/fuse", syscall.O_RDWR, 0)
+		if err != nil {
+			sylog.Debugf("Calling open: %+v\n", err)
+			return err
+		}
+
+		err = e.EngineConfig.SetPluginFuseFd(name, fd)
+		if err != nil {
+			sylog.Debugf("Unable to setup plugin %s fd: %+v\n", name, err)
+			return err
+		}
+
+		starterConfig.KeepFileDescriptor(fd)
+	}
+
 	return nil
 }
 

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -156,6 +156,7 @@ var authorizedFS = map[string]fsContext{
 	"proc":    {false},
 	"mqueue":  {false},
 	"cgroup":  {false},
+	"fuse":    {false},
 }
 
 var internalOptions = []string{"loop", "offset", "sizelimit", "key"}

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -6,7 +6,6 @@
 package singularity
 
 import (
-	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/oci"
 	"github.com/sylabs/singularity/pkg/image"
 )
 
@@ -95,17 +94,6 @@ type JSONConfig struct {
 	DeleteImage       bool          `json:"deleteImage,omitempty"`
 	Fakeroot          bool          `json:"fakeroot,omitempty"`
 	SignalPropagation bool          `json:"signalPropagation,omitempty"`
-}
-
-// NewConfig returns singularity.EngineConfig with a parsed FileConfig
-func NewConfig() *EngineConfig {
-	ret := &EngineConfig{
-		JSON:      &JSONConfig{},
-		OciConfig: &oci.Config{},
-		File:      &FileConfig{},
-	}
-
-	return ret
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.

--- a/pkg/runtime/engines/singularity/config/config_linux.go
+++ b/pkg/runtime/engines/singularity/config/config_linux.go
@@ -6,6 +6,9 @@
 package singularity
 
 import (
+	"encoding/json"
+	"errors"
+
 	"github.com/sylabs/singularity/internal/pkg/cgroups"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/oci"
 	"github.com/sylabs/singularity/pkg/network"
@@ -13,10 +16,123 @@ import (
 
 // EngineConfig stores both the JSONConfig and the FileConfig
 type EngineConfig struct {
-	JSON      *JSONConfig      `json:"jsonConfig"`
-	OciConfig *oci.Config      `json:"ociConfig"`
-	File      *FileConfig      `json:"-"`
-	Network   *network.Setup   `json:"-"`
-	Cgroups   *cgroups.Manager `json:"-"`
-	CryptDev  string           `json:"-"`
+	JSON      *JSONConfig                `json:"jsonConfig"`
+	OciConfig *oci.Config                `json:"ociConfig"`
+	File      *FileConfig                `json:"-"`
+	Network   *network.Setup             `json:"-"`
+	Cgroups   *cgroups.Manager           `json:"-"`
+	CryptDev  string                     `json:"-"`
+	Plugin    map[string]json.RawMessage `json:"plugin"` // Plugin is the raw JSON representation of the plugin configurations
+}
+
+// FuseInfo stores the FUSE-related information required or provided by
+// plugins implementing options to add FUSE filesystems in the
+// container.
+type FuseInfo struct {
+	DevFuseFd  int      // the filedescritor used to access the FUSE mount
+	MountPoint string   // the mount point for the FUSE filesystem
+	Program    []string // the FUSE driver program and all required arguments
+}
+
+// NewConfig returns singularity.EngineConfig with a parsed FileConfig
+func NewConfig() *EngineConfig {
+	ret := &EngineConfig{
+		JSON:      &JSONConfig{},
+		OciConfig: &oci.Config{},
+		File:      &FileConfig{},
+		Plugin:    make(map[string]json.RawMessage),
+	}
+
+	return ret
+}
+
+// GetPluginConfig retrieves the configuration for the named plugin
+func (e *EngineConfig) GetPluginConfig(plugin string, cfg interface{}) error {
+	if tmp, found := e.Plugin[plugin]; found {
+		return json.Unmarshal(tmp, cfg)
+	}
+
+	return nil
+}
+
+// SetPluginConfig sets the configuration for the named plugin
+func (e *EngineConfig) SetPluginConfig(plugin string, cfg interface{}) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	e.Plugin[plugin] = json.RawMessage(data)
+	return nil
+}
+
+// GetPluginFuseMounts returns the list of plugins which have a valid
+// FUSE configuration.
+//
+// In this context "valid" means that both the mount point and the FUSE
+// driver program exist in the configuration. This function DOES NOT
+// check if the /dev/fuse file descriptor has been assigned.
+func (e *EngineConfig) GetPluginFuseMounts() []string {
+	var list []string
+
+	for name, raw := range e.Plugin {
+		var info struct {
+			Fuse FuseInfo
+		}
+		if err := json.Unmarshal(raw, &info); err != nil {
+			// do not log anything because this would
+			// introduce a lot of noise into the log, even
+			// for the debug level
+			continue
+		}
+		if len(info.Fuse.Program) > 0 && info.Fuse.MountPoint != "" {
+			// This a valid configuration
+			list = append(list, name)
+		}
+	}
+
+	return list
+}
+
+// SetPluginFuseFd sets the /dev/fuse file descriptor fd for the
+// specified plugin
+//
+// This function tries to make sure that any additional configuration
+// already found in the "Fuse" object is preserved.
+func (e *EngineConfig) SetPluginFuseFd(name string, fd int) error {
+	raw, found := e.Plugin[name]
+	if !found {
+		// named plugin does not have a configuration
+		// entry, error out
+		return errors.New("plugin not found")
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		// cannot unmarshal value as JSON, error out
+		return errors.New("invalid JSON entry")
+	}
+
+	tmp, found := obj["Fuse"]
+	if !found {
+		// object does not have a Fuse key, error out
+		return errors.New("missing Fuse JSON object")
+	}
+
+	info, ok := tmp.(map[string]interface{})
+	if !ok {
+		// invalid value, error out
+		return errors.New("invalid Fuse JSON object")
+	}
+
+	info["DevFuseFd"] = fd
+	obj["Fuse"] = info
+	newval, err := json.Marshal(obj)
+	if err != nil {
+		// this should not happen
+		return errors.New("cannot marshal new JSON object")
+	}
+
+	e.Plugin[name] = json.RawMessage(newval)
+
+	return nil
 }

--- a/pkg/runtime/engines/singularity/config/config_unsupported.go
+++ b/pkg/runtime/engines/singularity/config/config_unsupported.go
@@ -17,3 +17,14 @@ type EngineConfig struct {
 	OciConfig *oci.Config `json:"ociConfig"`
 	File      *FileConfig `json:"-"`
 }
+
+// NewConfig returns singularity.EngineConfig with a parsed FileConfig
+func NewConfig() *EngineConfig {
+	ret := &EngineConfig{
+		JSON:      &JSONConfig{},
+		OciConfig: &oci.Config{},
+		File:      &FileConfig{},
+	}
+
+	return ret
+}


### PR DESCRIPTION
Since it's not possible to completely delegate the operations to a
plugin, add support for mounting FUSE filesystems in the container
WITHOUT adding support for any specific driver or method of operation.

People wishing to support specific FUSE filesystems would need to add a
plugin that:

1. Adds a flag to specify the mount point
2. Adds a flag to specify the FUSE driver to use (along with parameters)

The reason for doing it like this is that depending on the specifics of
the FUSE filesystem that needs to be supported, more or less support
would need to be added in singularity. By adding just the necessary
support to open the /dev/fuse device and run the FUSE driver, we make
sure that we don't under- or over-specify the assumptions as to what the
driver needs or supports.

Users wishing to use FUSE filesystem in their containers would need to
make sure that the _container_ provides the necessary support to run the
driver (e.g. by shipping the driver with the container image or by
setting up bind mounts to make sure the driver is in the expected
location).

This extends the Engine configuration by adding a Plugin object which
contains entries for each of the plugins. Nothing is assumed about the
configuration. The FUSE portion *does* require that the configuration
of each plugin has a "Fuse" key pointing to an object that has _at_
least a DevFuseFd, MountPoint and Program values. Plugins that do not
support FUSE filesystems do not need to provide these keys or objects.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>