### PR TITLE
Update the circleci config to version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 
 defaults: &defaults
   working_directory: /go/singularity
@@ -33,7 +33,7 @@ jobs:
           paths:
             - '/go/pkg/mod'
 
-  go1.11.9-stretch:
+  go111-stretch:
     <<: *defaults
     docker:
       - image: sylabsio/golang:1.11.9-stretch
@@ -50,7 +50,7 @@ jobs:
           command: |-
             make -j$(nproc) -C ./builddir check
 
-  go1.11.9-alpine:
+  go111-alpine:
     <<: *defaults
     docker:
       - image: sylabsio/golang:1.11.9-alpine
@@ -67,7 +67,7 @@ jobs:
           command: |-
             make -j$(nproc) -C ./builddir check
 
-  go1.11-macos:
+  go-macos:
     macos:
       xcode: "10.2.0"
     working_directory: /Users/distiller/go/src/github.com/sylabs/singularity
@@ -188,13 +188,13 @@ workflows:
       - cache_go_mod:
           requires:
             - get_source
-      - go1.11.9-stretch:
+      - go111-stretch:
           requires:
             - cache_go_mod
-      - go1.11.9-alpine:
+      - go111-alpine:
           requires:
             - cache_go_mod
-      - go1.11-macos:
+      - go-macos:
           requires:
             - get_source
       - unit_tests:


### PR DESCRIPTION
This requires removing dots (`.`) from our job names to comply with the
updated schema.

Fixes: #3812