### PR TITLE
Clear the cache by deleting the individual caches

### DIFF
--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -77,7 +77,12 @@ var CacheCleanCmd = &cobra.Command{
 }
 
 func cacheCleanCmd() error {
-	err := singularity.CleanSingularityCache(cleanAll, cacheCleanTypes, cacheName)
+	if cleanAll {
+		// cleanAll overrides all the other options, see above
+		cacheCleanTypes = []string{"all"}
+		cacheName = ""
+	}
+	err := singularity.CleanSingularityCache(cacheCleanTypes, cacheName)
 	if err != nil {
 		sylog.Fatalf("Failed while clean cache: %v", err)
 		os.Exit(255)

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -42,17 +42,6 @@ func Root() string {
 	return root
 }
 
-// Clean : wipes all files in the cache directory, will return a error if one occurs
-func Clean() error {
-	sylog.Debugf("Removing: %v", Root())
-
-	if err := os.RemoveAll(Root()); err != nil {
-		return fmt.Errorf("unable to clean all cache: %s", err)
-	}
-
-	return nil
-}
-
 func updateCacheRoot() {
 	if d := os.Getenv(DirEnv); d != "" {
 		root = d


### PR DESCRIPTION
Since it's possible for users to nuke their home directory (or in
general other directories in the system that they have access to) by
setting the environment variable SINGULARITY_CACHEDIR to the (in)correct
value, reimplement the way the "cache clean --all" command works by
iterating over the known cache types. This creates a maintainance burden
since the list of known types has to be kept in sync in multiple places,
but this chage is trying to be as small as possible while still being
correct.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>