### PR TITLE
Allow execution from a parent (rootless) user namespace

### DIFF
--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sylabs/singularity/pkg/network"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 	"github.com/sylabs/singularity/pkg/util/loop"
+	"github.com/sylabs/singularity/pkg/util/namespaces"
 	"github.com/sylabs/singularity/pkg/util/nvidia"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -103,6 +104,14 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 		c.sessionSize = int(engine.EngineConfig.File.SessiondirMaxSize)
 	} else if engine.EngineConfig.GetAllowSUID() && !c.userNS {
 		c.suidFlag = 0
+	}
+
+	// user namespace was not requested but we need to check
+	// if we are currently running in a user namespace and set
+	// value accordingly to avoid remount errors while running
+	// inside a user namespace
+	if !c.userNS {
+		c.userNS, _ = namespaces.IsInsideUserNamespace(os.Getpid())
 	}
 
 	p := &mount.Points{}

--- a/pkg/util/namespaces/user_linux.go
+++ b/pkg/util/namespaces/user_linux.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package namespaces
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// IsInsideUserNamespace checks if a process is already running in a
+// user namespace and also returns if the process has permissions to use
+// setgroups in this user namespace.
+func IsInsideUserNamespace(pid int) (bool, bool) {
+	// default values returned in case of error
+	insideUserNs := false
+	setgroupsAllowed := false
+
+	// can fail if the kernel doesn't support user namespace
+	r, err := os.Open(fmt.Sprintf("/proc/%d/uid_map", pid))
+	if err != nil {
+		return insideUserNs, setgroupsAllowed
+	}
+	defer r.Close()
+
+	scanner := bufio.NewScanner(r)
+	// we are interested only by the first line of
+	// uid_map which would give us the answer quickly
+	// based on the value of size field
+	if scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+
+		// trust values returned by procfs
+		size, _ := strconv.ParseUint(fields[2], 10, 32)
+
+		// a size of 4294967295 means the process is running
+		// in the host user namespace
+		if uint32(size) == ^uint32(0) {
+			return insideUserNs, setgroupsAllowed
+		}
+
+		// process is running inside user namespace
+		insideUserNs = true
+
+		// should not fail if open call passed
+		d, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/setgroups", pid))
+		if err != nil {
+			return insideUserNs, setgroupsAllowed
+		}
+		setgroupsAllowed = string(d) == "allow\n"
+	}
+
+	return insideUserNs, setgroupsAllowed
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Users may not want to install Singularity setuid binaries on their system and consequently prevent them to use `fakeroot` feature especially for image build. This PR fixes few issues preventing to build image from a parent user namespace already in rootless mode.

**This fixes or addresses the following GitHub issues:**

- Fixes #3753

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
