### PR TITLE
Typo on inspecting an empty sif file

### DIFF
--- a/cmd/internal/cli/inspect_linux.go
+++ b/cmd/internal/cli/inspect_linux.go
@@ -426,7 +426,7 @@ func getFileContent(abspath, name string, args []string) (string, error) {
 
 	b, err := cmd.Output()
 	if err != nil {
-		sylog.Fatalf("Unable to prossess command: %s: %s", err, b)
+		sylog.Fatalf("Unable to process command: %s: %s", err, b)
 	}
 
 	return string(b), nil


### PR DESCRIPTION
**Description of the Pull Request (PR):**

fixed typo on warning when running:

```sh
$ singularity sif new test.sif 
$ ls
$ test.sif
$ singularity inspect -d test.sif
FATAL:   Unable to prossess command: exit status 255: 
```

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
