### PR TITLE
Clean environment by setting variables to empty string rather than NULL

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -814,21 +814,20 @@ void do_exit(int sig) {
 static void cleanenv(void) {
     extern char **environ;
     char **e;
-    char *p = NULL;
 
     if ( environ == NULL || *environ == NULL ) {
         fatalf("no environment variables set\n");
     }
 
-    /* keep only SINGULARITY_MESSAGELEVEL for GO runtime */
+    /* 
+     * keep only SINGULARITY_MESSAGELEVEL for GO runtime, set others to empty
+     * string and not NULL (see issue #3703 for why)
+     */
     for (e = environ; *e != NULL; e++) {
-        if ( strncmp(MSGLVL_ENV "=", *e, sizeof(MSGLVL_ENV)) == 0 ) {
-            p = *e;
+        if ( strncmp(MSGLVL_ENV "=", *e, sizeof(MSGLVL_ENV)) != 0 ) {
+            *e = "";
         }
-        *e = NULL;
     }
-
-    *environ = p;
 }
 
 /*


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR cleans the environment in starter by setting existing/unwanted environment variables to the empty string rather than NULL. This fixes a weird bug based on how the Go runtime discovers `auxv` (See https://github.com/golang/go/blob/82cf8bca9cf20297bc0edf481cc530c9b3f4bf1e/src/runtime/os_linux.go#L192-L195).

**This fixes or addresses the following GitHub issues:**

- Fixes #3703 

Attn: @singularity-maintainers
