### PR TITLE
Encrypt the container file system

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	remote         bool
+	encrypt        bool
 	builderURL     string
 	detached       bool
 	libraryURL     string
@@ -118,6 +119,17 @@ var buildRemoteFlag = cmdline.Flag{
 	EnvKeys:      []string{"REMOTE"},
 }
 
+// -e|--encrypt
+var buildEncryptFlag = cmdline.Flag{
+	ID:           "buildEncryptFlag",
+	Value:        &encrypt,
+	DefaultValue: false,
+	Name:         "encrypt",
+	ShortHand:    "e",
+	Usage:        "Encrypt the file system after building (requires root)",
+	EnvKeys:      []string{"ENCRYPT"},
+}
+
 // -d|--detached
 var buildDetachedFlag = cmdline.Flag{
 	ID:           "buildDetachedFlag",
@@ -202,6 +214,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&buildNoHTTPSFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildNoTestFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildRemoteFlag, BuildCmd)
+	cmdManager.RegisterFlagForCmd(&buildEncryptFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSandboxFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSectionFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildTmpdirFlag, BuildCmd)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -23,6 +23,7 @@ import (
 )
 
 func run(cmd *cobra.Command, args []string) {
+
 	buildFormat := "sif"
 	if sandbox {
 		buildFormat = "sandbox"
@@ -157,6 +158,7 @@ func run(cmd *cobra.Command, args []string) {
 					LibraryAuthToken: authToken,
 					DockerAuthConfig: authConf,
 					Fakeroot:         fakeroot,
+					Encrypted:        encrypt,
 				},
 			})
 		if err != nil {
@@ -167,6 +169,7 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While performing build: %v", err)
 		}
 	}
+	sylog.Debugf("Ending build......")
 }
 
 func checkSections() error {

--- a/cmd/starter/c/include/message.h
+++ b/cmd/starter/c/include/message.h
@@ -14,7 +14,7 @@
  * the U.S. Government has been granted for itself and others acting on its
  * behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
  * to reproduce, distribute copies to the public, prepare derivative works, and
- * perform publicly and display publicly, and to permit other to do so. 
+ * perform publicly and display publicly, and to permit other to do so.
  */
 
 #ifndef _SINGULARITY_MESSAGE_H
@@ -31,26 +31,26 @@
 #define VERBOSE3 4
 #define DEBUG 5
 
-#define ANSI_COLOR_RED          "\x1b[31m"
-#define ANSI_COLOR_GREEN        "\x1b[32m"
-#define ANSI_COLOR_YELLOW       "\x1b[33m"
-#define ANSI_COLOR_BLUE         "\x1b[34m"
-#define ANSI_COLOR_MAGENTA      "\x1b[35m"
-#define ANSI_COLOR_CYAN         "\x1b[36m"
-#define ANSI_COLOR_GRAY         "\x1b[37m"
-#define ANSI_COLOR_LIGHTGRAY    "\x1b[90m"
-#define ANSI_COLOR_LIGHTRED     "\x1b[91m"
-#define ANSI_COLOR_LIGHTGREEN   "\x1b[92m"
-#define ANSI_COLOR_LIGHTYELLOW  "\x1b[93m"
-#define ANSI_COLOR_LIGHTBLUE    "\x1b[94m"
+#define ANSI_COLOR_RED "\x1b[31m"
+#define ANSI_COLOR_GREEN "\x1b[32m"
+#define ANSI_COLOR_YELLOW "\x1b[33m"
+#define ANSI_COLOR_BLUE "\x1b[34m"
+#define ANSI_COLOR_MAGENTA "\x1b[35m"
+#define ANSI_COLOR_CYAN "\x1b[36m"
+#define ANSI_COLOR_GRAY "\x1b[37m"
+#define ANSI_COLOR_LIGHTGRAY "\x1b[90m"
+#define ANSI_COLOR_LIGHTRED "\x1b[91m"
+#define ANSI_COLOR_LIGHTGREEN "\x1b[92m"
+#define ANSI_COLOR_LIGHTYELLOW "\x1b[93m"
+#define ANSI_COLOR_LIGHTBLUE "\x1b[94m"
 #define ANSI_COLOR_LIGHTMAGENTA "\x1b[95m"
-#define ANSI_COLOR_LIGHTCYAN    "\x1b[96m"
-#define ANSI_COLOR_RESET        "\x1b[0m"
+#define ANSI_COLOR_LIGHTCYAN "\x1b[96m"
+#define ANSI_COLOR_RESET "\x1b[0m"
 
-#define MSGLVL_ENV              "SINGULARITY_MESSAGELEVEL"
+#define MSGLVL_ENV "SINGULARITY_MESSAGELEVEL"
 
-void _print(int level, const char *function, const char *file, char *format, ...) __attribute__ ((__format__(printf, 4, 5)));
+void _print(int level, const char *function, const char *file, char *format, ...) __attribute__((__format__(printf, 4, 5)));
 
-#define singularity_message(a,b...) _print(a, __func__, __FILE__, b)
+#define singularity_message(a, b...) _print(a, __func__, __FILE__, b)
 
 #endif /*_SINGULARITY_MESSAGE_H */

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -48,7 +48,6 @@ func createSIF(path string, definition, ociConf []byte, squashfile string, encry
 		Groupid:  sif.DescrDefaultGroup,
 		Link:     sif.DescrUnusedLink,
 		Data:     definition,
-		Encrypt:  encrypted,
 	}
 	definput.Size = int64(binary.Size(definput.Data))
 

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -105,10 +105,11 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		}
 
 		s := stage{}
