### PR TITLE
Execute e2e tests inside their own pid and mount namespaces.

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -7,6 +7,16 @@ package e2e
 
 import (
 	"testing"
+
+	// This import will execute a CGO section with the help of a C
+	// constructor section "init". As we always require to run e2e
+	// tests as root, the C part is responsible of finding the original
+	// user who executes tests; it will also create a dedicated pid
+	// and mount namespace for e2e tests, and will finally restore
+	// identity to the original user but will retain privileges for
+	// Privileged method enabling the execution of a function with root
+	// privileges when required
+	_ "github.com/sylabs/singularity/e2e/internal/e2e/init"
 )
 
 func TestE2E(t *testing.T) {

--- a/e2e/internal/e2e/home.go
+++ b/e2e/internal/e2e/home.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package e2e
+
+import "testing"
+
+// SetupHomeDirectories creates temporary home directories for
+// privileged and unprivileged users and bind mount those directories
+// on top of real ones. It's possible because e2e tests are executed
+// in a dedicated mount namespace.
+func SetupHomeDirectories(t *testing.T) {
+}

--- a/e2e/internal/e2e/home_linux.go
+++ b/e2e/internal/e2e/home_linux.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/util/user"
+)
+
+// rpmMacrosContent contains required content to
+// place in $HOME/.rpmmacros file for yum bootstrap
+// build
+var rpmMacrosContent = `
+%_var /var
+%_dbpath %{_var}/lib/rpm
+`
+
+// SetupHomeDirectories creates temporary home directories for
+// privileged and unprivileged users and bind mount those directories
+// on top of real ones. It's possible because e2e tests are executed
+// in a dedicated mount namespace.
+func SetupHomeDirectories(t *testing.T) {
+	var unprivUser, privUser *user.User
+
+	sessionDir := buildcfg.SESSIONDIR
+	unprivUser = CurrentUser(t)
+
+	Privileged(func(t *testing.T) {
+		// there is no cleanup here because everything done (tmpfs, mounts)
+		// in our dedicated mount namespace will be automatically discarded
+		// by the kernel once all test processes exit
+
+		privUser = CurrentUser(t)
+
+		// create the temporary filesystem
+		if err := syscall.Mount("tmpfs", sessionDir, "tmpfs", 0, "mode=0777"); err != nil {
+			t.Fatalf("failed to mount temporary filesystem")
+		}
+
+		// want the already resolved current working directory
+		cwd, err := os.Readlink("/proc/self/cwd")
+		if err != nil {
+			t.Fatalf("could not readlink /proc/self/cwd: %s", err)
+		}
+		unprivResolvedHome, err := filepath.EvalSymlinks(unprivUser.Dir)
+		if err != nil {
+			t.Fatalf("could not resolve %s: %s", unprivUser.Dir, err)
+		}
+		privResolvedHome, err := filepath.EvalSymlinks(privUser.Dir)
+		if err != nil {
+			t.Fatalf("could not resolve %s: %s", privUser.Dir, err)
+		}
+
+		// prepare user temporary homes
+		unprivSessionHome := filepath.Join(sessionDir, unprivUser.Name)
+		privSessionHome := filepath.Join(sessionDir, privUser.Name)
+
+		oldUmask := syscall.Umask(0)
+		defer syscall.Umask(oldUmask)
+
+		if err := os.Mkdir(unprivSessionHome, 0700); err != nil {
+			t.Fatalf("failed to create temporary home %s: %s", unprivSessionHome, err)
+		}
+		if err := os.Chown(unprivSessionHome, int(unprivUser.UID), int(unprivUser.GID)); err != nil {
+			t.Fatalf("failed to set temporary home %s owner: %s", unprivSessionHome, err)
+		}
+		if err := os.Mkdir(privSessionHome, 0700); err != nil {
+			t.Fatalf("failed to create temporary home %s: %s", privSessionHome, err)
+		}
+
+		sourceDir := buildcfg.SOURCEDIR
+
+		// re-create the current source directory if it's located in the user
+		// home directory and bind it. Root home directory is not checked because
+		// the whole test suite can not run from there as we are dropping privileges
+		if strings.HasPrefix(sourceDir, unprivResolvedHome) {
+			trimmedSourceDir := strings.TrimPrefix(sourceDir, unprivResolvedHome)
+			sessionSourceDir := filepath.Join(unprivSessionHome, trimmedSourceDir)
+			if err := os.MkdirAll(sessionSourceDir, 0755); err != nil {
+				t.Fatalf("failed to create temporary home source directory %s: %s", sessionSourceDir, err)
+			}
+			if err := syscall.Mount(sourceDir, sessionSourceDir, "", syscall.MS_BIND, ""); err != nil {
+				t.Fatalf("failed to bind %s to %s: %s", sourceDir, sessionSourceDir, err)
+			}
+		}
+
+		// finally bind temporary homes on top of real ones
+		// in order to not screw them by accident during e2e
+		// tests execution
+		if err := syscall.Mount(unprivSessionHome, unprivResolvedHome, "", syscall.MS_BIND|syscall.MS_REC, ""); err != nil {
+			t.Fatalf("failed to bind %s to %s: %s", unprivSessionHome, unprivResolvedHome, err)
+		}
+		if err := syscall.Mount(privSessionHome, privResolvedHome, "", syscall.MS_BIND, ""); err != nil {
+			t.Fatalf("failed to bind %s to %s: %s", privSessionHome, privResolvedHome, err)
+		}
+		// change to the "new" working directory if above mount override
+		// the current working directory
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to change directory to %s: %s", cwd, err)
+		}
+
+		// create .rpmmacros files for yum bootstrap builds
+		macrosFile := filepath.Join(unprivSessionHome, ".rpmmacros")
+		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0444); err != nil {
+			t.Fatalf("could not write %s: %s", macrosFile, err)
+		}
+		macrosFile = filepath.Join(privSessionHome, ".rpmmacros")
+		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0444); err != nil {
+			t.Fatalf("could not write %s: %s", macrosFile, err)
+		}
+	})(t)
+}

