### PR TITLE
ORAS: discard logrus warnings depending on log level

### DIFF
--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -93,6 +93,7 @@ var PushCmd = &cobra.Command{
 			if err := oras.UploadImage(file, ref, ociAuth); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
+			sylog.Infof("Upload complete.")
 		}
 	},
 

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/safchain/ethtool v0.0.0-20180504150752-6e3f4faa84e1 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/seccomp/libseccomp-golang v0.9.0
-	github.com/sirupsen/logrus v1.0.5 // indirect
+	github.com/sirupsen/logrus v1.0.5
 	github.com/spf13/cobra v0.0.0-20190321000552-67fc4837d267
 	github.com/spf13/pflag v1.0.3
 	github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50 // indirect

--- a/internal/pkg/oras/oras.go
+++ b/internal/pkg/oras/oras.go
@@ -26,6 +26,7 @@ import (
 	"github.com/deislabs/oras/pkg/oras"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/image"
 )
@@ -83,6 +84,10 @@ func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) er
 		return nil, nil
 	}
 	pullHandler := oras.WithPullBaseHandler(images.HandlerFunc(handlerFunc))
+
+	// discard logrus output under normal log level,
+	// a higher log level (like verbose) will still allow this output to be seen
+	logrus.SetOutput(sylog.LevelWriter(1))
 
 	_, _, err = oras.Pull(orasctx.Background(), resolver, spec.String(), store, allowedMediaTypes, pullHandler)
 	if err != nil {
@@ -152,6 +157,10 @@ func UploadImage(path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	}
 
 	descriptors := []ocispec.Descriptor{desc}
+
+	// discard logrus output under normal log level,
+	// a higher log level (like verbose) will still allow this output to be seen
+	logrus.SetOutput(sylog.LevelWriter(1))
 
 	if _, err := oras.Push(context.Background(), resolver, spec.String(), store, descriptors, oras.WithConfig(conf)); err != nil {
 		return fmt.Errorf("unable to push: %s", err)

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -191,3 +191,14 @@ func Writer() io.Writer {
 
 	return os.Stderr
 }
+
+// LevelWriter returns an io.Writer to pass to an external packages logging utility.
+// This allows you to set the threshold for when output should be discarded
+// i.e if passed a level of 1, this function returns ioutil.Discard unless --debug is specified
+func LevelWriter(threshold int) io.Writer {
+	if int(loggerLevel) <= threshold {
+		return ioutil.Discard
+	}
+
+	return os.Stderr
+}

--- a/internal/pkg/sylog/sylog_dummy.go
+++ b/internal/pkg/sylog/sylog_dummy.go
@@ -56,3 +56,8 @@ func GetEnvVar() string {
 func Writer() io.Writer {
 	return ioutil.Discard
 }
+
+// LevelWriter is a dummy function returning ioutil.Discard writer.
+func LevelWriter(threshold int) io.Writer {
+	return ioutil.Discard
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The `containerd` packages used by `oras` to push images currently outputs warnings. This PR discards them unless a `-v` or `-d` sylog level is specified.

Also adds output on successful push with oras


**This fixes or addresses the following GitHub issues:**

- Fixes #3773 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
