### PR TITLE
Fix user namespace mappings and build section execution context

### DIFF
--- a/internal/pkg/fakeroot/fakeroot_test.go
+++ b/internal/pkg/fakeroot/fakeroot_test.go
@@ -55,7 +55,7 @@ func TestGetIDRangeUser(t *testing.T) {
 		},
 		{
 			name: "low base",
-			base: 65535,
+			base: 131071,
 		},
 		{
 			name: "high base",
@@ -63,11 +63,11 @@ func TestGetIDRangeUser(t *testing.T) {
 		},
 		{
 			name: "base not multiple of 65536",
-			base: 65537,
+			base: 131073,
 		},
 		{
 			name: "good base, no users",
-			base: 65536,
+			base: 131072,
 		},
 		{
 			name:         "good base, current user",
@@ -76,7 +76,7 @@ func TestGetIDRangeUser(t *testing.T) {
 			expectedMapping: &specs.LinuxIDMapping{
 				ContainerID: 1,
 				HostID:      65536 * 1024,
-				Size:        65535,
+				Size:        65536,
 			},
 		},
 	}
@@ -94,7 +94,7 @@ func TestGetIDRangeRoot(t *testing.T) {
 		},
 		{
 			name: "low base",
-			base: 65535,
+			base: 131071,
 		},
 		{
 			name: "high base",
@@ -102,7 +102,7 @@ func TestGetIDRangeRoot(t *testing.T) {
 		},
 		{
 			name: "base not multiple of 65536",
-			base: 65537,
+			base: 131073,
 		},
 		{
 			name: "good base, root user",
@@ -110,7 +110,7 @@ func TestGetIDRangeRoot(t *testing.T) {
 			expectedMapping: &specs.LinuxIDMapping{
 				ContainerID: 1,
 				HostID:      1,
-				Size:        65535,
+				Size:        65536,
 			},
 		},
 	}

--- a/internal/pkg/runtime/engines/engines_linux.go
+++ b/internal/pkg/runtime/engines/engines_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/starter"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild"
 	imgbuildConfig "github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild/config"
+	imgbuildserver "github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild/rpc/server"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/oci"
 	ociserver "github.com/sylabs/singularity/internal/pkg/runtime/engines/oci/rpc/server"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity"
@@ -119,7 +120,10 @@ func Init() {
 	methods := new(server.Methods)
 	registeredEngineRPCMethods = make(map[string]interface{})
 	registeredEngineRPCMethods[singularityConfig.Name] = methods
-	registeredEngineRPCMethods[imgbuildConfig.Name] = methods
+
+	buildmethods := new(imgbuildserver.Methods)
+	buildmethods.Methods = methods
+	registeredEngineRPCMethods[imgbuildConfig.Name] = buildmethods
 
 	ocimethods := new(ociserver.Methods)
 	ocimethods.Methods = methods

--- a/internal/pkg/runtime/engines/imgbuild/process_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/process_linux.go
@@ -24,14 +24,18 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 	e.cleanEnv()
 
 	if e.EngineConfig.RunSection("post") && e.EngineConfig.Recipe.BuildData.Post.Script != "" {
-		// Run %post script here
-		e.runScriptSection("post", e.EngineConfig.Recipe.BuildData.Post, true)
+		// Run %post script here. At this stage RPC server exited so nil
+		// is passed for RPC operation in order to execute section script
+		// from this process
+		e.runScriptSection(nil, "post", e.EngineConfig.Recipe.BuildData.Post, true)
 	}
 
 	if e.EngineConfig.RunSection("test") {
 		if !e.EngineConfig.Opts.NoTest && e.EngineConfig.Recipe.BuildData.Test.Script != "" {
-			// Run %test script
-			e.runScriptSection("test", e.EngineConfig.Recipe.BuildData.Test, false)
+			// Run %test script. At this stage RPC server exited so nil
+			// is passed for RPC operation in order to execute section
+			// script from this process
+			e.runScriptSection(nil, "test", e.EngineConfig.Recipe.BuildData.Test, false)
 		}
 	}
 

--- a/internal/pkg/runtime/engines/imgbuild/rpc/args.go
+++ b/internal/pkg/runtime/engines/imgbuild/rpc/args.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package rpc
+
+// CopyArgs defines the arguments to copy.
+type CopyArgs struct {
+	Source string
+	Dest   string
+}
+
+// RunScriptArgs defines the arguments to run script.
+type RunScriptArgs struct {
+	Script string
+	Args   []string
+	Envs   []string
+}

--- a/internal/pkg/runtime/engines/imgbuild/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/imgbuild/rpc/client/client.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package client
+
+import (
+	buildargs "github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild/rpc"
+	client "github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/client"
+)
+
+// RPC holds the state necessary for remote procedure calls.
+type RPC struct {
+	client.RPC
+}
+
+// Copy calls the copy RPC using the supplied arguments.
+func (t *RPC) Copy(source string, dest string) (int, error) {
+	arguments := &buildargs.CopyArgs{
+		Source: source,
+		Dest:   dest,
+	}
+	var reply int
+	err := t.Client.Call(t.Name+".Copy", arguments, &reply)
+	return reply, err
+}
+
+// RunScript calls the RunScript RPC methods using the supplied arguments.
+func (t *RPC) RunScript(script string, args, envs []string) (int, error) {
+	arguments := &buildargs.RunScriptArgs{
+		Script: script,
+		Args:   args,
+		Envs:   envs,
+	}
+	var reply int
+	err := t.Client.Call(t.Name+".RunScript", arguments, &reply)
+	return reply, err
+}

--- a/internal/pkg/runtime/engines/imgbuild/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/rpc/server/server_linux.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/sylabs/singularity/internal/pkg/build/copy"
+
+	buildargs "github.com/sylabs/singularity/internal/pkg/runtime/engines/imgbuild/rpc"
+	server "github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/server"
+)
+
+// Methods is a receiver type.
+type Methods struct {
+	*server.Methods
+}
+
+// Copy performs a file copy with the specified arguments.
+func (t *Methods) Copy(arguments *buildargs.CopyArgs, reply *int) (err error) {
+	return copy.Copy(arguments.Source, arguments.Dest)
+}
+
+// RunScript executes a section script.
+func (t *Methods) RunScript(arguments *buildargs.RunScriptArgs, reply *int) (err error) {
+	var b bytes.Buffer
+	if _, err := b.WriteString(arguments.Script); err != nil {
+		return fmt.Errorf("failed to write script on stdin: %v", err)
+	}
+
+	cmd := exec.Command("/bin/sh", arguments.Args...)
+	cmd.Env = arguments.Envs
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = &b
+
+	return cmd.Run()
+}

--- a/pkg/runtime/engines/singularity/config/data/singularity.conf
+++ b/pkg/runtime/engines/singularity/config/data/singularity.conf
@@ -243,7 +243,7 @@ memory fs type = {{ .MemoryFSType }}
 # usage and optimize kernel cache (useful for MPI)
 shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }}
 
-# FAKEROOT BASE ID: [INT] 65536 <= BASE <= 4294901760
+# FAKEROOT BASE ID: [INT] 131072 <= BASE <= 4294901760
 # DEFAULT: 4227858432
 # This is the start of allocatable UID/GID in containers for fakeroot users.
 # Each user will be allocated a range of 65535 UID/GID based on this base,


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Fix user namespace mappings size and change minimum value for fakeroot base id, so users will have a true 65536 range and root 1:1 couldn't be overlapped.

- Build section execution has changed for setup and files sections in order to execute them in RPC context and avoid schizophrenia with other sections, typically to address potential issue when building with fakeroot option, all sections except pre are now executed in the fakeroot context.

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
