### PR TITLE
Fix e2e tests privileges escalation issues and remove docker dependency

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -30,8 +30,6 @@ var testenv testingEnv
 
 // run tests min fuctionality for singularity run
 func actionRun(t *testing.T) {
-	e2e.EnsureImage(t)
-
 	tests := []struct {
 		name string
 		argv []string
@@ -77,8 +75,6 @@ func actionRun(t *testing.T) {
 
 // exec tests min fuctionality for singularity exec
 func actionExec(t *testing.T) {
-	e2e.EnsureImage(t)
-
 	user := e2e.CurrentUser(t)
 
 	// Create a temp testfile
@@ -246,8 +242,6 @@ func actionExec(t *testing.T) {
 
 // Shell interaction tests
 func actionShell(t *testing.T) {
-	e2e.EnsureImage(t)
-
 	hostname, err := os.Hostname()
 	if err != nil {
 		t.Fatalf("could not get hostname: %s", err)
@@ -303,8 +297,6 @@ func actionShell(t *testing.T) {
 
 // STDPipe tests pipe stdin/stdout to singularity actions cmd
 func STDPipe(t *testing.T) {
-	e2e.EnsureImage(t)
-
 	stdinTests := []struct {
 		name    string
 		command string
@@ -437,8 +429,6 @@ func STDPipe(t *testing.T) {
 
 // RunFromURI tests min fuctionality for singularity run/exec URI://
 func RunFromURI(t *testing.T) {
-	e2e.EnsureImage(t)
-
 	runScript := "testdata/runscript.sh"
 	bind := fmt.Sprintf("%s:/.singularity.d/runscript", runScript)
 
@@ -618,8 +608,6 @@ func RunFromURI(t *testing.T) {
 
 // PersistentOverlay test the --overlay function
 func PersistentOverlay(t *testing.T) {
-	e2e.EnsureImage(t)
-
 	const squashfsImage = "squashfs.simg"
 
 	dir, err := ioutil.TempDir(testenv.TestDir, "overlay_test")

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -6,46 +6,57 @@
 package e2e
 
 import (
+	"path/filepath"
 	"testing"
-
-	"github.com/sylabs/singularity/internal/pkg/test/exec"
 )
+
+const dockerInstanceName = "e2e-docker-instance"
 
 // PrepRegistry run a docker registry and push a busybox
 // image and the test image with oras transport.
-func PrepRegistry(t *testing.T) {
-	commands := [][]string{
-		{"run", "-d", "-p", "5000:5000", "--restart=always", "--name", "registry", "registry:2"},
-		{"pull", "busybox"},
-		{"tag", "busybox", "localhost:5000/my-busybox"},
-		{"push", "localhost:5000/my-busybox"},
-	}
+func PrepRegistry(t *testing.T, baseDir string) {
+	dockerDefinition := "testdata/Docker_registry.def"
+	dockerImage := filepath.Join(baseDir, "docker-e2e.sif")
 
-	for _, command := range commands {
-		cmd := exec.Command("docker", command...)
-		if res := cmd.Run(t); res.Error != nil {
-			t.Fatalf("Command failed.\n%s", res)
-		}
-	}
+	RunSingularity(
+		t,
+		"BuildDockerRegistry",
+		WithoutSubTest(),
+		WithPrivileges(true),
+		WithCommand("build"),
+		WithArgs("-s", dockerImage, dockerDefinition),
+		ExpectExit(0),
+	)
 
-	EnsureImage(t)
-	cmd, _, err := ImagePush(t, testenv.ImagePath, "oras://localhost:5000/oras_test_sif:latest")
-	if err != nil {
-		t.Fatalf("while prepping registry with command %q: %v", cmd, err)
-	}
+	RunSingularity(
+		t,
+		"RunDockerRegistry",
+		WithoutSubTest(),
+		WithPrivileges(true),
+		WithCommand("instance start"),
+		WithArgs("-w", "-B", "/sys", dockerImage, dockerInstanceName),
+		ExpectExit(0),
+	)
+
+	RunSingularity(
+		t,
+		"OrasPushTestImage",
+		WithoutSubTest(),
+		WithCommand("push"),
+		WithArgs(testenv.ImagePath, "oras://localhost:5000/oras_test_sif:latest"),
+		ExpectExit(0),
+	)
 }
 
 // KillRegistry stop and cleanup docker registry.
 func KillRegistry(t *testing.T) {
-	commands := [][]string{
-		{"kill", "registry"},
-		{"rm", "registry"},
-	}
-
-	for _, command := range commands {
-		cmd := exec.Command("docker", command...)
-		if res := cmd.Run(t); res.Error != nil {
-			t.Fatalf("Command failed.\n%s", res)
-		}
-	}
+	RunSingularity(
+		t,
+		"KillDockerRegistry",
+		WithoutSubTest(),
+		WithPrivileges(true),
+		WithCommand("instance stop"),
+		WithArgs("-s", "KILL", dockerInstanceName),
+		ExpectExit(0),
+	)
 }

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -35,23 +35,13 @@ func EnsureImage(t *testing.T) {
 			err)
 	}
 
-	opts := BuildOpts{
-		Force:   true,
-		Sandbox: false,
-	}
-
-	Privileged(func(t *testing.T) {
-		b, err := ImageBuild(
-			testenv.CmdPath,
-			opts,
-			testenv.ImagePath,
-			"./testdata/Singularity")
-
-		if err != nil {
-			t.Logf("Failed to build image %q.\nOutput:\n%s\n",
-				testenv.ImagePath,
-				b)
-			t.Fatalf("unexpected failure: %+v", err)
-		}
-	})(t)
+	RunSingularity(
+		t,
+		"BuildTestImage",
+		WithoutSubTest(),
+		WithPrivileges(true),
+		WithCommand("build"),
+		WithArgs("--force", testenv.ImagePath, "testdata/Singularity"),
+		ExpectExit(0),
+	)
 }

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -98,8 +98,11 @@ func Run(t *testing.T) {
 	os.Setenv("E2E_IMAGE_PATH", imagePath)
 	defer os.Remove(imagePath)
 
+	// build test image
+	singularitye2e.EnsureImage(t)
+
 	// Start registry for tests
-	singularitye2e.PrepRegistry(t)
+	singularitye2e.PrepRegistry(t, name)
 	defer singularitye2e.KillRegistry(t)
 
 	// RunE2ETests by functionality

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -1,0 +1,26 @@
+bootstrap: docker
+from: registry:2.7.1
+
+%post
+    apk add docker
+    # prevent docker to add iptables rules because it
+    # add few rules even with --iptables=false
+    rm -f /sbin/iptables
+
+%startscript
+    # if there is no docker0 bridge, we could safely
+    # remove the created one after the docker daemon
+    # started
+    if ! brctl show docker0; then
+        DELETE_BRIDGE=1
+    fi
+    dockerd --iptables=false --ip-forward=false --ip-masq=false --storage-driver=vfs &
+    /.singularity.d/runscript &
+    sleep 2
+    if ! -z ${DELETE_BRIDGE}; then
+        ip link set docker0 down || kill -TERM 1
+        brctl delbr docker0
+    fi
+    docker pull busybox || kill -TERM 1
+    docker tag busybox localhost:5000/my-busybox || kill -TERM 1
+    docker push localhost:5000/my-busybox || kill -TERM 1

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -42,7 +42,7 @@ unit-test:
 .PHONY: e2e-test
 e2e-test:
 	@echo " TEST sudo go test [e2e]"
-	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race \
+	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=30m -tags "$(GO_TAGS)" -failfast -cover -race \
 		./e2e
 	@echo "       PASS"
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes :
- an oversight in `ImageVerify` using old `test.WithoutPrivilege` conflicting with new privileges handling in e2e tests.
- removes docker dependency and instead use a docker instance hosting a docker registry allowing to fix #3809 in the meantime.
- increase e2e tests timeout to 30 minutes
- add `WithoutSubTest` as a `RunSingularity` command operation to run a singularity command as part
of current test for e2e helpers

**This fixes or addresses the following GitHub issues:**

- Fixes #3809


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
