### PR TITLE
Update conveyorPacker_oci.go

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -356,7 +356,7 @@ fi
 # CMD only - run CMD or override with args
 if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
     if [ $# -gt 0 ]; then
-        SINGULARITY_OCI_RUN="${CMDLINE_ARGS}"
+        SINGULARITY_OCI_RUN="${OCI_CMD} ${CMDLINE_ARGS}"
     else
         SINGULARITY_OCI_RUN="${OCI_CMD}"
     fi


### PR DESCRIPTION
It seems the command is missing

singularity-3.2.1-1.el7.x86_64

singularity -s run --nv -B /lustre/MedPhys/f_abide/:/data -B /lustrehome/diacono/lstm-for-aging/lstm-for-aging/:/opt/notebooks docker://medphys/vae-gpu --port=8887 --ip=90.147.168.157
/.singularity.d/runscript: 1: set: Illegal option --

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
