### PR TITLE
Fix pipe socket buffer size check

### DIFF
--- a/internal/pkg/util/exec/pipe_linux.go
+++ b/internal/pkg/util/exec/pipe_linux.go
@@ -55,7 +55,7 @@ func setPipe(data []byte) (int, error) {
 	}
 
 	if curSize, err := syscall.GetsockoptInt(fd[0], syscall.SOL_SOCKET, syscall.SO_SNDBUF); err == nil {
-		if curSize <= 65536 {
+		if curSize < 65536 {
 			sylog.Warningf("current buffer size is %d, you may encounter some issues", curSize)
 			sylog.Warningf("the minimum recommended value is 65536, you can adjust this value with:")
 			sylog.Warningf("\"echo 65536 > /proc/sys/net/core/wmem_default\"")


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes check for pipe socket buffer size to avoid false warning message during execution.

**This fixes or addresses the following GitHub issues:**

- Fixes #3715 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