-		s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")
+		s.b, err = types.NewBundle(conf.Opts.Encrypted, conf.Opts.TmpDir, "sbuild")
 		if err != nil {
 			return nil, err
 		}
+
 		s.name = d.Header["stage"]
 		s.b.Recipe = d
 

--- a/internal/pkg/runtime/engines/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/create_linux.go
@@ -60,7 +60,7 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 		flags = uintptr(syscall.MS_BIND | syscall.MS_REC)
 	}
 
-	sylog.Debugf("Mounting image directory %s\n", rootfs)
+	sylog.Debugf("Mounting image directory %s to %s\n", rootfs)
 	_, err = rpcOps.Mount(rootfs, sessionPath, "", syscall.MS_BIND, "errors=remount-ro")
 	if err != nil {
 		return fmt.Errorf("failed to mount directory filesystem %s: %s", rootfs, err)

--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -35,6 +35,12 @@ type MountArgs struct {
 	Data       string
 }
 
+// CryptArgs defines the arguments to mount.
+type CryptArgs struct {
+	Offset  uint64
+	Loopdev string
+}
+
 // ChrootArgs defines the arguments to chroot.
 type ChrootArgs struct {
 	Root   string

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -8,6 +8,7 @@ package client
 import (
 	"net/rpc"
 	"os"
+	"strings"
 
 	args "github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc"
 	"github.com/sylabs/singularity/pkg/util/loop"
@@ -19,7 +20,7 @@ type RPC struct {
 	Name   string
 }
 
-// Mount calls tme mount RPC using the supplied arguments.
+// Mount calls the mount RPC using the supplied arguments.
 func (t *RPC) Mount(source string, target string, filesystem string, flags uintptr, data string) (int, error) {
 	arguments := &args.MountArgs{
 		Source:     source,
@@ -30,6 +31,21 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 	}
 	var reply int
 	err := t.Client.Call(t.Name+".Mount", arguments, &reply)
+	return reply, err
+}
+
+// Decrypt calls the DeCrypt RPC using the supplied arguments.
+func (t *RPC) Decrypt(offset uint64, path string) (string, error) {
+	sp := strings.Split(path, "/")
+	loopdev := sp[len(sp)-1]
+	arguments := &args.CryptArgs{
+		Offset:  offset,
+		Loopdev: loopdev,
+	}
+
+	var reply string
+	err := t.Client.Call(t.Name+".Decrypt", arguments, &reply)
+
 	return reply, err
 }
 

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sylabs/singularity/pkg/util/crypt"
+
 	args "github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/mainthread"
@@ -30,6 +32,18 @@ func (t *Methods) Mount(arguments *args.MountArgs, reply *int) (err error) {
 	mainthread.Execute(func() {
 		err = syscall.Mount(arguments.Source, arguments.Target, arguments.Filesystem, arguments.Mountflags, arguments.Data)
 	})
+	return err
+}
+
+// DeCrypt decrypts the loop device by using dm-crypt interface
+func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) {
+
+	cryptDev := &crypt.Device{}
+
+	cryptName, err := cryptDev.GetCryptDevice(arguments.Loopdev)
+
+	*reply = "/dev/mapper/" + cryptName
+
 	return err
 }
 
@@ -134,6 +148,7 @@ func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) error {
 	} else {
 		var err error
 		image, err = os.OpenFile(arguments.Image, arguments.Mode, 0600)
+		defer image.Close()
 		if err != nil {
 			return fmt.Errorf("could not open image file: %v", err)
 		}

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -141,8 +143,9 @@ var authorizedTags = map[AuthorizedTag]struct {
 }
 
 var authorizedImage = map[string]fsContext{
-	"ext3":     {true},
-	"squashfs": {true},
+	"encryptfs": {true},
+	"ext3":      {true},
+	"squashfs":  {true},
 }
 
 var authorizedFS = map[string]fsContext{
@@ -581,6 +584,7 @@ func (p *Points) AddImage(tag AuthorizedTag, source string, dest string, fstype 
 	if flags&(syscall.MS_BIND|syscall.MS_REMOUNT|syscall.MS_REC) != 0 {
 		return fmt.Errorf("MS_BIND, MS_REC or MS_REMOUNT are not valid flags for image mount points")
 	}
+	sylog.Debugf("FStype is %s", fstype)
 	if _, ok := authorizedImage[fstype]; !ok {
 		return fmt.Errorf("mount %s image is not authorized", fstype)
 	}

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -42,6 +42,8 @@ type Bundle struct {
 
 // Options defines build time behavior to be executed on the bundle
 type Options struct {
+	// Encrypt specifies if the filesystem needs to be encrypteded
+	Encrypted bool `json:"encrypt"`
 	// sections are the parts of the definition to run during the build
 	Sections []string `json:"sections"`
 	// TmpDir specifies a non-standard temporary location to perform a build
@@ -70,7 +72,7 @@ type Options struct {
 }
 
 // NewBundle creates a Bundle environment
-func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
+func NewBundle(encrypted bool, bundleDir, bundlePrefix string) (b *Bundle, err error) {
 	b = &Bundle{}
 	b.JSONObjects = make(map[string][]byte)
 
@@ -86,6 +88,10 @@ func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
 
 	b.FSObjects = map[string]string{
 		"rootfs": "fs",
+	}
+
+	if encrypted == true {
+		b.Opts.Encrypted = true
 	}
 
 	for _, fso := range b.FSObjects {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -25,6 +25,8 @@ const (
 	SANDBOX
 	// SIF constant for sif format
 	SIF
+	// ENCRYPTFS constant for encrypted format
+	ENCRYPTFS
 )
 
 const (

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -74,6 +74,8 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 			continue
 		}
 
+		sylog.Debugf("Fs type is %s", fstype)
+
 		img.Partitions = []Section{
 			{
 				Offset: uint64(desc.Fileoff),
@@ -86,6 +88,8 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 			img.Partitions[0].Type = SQUASHFS
 		} else if fstype == sif.FsExt3 {
 			img.Partitions[0].Type = EXT3
+		} else if fstype == sif.FsEncrypt {
+			img.Partitions[0].Type = ENCRYPTFS
 		} else {
 			return fmt.Errorf("unknown file system type: %v", fstype)
 		}

--- a/pkg/runtime/engines/singularity/config/config_linux.go
+++ b/pkg/runtime/engines/singularity/config/config_linux.go
@@ -18,4 +18,5 @@ type EngineConfig struct {
 	File      *FileConfig      `json:"-"`
 	Network   *network.Setup   `json:"-"`
 	Cgroups   *cgroups.Manager `json:"-"`
+	CryptDev  string           `json:"-"`
 }

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package crypt
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/util/fs/lock"
+	"github.com/sylabs/singularity/pkg/util/loop"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// Device is
+type Device struct{}
+
+// createLoop attaches the file to the next available loop device and
+// sets the sizelimit on it
+func createLoop(file *os.File, offset, size uint64) (string, error) {
+	loopDev := &loop.Device{
+		MaxLoopDevices: 256,
+		Shared:         true,
+		Info: &loop.Info64{
+			SizeLimit: size,
+			Offset:    offset,
+			Flags:     loop.FlagsAutoClear,
+		},
+	}
+	idx := 0
+	if err := loopDev.AttachFromFile(file, os.O_RDWR, &idx); err != nil {
+		return "", fmt.Errorf("failed to attach image %s: %s", file.Name(), err)
+	}
+	return fmt.Sprintf("/dev/loop%d", idx), nil
+}
+
+// CloseCryptDevice closes the crypt device
+func (crypt *Device) CloseCryptDevice(path string) error {
+
+	cmd := exec.Command("/sbin/cryptsetup", "luksClose", path)
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: 0, Gid: 0}
+	fd, err := lock.Exclusive("/dev/mapper")
+	if err != nil {
+		return err
+	}
+	err = cmd.Run()
+	if err != nil {
+		sylog.Debugf("Unable to delete the crypt device %s", err)
+		return err
+	}
+	err = lock.Release(fd)
+	if err != nil {
+		sylog.Debugf("Unable to release the lock on /dev/mapper")
+		return err
+	}
+
+	return nil
+}
+
+// FormatCryptDevice allocates a loop device, encrypts, and returns the loop device name, and encrypted device name
+func (crypt *Device) FormatCryptDevice(path string) (string, string, error) {
+
+	// Read the password from terminal
+	fmt.Print("Enter the password to encrypt the filesystem: ")
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		sylog.Fatalf("Error parsing the password: %s", err)
+	}
+	input := string(password)
+
+	fmt.Print("\nConfirm the password: ")
+	password2, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		sylog.Fatalf("Error parsing the password: %s", err)
+	}
+	input2 := string(password2)
+	fmt.Println()
+
+	if input != input2 {
+		return "", "", errors.New("Passwords don't match")
+	}
+
+	squashF, err := os.Stat(path)
+	if err != nil {
+		sylog.Debugf("Error acquiring size of %s", path)
+		return "", "", err
+	}
+
+	squashFsSize := squashF.Size()
+
+	// Create a temporary file to format with crypt header
+	cryptF, err := ioutil.TempFile("", "crypt-")
+	if err != nil {
+		sylog.Debugf("Error creating temporary crypt file")
+		return "", "", err
+	}
+	defer cryptF.Close()
+
+	// Truncate the file taking the squashfs size and crypt header into account
+	// Crypt header is around 2MB in size. Slightly over-allocate to be safe
+	size := squashFsSize + 4*1024*1024 // 4MB for LUKS header
+
+	err = os.Truncate(cryptF.Name(), size)
+	if err != nil {
+		sylog.Debugf("Unable to truncate crypt file to size %d", size)
+		return "", "", err
+	}
+
+	// NOTE: This routine runs with root privileges. It's not necessary
+	// to explicitly set cmd's uid or gid here
+	cmd := exec.Command("/sbin/cryptsetup", "luksFormat", cryptF.Name())
+	stdin, err := cmd.StdinPipe()
+
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, input)
+	}()
+
+	err = cmd.Run()
+	if err != nil {
+		sylog.Verbosef("Unable to format crypt device")
+		return "", "", err
+	}
+
+	// Associate the temporary crypt file with a loop device
+	loop, err := createLoop(cryptF, 0, uint64(size))
+
+	sp := strings.Split(loop, "/")
+	loopdev := sp[len(sp)-1]
+
+	fd, err := lock.Exclusive("/dev/mapper")
+	if err != nil {
+		sylog.Debugf("Unable to acquire lock on /dev/mapper")
+		return "", "", err
+	}
+	nextCrypt := getNextAvailableCryptDevice()
+	cmd = exec.Command("/sbin/cryptsetup", "luksOpen", loopdev, nextCrypt)
+	cmd.Dir = "/dev"
+	stdin, err = cmd.StdinPipe()
+
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, input)
+	}()
+
+	err = cmd.Run()
+	if err != nil {
+		sylog.Verbosef("Unable to open crypt device: %s", nextCrypt)
+		return "", "", err
+	}
+
+	err = lock.Release(fd)
+	if err != nil {
+		sylog.Debugf("Unable to release lock on /dev/mapper")
+		return "", "", err
+	}
+
+	copyDeviceContents(path, "/dev/mapper/"+nextCrypt, squashFsSize)
+
+	// Open a new Temp file to stash the loop contents
+	loopF, err := ioutil.TempFile("", "loop-")
+	if err != nil {
+		sylog.Debugf("Error creating temporary crypt file")
+		return "", "", err
+	}
+
+	copyDeviceContents("/dev/"+loopdev, loopF.Name(), size)
+
+	return loopF.Name(), nextCrypt, err
+}
+
+// copyDeviceContents copies the contents of source to destination.
+// source and dest can either be a file or a block device
+func copyDeviceContents(source string, dest string, size int64) error {
+
+	squashFd, err := syscall.Open(source, syscall.O_RDWR, 0777)
+	if err != nil {
+		sylog.Debugf("Unable to open the file %s", source)
+		return err
+	}
+	defer syscall.Close(squashFd)
+
+	cryptFd, err := syscall.Open(dest, syscall.O_RDWR, 0777)
+
+	if err != nil {
+		sylog.Debugf("Unable to open the file: %s", dest)
+		return err
+	}
+
+	defer syscall.Close(cryptFd)
+
+	var writtenSoFar int64
+
+	buffer := make([]byte, 1024)
+	for writtenSoFar < size {
+		numRead, err := syscall.Read(squashFd, buffer)
+		if err != nil {
+			sylog.Debugf("Unable to read the the file %s", source)
+			return err
+		}
+		numWritten, err := syscall.Write(cryptFd, buffer)
+		if err != nil {
+			sylog.Debugf("Unable to write to destination %s", dest)
+			return err
+		}
+
+		if numRead != numWritten {
+			sylog.Debugf("numRead != numWritten")
+		}
+		writtenSoFar += int64(numWritten)
+	}
+
+	return nil
+}
+
+func getRandomString(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		sylog.Debugf("Something went wrong while generating random string")
+		return ""
+	}
+	return fmt.Sprintf("%x", b)
+}
+
+func getNextAvailableCryptDevice() string {
+	return getRandomString(15)
+}
+
+// GetCryptDevice returns the next available device in /dev/mapper for encryption/decryption
+func (crypt *Device) GetCryptDevice(loopDev string) (string, error) {
+
+	fmt.Print("Enter the password to decrypt the File System: ")
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		sylog.Fatalf("Error parsing input: %s", err)
+	}
+	fmt.Println()
+
+	fd, err := lock.Exclusive("/dev/mapper")
+	if err != nil {
+		sylog.Debugf("Unable to acquire lock on /dev/mapper while decrypting")
+		return "", err
+	}
+	defer lock.Release(fd)
+
+	maxRetries := 3 // Arbitrary number of retries.
+
+retry:
+	numRetries := 0
+	nextCrypt := getNextAvailableCryptDevice()
+	if nextCrypt == "" {
+		return "", errors.New("Crypt Device not available")
+	}
+
+	cmd := exec.Command("/sbin/cryptsetup", "luksOpen", loopDev, nextCrypt)
+	cmd.Dir = "/dev"
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: 0, Gid: 0}
+	stdin, err := cmd.StdinPipe()
+
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, string(password))
+	}()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "No key available") == true {
+			sylog.Debugf("Invalid password")
+		}
+		if strings.Contains(string(out), "Device already exists") == true {
+			numRetries++
+			if numRetries < maxRetries {
+				goto retry
+			}
+		}
+		return "", err
+	}
+	sylog.Debugf("Decrypted the FS successfully")
+
+	return nextCrypt, nil
+}

