### PR TITLE
Oras context fix

### DIFF
--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -93,6 +93,7 @@ var PushCmd = &cobra.Command{
 			if err := oras.UploadImage(file, ref, ociAuth); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
+			sylog.Infof("Upload complete")
 		}
 	},
 

--- a/internal/pkg/oras/oras.go
+++ b/internal/pkg/oras/oras.go
@@ -153,7 +153,7 @@ func UploadImage(path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 
 	descriptors := []ocispec.Descriptor{desc}
 
-	if _, err := oras.Push(context.Background(), resolver, spec.String(), store, descriptors, oras.WithConfig(conf)); err != nil {
+	if _, err := oras.Push(orasctx.Background(), resolver, spec.String(), store, descriptors, oras.WithConfig(conf)); err != nil {
 		return fmt.Errorf("unable to push: %s", err)
 	}
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The oras project has implemented a `context` that will automatically discard logrus output. My original implementation used this, but while implementing caching in #3682, I switched it to the standard `context` implementation. This PR reverts that error.

Also adds output on successful push with oras.

Context package for reference: https://github.com/deislabs/oras/blob/master/pkg/context/context.go


**This fixes or addresses the following GitHub issues:**

- Fixes #3773 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
