### PR TITLE
Add fusecmd example plugin

### DIFF
--- a/examples/plugins/fusecmd/README.md
+++ b/examples/plugins/fusecmd/README.md
@@ -1,0 +1,22 @@
+Singularity fusecmd mount plugin
+================================
+
+This plugin adds the --fusecmd option to singularity.   The parameter
+is a string which is a command with plus its parameters to run inside the
+container to implement a libfuse3-based filesystem. The last parameter is a
+mountpoint that will be pre-mounted and replaced with a a /dev/fd/NN path to
+the fuse file descriptor.
+
+From the top level of a singularity source directory, run:
+
+	singularity plugin compile examples/plugins/fusecmd
+
+Installing
+----------
+
+Once you have compiled the plugin into a SIF file, you can install it
+into the correct singularity directory using the command:
+
+	$ sudo singularity plugin install examples/plugins/fusecmd/fusecmd.sif
+
+Singularity will automatically load the plugin code from now on.

--- a/examples/plugins/fusecmd/main.go
+++ b/examples/plugins/fusecmd/main.go
@@ -44,8 +44,11 @@ type pluginConfig struct {
 func fusecmdCallback(f *pflag.Flag, cfg *singularity.EngineConfig) {
 	cmd := f.Value.String()
 
+        // This will be called even if the flag was not used.
+        // Assume that an empty mount point means the user did not pass
+        // the flag and return silently.
 	if cmd == "" {
-                sylog.Fatalf("Empty command")
+                return
 	}
 
         words := strings.Fields(cmd)

--- a/examples/plugins/fusecmd/main.go
+++ b/examples/plugins/fusecmd/main.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the URIs of this project regarding your
+// rights to use or distribute this software.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	pluginapi "github.com/sylabs/singularity/pkg/plugin"
+	singularity "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
+)
+
+var Plugin = pluginapi.Plugin{
+	Manifest: pluginapi.Manifest{
+		Name:        "sylabs.io/fusecmd",
+		Version:     "0.0.1",
+		Description: "Singularity plugin adding the --fusecmd option for premounting FUSE filesystems",
+	},
+
+	Initializer: impl,
+}
+
+type pluginImplementation struct {
+}
+
+var impl = pluginImplementation{}
+
+type FuseConfig struct {
+	DevFuseFd  int
+	MountPoint string
+	Program    []string
+}
+
+type pluginConfig struct {
+	Fuse FuseConfig
+}
+
+func fusecmdCallback(f *pflag.Flag, cfg *singularity.EngineConfig) {
+	cmd := f.Value.String()
+
+	if cmd == "" {
+                sylog.Fatalf("Empty command")
+	}
+
+        words := strings.Fields(cmd)
+        if len(words) == 1 {
+                sylog.Fatalf("No whitespace separators found in command")
+	}
+
+        mnt := words[len(words)-1]
+	if !strings.HasPrefix(mnt, "/") {
+		sylog.Fatalf("Invalid mount point %s.\n", mnt)
+	}
+        words = words[0:len(words)-1]
+
+	sylog.Verbosef("Mounting FUSE filesystem with %s %s\n",
+                strings.Join(words, " "), mnt)
+
+	config := pluginConfig{
+                        Fuse: FuseConfig{
+                                MountPoint: mnt,
+                                Program:    words,
+                        },
+                    }
+
+	if err := cfg.SetPluginConfig(Plugin.Manifest.Name, config); err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot set plugin configuration: %+v\n", err)
+		return
+	}
+}
+
+func (p pluginImplementation) Initialize(r pluginapi.HookRegistration) {
+	flag := pluginapi.StringFlagHook{
+		Flag: pflag.Flag{
+			Name:  "fusecmd",
+			Usage: "Command to run inside the container to " +
+                               "implement a libfuse3-based filesystem. " +
+                               "The last parameter is a mountpoint that " +
+                               "will be pre-mounted and replaced with a " +
+                               "/dev/fd/NN path to the fuse file descriptor.",
+		},
+		Callback: fusecmdCallback,
+	}
+
+	r.RegisterStringFlag(flag)
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is a work in progress, do not merge yet.

This is an example plugin implementing a --fusecmd option.  It based on pr #3679.  It is closer to what I have in mind for a general purpose fuse premounting option.  It has some problems though:
1. It does not work with multiple --fusecmd options.  I see that the plugin support code in pkg/runtime/engines/singularity/config/config_linux.go supports multiple mountpoints with associated programs but I need some help with figuring out how to combine them into a single config that gets marshalled into json.
2. If it is not used in combination with --pid, it leaves behind the fuse processes when it exits.  I haven't thought of a general way to workaround that, other than having the --fusecmd option imply the --pid option.  Is there a way for a plugin to do that?


**This fixes or addresses the following GitHub issues:**

- Addresses some of my comments in #3679


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers, @mem, @bauerm97 
