### PR TITLE
Oras Support for Actions and Build commands

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -223,23 +223,31 @@ func RunFromURI(t *testing.T) {
 		{"RunFromDockerOK", "docker://busybox:latest", "run", []string{size}, runOpts, true},
 		{"RunFromLibraryOK", "library://busybox:latest", "run", []string{size}, runOpts, true},
 		{"RunFromShubOK", "shub://singularityhub/busybox", "run", []string{size}, runOpts, true},
+		{"RunFromOrasOK", "oras://localhost:5000/oras_test_sif:latest", "run", []string{size}, runOpts, true},
 		{"RunFromDockerKO", "docker://busybox:latest", "run", []string{"0"}, runOpts, false},
 		{"RunFromLibraryKO", "library://busybox:latest", "run", []string{"0"}, runOpts, false},
 		{"RunFromShubKO", "shub://singularityhub/busybox", "run", []string{"0"}, runOpts, false},
+		{"RunFromOrasKO", "oras://localhost:5000/oras_test_sif:latest", "run", []string{"0"}, runOpts, false},
+
 		// exec from a supported URI's and check the exit code
 		{"trueDocker", "docker://busybox:latest", "exec", []string{"true"}, e2e.ExecOpts{}, true},
 		{"trueLibrary", "library://busybox:latest", "exec", []string{"true"}, e2e.ExecOpts{}, true},
 		{"trueShub", "shub://singularityhub/busybox", "exec", []string{"true"}, e2e.ExecOpts{}, true},
+		{"trueOras", "oras://localhost:5000/oras_test_sif:latest", "exec", []string{"true"}, e2e.ExecOpts{}, true},
 		{"falseDocker", "docker://busybox:latest", "exec", []string{"false"}, e2e.ExecOpts{}, false},
 		{"falselibrary", "library://busybox:latest", "exec", []string{"false"}, e2e.ExecOpts{}, false},
 		{"falseShub", "shub://singularityhub/busybox", "exec", []string{"false"}, e2e.ExecOpts{}, false},
+		{"falseOras", "oras://localhost:5000/oras_test_sif:latest", "exec", []string{"false"}, e2e.ExecOpts{}, false},
+
 		// exec from URI with user namespace enabled
 		{"trueDockerUserns", "docker://busybox:latest", "exec", []string{"true"}, e2e.ExecOpts{Userns: true}, true},
 		{"trueLibraryUserns", "library://busybox:latest", "exec", []string{"true"}, e2e.ExecOpts{Userns: true}, true},
 		{"trueShubUserns", "shub://singularityhub/busybox", "exec", []string{"true"}, e2e.ExecOpts{Userns: true}, true},
+		{"trueOrasUserns", "oras://localhost:5000/oras_test_sif:latest", "exec", []string{"true"}, e2e.ExecOpts{Userns: true}, true},
 		{"falseDockerUserns", "docker://busybox:latest", "exec", []string{"false"}, e2e.ExecOpts{Userns: true}, false},
 		{"falselibraryUserns", "library://busybox:latest", "exec", []string{"false"}, e2e.ExecOpts{Userns: true}, false},
 		{"falseShubUserns", "shub://singularityhub/busybox", "exec", []string{"false"}, e2e.ExecOpts{Userns: true}, false},
+		{"falseOrasUserns", "oras://localhost:5000/oras_test_sif:latest", "exec", []string{"false"}, e2e.ExecOpts{Userns: true}, false},
 	}
 
 	for _, tt := range tests {

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -38,9 +38,10 @@ func buildFrom(t *testing.T) {
 		{"Debootstrap", "debootstrap", "../examples/debian/Singularity", true},
 		{"DockerURI", "", "docker://busybox", true},
 		{"DockerDefFile", "", "../examples/docker/Singularity", true},
-		{"SHubURI", "", "shub://GodloveD/busybox", true},
-		{"SHubDefFile", "", "../examples/shub/Singularity", true},
+		{"ShubURI", "", "shub://GodloveD/busybox", true},
+		{"ShubDefFile", "", "../examples/shub/Singularity", true},
 		{"LibraryDefFile", "", "../examples/library/Singularity", true},
+		{"OrasURI", "", "oras://localhost:5000/oras_test_sif:latest", true},
 		{"Yum", "yum", "../examples/centos/Singularity", true},
 		{"Zypper", "zypper", "../examples/opensuse/Singularity", true},
 	}

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -25,6 +25,12 @@ func PrepRegistry(t *testing.T) {
 			t.Fatalf("Command failed.\n%s", res)
 		}
 	}