--- a/e2e/internal/e2e/init/init.go
+++ b/e2e/internal/e2e/init/init.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package init
+
+// do nothing on unsupported platform

--- a/e2e/internal/e2e/init/init_linux.go
+++ b/e2e/internal/e2e/init/init_linux.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package init
+
+/*
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <sched.h>
+#include <sys/mount.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#define SIZE    128
+
+// getProcInfo returns the parent PID, UID, and GID associated with the
+// supplied PID.
+static pid_t getProcInfo(pid_t pid, uid_t *uid, gid_t *gid) {
+	FILE *status;
+	char procPath[SIZE];
+	char *line = NULL;
+	size_t len = 0;
+	pid_t ppid = 1;
+
+	memset(procPath, 0, SIZE);
+	if ( snprintf(procPath, SIZE-1, "/proc/%d/status", pid) > SIZE-1 ) {
+		// set returned PID to 1 to trigger error from getUnprivIDs call
+		return 1;
+	}
+
+	status = fopen(procPath, "r");
+	if ( status == NULL ) {
+		// set returned PID to 1 to trigger error from getUnprivIDs call
+		return 1;
+	}
+
+	while ( getline(&line, &len, status) != -1 ) {
+		if ( ppid == 1 ) {
+			sscanf(line, "PPid:\t%d", &ppid);
+		}
+		if ( *uid == 0 ) {
+			sscanf(line, "Uid:\t%d", uid);
+		}
+		if ( *gid == 0 ) {
+			sscanf(line, "Gid:\t%d", gid);
+		}
+	}
+
+	free(line);
+	fclose(status);
+
+	return ppid;
+}
+
+// getUnprivIDs searches recursively up the process parent chain to find a
+// process with a non-root UID, then returns the UID and GID of that process.
+static int getUnprivIDs(pid_t pid, uid_t *uid, gid_t *gid) {
+	// PID 1 here means we didn't find a process containing
+	// identity of the original user or an error occurred in
+	// getProcInfo
+	if ( pid == 1 ) {
+		return -1;
+	}
+	pid_t ppid = getProcInfo(pid, uid, gid);
+	if ( *uid == 0 ) {
+		return getUnprivIDs(ppid, uid, gid);
+	}
+	return 0;
+}
+
+// create and use a PID namespace if possible to avoid leaving some processes
+// once tests are done. Child process won't catch orphaned child processes like
+// instances, and we can't really catch them correctly to avoid conflicts during
+// `cmd.Wait()` calls. But this is not a big deal compared to detached processes
+// that could keep running on host machine after the tests execution.
+static void create_pid_namespace(void) {
+	if ( unshare(CLONE_NEWPID) == 0 ) {
+		pid_t forked = fork();
+		if ( forked > 0 ) {
+			// parent process will wait that tests execution finished
+			int status, exit_status = 0;
+			pid_t child;
+
+			child = waitpid(forked, &status, 0);
+			if ( child < 0 ) {
+				fprintf(stderr, "unexpected error while waiting children: %s\n", strerror(errno));
+				exit(1);
+			}
+
+			if ( WIFEXITED(status) ) {
+				if ( WEXITSTATUS(status) != 0 ) {
+					exit_status = WEXITSTATUS(status);
+				}
+			} else if ( WIFSIGNALED(status) ) {
+				kill(getpid(), WTERMSIG(status));
+				exit_status = 128 + WTERMSIG(status);
+			}
+			exit(exit_status);
+		}
+
+		// mount a new proc filesystem for the new PID namespace
+		if ( mount(NULL, "/proc", "proc", MS_NOSUID|MS_NODEV, NULL) < 0 ) {
+			fprintf(stderr, "failed to set private mount propagation: %s\n", strerror(errno));
+			exit(1);
+		}
+		// return to the child process
+	}
+}
+
+// create and use a mount namespace in order to bind a temporary
+// filesystem on top of home directories and not screw them up by
+// accident during tests execution.
+static void create_mount_namespace(void) {
+	if ( unshare(CLONE_FS) < 0 ) {
+		fprintf(stderr, "failed to unshare filesystem: %s\n", strerror(errno));
+		exit(1);
+	}
+	if ( unshare(CLONE_NEWNS) < 0 ) {
+		fprintf(stderr, "failed to create mount namespace: %s\n", strerror(errno));
+		exit(1);
+	}
+	if ( mount(NULL, "/", NULL, MS_PRIVATE|MS_REC, NULL) < 0 ) {
+		fprintf(stderr, "failed to set private mount propagation: %s\n", strerror(errno));
+		exit(1);
+	}
+}
+
+// This is the CGO init constructor called before executing any Go code
+// in e2e/e2e_test.go.
+__attribute__((constructor)) static void init(void) {
+	uid_t uid = 0;
+	gid_t gid = 0;
+
+	if ( getuid() != 0 ) {
+		fprintf(stderr, "tests must be executed as root user\n");
+		exit(1);
+	}
+	if ( getUnprivIDs(getppid(), &uid, &gid) < 0 ) {
+		fprintf(stderr, "failed to retrieve user information\n");
+		exit(1);
+	}
+	if ( uid == 0 || gid == 0 ) {
+		fprintf(stderr, "failed to retrieve user information\n");
+		exit(1);
+	}
+
+	create_mount_namespace();
+	create_pid_namespace();
+
+	// set original user identity and retain privileges for
+	// Privileged method
+	if ( setresgid(gid, gid, 0) < 0 ) {
+		fprintf(stderr, "setresgid failed: %s\n", strerror(errno));
+		exit(1);
+	}
+	if ( setresuid(uid, uid, 0) < 0 ) {
+		fprintf(stderr, "setresuid failed: %s\n", strerror(errno));
+		exit(1);
+	}
+}
+*/
+import "C"

