### PR TITLE
Add script to run e2e tests

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -34,7 +34,7 @@ dist:
 .PHONY: unit-test
 unit-test:
 	@echo " TEST sudo go test [unit]"
-	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race \
+	$(V)cd $(SOURCEDIR) && sudo -E scripts/go-test \
 		`$(GO) list ./... | grep -v "cmd/singularity\|pkg/network\|e2e"`
 	@echo "       PASS"
 
@@ -42,15 +42,13 @@ unit-test:
 .PHONY: e2e-test
 e2e-test:
 	@echo " TEST sudo go test [e2e]"
-	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=30m -tags "$(GO_TAGS)" -failfast -cover -race \
-		./e2e
+	$(V)cd $(SOURCEDIR) && scripts/e2e-test
 	@echo "       PASS"
 
 .PHONY: integration-test
 integration-test:
 	@echo " TEST sudo go test [integration]"
-	$(V)cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race \
-		./cmd/singularity ./pkg/network
+	$(V)cd $(SOURCEDIR) && sudo -E scripts/go-test ./cmd/singularity ./pkg/network
 	@echo "       PASS"
 
 .PHONY: test
@@ -58,7 +56,7 @@ test:
 	@echo " TEST sudo go test [all]"
 	$(V)M=0; eval 'while [ $$M -le 20 ]; do sleep 60; M=`expr $$M + 1`; echo "Still testing ($$M) ..."; done &' ; \
     	trap "kill $$! || true" 0; \
-		cd $(SOURCEDIR) && sudo -E $(GO) test $(GO_MODFLAGS) -count=1 -timeout=20m -tags "$(GO_TAGS)" -failfast -cover -race ./...
+		cd $(SOURCEDIR) && sudo -E scripts/go-test ./...
 	@echo "       PASS"
 
 .PHONY: testall

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if test ! -e scripts/go-test ; then
+	echo 'E: Cannot find scripts/go-test. Abort.'
+	exit 1
+fi
+
+if test ! -d e2e ; then
+	echo 'E: Cannot find e2e directory. Abort.'
+	exit 1
+fi
+
+sudo -v
+
+sudo \
+	env -i \
+		PATH=$PATH \
+		HOME=$HOME \
+		SINGULARITY_E2E=1 \
+	scripts/go-test "$@" ./e2e


### PR DESCRIPTION
Change makefiles to use both e2e-test and go-test scripts.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>