### PR TITLE
Slightly improved 'key pull' usability

### DIFF
--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -618,10 +618,13 @@ func FetchPubkey(fingerprint, keyserverURI, authToken string, noPrompt bool) (op
 		return nil, fmt.Errorf("not a valid key lenth: %s: must be over 8 chars", fingerprint)
 	}
 
-	// Harvest the last 8 chars of the fingerprint string
-	sylog.Debugf("Getting the last 8 chars from: %s", fingerprint)
-	fingerprint = fingerprint[len(fingerprint)-8:]
-	sylog.Debugf("Results: %s", fingerprint)
+	// Only chop the fingerprint if its less then 40 chars
+	if len(fingerprint) < 40 {
+		// Harvest the last 8 chars of the fingerprint string
+		sylog.Debugf("Getting the last 8 chars from: %s", fingerprint)
+		fingerprint = fingerprint[len(fingerprint)-8:]
+		sylog.Debugf("Results: %s", fingerprint)
+	}
 
 	// Decode fingerprint and ensure proper length.
 	var fp []byte

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -614,17 +614,20 @@ func SearchPubkey(search, keyserverURI, authToken string) error {
 
 // FetchPubkey pulls a public key from the Key Service.
 func FetchPubkey(fingerprint, keyserverURI, authToken string, noPrompt bool) (openpgp.EntityList, error) {
+	if len(fingerprint) < 8 {
+		return nil, fmt.Errorf("not a valid key lenth: %s: must be over 8 chars", fingerprint)
+	}
+
+	// Harvest the last 8 chars of the fingerprint string
+	sylog.Debugf("Getting the last 8 chars from: %s", fingerprint)
+	fingerprint = fingerprint[len(fingerprint)-8:]
+	sylog.Debugf("Results: %s", fingerprint)
 
 	// Decode fingerprint and ensure proper length.
 	var fp []byte
 	fp, err := hex.DecodeString(fingerprint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode fingerprint: %v", err)
-	}
-
-	// theres probably a better way to do this
-	if len(fp) != 4 && len(fp) != 20 {
-		return nil, fmt.Errorf("not a valid key lenth: only accepts 8, or 40 chars")
 	}
 
 	// Get a Key Service client.


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR slightly improves the 'key pull' function.

#### Example

```bash
# in this PR
$ singularity key pull CE4F3F38D871E
# will pull the Sylabs Admin key

# before this PR it will error out and say its to long, or short
$ singularity key pull CE4F3F38D871E
ERROR:   pull failed: unable to pull key from server: failed to decode fingerprint: encoding/hex: odd length hex string

# or with one less char
$ singularity key pull E4F3F38D871E
ERROR:   pull failed: unable to pull key from server: not a valid key lenth: only accepts 8, or 40 chars

```

## This fixes or addresses the following GitHub issues:

- Fixes #2893

<br>