+
+	EnsureImage(t)
+	cmd, _, err := ImagePush(t, testenv.ImagePath, "oras://localhost:5000/oras_test_sif:latest")
+	if err != nil {
+		t.Fatalf("while prepping registry with command %q: %v", cmd, err)
+	}
 }
 
 func KillRegistry(t *testing.T) {

--- a/e2e/internal/e2e/imagepush.go
+++ b/e2e/internal/e2e/imagepush.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func ImagePush(t *testing.T, imagePath, imgURI string) (string, []byte, error) {
+	argv := []string{"push"}
+
+	if imagePath != "" {
+		argv = append(argv, imagePath)
+	}
+
+	argv = append(argv, imgURI)
+
+	cmd := fmt.Sprintf("%s %s", testenv.CmdPath, strings.Join(argv, " "))
+	out, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput()
+
+	return cmd, out, err
+
+}

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -7,12 +7,9 @@
 package push
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -27,21 +24,6 @@ type testingEnv struct {
 }
 
 var testenv testingEnv
-
-func imagePush(t *testing.T, imagePath, imgURI string) (string, []byte, error) {
-	argv := []string{"push"}
-
-	if imagePath != "" {
-		argv = append(argv, imagePath)
-	}
-
-	argv = append(argv, imgURI)
-
-	cmd := fmt.Sprintf("%s %s", testenv.CmdPath, strings.Join(argv, " "))
-	out, err := exec.Command(testenv.CmdPath, argv...).CombinedOutput()
-
-	return cmd, out, err
-}
 
 func testPushCmd(t *testing.T) {
 
@@ -96,7 +78,7 @@ func testPushCmd(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpdir)
 
-			cmd, out, err := imagePush(t, tt.imagePath, tt.dstURI)
+			cmd, out, err := e2e.ImagePush(t, tt.imagePath, tt.dstURI)
 			switch {
 			case tt.expectSuccess && err == nil:
 				// PASS: expecting success, succeeded

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -296,6 +296,8 @@ func getcp(def types.Definition, libraryURL, authToken string) (ConveyorPacker, 
 	switch def.Header["bootstrap"] {
 	case "library":
 		return &sources.LibraryConveyorPacker{}, nil
+	case "oras":
+		return &sources.OrasConveyorPacker{}, nil
 	case "shub":
 		return &sources.ShubConveyorPacker{}, nil
 	case "docker", "docker-archive", "docker-daemon", "oci", "oci-archive":

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sources
+
+import (
+	"fmt"
+
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
+	"github.com/sylabs/singularity/internal/pkg/oras"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/internal/pkg/util/uri"
+	"github.com/sylabs/singularity/pkg/build/types"
+)
+
+// OrasConveyorPacker only needs to hold a packer to pack the image it pulls
+// as well as extra information about the library it's pulling from
+type OrasConveyorPacker struct {
+	LocalPacker
+}
+
+// Get downloads container from Singularityhub
+func (cp *OrasConveyorPacker) Get(b *types.Bundle) (err error) {
+	sylog.Debugf("Getting container from registry using ORAS")
+
+	// uri with leading // for oras handlers to consume
+	ref := "//" + b.Recipe.Header["from"]
+	// full uri for name determination and output
+	fullRef := "oras:" + ref
+
+	sum, err := oras.ImageSHA(ref, b.Opts.DockerAuthConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get SHA of %v: %v", fullRef, err)
+	}
+
+	imageName := uri.GetName(fullRef)
+	cacheImagePath := cache.OrasImage(sum, imageName)
+	if exists, err := cache.OrasImageExists(sum, imageName); err != nil {
+		return fmt.Errorf("unable to check if %v exists: %v", cacheImagePath, err)
+	} else if !exists {
+		sylog.Infof("Downloading image with ORAS")
+
+		if err := oras.DownloadImage(cacheImagePath, ref, b.Opts.DockerAuthConfig); err != nil {
+			return fmt.Errorf("unable to Download Image: %v", err)
+		}
+
+		if cacheFileHash, err := oras.ImageHash(cacheImagePath); err != nil {
+			return fmt.Errorf("error getting ImageHash: %v", err)
+		} else if cacheFileHash != sum {
+			return fmt.Errorf("cached file hash(%s) and expected hash(%s) does not match", cacheFileHash, sum)
+		}
+	}
+
+	// insert base metadata before unpacking fs
+	if err = makeBaseEnv(b.Rootfs()); err != nil {
+		return fmt.Errorf("While inserting base environment: %v", err)
+	}
+
+	cp.LocalPacker, err = GetLocalPacker(cacheImagePath, b)
+	return err
+}

--- a/internal/pkg/util/uri/uri.go
+++ b/internal/pkg/util/uri/uri.go
@@ -19,6 +19,8 @@ const (
 	HTTP = "http"
 	// HTTPS is the keyword for https ref
 	HTTPS = "https"
+	// Oras is the keyword for an oras ref
+	Oras = "oras"
 )
 
 // validURIs contains a list of known uris


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Adds `oras://` transport to `actions` and `build` commands
- Adds basic e2e tests for these commands
  - I did not add unit tests because I need to setup a local registry to properly test this so e2e seemed most appropriate 


**This fixes or addresses the following GitHub issues:**

- Fixes #3655 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
