### PR TITLE
Add workaround for false-negative in ShellExit test

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -255,6 +255,7 @@ func (c *actionTests) actionShell(t *testing.T) {
 				// to fail because the "Singularity" that
 				// we are looking for is chopped from the
 				// front.
+				// TODO(mem): This test was added back in 491a71716013654acb2276e4b37c2e015d2dfe09
 				e2e.ConsoleSendLine("cd /"),
 				e2e.ConsoleExpect("Singularity"),
 				e2e.ConsoleSendLine("exit"),

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -250,6 +250,12 @@ func (c *actionTests) actionShell(t *testing.T) {
 			name: "ShellExit",
 			argv: []string{c.env.ImagePath},
 			consoleOps: []e2e.SingularityConsoleOp{
+				// "cd /" to work around issue where a long
+				// working directory name causes the test
+				// to fail because the "Singularity" that
+				// we are looking for is chopped from the
+				// front.
+				e2e.ConsoleSendLine("cd /"),
 				e2e.ConsoleExpect("Singularity"),
 				e2e.ConsoleSendLine("exit"),
 			},


### PR DESCRIPTION
Add "cd /" to work around issue where a long working directory name
causes the test to fail because the "Singularity" that we are looking
for is chopped from the front.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>