--- a/vendor/github.com/sylabs/sif/pkg/sif/create.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/create.go
@@ -129,7 +129,6 @@ func writeDataObject(fimg *FileImage, index int, input DescriptorInput) error {
 			return fmt.Errorf("copying data object data to SIF file: %s", err)
 		}
 	} else {
-		fmt.Printf("Input name: %s, Input size: %d\n", input.Fname, input.Size)
 		if n, err := io.Copy(fimg.Fp, input.Fp); err != nil {
 			return fmt.Errorf("copying data object file to SIF file: %s", err)
 		} else if n != input.Size && input.Size != 0 {

--- a/vendor/github.com/sylabs/sif/pkg/sif/create.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/create.go
@@ -129,6 +129,7 @@ func writeDataObject(fimg *FileImage, index int, input DescriptorInput) error {
 			return fmt.Errorf("copying data object data to SIF file: %s", err)
 		}
 	} else {
+		fmt.Printf("Input name: %s, Input size: %d\n", input.Fname, input.Size)
 		if n, err := io.Copy(fimg.Fp, input.Fp); err != nil {
 			return fmt.Errorf("copying data object file to SIF file: %s", err)
 		} else if n != input.Size && input.Size != 0 {

--- a/vendor/github.com/sylabs/sif/pkg/sif/fmt.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/fmt.go
@@ -89,6 +89,8 @@ func fstypeStr(ftype Fstype) string {
 		return "Archive"
 	case FsRaw:
 		return "Raw"
+	case FsEncrypt:
+		return "FsEncrypt"
 	}
 	return "Unknown fs-type"
 }

--- a/vendor/github.com/sylabs/sif/pkg/sif/sif.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/sif.go
@@ -148,6 +148,7 @@ const (
 	FsExt3                      // EXT3 file system, RDWR (deprecated)
 	FsImmuObj                   // immutable data object archive
 	FsRaw                       // raw data
+	FsEncrypt                   // Encrypted File System
 )
 
 // Parttype represents the different SIF container partition types (system and data)
@@ -299,6 +300,7 @@ type DescriptorInput struct {
 	Link      uint32   // link to be set for new descriptor
 	Size      int64    // size of the data object for the new descriptor
 	Alignment int      // Align requirement for data object
+	Encrypt   bool
 
 	Fname string    // file containing data associated with the new descriptor
 	Fp    io.Reader // file pointer to opened 'fname'


### PR DESCRIPTION

**Description of the Pull Request (PR):**

Implemented review feedback from https://github.com/sylabs/singularity/pull/3729

Locking /dev/mapper before creating crypt devices to avoid races

Deleted encryptfs.go, which is not necessary

Generate random number for crypt device

Ext3->Squashfs for encrypted FS

**This fixes or addresses the following GitHub issues:**

- Fixes #3605
- Fixes #3662 
- Fixes #3664 
- Fixes #3285
- Fixes #3517 
- Fixes #3518 
- Fixes #3519 

NOTE: CI tests are still failing. I am resolving the failures now. Pushing the code to get feedback on the latest changes while I resolve other issues.


Attn: @singularity-maintainers
