### PR TITLE
Simplify code cache listing code

### DIFF
--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -17,48 +17,45 @@ import (
 )
 
 var (
-	cleanAll        bool
+	cacheCleanForce bool
 	cacheCleanTypes []string
-	cacheName       []string
+	cacheCleanNames []string
 )
-
-// -a|--all
-var cacheCleanAllFlag = cmdline.Flag{
-	ID:           "cacheCleanAllFlag",
-	Value:        &cleanAll,
-	DefaultValue: false,
-	Name:         "all",
-	ShortHand:    "a",
-	Usage:        "clean all cache (will override all other options)",
-	EnvKeys:      []string{"ALL"},
-}
 
 // -T|--type
 var cacheCleanTypesFlag = cmdline.Flag{
-	ID:           "cacheCleanTypesFlag",
+	ID:           "cacheCleanTypes",
 	Value:        &cacheCleanTypes,
-	DefaultValue: []string{"blob"},
+	DefaultValue: []string{"all"},
 	Name:         "type",
 	ShortHand:    "T",
-	Usage:        "clean cache type, choose between: library, oci, shub, blob, net and oras",
-	EnvKeys:      []string{"TYPE"},
+	Usage:        "a list of cache types to clean (possible values: library, oci, shub, blob, net, oras, all)",
 }
 
 // -N|--name
 var cacheCleanNameFlag = cmdline.Flag{
 	ID:           "cacheCleanNameFlag",
-	Value:        &cacheName,
+	Value:        &cacheCleanNames,
 	DefaultValue: []string{},
 	Name:         "name",
 	ShortHand:    "N",
 	Usage:        "specify a container cache to clean (will clear all cache with the same name)",
-	EnvKeys:      []string{"NAME"},
+}
+
+// -f|--force
+var cacheCleanForceFlag = cmdline.Flag{
+	ID:           "cacheCleanForceFlag",
+	Value:        &cacheCleanForce,
+	DefaultValue: false,
+	Name:         "force",
+	ShortHand:    "f",
+	Usage:        "force cleaning the cache (otherwise operate in dry run mode)",
 }
 
 func init() {
-	cmdManager.RegisterFlagForCmd(&cacheCleanAllFlag, CacheCleanCmd)
 	cmdManager.RegisterFlagForCmd(&cacheCleanTypesFlag, CacheCleanCmd)
 	cmdManager.RegisterFlagForCmd(&cacheCleanNameFlag, CacheCleanCmd)
+	cmdManager.RegisterFlagForCmd(&cacheCleanForceFlag, CacheCleanCmd)
 }
 
 // CacheCleanCmd is 'singularity cache clean' and will clear your local singularity cache
