### PR TITLE
Fix problem with internal/pkg/build/sources/conveyorPacker_busybox.go

### DIFF
--- a/examples/busybox/Singularity
+++ b/examples/busybox/Singularity
@@ -1,5 +1,5 @@
 BootStrap: busybox
-MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
+MirrorURL: https://www.busybox.net/downloads/binaries/1.26.2-defconfig-multiarch/busybox-x86_64
 
 %post
     echo "Hello from inside the container"

--- a/examples/instances/Singularity
+++ b/examples/instances/Singularity
@@ -1,5 +1,5 @@
 BootStrap: busybox
-MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
+MirrorURL: https://www.busybox.net/downloads/binaries/1.26.2-defconfig-multiarch/busybox-x86_64
 
 %startscript
     exec nc -ll -p $1 -e /bin/cat 2>/dev/null


### PR DESCRIPTION

**Description of the Pull Request (PR):**

Update the mirror url in the busybox example file since the one previously there is not available anymore.

**This fixes or addresses the following GitHub issues:**

- Fixes #3707 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers