### PR TITLE
Encrypted File System inside SIF

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	remote         bool
+	encrypt        bool
 	builderURL     string
 	detached       bool
 	libraryURL     string
@@ -118,6 +119,17 @@ var buildRemoteFlag = cmdline.Flag{
 	EnvKeys:      []string{"REMOTE"},
 }
 
+// -e|--encrypt
+var buildEncryptFlag = cmdline.Flag{
+	ID:           "buildEncryptFlag",
+	Value:        &encrypt,
+	DefaultValue: false,
+	Name:         "encrypt",
+	ShortHand:    "e",
+	Usage:        "Encrypt the file system after building (requires root)",
+	EnvKeys:      []string{"ENCRYPT"},
+}
+
 // -d|--detached
 var buildDetachedFlag = cmdline.Flag{
 	ID:           "buildDetachedFlag",
@@ -202,6 +214,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&buildNoHTTPSFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildNoTestFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildRemoteFlag, BuildCmd)
+	cmdManager.RegisterFlagForCmd(&buildEncryptFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSandboxFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSectionFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildTmpdirFlag, BuildCmd)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -157,6 +157,7 @@ func run(cmd *cobra.Command, args []string) {
 					LibraryAuthToken: authToken,
 					DockerAuthConfig: authConf,
 					Fakeroot:         fakeroot,
+					Encrypted:        encrypt,
 				},
 			})
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/sylabs/scs-build-client v0.0.4
 	github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec
 	github.com/sylabs/scs-library-client v0.2.2
-	github.com/sylabs/sif v1.0.4
+	github.com/sylabs/sif v1.0.5
 	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e // indirect
 	github.com/vishvananda/netlink v1.0.0 // indirect
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/sylabs/sif v1.0.4-0.20190517011411-f5e78ee40f0b h1:GhPf6kQvxegETxi+uJ
 github.com/sylabs/sif v1.0.4-0.20190517011411-f5e78ee40f0b/go.mod h1:YSrurscNfLqBihRfK4gWYv22UThLcwK76nXg3fLP43o=
 github.com/sylabs/sif v1.0.4 h1:/jkycAIWe0Ro5+QrT23/TCeWSmHHcnMGaPHX6xovqMU=
 github.com/sylabs/sif v1.0.4/go.mod h1:YSrurscNfLqBihRfK4gWYv22UThLcwK76nXg3fLP43o=
+github.com/sylabs/sif v1.0.5 h1:33QYALonFWAIfW1pr1luwyI90UyVVAn7rCJWyQDgIho=
+github.com/sylabs/sif v1.0.5/go.mod h1:YSrurscNfLqBihRfK4gWYv22UThLcwK76nXg3fLP43o=
 github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e h1:QjF5rxNgRSLHJDwKUvfYP3qOx1vTDzUi/+oSC8FXnCI=
 github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -25,13 +25,14 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
 	singularityConfig "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
+	"github.com/sylabs/singularity/pkg/util/crypt"
 )
 
 // SIFAssembler doesnt store anything
 type SIFAssembler struct {
 }
 
