### PR TITLE
Avoid having the cache related info message displayed all the time

### DIFF
--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -148,7 +148,7 @@ func getCacheBasedir() string {
 	}
 
 	// If the environment variable is not set, we use the default cache.
-	sylog.Infof("environment variable %s not set, using default image cache", DirEnv)
+	sylog.Debugf("environment variable %s not set, using default image cache", DirEnv)
 	basedir = syfs.ConfigDir()
 
 	return basedir


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Switch a `sylog.Infof()` call to a `sylog.Debugf()` call to avoid having the following message displayed all the time while using the CLI:
```
INFO:    environment variable SINGULARITY_CACHEDIR not set, using default image cache
```

**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers