### PR TITLE
updating golden txt files to fix help test failures

### DIFF
--- a/e2e/testdata/help/help-oci-attach.txt
+++ b/e2e/testdata/help/help-oci-attach.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci attach <container_ID>
 
 Description:
-  Attach will attach console to a running container process running within container identified by container ID.
+  Attach will attach console to a running container process running within 
+  container identified by container ID.
 
 Options:
   -h, --help   help for attach

--- a/e2e/testdata/help/help-oci-create.txt
+++ b/e2e/testdata/help/help-oci-create.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci create -b <bundle_path> [create options...] <container_ID>
 
 Description:
-  Create invoke create operation to create a container instance from an OCI bundle directory
+  Create invoke create operation to create a container instance from an OCI 
+  bundle directory
 
 Options:
   -b, --bundle string        specify the OCI bundle path (required)

--- a/e2e/testdata/help/help-oci-delete.txt
+++ b/e2e/testdata/help/help-oci-delete.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci delete <container_ID>
 
 Description:
-  Delete invoke delete operation to delete resources that were created for container identified by container ID.
+  Delete invoke delete operation to delete resources that were created for 
+  container identified by container ID.
 
 Options:
   -h, --help   help for delete

--- a/e2e/testdata/help/help-oci-exec.txt
+++ b/e2e/testdata/help/help-oci-exec.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci exec <container_ID> <command> <args>
 
 Description:
-  Exec will execute the provided command/arguments within container identified by container ID.
+  Exec will execute the provided command/arguments within container identified 
+  by container ID.
 
 Options:
   -h, --help   help for exec

--- a/e2e/testdata/help/help-oci-kill.txt
+++ b/e2e/testdata/help/help-oci-kill.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci kill [kill options...] <container_ID>
 
 Description:
-  Kill invoke kill operation to kill processes running within container identified by container ID.
+  Kill invoke kill operation to kill processes running within container 
+  identified by container ID.
 
 Options:
   -f, --force            kill container process with SIGKILL

--- a/e2e/testdata/help/help-oci-resume.txt
+++ b/e2e/testdata/help/help-oci-resume.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci resume <container_ID>
 
 Description:
-  Resume will resume all processes previously paused for the specified container ID.
+  Resume will resume all processes previously paused for the specified container 
+  ID.
 
 Options:
   -h, --help   help for resume

--- a/e2e/testdata/help/help-oci-start.txt
+++ b/e2e/testdata/help/help-oci-start.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci start <container_ID>
 
 Description:
-  Start invoke start operation to start a previously created container identified by container ID.
+  Start invoke start operation to start a previously created container 
+  identified by container ID.
 
 Options:
   -h, --help   help for start

--- a/e2e/testdata/help/help-oci-state.txt
+++ b/e2e/testdata/help/help-oci-state.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci state <container_ID>
 
 Description:
-  State invoke state operation to query state of a created/running/stopped container identified by container ID.
+  State invoke state operation to query state of a created/running/stopped 
+  container identified by container ID.
 
 Options:
   -h, --help                 help for state

--- a/e2e/testdata/help/help-oci-umount.txt
+++ b/e2e/testdata/help/help-oci-umount.txt
@@ -4,7 +4,8 @@ Usage:
   singularity oci umount <bundle_path>
 
 Description:
-  Umount will umount an OCI bundle previously mounted with singularity oci mount.
+  Umount will umount an OCI bundle previously mounted with singularity oci 
+  mount.
 
 Options:
   -h, --help   help for umount

--- a/e2e/testdata/help/help-oci-update.txt
+++ b/e2e/testdata/help/help-oci-update.txt
@@ -4,8 +4,8 @@ Usage:
   singularity oci update [update options...] <container_ID>
 
 Description:
-  Update will update cgroups resources for the specified container ID.
-  Container must be in a RUNNING or CREATED state.
+  Update will update cgroups resources for the specified container ID. Container 
+  must be in a RUNNING or CREATED state.
 
 Options:
   -f, --from-file string   specify path to OCI JSON cgroups resource file


### PR DESCRIPTION
This should fix recent test failure having to do with updating help but not updating help text files in test materials.  

Attn: @singularity-maintainers