-func createSIF(path string, definition, ociConf []byte, squashfile string) (err error) {
+func createSIF(path string, definition, ociConf []byte, squashfile string, encrypted bool) (err error) {
 	// general info for the new SIF file creation
 	cinfo := sif.CreateInfo{
 		Pathname:   path,
@@ -90,7 +91,13 @@ func createSIF(path string, definition, ociConf []byte, squashfile string) (err 
 	parinput.Fp = fp
 	parinput.Size = fi.Size()
 
-	err = parinput.SetPartExtra(sif.FsSquash, sif.PartPrimSys, sif.GetSIFArch(runtime.GOARCH))
+	sifType := sif.FsSquash
+
+	if encrypted {
+		sifType = sif.FsEncryptedSquashfs
+	}
+
+	err = parinput.SetPartExtra(sifType, sif.PartPrimSys, sif.GetSIFArch(runtime.GOARCH))
 	if err != nil {
 		return
 	}
@@ -139,19 +146,17 @@ func getMksquashfsPath() (string, error) {
 func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	sylog.Infof("Creating SIF file...")
 
+	var fsPath string
+
 	mksquashfs, err := getMksquashfsPath()
 	if err != nil {
 		return fmt.Errorf("While searching for mksquashfs: %v", err)
 	}
-
 	f, err := ioutil.TempFile(b.Path, "squashfs-")
-	squashfsPath := f.Name() + ".img"
+	fsPath = f.Name()
 	f.Close()
-	os.Remove(f.Name())
-	os.Remove(squashfsPath)
-	defer os.Remove(squashfsPath)
-
-	args := []string{b.Rootfs(), squashfsPath, "-noappend"}
+	defer os.Remove(fsPath)
+	args := []string{b.Rootfs(), fsPath, "-noappend"}
 
 	// build squashfs with all-root flag when building as a user
 	if syscall.Getuid() != 0 {
@@ -177,7 +182,29 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		return fmt.Errorf("While running mksquashfs: %v: %s", err, strings.Replace(string(errOut), "\n", " ", -1))
 	}
 
-	err = createSIF(path, b.Recipe.Raw, b.JSONObjects["oci-config"], squashfsPath)
+	if b.Opts.Encrypted {
+		// A dm-crypt device needs to be created with squashfs
+		cryptDev := &crypt.Device{}
+
+		key, err := cryptDev.ReadKeyFromStdin(true)
+		if err != nil {
+			return fmt.Errorf("unable to read key from stdin")
+		}
+		loopPath, cryptName, err := cryptDev.FormatCryptDevice(fsPath, key)
+		if err != nil {
+			return fmt.Errorf("unable to format crypt device: %s", cryptName)
+		}
+
+		defer os.Remove(loopPath)
+
+		err = cryptDev.CloseCryptDevice(cryptName)
+		if err != nil {
+			return fmt.Errorf("unable to close crypt device: %s", cryptName)
+		}
+		fsPath = loopPath
+	}
+
+	err = createSIF(path, b.Recipe.Raw, b.JSONObjects["oci-config"], fsPath, b.Opts.Encrypted)
 	if err != nil {
 		return fmt.Errorf("While creating SIF: %v", err)
 	}

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -186,6 +186,10 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		// A dm-crypt device needs to be created with squashfs
 		cryptDev := &crypt.Device{}
 
+		// TODO (schebro): Fix #3876
+		// Detach the following code from the squashfs creation. SIF can be
+		// created first and encrypted after. This gives the flexibility to
+		// encrypt an existing SIF
 		key, err := cryptDev.ReadKeyFromStdin(true)
 		if err != nil {
 			return fmt.Errorf("unable to read key from stdin")

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -105,7 +105,11 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		}
 
 		s := stage{}
-		s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")
+		if conf.Opts.Encrypted {
+			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild")
+		} else {
+			s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/runtime/engines/singularity/cleanup_linux.go
+++ b/internal/pkg/runtime/engines/singularity/cleanup_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -35,6 +35,12 @@ type MountArgs struct {
 	Data       string
 }
 
+// CryptArgs defines the arguments to mount.
+type CryptArgs struct {
+	Offset  uint64
+	Loopdev string
+}
+
 // ChrootArgs defines the arguments to chroot.
 type ChrootArgs struct {
 	Root   string

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -8,6 +8,7 @@ package client
 import (
 	"net/rpc"
 	"os"
+	"path/filepath"
 
 	args "github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc"
 	"github.com/sylabs/singularity/pkg/util/loop"
@@ -19,7 +20,7 @@ type RPC struct {
 	Name   string
 }
 
-// Mount calls tme mount RPC using the supplied arguments.
+// Mount calls the mount RPC using the supplied arguments.
 func (t *RPC) Mount(source string, target string, filesystem string, flags uintptr, data string) (int, error) {
 	arguments := &args.MountArgs{
 		Source:     source,
@@ -30,6 +31,20 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 	}
 	var reply int
 	err := t.Client.Call(t.Name+".Mount", arguments, &reply)
+	return reply, err
+}
+
+// Decrypt calls the DeCrypt RPC using the supplied arguments.
+func (t *RPC) Decrypt(offset uint64, path string) (string, error) {
+	loopdev := filepath.Base(path)
+	arguments := &args.CryptArgs{
+		Offset:  offset,
+		Loopdev: loopdev,
+	}
+
+	var reply string
+	err := t.Client.Call(t.Name+".Decrypt", arguments, &reply)
+
 	return reply, err
 }
 

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -141,8 +141,9 @@ var authorizedTags = map[AuthorizedTag]struct {
 }
 
 var authorizedImage = map[string]fsContext{
-	"ext3":     {true},
-	"squashfs": {true},
+	"encryptfs": {true},
+	"ext3":      {true},
+	"squashfs":  {true},
 }
 
 var authorizedFS = map[string]fsContext{

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -52,6 +52,8 @@ type Options struct {
 	LibraryAuthToken string `json:"libraryAuthToken"`
 	// contains docker credentials if specified
 	DockerAuthConfig *ocitypes.DockerAuthConfig
+	// Encrypted specifies if the filesystem needs to be encrypteded
+	Encrypted bool `json:"encrypt"`
 	// noTest indicates if build should skip running the test script
 	NoTest bool `json:"noTest"`
 	// force automatically deletes an existing container at build destination while performing build
@@ -69,8 +71,8 @@ type Options struct {
 	ImgCache *cache.Handle
 }
 
-// NewBundle creates a Bundle environment
-func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
+// Common code between NewBundle and NewEncryptedBundle
+func bundleCommon(encrypted bool, bundleDir, bundlePrefix string) (b *Bundle, err error) {
 	b = &Bundle{}
 	b.JSONObjects = make(map[string][]byte)
 
@@ -88,6 +90,8 @@ func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
 		"rootfs": "fs",
 	}
 
+	b.Opts.Encrypted = encrypted
+
 	for _, fso := range b.FSObjects {
 		if err = os.MkdirAll(filepath.Join(b.Path, fso), 0755); err != nil {
 			return
@@ -95,6 +99,17 @@ func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
 	}
 
 	return b, nil
+
+}
+
+// NewEncryptedBundle creates an Encrypted Bundle environment
+func NewEncryptedBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
+	return bundleCommon(true, bundleDir, bundlePrefix)
+}
+
+// NewBundle creates a Bundle environment
+func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
+	return bundleCommon(false, bundleDir, bundlePrefix)
 }
 
 // Rootfs give the path to the root filesystem in the Bundle

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -25,6 +25,8 @@ const (
 	SANDBOX
 	// SIF constant for sif format
 	SIF
+	// ENCRYPTSQUASHFS constant for encrypted squashfs format
+	ENCRYPTSQUASHFS
 )
 
 const (

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -94,6 +94,8 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 			img.Partitions[0].Type = SQUASHFS
 		} else if fstype == sif.FsExt3 {
 			img.Partitions[0].Type = EXT3
+		} else if fstype == sif.FsEncryptedSquashfs {
+			img.Partitions[0].Type = ENCRYPTSQUASHFS
 		} else {
 			return fmt.Errorf("unknown file system type: %v", fstype)
 		}

--- a/pkg/runtime/engines/singularity/config/config_linux.go
+++ b/pkg/runtime/engines/singularity/config/config_linux.go
@@ -18,4 +18,5 @@ type EngineConfig struct {
 	File      *FileConfig      `json:"-"`
 	Network   *network.Setup   `json:"-"`
 	Cgroups   *cgroups.Manager `json:"-"`
+	CryptDev  string           `json:"-"`
 }

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package crypt
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/util/fs/lock"
+	"github.com/sylabs/singularity/pkg/util/loop"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// Device describes a crypt device
+type Device struct{}
+
+// createLoop attaches the file to the next available loop device and
+// sets the sizelimit on it
+func createLoop(file *os.File, offset, size uint64) (string, error) {
+	loopDev := &loop.Device{
+		MaxLoopDevices: 256,
+		Shared:         true,
+		Info: &loop.Info64{
+			SizeLimit: size,
+			Offset:    offset,
+			Flags:     loop.FlagsAutoClear,
+		},
+	}
+	idx := 0
+	if err := loopDev.AttachFromFile(file, os.O_RDWR, &idx); err != nil {
+		return "", fmt.Errorf("failed to attach image %s: %s", file.Name(), err)
+	}
+	return fmt.Sprintf("/dev/loop%d", idx), nil
+}
+
+// CloseCryptDevice closes the crypt device
+func (crypt *Device) CloseCryptDevice(path string) error {
+
+	cmd := exec.Command("/sbin/cryptsetup", "luksClose", path)
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: 0, Gid: 0}
+	fd, err := lock.Exclusive("/dev/mapper")
+	if err != nil {
+		return err
+	}
+	defer lock.Release(fd)
+	err = cmd.Run()
+	if err != nil {
+		sylog.Debugf("Unable to delete the crypt device %s", err)
+		return err
+	}
+
+	return nil
+}
+
+// ReadKeyFromStdin reads key from terminal and returns it
+func (crypt *Device) ReadKeyFromStdin(confirm bool) (string, error) {
+
+	fmt.Print("Enter the Key: ")
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		sylog.Fatalf("Error parsing the key: %s", err)
+	}
+
+	input := string(password)
+	fmt.Println()
+	if confirm {
+		fmt.Print("Confirm the Key: ")
+		password2, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			sylog.Fatalf("Error parsing the key: %s", err)
+		}
+		input2 := string(password2)
+		fmt.Println()
+		if input != input2 {
+			return "", errors.New("Keys don't match")
+		}
+	}
+
+	return input, nil
+}
+
+// FormatCryptDevice allocates a loop device, encrypts, and returns the loop device name, and encrypted device name
+func (crypt *Device) FormatCryptDevice(path, key string) (string, string, error) {
+
+	f, err := os.Stat(path)
+	if err != nil {
+		return "", "", fmt.Errorf("failed getting size of %s", path)
+	}
+
+	fSize := f.Size()
+
+	// Create a temporary file to format with crypt header
+	cryptF, err := ioutil.TempFile("", "crypt-")
+	if err != nil {
+		sylog.Debugf("Error creating temporary crypt file")
+		return "", "", err
+	}
+	defer cryptF.Close()
+
+	// Truncate the file taking the squashfs size and crypt header into account
+	// Crypt header is around 2MB in size. Slightly over-allocate to be safe
+	devSize := fSize + 4*1024*1024 // 4MB for LUKS header
+
+	err = os.Truncate(cryptF.Name(), devSize)
+	if err != nil {
+		sylog.Debugf("Unable to truncate crypt file to size %d", devSize)
+		return "", "", err
+	}
+
+	// NOTE: This routine runs with root privileges. It's not necessary
+	// to explicitly set cmd's uid or gid here
+	cmd := exec.Command("/sbin/cryptsetup", "luksFormat", cryptF.Name())
+	stdin, err := cmd.StdinPipe()
+
+	if err != nil {
+		return "", "", err
+	}
+
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, key)
+	}()
+
+	err = cmd.Run()
+	if err != nil {
+		return "", "", fmt.Errorf("unable to format crypt device: %s", cryptF.Name())
+	}
+
+	// Associate the temporary crypt file with a loop device
+	loop, err := createLoop(cryptF, 0, uint64(devSize))
+	if err != nil {
+		return "", "", err
+	}
+
+	loopdev := filepath.Base(loop)
+
+	fd, err := lock.Exclusive("/dev/mapper")
+	if err != nil {
+		return "", "", fmt.Errorf("unable to acquire lock on /dev/mapper")
+	}
+	defer lock.Release(fd)
+
+	nextCrypt := getNextAvailableCryptDevice()
+	cmd = exec.Command("/sbin/cryptsetup", "luksOpen", loopdev, nextCrypt)
+	cmd.Dir = "/dev"
+	stdin, err = cmd.StdinPipe()
+	if err != nil {
+		return "", "", err
+	}
+
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, key)
+	}()
+
+	err = cmd.Run()
+	if err != nil {
+		sylog.Verbosef("Unable to open crypt device: %s", nextCrypt)
+		return "", "", err
+	}
+
+	copyDeviceContents(path, "/dev/mapper/"+nextCrypt, fSize)
+
+	// Open a new Temp file to stash the loop contents
+	loopF, err := ioutil.TempFile("", "loop-")
+	if err != nil {
+		sylog.Debugf("Error creating temporary crypt file")
+		return "", "", err
+	}
+
+	copyDeviceContents("/dev/"+loopdev, loopF.Name(), devSize)
+
+	return loopF.Name(), nextCrypt, err
+}
+
+// copyDeviceContents copies the contents of source to destination.
+// source and dest can either be a file or a block device
+func copyDeviceContents(source, dest string, size int64) error {
+	sourceFd, err := syscall.Open(source, syscall.O_RDWR, 0777)
+	if err != nil {
+		return fmt.Errorf("Unable to open the file %s", source)
+	}
+	defer syscall.Close(sourceFd)
+
+	destFd, err := syscall.Open(dest, syscall.O_RDWR, 0777)
+	if err != nil {
+		return fmt.Errorf("Unable to open the file: %s", dest)
+	}
+	defer syscall.Close(destFd)
+
+	var writtenSoFar int64
+
+	buffer := make([]byte, 1024)
+	for writtenSoFar < size {
+		numRead, err := syscall.Read(sourceFd, buffer)
+		if err != nil {
+			return fmt.Errorf("Unable to read the the file %s", source)
+		}
+		numWritten, err := syscall.Write(destFd, buffer)
+		if err != nil {
+			return fmt.Errorf("Unable to write to destination %s", dest)
+		}
+
+		if numRead != numWritten {
+			sylog.Debugf("numRead != numWritten")
+		}
+		writtenSoFar += int64(numWritten)
+	}
+
+	return nil
+}
+
+func getNextAvailableCryptDevice() string {
+	return (uuid.NewV4()).String()
+}
+
+// GetCryptDevice returns the next available device in /dev/mapper for encryption/decryption
+func (crypt *Device) GetCryptDevice(key, loopDev string) (string, error) {
+	fd, err := lock.Exclusive("/dev/mapper")
+	if err != nil {
+		sylog.Debugf("Unable to acquire lock on /dev/mapper while decrypting")
+		return "", err
+	}
+	defer lock.Release(fd)
+
+	maxRetries := 3 // Arbitrary number of retries.
+
+retry:
+	numRetries := 0
+	nextCrypt := getNextAvailableCryptDevice()
+	if nextCrypt == "" {
+		return "", errors.New("Crypt Device not available")
+	}
+
+	cmd := exec.Command("/sbin/cryptsetup", "luksOpen", loopDev, nextCrypt)
+	cmd.Dir = "/dev"
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: 0, Gid: 0}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return "", err
+	}
+
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, key)
+	}()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "No key available") {
+			sylog.Debugf("Invalid password")
+		}
+		if strings.Contains(string(out), "Device already exists") {
+			numRetries++
+			if numRetries < maxRetries {
+				goto retry
+			}
+		}
+		return "", err
+	}
+	sylog.Debugf("Decrypted the FS successfully")
+
+	return nextCrypt, nil
+}

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -66,6 +66,10 @@ func (crypt *Device) CloseCryptDevice(path string) error {
 }
 
 // ReadKeyFromStdin reads key from terminal and returns it
