### PR TITLE
Fix SELinux unconfined test

### DIFF
--- a/internal/pkg/security/security_test.go
+++ b/internal/pkg/security/security_test.go
@@ -84,7 +84,7 @@ func TestConfigure(t *testing.T) {
 			desc: "with unconfined SELinux context",
 			spec: specs.Spec{
 				Process: &specs.Process{
-					SelinuxLabel: "unconfined_u:unconfined_r:unconfined_t",
+					SelinuxLabel: "unconfined_u:unconfined_r:unconfined_t:s0",
 				},
 			},
 			disabled: !selinux.Enabled(),


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add missing `:s0` to SELinux exec context

**This fixes or addresses the following GitHub issues:**

- Fixes #3700 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
