### PR TITLE
Add mandatory argument to RunSingularity to specify binary to use

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -61,7 +61,7 @@ func (c *actionTests) actionRun(t *testing.T) {
 	for _, tt := range tests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("run"),
 			e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit),
@@ -229,7 +229,7 @@ func (c *actionTests) actionExec(t *testing.T) {
 	for _, tt := range tests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),
 			e2e.WithDir("/tmp"),
 			e2e.WithArgs(tt.argv...),
@@ -293,7 +293,7 @@ func (c *actionTests) actionShell(t *testing.T) {
 	for _, tt := range tests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("shell"),
 			e2e.WithArgs(tt.argv...),
 			e2e.ConsoleRun(tt.consoleOps...),
@@ -378,7 +378,7 @@ func (c *actionTests) STDPipe(t *testing.T) {
 	for _, tt := range stdinTests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
 			e2e.WithStdin(&input),
@@ -430,7 +430,7 @@ func (c *actionTests) STDPipe(t *testing.T) {
 	for _, tt := range stdoutTests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(
@@ -620,7 +620,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 	for _, tt := range tests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit),
@@ -754,7 +754,7 @@ func (c *actionTests) PersistentOverlay(t *testing.T) {
 	for _, tt := range tests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.argv...),
 			e2e.WithPrivileges(tt.privileged),

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -59,7 +59,7 @@ func (c *actionTests) actionRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("run"),
@@ -227,7 +227,7 @@ func (c *actionTests) actionExec(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),
@@ -291,7 +291,7 @@ func (c *actionTests) actionShell(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("shell"),
@@ -376,7 +376,7 @@ func (c *actionTests) STDPipe(t *testing.T) {
 	var input bytes.Buffer
 
 	for _, tt := range stdinTests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand(tt.command),
@@ -428,7 +428,7 @@ func (c *actionTests) STDPipe(t *testing.T) {
 		},
 	}
 	for _, tt := range stdoutTests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand(tt.command),
@@ -618,7 +618,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand(tt.command),
@@ -752,7 +752,7 @@ func (c *actionTests) PersistentOverlay(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -93,7 +93,7 @@ func (c *ctx) testDockerPulls(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("pull"),
@@ -118,7 +118,7 @@ func (c *ctx) testDockerAUFS(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	defer os.Remove(imagePath)
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
 		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-aufs-sanity"}...),
@@ -147,7 +147,7 @@ func (c *ctx) testDockerAUFS(t *testing.T) {
 	}
 
 	for _, tt := range fileTests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),
@@ -162,7 +162,7 @@ func (c *ctx) testDockerPermissions(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	defer os.Remove(imagePath)
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
 		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-singularity-userperms"}...),
@@ -190,7 +190,7 @@ func (c *ctx) testDockerPermissions(t *testing.T) {
 		},
 	}
 	for _, tt := range fileTests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),
@@ -205,7 +205,7 @@ func (c *ctx) testDockerWhiteoutSymlink(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	defer os.Remove(imagePath)
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
 		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-singularity-linkwh"}...),
@@ -267,7 +267,7 @@ func (c *ctx) testDockerDefFile(t *testing.T) {
 			From:      tt.from,
 		})
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithPrivileges(true),
@@ -335,7 +335,7 @@ func (c *ctx) testDockerRegistry(t *testing.T) {
 	for _, tt := range tests {
 		defFile := e2e.PrepareDefFile(tt.dfd)
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -95,7 +95,7 @@ func (c *ctx) testDockerPulls(t *testing.T) {
 	for _, tt := range tests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("pull"),
 			e2e.WithArgs(append(tt.options, tt.image, tt.uri)...),
 			e2e.PostRun(func(t *testing.T) {
@@ -120,8 +120,6 @@ func (c *ctx) testDockerAUFS(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"DockerAUFS",
-		e2e.WithoutSubTest(),
 		e2e.WithCommand("build"),
 		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-aufs-sanity"}...),
 		e2e.ExpectExit(0),
@@ -151,7 +149,7 @@ func (c *ctx) testDockerAUFS(t *testing.T) {
 	for _, tt := range fileTests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit),
@@ -166,8 +164,6 @@ func (c *ctx) testDockerPermissions(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"DockerPermissions",
-		e2e.WithoutSubTest(),
 		e2e.WithCommand("build"),
 		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-singularity-userperms"}...),
 		e2e.ExpectExit(0),
@@ -196,7 +192,7 @@ func (c *ctx) testDockerPermissions(t *testing.T) {
 	for _, tt := range fileTests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit),
@@ -211,8 +207,6 @@ func (c *ctx) testDockerWhiteoutSymlink(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"DockerWhiteoutSymlink",
-		e2e.WithoutSubTest(),
 		e2e.WithCommand("build"),
 		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-singularity-linkwh"}...),
 		e2e.PostRun(func(t *testing.T) {
@@ -275,7 +269,7 @@ func (c *ctx) testDockerDefFile(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),
 			e2e.WithArgs([]string{imagePath, deffile}...),
@@ -343,7 +337,6 @@ func (c *ctx) testDockerRegistry(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),
 			e2e.WithArgs([]string{imagePath, defFile}...),

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -90,7 +90,7 @@ func (c *ctx) singularityEnv(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("exec"),

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -92,7 +92,6 @@ func (c *ctx) singularityEnv(t *testing.T) {
 	for _, tt := range tests {
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("exec"),
 			e2e.WithEnv(tt.env),

--- a/e2e/help/help.go
+++ b/e2e/help/help.go
@@ -55,7 +55,7 @@ func (c *ctx) testHelpOciContent(t *testing.T) {
 			assert.Assert(t, golden.String(got, path))
 		}
 
-		e2e.RunSingularity(t, tc.name, e2e.WithCommand("help"), e2e.WithArgs(tc.cmds...),
+		e2e.RunSingularity(t, e2e.AsSubtest(tc.name), e2e.WithCommand("help"), e2e.WithArgs(tc.cmds...),
 			e2e.PostRun(func(t *testing.T) {
 				if t.Failed() {
 					t.Fatalf("Failed to run help command on test: %s", tc.name)
@@ -123,7 +123,7 @@ func (c *ctx) testCommands(t *testing.T) {
 				argRun = tf.argv
 			}
 
-			e2e.RunSingularity(t, tf.name, e2e.WithCommand(cmdRun), e2e.WithArgs(argRun),
+			e2e.RunSingularity(t, e2e.AsSubtest(tf.name), e2e.WithCommand(cmdRun), e2e.WithArgs(argRun),
 				e2e.PostRun(func(t *testing.T) {
 					if t.Failed() {
 						t.Fatalf("Failed to run help flag while running command:\n%s\n", tt.name)
@@ -158,7 +158,7 @@ func (c *ctx) testFailure(t *testing.T) {
 
 	for _, tt := range tests {
 
-		e2e.RunSingularity(t, tt.name, e2e.WithArgs(tt.argv...),
+		e2e.RunSingularity(t, e2e.AsSubtest(tt.name), e2e.WithArgs(tt.argv...),
 			e2e.PostRun(func(t *testing.T) {
 				if !t.Failed() {
 					t.Fatalf("While running command:\n%s\nUnexpected success", tt.name)
@@ -192,7 +192,7 @@ func (c *ctx) testSingularity(t *testing.T) {
 			}
 		}
 
-		e2e.RunSingularity(t, tt.name, e2e.WithArgs(tt.argv...),
+		e2e.RunSingularity(t, e2e.AsSubtest(tt.name), e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit, printSuccessOrFailureFn))
 	}
 

--- a/e2e/help/help.go
+++ b/e2e/help/help.go
@@ -55,7 +55,7 @@ func (c *ctx) testHelpOciContent(t *testing.T) {
 			assert.Assert(t, golden.String(got, path))
 		}
 
-		e2e.RunSingularity(t, e2e.AsSubtest(tc.name), e2e.WithCommand("help"), e2e.WithArgs(tc.cmds...),
+		c.env.RunSingularity(t, e2e.AsSubtest(tc.name), e2e.WithCommand("help"), e2e.WithArgs(tc.cmds...),
 			e2e.PostRun(func(t *testing.T) {
 				if t.Failed() {
 					t.Fatalf("Failed to run help command on test: %s", tc.name)
@@ -123,7 +123,7 @@ func (c *ctx) testCommands(t *testing.T) {
 				argRun = tf.argv
 			}
 
-			e2e.RunSingularity(t, e2e.AsSubtest(tf.name), e2e.WithCommand(cmdRun), e2e.WithArgs(argRun),
+			c.env.RunSingularity(t, e2e.AsSubtest(tf.name), e2e.WithCommand(cmdRun), e2e.WithArgs(argRun),
 				e2e.PostRun(func(t *testing.T) {
 					if t.Failed() {
 						t.Fatalf("Failed to run help flag while running command:\n%s\n", tt.name)
@@ -158,7 +158,7 @@ func (c *ctx) testFailure(t *testing.T) {
 
 	for _, tt := range tests {
 
-		e2e.RunSingularity(t, e2e.AsSubtest(tt.name), e2e.WithArgs(tt.argv...),
+		c.env.RunSingularity(t, e2e.AsSubtest(tt.name), e2e.WithArgs(tt.argv...),
 			e2e.PostRun(func(t *testing.T) {
 				if !t.Failed() {
 					t.Fatalf("While running command:\n%s\nUnexpected success", tt.name)
@@ -192,7 +192,7 @@ func (c *ctx) testSingularity(t *testing.T) {
 			}
 		}
 
-		e2e.RunSingularity(t, e2e.AsSubtest(tt.name), e2e.WithArgs(tt.argv...),
+		c.env.RunSingularity(t, e2e.AsSubtest(tt.name), e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit, printSuccessOrFailureFn))
 	}
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -59,7 +59,6 @@ func (c *imgBuildTests) buildFrom(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
@@ -136,7 +135,6 @@ func (c *imgBuildTests) nonRootBuild(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
@@ -179,7 +177,6 @@ func (c *imgBuildTests) buildLocalImage(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"test-sandbox",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--sandbox", sandboxImage, c.env.ImagePath),
@@ -209,19 +206,17 @@ func (c *imgBuildTests) buildLocalImage(t *testing.T) {
 
 	for i, tt := range tests {
 		imagePath := filepath.Join(tmpdir, fmt.Sprintf("image-%d", i))
-		t.Run(tt.name, e2e.Privileged(func(t *testing.T) {
-			e2e.RunSingularity(
-				t,
-				tt.name,
-				e2e.WithPrivileges(true),
-				e2e.WithCommand("build"),
-				e2e.WithArgs(imagePath, tt.buildSpec),
-				e2e.PostRun(func(t *testing.T) {
-					e2e.ImageVerify(t, c.env.CmdPath, imagePath)
-				}),
-				e2e.ExpectExit(0),
-			)
-		}))
+		e2e.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithPrivileges(true),
+			e2e.WithCommand("build"),
+			e2e.WithArgs(imagePath, tt.buildSpec),
+			e2e.PostRun(func(t *testing.T) {
+				e2e.ImageVerify(t, c.env.CmdPath, imagePath)
+			}),
+			e2e.ExpectExit(0),
+		)
 	}
 }
 
@@ -229,7 +224,6 @@ func (c *imgBuildTests) badPath(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	e2e.RunSingularity(
 		t,
-		"bad path",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(imagePath, "/some/dumb/path"),
@@ -426,7 +420,6 @@ func (c *imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
@@ -724,7 +717,6 @@ func (c *imgBuildTests) buildDefinition(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -57,7 +57,7 @@ func (c *imgBuildTests) buildFrom(t *testing.T) {
 		}
 		args = append(args, imagePath, tt.buildSpec)
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),
@@ -133,7 +133,7 @@ func (c *imgBuildTests) nonRootBuild(t *testing.T) {
 		}
 		args = append(args, imagePath, tt.buildSpec)
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("build"),
@@ -175,7 +175,7 @@ func (c *imgBuildTests) buildLocalImage(t *testing.T) {
 
 	sandboxImage := path.Join(tmpdir, "test-sandbox")
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("build"),
@@ -206,7 +206,7 @@ func (c *imgBuildTests) buildLocalImage(t *testing.T) {
 
 	for i, tt := range tests {
 		imagePath := filepath.Join(tmpdir, fmt.Sprintf("image-%d", i))
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithPrivileges(true),
@@ -222,7 +222,7 @@ func (c *imgBuildTests) buildLocalImage(t *testing.T) {
 
 func (c *imgBuildTests) badPath(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("build"),
@@ -418,7 +418,7 @@ func (c *imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 		}
 		args = append(args, imagePath, defFile)
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),
@@ -715,7 +715,7 @@ func (c *imgBuildTests) buildDefinition(t *testing.T) {
 		}
 		args = append(args, imagePath, defFile)
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("build"),

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -34,9 +34,8 @@ func (c *ctx) testBasicEchoServer(t *testing.T) {
 	args := []string{c.env.ImagePath, instanceName, strconv.Itoa(instanceStartPort)}
 
 	// Start the instance.
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
-		instanceName,
 		e2e.WithCommand("instance start"),
 		e2e.WithPrivileges(c.privileged),
 		e2e.WithArgs(args...),
@@ -61,9 +60,8 @@ func (c *ctx) testCreateManyInstances(t *testing.T) {
 		port := instanceStartPort + i
 		instanceName := "echo" + strconv.Itoa(i+1)
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
-			instanceName,
 			e2e.WithCommand("instance start"),
 			e2e.WithPrivileges(c.privileged),
 			e2e.WithArgs(c.env.ImagePath, instanceName, strconv.Itoa(port)),
@@ -106,9 +104,8 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 	}
 
 	// Start an instance with the temporary directory as the home directory.
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
-		instanceName,
 		e2e.WithCommand("instance start"),
 		e2e.WithPrivileges(c.privileged),
 		e2e.WithArgs(
@@ -156,9 +153,8 @@ func (c *ctx) testContain(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Start the instance.
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
-		instanceName,
 		e2e.WithCommand("instance start"),
 		e2e.WithPrivileges(c.privileged),
 		e2e.WithArgs(
@@ -212,9 +208,8 @@ func (c *ctx) testInstanceFromURI(t *testing.T) {
 
 	for _, i := range instances {
 		args := []string{i.uri, i.name}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
-			i.name,
 			e2e.WithCommand("instance start"),
 			e2e.WithPrivileges(c.privileged),
 			e2e.WithArgs(args...),

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -69,18 +69,11 @@ func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (s
 }
 
 func (c *ctx) execInstance(t *testing.T, instance string, execArgs ...string) (stdout string, stderr string, success bool) {
-	name := "Exec"
-
 	args := []string{"instance://" + instance}
 	args = append(args, execArgs...)
 
-	if len(execArgs) > 0 {
-		name = fmt.Sprintf("%s_%s", name, execArgs[0])
-	}
-
 	e2e.RunSingularity(
 		t,
-		name,
 		e2e.WithCommand("exec"),
 		e2e.WithPrivileges(c.privileged),
 		e2e.WithArgs(args...),

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -31,9 +31,8 @@ type instanceList struct {
 func (c *ctx) listInstance(t *testing.T, listArgs ...string) (stdout string, stderr string, success bool) {
 	var args []string
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
-		"List",
 		e2e.WithCommand("instance list"),
 		e2e.WithPrivileges(c.privileged),
 		e2e.WithArgs(args...),
@@ -53,9 +52,8 @@ func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (s
 		args = append(args, instance)
 	}
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
-		"Stop",
 		e2e.WithCommand("instance stop"),
 		e2e.WithPrivileges(c.privileged),
 		e2e.WithArgs(args...),
@@ -72,7 +70,7 @@ func (c *ctx) execInstance(t *testing.T, instance string, execArgs ...string) (s
 	args := []string{"instance://" + instance}
 	args = append(args, execArgs...)
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("exec"),
 		e2e.WithPrivileges(c.privileged),
@@ -99,9 +97,8 @@ func (c *ctx) expectedNumberOfInstances(t *testing.T, n int) {
 		nbInstances = len(instances.Instances)
 	}
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
-		"GetNumberOfInstances",
 		e2e.WithCommand("instance list"),
 		e2e.WithPrivileges(c.privileged),
 		e2e.WithArgs([]string{"--json"}...),

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -32,7 +32,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 		dockerDefinition := "testdata/Docker_registry.def"
 		dockerImage := filepath.Join(env.TestDir, "docker-e2e.sif")
 
-		RunSingularity(
+		env.RunSingularity(
 			t,
 			WithPrivileges(true),
 			WithCommand("build"),
@@ -42,7 +42,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 
 		var umountFn func(*testing.T)
 
-		RunSingularity(
+		env.RunSingularity(
 			t,
 			WithPrivileges(true),
 			WithCommand("instance start"),
@@ -77,7 +77,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 			}
 		}
 
-		RunSingularity(
+		env.RunSingularity(
 			t,
 			WithCommand("push"),
 			WithArgs(env.ImagePath, env.OrasTestImage),
@@ -94,7 +94,7 @@ func KillRegistry(t *testing.T, env TestEnv) {
 
 	var umountFn func(*testing.T)
 
-	RunSingularity(
+	env.RunSingularity(
 		t,
 		WithPrivileges(true),
 		WithCommand("instance stop"),

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -34,8 +34,6 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 
 		RunSingularity(
 			t,
-			"BuildDockerRegistry",
-			WithoutSubTest(),
 			WithPrivileges(true),
 			WithCommand("build"),
 			WithArgs("-s", dockerImage, dockerDefinition),
@@ -46,8 +44,6 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 
 		RunSingularity(
 			t,
-			"RunDockerRegistry",
-			WithoutSubTest(),
 			WithPrivileges(true),
 			WithCommand("instance start"),
 			WithArgs("-w", "-B", "/sys", dockerImage, dockerInstanceName),
@@ -83,8 +79,6 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 
 		RunSingularity(
 			t,
-			"OrasPushTestImage",
-			WithoutSubTest(),
 			WithCommand("push"),
 			WithArgs(env.ImagePath, env.OrasTestImage),
 			ExpectExit(0),
@@ -102,8 +96,6 @@ func KillRegistry(t *testing.T, env TestEnv) {
 
 	RunSingularity(
 		t,
-		"KillDockerRegistry",
-		WithoutSubTest(),
 		WithPrivileges(true),
 		WithCommand("instance stop"),
 		WithArgs("-s", "KILL", dockerInstanceName),

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -5,6 +5,8 @@
 
 package e2e
 
+import "testing"
+
 type TestEnv struct {
 	RunDisabled   bool
 	CmdPath       string
@@ -13,4 +15,12 @@ type TestEnv struct {
 	TestDir       string
 	TestRegistry  string
 	KeyringDir    string
+}
+
+// RunSingularity is a convinience wrapper for the standalone
+// RunSingularity function, ensuring that RunSingularity gets called
+// with the correct singularity path as specified by the test
+// environment.
+func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
+	RunSingularity(t, env.CmdPath, cmdOps...)
 }

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -28,7 +28,7 @@ func EnsureImage(t *testing.T, env TestEnv) {
 			err)
 	}
 
-	RunSingularity(
+	env.RunSingularity(
 		t,
 		WithPrivileges(true),
 		WithCommand("build"),
@@ -38,7 +38,7 @@ func EnsureImage(t *testing.T, env TestEnv) {
 }
 
 // PullImage will pull a test image.
-func PullImage(t *testing.T, imageURL string, path string) {
+func PullImage(t *testing.T, env TestEnv, imageURL string, path string) {
 	switch _, err := os.Stat(path); {
 	case err == nil:
 		// OK: file exists, return
@@ -52,7 +52,7 @@ func PullImage(t *testing.T, imageURL string, path string) {
 		t.Fatalf("Failed when checking image %q: %+v\n", path, err)
 	}
 
-	RunSingularity(
+	env.RunSingularity(
 		t,
 		WithPrivileges(false),
 		WithCommand("pull"),

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -30,8 +30,6 @@ func EnsureImage(t *testing.T, env TestEnv) {
 
 	RunSingularity(
 		t,
-		"BuildTestImage",
-		WithoutSubTest(),
 		WithPrivileges(true),
 		WithCommand("build"),
 		WithArgs("--force", env.ImagePath, "testdata/Singularity"),
@@ -56,8 +54,6 @@ func PullImage(t *testing.T, imageURL string, path string) {
 
 	RunSingularity(
 		t,
-		"PullTestImage",
-		WithoutSubTest(),
 		WithPrivileges(false),
 		WithCommand("pull"),
 		WithArgs("--force", "--allow-unsigned", path, imageURL),

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -75,6 +75,7 @@ func ImageVerify(t *testing.T, cmdPath string, imagePath string) {
 	for _, tt := range tests {
 		RunSingularity(
 			t,
+			cmdPath,
 			AsSubtest(tt.name),
 			WithCommand("exec"),
 			WithArgs(tt.argv...),

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -75,7 +75,7 @@ func ImageVerify(t *testing.T, cmdPath string, imagePath string) {
 	for _, tt := range tests {
 		RunSingularity(
 			t,
-			tt.name,
+			AsSubtest(tt.name),
 			WithCommand("exec"),
 			WithArgs(tt.argv...),
 			ExpectExit(tt.exit),

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -375,7 +375,11 @@ func ExpectExit(code int, resultOps ...SingularityCmdResultOp) SingularityCmdOp 
 
 // RunSingularity executes a singularity command within an test execution
 // context.
-func RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
+//
+// cmdPath specifies the path to the singularity binary and cmdOps
+// provides a list of operations to be executed before or after running
+// the command.
+func RunSingularity(t *testing.T, cmdPath string, cmdOps ...SingularityCmdOp) {
 	s := new(singularityCmd)
 
 	for _, op := range cmdOps {
@@ -388,7 +392,7 @@ func RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 
 	fn := func(t *testing.T) {
 		s.result = new(SingularityCmdResult)
-		s.result.FullCmd = fmt.Sprintf("singularity %s", strings.Join(s.args, " "))
+		s.result.FullCmd = fmt.Sprintf("%s %s", cmdPath, strings.Join(s.args, " "))
 
 		var (
 			stdout bytes.Buffer
@@ -397,7 +401,7 @@ func RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 
 		s.t = t
 
-		cmd := exec.Command("singularity", s.args...)
+		cmd := exec.Command(cmdPath, s.args...)
 
 		cmd.Env = s.envs
 		if len(cmd.Env) == 0 {

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -37,7 +37,6 @@ func checkOciState(t *testing.T, containerID string, state string) {
 
 	e2e.RunSingularity(
 		t,
-		"State",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci state"),
 		e2e.WithArgs(containerID),
@@ -54,7 +53,6 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 
 	e2e.RunSingularity(
 		t,
-		"OciMount",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci mount"),
 		e2e.WithArgs(c.env.ImagePath, bundleDir),
@@ -83,7 +81,6 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	cleanup := func() {
 		e2e.RunSingularity(
 			t,
-			"OciUmount",
 			e2e.WithPrivileges(true),
 			e2e.WithCommand("oci umount"),
 			e2e.WithArgs(bundleDir),
@@ -106,7 +103,6 @@ func (c *ctx) testOciRun(t *testing.T) {
 	// oci run -b
 	e2e.RunSingularity(
 		t,
-		"OciRunInteractive",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci run"),
 		e2e.WithArgs("-b", bundleDir, containerID),
@@ -123,7 +119,6 @@ func (c *ctx) testOciRun(t *testing.T) {
 	// oci state should fail
 	e2e.RunSingularity(
 		t,
-		"OciRunStateFailure",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci state"),
 		e2e.WithArgs(containerID),
@@ -142,7 +137,6 @@ func (c *ctx) testOciAttach(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciAttachCreate",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci create"),
 		e2e.WithArgs("-b", bundleDir, containerID),
@@ -175,7 +169,6 @@ func (c *ctx) testOciAttach(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciAttachInteractive",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci attach"),
 		e2e.WithArgs(containerID),
@@ -194,7 +187,6 @@ func (c *ctx) testOciAttach(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciAttachDelete",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci delete"),
 		e2e.WithArgs(containerID),
@@ -213,7 +205,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciBasicCreate",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci create"),
 		e2e.WithArgs("-b", bundleDir, containerID),
@@ -246,7 +237,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciPause",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci pause"),
 		e2e.WithArgs(containerID),
@@ -264,7 +254,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciResume",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci resume"),
 		e2e.WithArgs(containerID),
@@ -282,7 +271,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciBasicAlreadyStarted",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),
@@ -291,7 +279,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciBasicExecId",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci exec"),
 		e2e.WithArgs(containerID, "id"),
@@ -314,7 +301,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciBasicDelete",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci delete"),
 		e2e.WithArgs(containerID),
@@ -323,7 +309,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 
 	e2e.RunSingularity(
 		t,
-		"OciBasicStateAfterDelete",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci state"),
 		e2e.WithArgs(containerID),
@@ -331,7 +316,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 	)
 	e2e.RunSingularity(
 		t,
-		"OciBasicKillAfterDelete",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci kill"),
 		e2e.WithArgs(containerID),
@@ -339,7 +323,6 @@ func (c *ctx) testOciBasic(t *testing.T) {
 	)
 	e2e.RunSingularity(
 		t,
-		"OciBasicStartAfterDelete",
 		e2e.WithPrivileges(true),
 		e2e.WithCommand("oci start"),
 		e2e.WithArgs(containerID),

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -215,7 +215,7 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 
 	argv += tt.srcURI
 
-	e2e.RunSingularity(
+	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest(tt.desc),
 		e2e.WithPrivileges(false),
@@ -225,11 +225,9 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 		// If nothing is specified with WithEnv(), the framework will pick up os.Environ(); if we need to had a
 		// new environment variable, we need to explicitly also add os.Environ()
 		e2e.WithEnv(append(os.Environ(), c.env.KeyringDir)),
-		e2e.ExpectExit(tt.expectedExitCode),
-		e2e.PostRun(func(t *testing.T) {
-			checkPullResult(t, tt)
-		}),
-	)
+		e2e.ExpectExit(tt.expectedExitCode))
+
+	checkPullResult(t, tt)
 }
 
 func getImageNameFromURI(imgURI string) string {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -217,7 +217,7 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 
 	e2e.RunSingularity(
 		t,
-		tt.desc,
+		e2e.AsSubtest(tt.desc),
 		e2e.WithPrivileges(false),
 		e2e.WithCommand("pull"),
 		e2e.WithArgs(strings.Split(argv, " ")...),

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -41,7 +41,7 @@ func (c *ctx) remoteAdd(t *testing.T) {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -61,7 +61,7 @@ func (c *ctx) remoteAdd(t *testing.T) {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(255),
@@ -95,7 +95,7 @@ func (c *ctx) remoteRemove(t *testing.T) {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -114,7 +114,7 @@ func (c *ctx) remoteRemove(t *testing.T) {
 		argv := []string{"--config", config.Name(), "remove", tt.remote}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -132,7 +132,7 @@ func (c *ctx) remoteRemove(t *testing.T) {
 		argv := []string{"--config", config.Name(), "remove", tt.remote}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(255),
@@ -162,7 +162,7 @@ func (c *ctx) remoteUse(t *testing.T) {
 		argv := []string{"--config", config.Name(), "use", tt.remote}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(255),
@@ -183,7 +183,7 @@ func (c *ctx) remoteUse(t *testing.T) {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -202,7 +202,7 @@ func (c *ctx) remoteUse(t *testing.T) {
 		argv := []string{"--config", config.Name(), "use", tt.remote}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -236,7 +236,7 @@ func (c *ctx) remoteStatus(t *testing.T) {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -254,7 +254,7 @@ func (c *ctx) remoteStatus(t *testing.T) {
 		argv := []string{"--config", config.Name(), "status", tt.remote}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -273,7 +273,7 @@ func (c *ctx) remoteStatus(t *testing.T) {
 		argv := []string{"--config", config.Name(), "status", tt.remote}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(255),
@@ -300,7 +300,7 @@ func (c *ctx) remoteList(t *testing.T) {
 		argv := []string{"--config", config.Name(), "list"}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -321,7 +321,7 @@ func (c *ctx) remoteList(t *testing.T) {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -338,7 +338,7 @@ func (c *ctx) remoteList(t *testing.T) {
 		argv := []string{"--config", config.Name(), "list"}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -357,7 +357,7 @@ func (c *ctx) remoteList(t *testing.T) {
 		argv := []string{"--config", config.Name(), "use", tt.remote}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),
@@ -374,7 +374,7 @@ func (c *ctx) remoteList(t *testing.T) {
 		argv := []string{"--config", config.Name(), "list"}
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
 			e2e.WithArgs(argv...),
 			e2e.ExpectExit(0),

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -39,7 +39,7 @@ func (c *ctx) remoteAdd(t *testing.T) {
 
 	for _, tt := range testPass {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -59,7 +59,7 @@ func (c *ctx) remoteAdd(t *testing.T) {
 
 	for _, tt := range testFail {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -93,7 +93,7 @@ func (c *ctx) remoteRemove(t *testing.T) {
 
 	for _, tt := range add {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -112,7 +112,7 @@ func (c *ctx) remoteRemove(t *testing.T) {
 
 	for _, tt := range testPass {
 		argv := []string{"--config", config.Name(), "remove", tt.remote}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -130,7 +130,7 @@ func (c *ctx) remoteRemove(t *testing.T) {
 
 	for _, tt := range testFail {
 		argv := []string{"--config", config.Name(), "remove", tt.remote}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -160,7 +160,7 @@ func (c *ctx) remoteUse(t *testing.T) {
 
 	for _, tt := range testFail {
 		argv := []string{"--config", config.Name(), "use", tt.remote}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -181,7 +181,7 @@ func (c *ctx) remoteUse(t *testing.T) {
 
 	for _, tt := range add {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -200,7 +200,7 @@ func (c *ctx) remoteUse(t *testing.T) {
 
 	for _, tt := range testPass {
 		argv := []string{"--config", config.Name(), "use", tt.remote}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -234,7 +234,7 @@ func (c *ctx) remoteStatus(t *testing.T) {
 
 	for _, tt := range add {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -252,7 +252,7 @@ func (c *ctx) remoteStatus(t *testing.T) {
 
 	for _, tt := range testPass {
 		argv := []string{"--config", config.Name(), "status", tt.remote}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -271,7 +271,7 @@ func (c *ctx) remoteStatus(t *testing.T) {
 
 	for _, tt := range testFail {
 		argv := []string{"--config", config.Name(), "status", tt.remote}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -298,7 +298,7 @@ func (c *ctx) remoteList(t *testing.T) {
 
 	for _, tt := range testPass {
 		argv := []string{"--config", config.Name(), "list"}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -319,7 +319,7 @@ func (c *ctx) remoteList(t *testing.T) {
 
 	for _, tt := range add {
 		argv := []string{"--config", config.Name(), "add", tt.remote, tt.uri}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -336,7 +336,7 @@ func (c *ctx) remoteList(t *testing.T) {
 
 	for _, tt := range testPass {
 		argv := []string{"--config", config.Name(), "list"}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -355,7 +355,7 @@ func (c *ctx) remoteList(t *testing.T) {
 
 	for _, tt := range use {
 		argv := []string{"--config", config.Name(), "use", tt.remote}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),
@@ -372,7 +372,7 @@ func (c *ctx) remoteList(t *testing.T) {
 
 	for _, tt := range testPass {
 		argv := []string{"--config", config.Name(), "list"}
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithCommand("remote"),

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -78,6 +78,8 @@ func (c *ctx) singularityVerifyKeyNum(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		e2e.PullImage(t, c.env, tt.imageURL, tt.imagePath)
+
 		verifyOutput := func(t *testing.T, r *e2e.SingularityCmdResult) {
 			// Get the Signatures and compare it
 			eNum, err := jsonparser.GetInt(r.Stdout, keyNumPath...)
@@ -90,15 +92,12 @@ func (c *ctx) singularityVerifyKeyNum(t *testing.T) {
 		}
 
 		// Inspect the container, and get the output
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("verify"),
 			e2e.WithArgs("--json", tt.imagePath),
-			e2e.PreRun(func(t *testing.T) {
-				e2e.PullImage(t, tt.imageURL, tt.imagePath)
-			}),
 			e2e.ExpectExit(tt.expectExit, verifyOutput),
 		)
 	}
@@ -269,16 +268,15 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 		}
 		args = append(args, tt.imagePath)
 
+		e2e.PullImage(t, c.env, tt.imageURL, tt.imagePath)
+
 		// Inspect the container, and get the output
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("verify"),
 			e2e.WithArgs(args...),
-			e2e.PreRun(func(t *testing.T) {
-				e2e.PullImage(t, tt.imageURL, tt.imagePath)
-			}),
 			e2e.ExpectExit(tt.expectExit, verifyOutput),
 		)
 	}

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -92,7 +92,7 @@ func (c *ctx) singularityVerifyKeyNum(t *testing.T) {
 		// Inspect the container, and get the output
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("verify"),
 			e2e.WithArgs("--json", tt.imagePath),
@@ -272,7 +272,7 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 		// Inspect the container, and get the output
 		e2e.RunSingularity(
 			t,
-			tt.name,
+			e2e.AsSubtest(tt.name),
 			e2e.WithPrivileges(false),
 			e2e.WithCommand("verify"),
 			e2e.WithArgs(args...),

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -40,7 +40,6 @@ func (c *ctx) testSemanticVersion(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithArgs(tt.args...),
 			e2e.PostRun(func(t *testing.T) {
 				if t.Failed() {
@@ -82,7 +81,6 @@ func (c *ctx) testEqualVersion(t *testing.T) {
 
 		e2e.RunSingularity(
 			t,
-			tt.name,
 			e2e.WithArgs(tt.args...),
 			e2e.PostRun(func(t *testing.T) {
 				if t.Failed() {

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -38,7 +38,7 @@ func (c *ctx) testSemanticVersion(t *testing.T) {
 			}
 		}
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithArgs(tt.args...),
 			e2e.PostRun(func(t *testing.T) {
@@ -79,7 +79,7 @@ func (c *ctx) testEqualVersion(t *testing.T) {
 			}
 		}
 
-		e2e.RunSingularity(
+		c.env.RunSingularity(
 			t,
 			e2e.WithArgs(tt.args...),
 			e2e.PostRun(func(t *testing.T) {


### PR DESCRIPTION
Add mandatory argument to RunSingularity to specify binary to use

RunSingularity is using "singularity" as the command it wants to run,
which means it's picking up singularity from the user's PATH, which
might or might not correspond to the singularity binary that matches the
code to be tested (e.g. mconfig --prefix=/usr/local/test, and then run
run the E2E suite without adding /usr/local/test/bin to the path).

Fix this by adding a cmdPath argument to RunSingularity which specifies
where the singularity binary is located. This plays nice with the
existing code that records the location of this binary in the
E2E_CMD_PATH environment variable. It's the responsability of the test
calling RunSingularity to pass the correct value derived from this
environment variable.

This is replacing the existing "name" argument, which is mandatory, but
it's only used if a subtest run is requested, which is optional. Convert
this into an option "WithSubtest", which takes the name of the subtest as
an argument and is self-documenting.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>