### PR TITLE
Fixed panic when exec/run a container in the library that does not exist

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -140,9 +140,16 @@ func handleLibrary(u, libraryURL string) (string, error) {
 
 	imageRef := libraryhelper.NormalizeLibraryRef(u)
 
-	libraryImage, _, err := c.GetImage(ctx, imageRef)
+	libraryImage, existOk, err := c.GetImage(ctx, imageRef)
 	if err != nil {
 		return "", err
+	}
+	if !existOk {
+		return "", fmt.Errorf("image does not exist in the library: %s", imageRef)
+	}
+	if libraryImage == nil {
+		// It should never get here
+		return "", fmt.Errorf("failed getting image from the library: %s", imageRef)
 	}
 
 	imageName := uri.GetName("library://" + imageRef)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -147,10 +147,6 @@ func handleLibrary(u, libraryURL string) (string, error) {
 	if !existOk {
 		return "", fmt.Errorf("image does not exist in the library: %s", imageRef)
 	}
-	if libraryImage == nil {
-		// It should never get here
-		return "", fmt.Errorf("failed getting image from the library: %s", imageRef)
-	}
 
 	imageName := uri.GetName("library://" + imageRef)
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -65,10 +65,6 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 	if !existOk {
 		return fmt.Errorf("image does not exist in the library: %s", imageRef)
 	}
-	if libraryImage == nil {
-		// It should never get here
-		return fmt.Errorf("failed getting image from the library: %s", imageRef)
-	}
 
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)
 	exists, err := cache.LibraryImageExists(libraryImage.Hash, imageName)

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -63,10 +63,11 @@ func LibraryPull(name, ref, transport, fullURI, libraryURI, keyServerURL, authTo
 		return fmt.Errorf("while getting image info: %v", err)
 	}
 	if !existOk {
-		return fmt.Errorf("image does not exist in the library")
+		return fmt.Errorf("image does not exist in the library: %s", imageRef)
 	}
 	if libraryImage == nil {
-		return fmt.Errorf("failed getting image from the library")
+		// It should never get here
+		return fmt.Errorf("failed getting image from the library: %s", imageRef)
 	}
 
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -65,10 +65,6 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 	if !existOk {
 		return fmt.Errorf("image does not exist in the library: %s", imageRef)
 	}
-	if libraryImage == nil {
-		// It should never get here
-		return fmt.Errorf("failed getting image from the library: %s", imageRef)
-	}
 
 	imageName := uri.GetName("library://" + imageRef)
 	imagePath := cache.LibraryImage(libraryImage.Hash, imageName)

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -63,10 +63,11 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 		return fmt.Errorf("while getting image info: %v", err)
 	}
 	if !existOk {
-		return fmt.Errorf("image does not exist in the library")
+		return fmt.Errorf("image does not exist in the library: %s", imageRef)
 	}
 	if libraryImage == nil {
-		return fmt.Errorf("failed getting image from the library")
+		// It should never get here
+		return fmt.Errorf("failed getting image from the library: %s", imageRef)
 	}
 
 	imageName := uri.GetName("library://" + imageRef)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes the panic when using actions command on a library image that does not exist.

## This fixes or addresses the following GitHub issues:

- Fixes #3735 
- Related to #3614 
