### PR TITLE
Fix parent process signal propagation

### DIFF
--- a/internal/pkg/runtime/engines/singularity/monitor.go
+++ b/internal/pkg/runtime/engines/singularity/monitor.go
@@ -25,6 +25,12 @@ func (engine *EngineOperations) MonitorContainer(pid int, signals chan os.Signal
 				continue
 			}
 			return status, nil
+		default:
+			if engine.EngineConfig.GetSignalPropagation() {
+				if err := syscall.Kill(pid, s.(syscall.Signal)); err != nil {
+					return status, fmt.Errorf("interrupted by signal %s", s.String())
+				}
+			}
 		}
 	}
 }

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -54,46 +54,47 @@ type FileConfig struct {
 
 // JSONConfig stores engine specific confguration that is allowed to be set by the user
 type JSONConfig struct {
-	ScratchDir    []string      `json:"scratchdir,omitempty"`
-	OverlayImage  []string      `json:"overlayImage,omitempty"`
-	BindPath      []string      `json:"bindpath,omitempty"`
-	NetworkArgs   []string      `json:"networkArgs,omitempty"`
-	Security      []string      `json:"security,omitempty"`
-	LibrariesPath []string      `json:"librariesPath,omitempty"`
-	ImageList     []image.Image `json:"imageList,omitempty"`
-	OpenFd        []int         `json:"openFd,omitempty"`
-	TargetGID     []int         `json:"targetGID,omitempty"`
-	Image         string        `json:"image"`
-	Workdir       string        `json:"workdir,omitempty"`
-	CgroupsPath   string        `json:"cgroupsPath,omitempty"`
-	HomeSource    string        `json:"homedir,omitempty"`
-	HomeDest      string        `json:"homeDest,omitempty"`
-	Command       string        `json:"command,omitempty"`
-	Shell         string        `json:"shell,omitempty"`
-	TmpDir        string        `json:"tmpdir,omitempty"`
-	AddCaps       string        `json:"addCaps,omitempty"`
-	DropCaps      string        `json:"dropCaps,omitempty"`
-	Hostname      string        `json:"hostname,omitempty"`
-	Network       string        `json:"network,omitempty"`
-	DNS           string        `json:"dns,omitempty"`
-	Cwd           string        `json:"cwd,omitempty"`
-	TargetUID     int           `json:"targetUID,omitempty"`
-	WritableImage bool          `json:"writableImage,omitempty"`
-	WritableTmpfs bool          `json:"writableTmpfs,omitempty"`
-	Contain       bool          `json:"container,omitempty"`
-	Nv            bool          `json:"nv,omitempty"`
-	CustomHome    bool          `json:"customHome,omitempty"`
-	Instance      bool          `json:"instance,omitempty"`
-	InstanceJoin  bool          `json:"instanceJoin,omitempty"`
-	BootInstance  bool          `json:"bootInstance,omitempty"`
-	RunPrivileged bool          `json:"runPrivileged,omitempty"`
-	AllowSUID     bool          `json:"allowSUID,omitempty"`
-	KeepPrivs     bool          `json:"keepPrivs,omitempty"`
-	NoPrivs       bool          `json:"noPrivs,omitempty"`
-	NoHome        bool          `json:"noHome,omitempty"`
-	NoInit        bool          `json:"noInit,omitempty"`
-	DeleteImage   bool          `json:"deleteImage,omitempty"`
-	Fakeroot      bool          `json:"fakeroot,omitempty"`
+	ScratchDir        []string      `json:"scratchdir,omitempty"`
+	OverlayImage      []string      `json:"overlayImage,omitempty"`
+	BindPath          []string      `json:"bindpath,omitempty"`
+	NetworkArgs       []string      `json:"networkArgs,omitempty"`
+	Security          []string      `json:"security,omitempty"`
+	LibrariesPath     []string      `json:"librariesPath,omitempty"`
+	ImageList         []image.Image `json:"imageList,omitempty"`
+	OpenFd            []int         `json:"openFd,omitempty"`
+	TargetGID         []int         `json:"targetGID,omitempty"`
+	Image             string        `json:"image"`
+	Workdir           string        `json:"workdir,omitempty"`
+	CgroupsPath       string        `json:"cgroupsPath,omitempty"`
+	HomeSource        string        `json:"homedir,omitempty"`
+	HomeDest          string        `json:"homeDest,omitempty"`
+	Command           string        `json:"command,omitempty"`
+	Shell             string        `json:"shell,omitempty"`
+	TmpDir            string        `json:"tmpdir,omitempty"`
+	AddCaps           string        `json:"addCaps,omitempty"`
+	DropCaps          string        `json:"dropCaps,omitempty"`
+	Hostname          string        `json:"hostname,omitempty"`
+	Network           string        `json:"network,omitempty"`
+	DNS               string        `json:"dns,omitempty"`
+	Cwd               string        `json:"cwd,omitempty"`
+	TargetUID         int           `json:"targetUID,omitempty"`
+	WritableImage     bool          `json:"writableImage,omitempty"`
+	WritableTmpfs     bool          `json:"writableTmpfs,omitempty"`
+	Contain           bool          `json:"container,omitempty"`
+	Nv                bool          `json:"nv,omitempty"`
+	CustomHome        bool          `json:"customHome,omitempty"`
+	Instance          bool          `json:"instance,omitempty"`
+	InstanceJoin      bool          `json:"instanceJoin,omitempty"`
+	BootInstance      bool          `json:"bootInstance,omitempty"`
+	RunPrivileged     bool          `json:"runPrivileged,omitempty"`
+	AllowSUID         bool          `json:"allowSUID,omitempty"`
+	KeepPrivs         bool          `json:"keepPrivs,omitempty"`
+	NoPrivs           bool          `json:"noPrivs,omitempty"`
+	NoHome            bool          `json:"noHome,omitempty"`
+	NoInit            bool          `json:"noInit,omitempty"`
+	DeleteImage       bool          `json:"deleteImage,omitempty"`
+	Fakeroot          bool          `json:"fakeroot,omitempty"`
+	SignalPropagation bool          `json:"signalPropagation,omitempty"`
 }
 
 // NewConfig returns singularity.EngineConfig with a parsed FileConfig
@@ -497,4 +498,18 @@ func (e *EngineConfig) GetDeleteImage() bool {
 // SetDeleteImage sets if container image must be deleted after use
 func (e *EngineConfig) SetDeleteImage(delete bool) {
 	e.JSON.DeleteImage = delete
+}
+
+// SetSignalPropagation sets if engine must propagate signals from
+// master process -> container process when PID namespace is disabled
+// or from master process -> sinit process -> container
+// process when PID namespace is enabled
+func (e *EngineConfig) SetSignalPropagation(propagation bool) {
+	e.JSON.SignalPropagation = propagation
+}
+
+// GetSignalPropagation returns if engine propagate signals across
+// processes (see SetSignalPropagation)
+func (e *EngineConfig) GetSignalPropagation() bool {
+	return e.JSON.SignalPropagation
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR add signal propagation support to relay signal from master process to container process and when `sinit` shim process is running to also relay signal to container process.
Signals are propagated only if Singularity processes are not in the same process group as the one controlling the terminal or if Singularity doesn't have at least one of standard file descriptor pointing to a terminal. Which means that Singularity master process will propagate signal if run like :

```
singularity exec image sleep 100 &
setsid singularity exec image sleep 100
```

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
