### PR TITLE
Add a branch filter so that pull requests beginning with 'pr-e2e-' will run the e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,4 +205,6 @@ workflows:
             - get_source
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - /pr-e2e-*/


### PR DESCRIPTION
**Description of the Pull Request (PR):**

PRs against the e2e tests will now be able to trigger those tests be run if their branch name begins with `pr-e2e-`.