--- a/e2e/internal/e2e/priv.go
+++ b/e2e/internal/e2e/priv.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package e2e
+
+import (
+	"testing"
+)
+
+// Privileged wraps the supplied test function with calls to ensure
+// the test is run with elevated privileges.
+func Privileged(f func(*testing.T)) func(*testing.T) {
+	return f
+}

--- a/e2e/internal/e2e/priv_linux.go
+++ b/e2e/internal/e2e/priv_linux.go
@@ -5,88 +5,6 @@
 
 package e2e
 
-/*
-#define _GNU_SOURCE
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-
-#define SIZE    128
-
-// getProcInfo returns the parent PID, UID, and GID associated with the
-// supplied PID.
-static pid_t getProcInfo(pid_t pid, uid_t *uid, gid_t *gid) {
-	FILE *status;
-	char procPath[SIZE];
-	char *line = NULL;
-	size_t len = 0;
-	pid_t ppid = 1;
-
-	memset(procPath, 0, SIZE);
-	snprintf(procPath, SIZE-1, "/proc/%d/status", pid);
-
-	status = fopen(procPath, "r");
-	if ( status == NULL ) {
-		return 1;
-	}
-
-	while ( getline(&line, &len, status) != -1 ) {
-		if ( ppid == 1 ) {
-			sscanf(line, "PPid:\t%d", &ppid);
-		}
-		if ( *uid == 0 ) {
-			sscanf(line, "Uid:\t%d", uid);
-		}
-		if ( *gid == 0 ) {
-			sscanf(line, "Gid:\t%d", gid);
-		}
-	}
-
-	free(line);
-	fclose(status);
-
-	return ppid;
-}
-
-// getUnprivIDs searches recursively up the process parent chain to find a
-// process with a non-root UID, then returns the UID and GID of that process.
-static int getUnprivIDs(pid_t pid, uid_t *uid, gid_t *gid) {
-	if ( pid == 1 ) {
-		return -1;
-	}
-	pid_t ppid = getProcInfo(pid, uid, gid);
-	if ( *uid == 0 ) {
-		return getUnprivIDs(ppid, uid, gid);
-	}
-	return 0;
-}
-
-__attribute__((constructor)) static void init(void) {
-	uid_t uid = 0;
-	gid_t gid = 0;
-
-	if ( getUnprivIDs(getppid(), &uid, &gid) < 0 ) {
-		fprintf(stderr, "failed to retrieve user information\n");
-		exit(1);
-	}
-	if ( uid == 0 || gid == 0 ) {
-		fprintf(stderr, "failed to retrieve user information\n");
-		exit(1);
-	}
-	if ( setresgid(gid, gid, 0) < 0 ) {
-		fprintf(stderr, "setresgid failed: %s\n", strerror(errno));
-		exit(1);
-	}
-	if ( setresuid(uid, uid, 0) < 0 ) {
-		fprintf(stderr, "setresuid failed: %s\n", strerror(errno));
-		exit(1);
-	}
-}
-*/
-import "C"
-
 import (
 	"os"
 	"runtime"
@@ -94,15 +12,13 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/client/cache"
-
-	"github.com/sylabs/singularity/internal/pkg/util/user"
 )
 
 var (
-	// uid user running test.
-	uid = os.Getuid()
-	// gid group running test.
-	gid = os.Getgid()
+	// uid of original user running test.
+	origUID = os.Getuid()
+	// gid of original group running test.
+	origGID = os.Getgid()
 )
 
 // Privileged wraps the supplied test function with calls to ensure
