### PR TITLE
Skip e2e tests for pull requests based on the contents of their commit range

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,3 @@ workflows:
       - e2e_tests:
           requires:
             - get_source
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,26 @@ jobs:
       - attach_workspace:
           at: ~/go
       - run:
+          name: Check changes
+          command: |-
+              if [[ -z "$CIRCLE_COMPARE_URL" ]]; then
+                  echo "CIRCLE_COMPARE_URL is required to get the git commit range, did circleci remove it?"
+                  circleci step halt
+              fi
+
+              COMMIT_RANGE=$(echo "$CIRCLE_COMPARE_URL" | sed 's:^.*/compare/::g')
+
+              echo "CIRCLE_BRANCH: $CIRCLE_BRANCH"
+              echo "CIRCLE_COMMIT_URL: $CIRCLE_COMPARE_URL"
+              echo "COMMIT_RANGE: $COMMIT_RANGE"
+
+              # Skip tests if no there were no changes to e2e/ or vendor/ and the branch is not master
+              if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "^e2e" -e "^vendor") && "$CIRCLE_BRANCH" != "master" ]]; then
+                  echo "Skipping e2e tests"
+                  circleci step halt
+              fi
+
+      - run:
           name: Setup environment
           command: |-
             echo 'export GOPATH=$HOME/go' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,7 @@ jobs:
       - run:
           name: Check changes
           command: |-
+              printenv
               if [[ -z "$CIRCLE_COMPARE_URL" ]]; then
                   echo "CIRCLE_COMPARE_URL is required to get the git commit range, did circleci remove it?"
                   circleci step halt
@@ -151,7 +152,7 @@ jobs:
               COMMIT_RANGE=$(echo "$CIRCLE_COMPARE_URL" | sed 's:^.*/compare/::g')
 
               echo "CIRCLE_BRANCH: $CIRCLE_BRANCH"
-              echo "CIRCLE_COMMIT_URL: $CIRCLE_COMPARE_URL"
+              echo "CIRCLE_COMPARE_URL: $CIRCLE_COMPARE_URL"
               echo "COMMIT_RANGE: $COMMIT_RANGE"
 
               # Skip tests if no there were no changes to e2e/ or vendor/ and the branch is not master


### PR DESCRIPTION
We only want to run e2e tests under the following condtions:

- Changes are made to the `e2e` directory
- Changes are made to the `vendor` directory
- Merging a pull request into `master`

This requires the use of the `$CIRCLE_COMPARE_URL` environment variable
provided by circleci.

In later versions, that environment variable may not be present. If that
happens, consider the `iynere/compare-url` orb for a short-term fix.

- Fixes #3430
- Fixes #3806