+// TODO (schebro): Fix #3816, #3851
+// Currently keys are being read interactively from the terminal.
+// Keys should be non-interactive, preferably in a keyfile that can
+// be passed to cryptsetup utility
 func (crypt *Device) ReadKeyFromStdin(confirm bool) (string, error) {
 
 	fmt.Print("Enter the Key: ")
@@ -122,6 +126,17 @@ func (crypt *Device) FormatCryptDevice(path, key string) (string, string, error)
 
 	// NOTE: This routine runs with root privileges. It's not necessary
 	// to explicitly set cmd's uid or gid here
+	// TODO (schebro): Fix #3818, #3821
+	// Currently we are relying on host's cryptsetup utility to encrypt and decrypt
+	// the SIF. The possiblity to saving a version of cryptsetup inside the container should be
+	// investigated. To do that, at least one additional partition is required, which is
+	// not encrypted.
+
+	// TODO (schebro): Fix #3819
+	// If we choose not to save a version of cryptsetup in container, host's cryptsetup utility's
+	// paty should be saved in a configuration file at build time (similar to mksquashfs) for
+	// security reasons
+
 	cmd := exec.Command("/sbin/cryptsetup", "luksFormat", cryptF.Name())
 	stdin, err := cmd.StdinPipe()
 

--- a/vendor/github.com/sylabs/sif/pkg/sif/fmt.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/fmt.go
@@ -89,6 +89,8 @@ func fstypeStr(ftype Fstype) string {
 		return "Archive"
 	case FsRaw:
 		return "Raw"
+	case FsEncryptedSquashfs:
+		return "Encrypted squashfs"
 	}
 	return "Unknown fs-type"
 }