@@ -113,10 +29,10 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 
 		runtime.LockOSThread()
 
-		if err := syscall.Setresuid(0, 0, uid); err != nil {
+		if err := syscall.Setresuid(0, 0, origUID); err != nil {
 			t.Fatalf("privileges escalation failed: %s", err)
 		}
-		if err := syscall.Setresgid(0, 0, gid); err != nil {
+		if err := syscall.Setresgid(0, 0, origGID); err != nil {
 			t.Fatalf("privileges escalation failed: %s", err)
 		}
 		// NEED FIX: it shouldn't be set/restored globally, only
@@ -124,10 +40,10 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 		os.Setenv(cache.DirEnv, cacheDirPriv)
 
 		defer func() {
-			if err := syscall.Setresgid(gid, gid, 0); err != nil {
+			if err := syscall.Setresgid(origGID, origGID, 0); err != nil {
 				t.Fatalf("privileges drop failed: %s", err)
 			}
-			if err := syscall.Setresuid(uid, uid, 0); err != nil {
+			if err := syscall.Setresuid(origUID, origUID, 0); err != nil {
 				t.Fatalf("privileges drop failed: %s", err)
 			}
 			// NEED FIX: see above comment
@@ -137,17 +53,4 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 
 		f(t)
 	}
-}
-
-// CurrentUser returns the current user account information. Use of user.Current is
-// not safe with e2e tests as the user information is cached after the first call,
-// so it will always return the same user information which could be wrong if
-// user.Current was first called in unprivileged context and called after in a
-// privileged context as it will return information of unprivileged user.
-func CurrentUser(t *testing.T) *user.User {
-	u, err := user.GetPwUID(uint32(os.Getuid()))
-	if err != nil {
-		t.Fatalf("failed to retrieve user information")
-	}
-	return u
 }

--- a/e2e/internal/e2e/user.go
+++ b/e2e/internal/e2e/user.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/util/user"
+)
+
+// CurrentUser returns the current user account information. Use of user.Current is
+// not safe with e2e tests as the user information is cached after the first call,
+// so it will always return the same user information which could be wrong if
+// user.Current was first called in unprivileged context and called after in a
+// privileged context as it will return information of unprivileged user.
+func CurrentUser(t *testing.T) *user.User {
+	u, err := user.GetPwUID(uint32(os.Getuid()))
+	if err != nil {
+		t.Fatalf("failed to retrieve user information")
+	}
+	return u
+}

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
-	"github.com/sylabs/singularity/internal/pkg/test"
 	"github.com/sylabs/singularity/internal/pkg/test/exec"
 )
 
@@ -25,9 +24,6 @@ type ctx struct {
 // It Verifies that adding valid endpoints results in success and invalid
 // one's results in failure.
 func (c *ctx) remoteAdd(t *testing.T) {
-
-	test.DropPrivilege(t)
-
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -78,8 +74,6 @@ func (c *ctx) remoteAdd(t *testing.T) {
 // 2. Deletes the already added entries
 // 3. Verfies that removing an invalid entry results in a failure
 func (c *ctx) remoteRemove(t *testing.T) {
-	test.DropPrivilege(t)
-
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -147,8 +141,6 @@ func (c *ctx) remoteRemove(t *testing.T) {
 // 1. Tries to use non-existing remote entry
 // 2. Adds remote entries and tries to use those
 func (c *ctx) remoteUse(t *testing.T) {
-	test.DropPrivilege(t)
-
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -217,8 +209,6 @@ func (c *ctx) remoteUse(t *testing.T) {
 // 2. Verifies that remote status command succeeds on existing endpoints
 // 3. Verifies that remote status command fails on non-existing endpoints
 func (c *ctx) remoteStatus(t *testing.T) {
-	test.DropPrivilege(t)
-
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -284,8 +274,6 @@ func (c *ctx) remoteStatus(t *testing.T) {
 
 // remoteList tests the functionality of "singularity remote list" command
 func (c *ctx) remoteList(t *testing.T) {
-	test.DropPrivilege(t)
-
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -73,6 +73,12 @@ func Run(t *testing.T) {
 		return filepath.Join(buildcfg.SYSCONFDIR, "singularity", fn)
 	}
 
+	// e2e tests need to run in a somehow agnostic environment, so we
+	// don't use environment of user executing tests in order to not
+	// wrongly interfering with cache stuff, sylabs library tokens,
+	// PGP keys
+	singularitye2e.SetupHomeDirectories(t)
+
 	// Ensure config files are installed
 	configFiles := []string{
 		sysconfdir("singularity.conf"),

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -16,11 +16,15 @@ from: registry:2.7.1
     fi
     dockerd --iptables=false --ip-forward=false --ip-masq=false --storage-driver=vfs &
     /.singularity.d/runscript &
-    sleep 2
-    if ! -z ${DELETE_BRIDGE}; then
+    # wait until docker registry is up
+    while ! wget 127.0.0.1:5000 >/dev/null 2>&1; do sleep 0.2; done
+    if [ ! -z "${DELETE_BRIDGE}" ]; then
         ip link set docker0 down || kill -TERM 1
         brctl delbr docker0
     fi
     docker pull busybox || kill -TERM 1
     docker tag busybox localhost:5000/my-busybox || kill -TERM 1
     docker push localhost:5000/my-busybox || kill -TERM 1
+    # e2e PrepRegistry will repeatedly trying to connect to this port
+    # giving indication that it can start
+    nc -l -p 5111

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -14,6 +14,7 @@ config_add_def PACKAGE_BUGREPORT \"support@sylabs.io\"
 config_add_def PACKAGE_URL \"\"
 
 config_add_def BUILDDIR \"$builddir\"
+config_add_def SOURCEDIR \"$sourcedir\"
 config_add_def PREFIX \"$prefix\"
 config_add_def EXECPREFIX \"$exec_prefix\"
 config_add_def BINDIR \"$bindir\"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Execute e2e tests inside their own pid and mount namespaces:
  - pid namespace ensure no pending process will live after tests finished
  - mount namespace will allow to manipulate binds without to worry about host mount namespace, and it allow actually to setup temporary home directories
- A temporary filesystem is now setup and home directories are
created in this temporary filesystem and bound to the original
ones, that would ease e2e tests and avoid to screw them up during
tests execution (think about singularity cache, library tokens, PGP
keys ...)
- Remove unnecessary call to `EnsureImage`, cleanup code a bit.

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