@@ -82,7 +79,7 @@ func cacheCleanCmd() error {
 	if imgCache == nil {
 		sylog.Fatalf("failed to create an image cache handle")
 	}
-	err := singularity.CleanSingularityCache(imgCache, cleanAll, cacheCleanTypes, cacheName)
+	err := singularity.CleanSingularityCache(imgCache, cacheCleanForce, cacheCleanTypes, cacheCleanNames)
 	if err != nil {
 		sylog.Fatalf("Failed while clean cache: %v", err)
 	}

--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -17,46 +17,32 @@ import (
 
 var (
 	cacheListTypes   []string
-	allList          bool
-	cacheListSummary bool
+	cacheListVerbose bool
 )
 
 // -T|--type
 var cacheListTypesFlag = cmdline.Flag{
 	ID:           "cacheListTypes",
 	Value:        &cacheListTypes,
-	DefaultValue: []string{"library", "oci", "shub", "blobSum"},
+	DefaultValue: []string{"all"},
 	Name:         "type",
 	ShortHand:    "T",
-	Usage:        "a list of cache types to display, possible entries: library, oci, shub, blob(s), blobSum, all",
-	EnvKeys:      []string{"TYPE"},
+	Usage:        "a list of cache types to display, possible entries: library, oci, shub, blob(s), all",
 }
 
 // -s|--summary
-var cacheListSummaryFlag = cmdline.Flag{
-	ID:           "cacheListSummary",
-	Value:        &cacheListSummary,
+var cacheListVerboseFlag = cmdline.Flag{
+	ID:           "cacheListVerbose",
+	Value:        &cacheListVerbose,
 	DefaultValue: false,
-	Name:         "summary",
-	ShortHand:    "s",
-	Usage:        "display a cache summary",
-}
-
-// -a|--all
-var cacheListAllFlag = cmdline.Flag{
-	ID:           "cacheListAllFlag",
-	Value:        &allList,
-	DefaultValue: false,
-	Name:         "all",
-	ShortHand:    "a",
-	Usage:        "list all cache types",
-	EnvKeys:      []string{"ALL"},
+	Name:         "verbose",
+	ShortHand:    "v",
+	Usage:        "include cache entries in the output",
 }
 
 func init() {
 	cmdManager.RegisterFlagForCmd(&cacheListTypesFlag, CacheListCmd)
-	cmdManager.RegisterFlagForCmd(&cacheListSummaryFlag, CacheListCmd)
-	cmdManager.RegisterFlagForCmd(&cacheListAllFlag, CacheListCmd)
+	cmdManager.RegisterFlagForCmd(&cacheListVerboseFlag, CacheListCmd)
 }
 
 // CacheListCmd is 'singularity cache list' and will list your local singularity cache
@@ -81,7 +67,7 @@ func cacheListCmd() error {
 		sylog.Fatalf("failed to create image cache handle")
 	}
 
-	err := singularity.ListSingularityCache(imgCache, cacheListTypes, allList, cacheListSummary)
+	err := singularity.ListSingularityCache(imgCache, cacheListTypes, cacheListVerbose)
 	if err != nil {
 		sylog.Fatalf("An error occurred while listing cache: %v", err)
 		return err

--- a/internal/app/singularity/cache_linux.go
+++ b/internal/app/singularity/cache_linux.go
@@ -1,0 +1,63 @@
+package singularity
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sylabs/singularity/internal/pkg/client/cache"
+)
+
+var (
+	errInvalidCacheHandle = errors.New("invalid cache handle")
+	errInvalidCacheType   = errors.New("invalid cache type")
+)
+
+func normalizeCacheList(cacheList []string) ([]string, error) {
+	all := false
+	list := []string{}
+
+	for _, e := range cacheList {
+		switch e {
+		case "library", "oci", "shub", "blob", "net", "oras":
+			list = append(list, e)
+
+		case "blobs":
+			list = append(list, "blob")
+
+		case "all":
+			// cacheList contains "all", fall back to all
+			// entries, but continue validating entries just
+			// to be on the safe side
+			all = true
+
+		default:
+			return nil, fmt.Errorf("cache value %s: %+v", e, errInvalidCacheType)
+		}
+	}
+
+	if all {
+		// cleanAll overrides all the specified names
+		list = []string{"library", "oci", "shub", "blob", "net", "oras"}
+	}
+
+	return list, nil
+}
+
+func cacheTypeToDir(imgCache *cache.Handle, cacheType string) (string, error) {
+	switch cacheType {
+	case "library":
+		return imgCache.Library, nil
+	case "oci":
+		return imgCache.OciTemp, nil
+	case "shub":
+		return imgCache.Shub, nil
+	case "blob":
+		return imgCache.OciBlob, nil
+	case "net":
+		return imgCache.Net, nil
+	case "oras":
+		return imgCache.Oras, nil
+	}
+
+	return "", errInvalidCacheType
+}

--- a/internal/app/singularity/cache_list_linux.go
+++ b/internal/app/singularity/cache_list_linux.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
@@ -41,223 +42,139 @@ func findSize(size int64) string {
 // listTypeCache will list a cache type with given name (cacheType). The options are 'library', and 'oci'.
 // Will return: the number of containers for that type (int), the total space the container type is using (int64),
 // and an error if one occurs.
-func listTypeCache(imgCache *cache.Handle, printList bool, cacheType string) (int, int64, error) {
-	var totalSize int64
-	count := 0
-	cachePath := ""
-
-	// check what cache we need to list, and set are path.
-	switch cacheType {
-	case "library":
-		cachePath = imgCache.Library
-	case "oci":
-		cachePath = imgCache.OciTemp
-	case "shub":
-		cachePath = imgCache.Shub
-	case "":
-		return 0, 0, fmt.Errorf("no cache type specifyed")
-	default:
-		return 0, 0, fmt.Errorf("not a valid type: %s", cacheType)
-	}
-
-	cacheTmp, err := ioutil.ReadDir(cachePath)
-	if err != nil {
-		return 0, 0, fmt.Errorf("unable to open: %s directory: %v", cacheType, err)
-	}
-	for _, f := range cacheTmp {
-		checkStat, err := os.Stat(filepath.Join(cachePath, f.Name()))
-		if err != nil {
-			return 0, 0, fmt.Errorf("unable to open stat on: %v: %v", filepath.Join(cachePath, f.Name()), err)
-		}
-		if checkStat.Mode().IsDir() {
-			cacheFile, err := ioutil.ReadDir(filepath.Join(cachePath, f.Name()))
-			if err != nil {
-				return 0, 0, fmt.Errorf("unable to look in: %s: %v", cachePath, err)
-			}
-			for _, b := range cacheFile {
-				fileInfo, err := os.Stat(filepath.Join(cachePath, f.Name(), b.Name()))
-				if err != nil {
-					return 0, 0, fmt.Errorf("unable to get stat for: %s: %v", cachePath, err)
-				}
-				if printList {
-					fmt.Printf("%-24.22s %-22s %-16s %s\n", b.Name(), fileInfo.ModTime().Format("2006-01-02 15:04:05"), findSize(fileInfo.Size()), cacheType)
-				}
-				count++
-				totalSize += fileInfo.Size()
-			}
-		} else {
-			// stray file in ~/.singularity/cache
-			sylog.Debugf("stray file in cache dir: %v", filepath.Join(cachePath, f.Name()))
-		}
-	}
-
-	return count, totalSize, nil
-}
-
-func listBlobCache(imgCache *cache.Handle, printList bool) (int, int64, error) {
-	// loop through ociBlob cache
-	count := 0
-	var totalSize int64
-
-	_, err := os.Stat(filepath.Join(imgCache.OciBlob, "/blobs"))
+func listTypeCache(printList bool, name, cachePath string) (int, int64, error) {
+	_, err := os.Stat(cachePath)
 	if os.IsNotExist(err) {
 		return 0, 0, nil
+	} else if err != nil {
+		return 0, 0, fmt.Errorf("unable to open cache %s at directory %s: %v", name, cachePath, err)
 	}
-	blobs, err := ioutil.ReadDir(filepath.Join(imgCache.OciBlob, "/blobs/"))
+
+	cacheDirs, err := ioutil.ReadDir(cachePath)
 	if err != nil {
-		return 0, 0, fmt.Errorf("unable to open oci-blob directory: %v", err)
+		return 0, 0, fmt.Errorf("unable to open cache %s at directory %s: %v", name, cachePath, err)
 	}
-	for _, f := range blobs {
-		checkStat, err := os.Stat(filepath.Join(imgCache.OciBlob, "blobs", f.Name()))
+
+	var (
+		totalSize int64
+		count     int
+	)
+
+	for _, dir := range cacheDirs {
+		checkStat, err := os.Stat(filepath.Join(cachePath, dir.Name()))
 		if err != nil {
-			return 0, 0, fmt.Errorf("unable to open stat on: %v: %v", filepath.Join(imgCache.OciBlob, "blobs", f.Name()), err)
+			return 0, 0, fmt.Errorf("unable to open stat on: %v: %v", filepath.Join(cachePath, dir.Name()), err)
 		}
-		if checkStat.Mode().IsDir() {
-			blob, err := ioutil.ReadDir(filepath.Join(imgCache.OciBlob, "/blobs/", f.Name()))
+
+		if !checkStat.Mode().IsDir() {
+			// stray file in ~/.singularity/cache
+			sylog.Debugf("stray file in cache dir: %v", filepath.Join(cachePath, dir.Name()))
+			continue
+		}
+
+		cacheEntries, err := ioutil.ReadDir(filepath.Join(cachePath, dir.Name()))
+		if err != nil {
+			return 0, 0, fmt.Errorf("unable to look in: %s: %v", cachePath, err)
+		}
+
+		for _, entry := range cacheEntries {
+			fileInfo, err := os.Stat(filepath.Join(cachePath, dir.Name(), entry.Name()))
 			if err != nil {
-				return 0, 0, fmt.Errorf("unable to look in oci-blob cache: %v", err)
+				return 0, 0, fmt.Errorf("unable to get stat for: %s: %v", cachePath, err)
 			}
-			for _, b := range blob {
-				fileInfo, err := os.Stat(filepath.Join(imgCache.OciBlob, "/blobs/", f.Name(), b.Name()))
-				if err != nil {
-					return 0, 0, fmt.Errorf("unable to get stat for oci-blob cache: %v", err)
-				}
-				if printList {
-					fmt.Printf("%-24.22s %-22s %-16s %s\n", b.Name(), fileInfo.ModTime().Format("2006-01-02 15:04:05"), findSize(fileInfo.Size()), "blob")
-				}
-				count++
-				totalSize += fileInfo.Size()
+
+			if printList {
+				fmt.Printf("%-24.22s %-22s %-16s %s\n",
+					entry.Name(),
+					fileInfo.ModTime().Format("2006-01-02 15:04:05"),
+					findSize(fileInfo.Size()),
+					name)
 			}
-		} else {
-			// stray file in ~/.singularity/cache/library
-			sylog.Debugf("stray file in cache directory: %v", filepath.Join(imgCache.Library, f.Name()))
+			totalSize += fileInfo.Size()
 		}
+
+		count += len(cacheEntries)
 	}
+
 	return count, totalSize, nil
 }
 
-// ListSingularityCache will list local singularity cache, typeNameList is a []string of what cache
-// to list (seprate each type with a comma; like: library,oci,blob) allList force list all cache.
-func ListSingularityCache(imgCache *cache.Handle, cacheListTypes []string, listAll, cacheListSummary bool) error {
-	libraryList := false
-	ociList := false
-	shubList := false
-	blobList := false
-	blobSum := false
-
-	for _, t := range cacheListTypes {
-		switch t {
-		case "library":
-			libraryList = true
-		case "oci":
-			ociList = true
-		case "shub":
-			shubList = true
-		case "blob", "blobs":
-			blobList = true
-		case "blobSum":
-			blobSum = true
-		case "all":
-			listAll = true
-		case "":
-		default:
-			return fmt.Errorf("not a valid type: %s", t)
-		}
+// ListSingularityCache will list the local singularity cache for the
+// types specified by cacheListTypes. If cacheListTypes contains the
+// value "all", all the cache entries are considered. If cacheListVerbose is
+// true, the entries will be shown in the output, otherwise only a
+// summary is provided.
+func ListSingularityCache(imgCache *cache.Handle, cacheListTypes []string, cacheListVerbose bool) error {
+	if imgCache == nil {
+		return errInvalidCacheHandle
 	}
 
-	if listAll {
-		libraryList = true
-		ociList = true
-		blobList = true
+	cacheTypes, err := normalizeCacheList(cacheListTypes)
+	if err != nil {
+		return err
 	}
 
-	var containerCount int
-	var containerSpace int64
-	var blobCount int
-	var blobSpace int64
+	var (
+		containerCount, blobCount             int
+		containerSpace, blobSpace, totalSpace int64
+	)
 
-	// this next part is very messy, but it ensures that the '--summary' flag will be
-	// compatible with '--type=', and '--all' flag.
-
-	if !cacheListSummary {
+	if cacheListVerbose {
 		fmt.Printf("%-24s %-22s %-16s %s\n", "NAME", "DATE CREATED", "SIZE", "TYPE")
 	}
 
-	if listAll {
-		libraryCount, librarySize, err := listTypeCache(imgCache, true, "library")
-		if err != nil {
-			return err
+	containersShown := false
+	blobsShown := false
+
+	for _, cacheType := range cacheTypes {
+		if cacheType == "blob" {
+			// the type blob is special: 1. there's a
+			// separate counter for it; 2. the cache entries
+			// are actually one level deeper
+			cacheDir, _ := cacheTypeToDir(imgCache, cacheType)
+			cacheDir = filepath.Join(cacheDir, "blobs")
+			blobsCount, blobsSize, err := listTypeCache(cacheListVerbose, cacheType, cacheDir)
+			if err != nil {
+				fmt.Print(err)
+				return err
+			}
+			blobCount = blobsCount
+			blobSpace = blobsSize
+			totalSpace += blobsSize
+			blobsShown = true
+		} else {
+			cacheDir, _ := cacheTypeToDir(imgCache, cacheType)
+			count, size, err := listTypeCache(cacheListVerbose, cacheType, cacheDir)
+			if err != nil {
+				fmt.Print(err)
+				return err
+			}
+			containerCount += count
+			containerSpace += size
+			totalSpace += size
+			containersShown = true
 		}
-		containerCount += libraryCount
-		containerSpace += librarySize
-	} else if libraryList {
-		libraryCount, librarySize, err := listTypeCache(imgCache, !cacheListSummary, "library")
-		if err != nil {
-			return err
-		}
-		containerCount += libraryCount
-		containerSpace += librarySize
 	}
 
-	if listAll {
-		ociCount, ociSize, err := listTypeCache(imgCache, true, "oci")
-		if err != nil {
-			return err
-		}
-		containerCount += ociCount
-		containerSpace += ociSize
-	} else if ociList {
-		ociCount, ociSize, err := listTypeCache(imgCache, !cacheListSummary, "oci")
-		if err != nil {
-			return err
-		}
-		containerCount += ociCount
-		containerSpace += ociSize
+	if cacheListVerbose {
+		fmt.Print("\n")
 	}
 
-	if listAll {
-		shubCount, shubSize, err := listTypeCache(imgCache, true, "shub")
-		if err != nil {
-			return err
-		}
-		containerCount += shubCount
-		containerSpace += shubSize
-	} else if shubList {
-		shubCount, shubSize, err := listTypeCache(imgCache, !cacheListSummary, "shub")
-		if err != nil {
-			return err
-		}
-		containerCount += shubCount
-		containerSpace += shubSize
+	out := new(strings.Builder)
+	out.WriteString("There are")
+	if containersShown {
+		fmt.Fprintf(out, " %d container file(s) using %s", containerCount, findSize(containerSpace))
 	}
+	if containersShown && blobsShown {
+		fmt.Fprintf(out, " and")
+	}
+	if blobsShown {
+		fmt.Fprintf(out, " %d oci blob file(s) using %s", blobCount, findSize(blobSpace))
+	}
+	out.WriteString(" of space\n")
 
-	if listAll {
-		blobsCount, blobsSize, err := listBlobCache(imgCache, true)
-		if err != nil {
-			return err
-		}
-		blobCount = blobsCount
-		blobSpace = blobsSize
-	} else if blobSum {
-		blobsCount, blobsSize, err := listBlobCache(imgCache, false)
-		if err != nil {
-			return err
-		}
-		blobCount = blobsCount
-		blobSpace = blobsSize
-	} else if blobList {
-		blobsCount, blobsSize, err := listBlobCache(imgCache, !cacheListSummary)
-		if err != nil {
-			return err
-		}
-		blobCount = blobsCount
-		blobSpace = blobsSize
-	}
-
-	if !listAll || cacheListSummary {
-		fmt.Printf("\nThere %d containers using: %v, %d oci blob file(s) using %v of space.\n", containerCount, findSize(containerSpace), blobCount, findSize(blobSpace))
-		fmt.Printf("Total space used: %v\n", findSize(containerSpace+blobSpace))
-	}
+	fmt.Print(out.String())
+	fmt.Printf("Total space used: %s\n", findSize(totalSpace))
 
 	return nil
 }


### PR DESCRIPTION
Remove some of the code repetition by moving all the common code to a
single location.

The summary for the listing is printed will all the listings, and the
--summary flag consistently means "only print the summary", without
printing the invidual entries.

Remove the "blobSum" type, as it's used to request a summary for the
blobs, which is the same thing --summary does when passing the -T blob
flag.

Make the default -T value for list and clean the same.

Fixes: #3718, #3717

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>