--- a/vendor/github.com/sylabs/sif/pkg/sif/sif.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/sif.go
@@ -144,10 +144,11 @@ type Fstype int32
 
 // List of supported file systems
 const (
-	FsSquash  Fstype = iota + 1 // Squashfs file system, RDONLY
-	FsExt3                      // EXT3 file system, RDWR (deprecated)
-	FsImmuObj                   // immutable data object archive
-	FsRaw                       // raw data
+	FsSquash            Fstype = iota + 1 // Squashfs file system, RDONLY
+	FsExt3                                // EXT3 file system, RDWR (deprecated)
+	FsImmuObj                             // immutable data object archive
+	FsRaw                                 // raw data
+	FsEncryptedSquashfs                   // Encrypted Squashfs file system, RDONLY
 )
 
 // Parttype represents the different SIF container partition types (system and data)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -269,7 +269,7 @@ github.com/sylabs/scs-build-client/client
 github.com/sylabs/scs-key-client/client
 # github.com/sylabs/scs-library-client v0.2.2
 github.com/sylabs/scs-library-client/client
-# github.com/sylabs/sif v1.0.4
+# github.com/sylabs/sif v1.0.5
 github.com/sylabs/sif/pkg/siftool
 github.com/sylabs/sif/pkg/sif
 github.com/sylabs/sif/internal/app/siftool


### PR DESCRIPTION
Description of the Pull Request (PR):

Implemented review feedback

Locking /dev/mapper before creating crypt devices to avoid races

Deleted encryptfs.go, which is not necessary

Generate random number for crypt device

Ext3->Squashfs for encrypted FS

This fixes or addresses the following GitHub issues:

Fixes #3605
Fixes #3662
Fixes #3664
Fixes #3285
Fixes #3517
Fixes #3518
Fixes #3519
NOTE: CI tests are still failing. I am resolving the failures now. Pushing the code to get feedback on the latest changes while I resolve other issues.

Attn: @singularity-maintainers