### PR TITLE
Disable tests or test cases that access singularity hub

### DIFF
--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -255,7 +255,8 @@ func testSTDINPipe(t *testing.T) {
 		// Stdin to URI based image
 		{"sh", "library", []string{"-c", "echo true | singularity shell library://busybox"}, 0},
 		{"sh", "docker", []string{"-c", "echo true | singularity shell docker://busybox"}, 0},
-		{"sh", "shub", []string{"-c", "echo true | singularity shell shub://singularityhub/busybox"}, 0},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"sh", "shub", []string{"-c", "echo true | singularity shell shub://singularityhub/busybox"}, 0},
 		// Test apps
 		{"sh", "appsFoo", []string{"-c", fmt.Sprintf("singularity run --app foo %s | grep 'FOO'", appsImage)}, 0},
 		// Test target pwd
@@ -309,24 +310,30 @@ func testRunFromURI(t *testing.T) {
 		// Run from supported URI's and check the runscript call works
 		{"RunFromDockerOK", "docker://busybox:latest", "run", []string{size}, runOpts, true},
 		{"RunFromLibraryOK", "library://busybox:latest", "run", []string{size}, runOpts, true},
-		{"RunFromShubOK", "shub://singularityhub/busybox", "run", []string{size}, runOpts, true},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"RunFromShubOK", "shub://singularityhub/busybox", "run", []string{size}, runOpts, true},
 		{"RunFromDockerKO", "docker://busybox:latest", "run", []string{"0"}, runOpts, false},
 		{"RunFromLibraryKO", "library://busybox:latest", "run", []string{"0"}, runOpts, false},
-		{"RunFromShubKO", "shub://singularityhub/busybox", "run", []string{"0"}, runOpts, false},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"RunFromShubKO", "shub://singularityhub/busybox", "run", []string{"0"}, runOpts, false},
 		// exec from a supported URI's and check the exit code
 		{"trueDocker", "docker://busybox:latest", "exec", []string{"true"}, opts{}, true},
 		{"trueLibrary", "library://busybox:latest", "exec", []string{"true"}, opts{}, true},
-		{"trueShub", "shub://singularityhub/busybox", "exec", []string{"true"}, opts{}, true},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"trueShub", "shub://singularityhub/busybox", "exec", []string{"true"}, opts{}, true},
 		{"falseDocker", "docker://busybox:latest", "exec", []string{"false"}, opts{}, false},
 		{"falselibrary", "library://busybox:latest", "exec", []string{"false"}, opts{}, false},
-		{"falseShub", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{}, false},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"falseShub", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{}, false},
 		// exec from URI with user namespace enabled
 		{"trueDockerUserns", "docker://busybox:latest", "exec", []string{"true"}, opts{userns: true}, true},
 		{"trueLibraryUserns", "library://busybox:latest", "exec", []string{"true"}, opts{userns: true}, true},
-		{"trueShubUserns", "shub://singularityhub/busybox", "exec", []string{"true"}, opts{userns: true}, true},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"trueShubUserns", "shub://singularityhub/busybox", "exec", []string{"true"}, opts{userns: true}, true},
 		{"falseDockerUserns", "docker://busybox:latest", "exec", []string{"false"}, opts{userns: true}, false},
 		{"falselibraryUserns", "library://busybox:latest", "exec", []string{"false"}, opts{userns: true}, false},
-		{"falseShubUserns", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{userns: true}, false},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"falseShubUserns", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{userns: true}, false},
 	}
 
 	for _, tt := range tests {

--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -123,8 +123,10 @@ func TestBuild(t *testing.T) {
 		{"Debootstrap", "debootstrap", "../../examples/debian/Singularity", true},
 		{"DockerURI", "", "docker://busybox", true},
 		{"DockerDefFile", "", "../../examples/docker/Singularity", true},
-		{"SHubURI", "", "shub://GodloveD/busybox", true},
-		{"SHubDefFile", "", "../../examples/shub/Singularity", true},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"SHubURI", "", "shub://GodloveD/busybox", true},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"SHubDefFile", "", "../../examples/shub/Singularity", true},
 		{"LibraryDefFile", "", "../../examples/library/Singularity", true},
 		{"Yum", "yum", "../../examples/centos/Singularity", true},
 		{"Zypper", "zypper", "../../examples/opensuse/Singularity", true},

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -404,10 +404,11 @@ func testInstanceFromURI(t *testing.T) {
 			name: "test_from_library",
 			uri:  "library://busybox",
 		},
-		{
-			name: "test_from_shub",
-			uri:  "shub://singularityhub/busybox",
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name: "test_from_shub",
+		// 	uri:  "shub://singularityhub/busybox",
+		// },
 	}
 
 	for _, i := range instances {

--- a/cmd/singularity/pull_test.go
+++ b/cmd/singularity/pull_test.go
@@ -92,7 +92,8 @@ func TestPull(t *testing.T) {
 		{"NotDefaultPath", "library://sylabs/tests/not-default:1.0.0", true, true, "", "/tmp", imagePath, true}, // pull a untrusted container with -U, and --path <path>
 		{"NotDefaultFail2", "library://sylabs/tests/not-default:1.0.0", false, false, "", "/tmp", "", false},    // pull a untrusted container; should fail
 		{"Pull_Docker", "docker://alpine:3.8", true, false, "", "", imagePath, true},                            // https://hub.docker.com/
-		{"Pull_Shub", "shub://GodloveD/busybox", true, false, "", "", imagePath, true},                          // https://singularity-hub.org/
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"Pull_Shub", "shub://GodloveD/busybox", true, false, "", "", imagePath, true},                          // https://singularity-hub.org/
 		{"PullWithHash", "library://sylabs/tests/signed:sha256.5c439fd262095766693dae95fb81334c3a02a7f0e4dc6291e0648ed4ddc61c6c", true, true, "", "", imagePath, true},
 		{"PullWithoutTransportProtocol", "alpine:3.8", true, true, "", "", imagePath, true},
 		{"PullNonExistent", "library://this_should_not/exist/not_exist", true, false, "", "", imagePath, false}, // pull a non-existent container

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -339,20 +339,22 @@ func (c *actionTests) STDPipe(t *testing.T) {
 			input:   "false",
 			exit:    1,
 		},
-		{
-			name:    "TrueShub",
-			command: "shell",
-			argv:    []string{"shub://singularityhub/busybox"},
-			input:   "true",
-			exit:    0,
-		},
-		{
-			name:    "FalseShub",
-			command: "shell",
-			argv:    []string{"shub://singularityhub/busybox"},
-			input:   "false",
-			exit:    1,
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "TrueShub",
+		// 	command: "shell",
+		// 	argv:    []string{"shub://singularityhub/busybox"},
+		// 	input:   "true",
+		// 	exit:    0,
+		// },
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "FalseShub",
+		// 	command: "shell",
+		// 	argv:    []string{"shub://singularityhub/busybox"},
+		// 	input:   "false",
+		// 	exit:    1,
+		// },
 	}
 
 	var input bytes.Buffer
@@ -450,12 +452,13 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 			argv:    []string{"--bind", bind, "library://busybox:latest", size},
 			exit:    0,
 		},
-		{
-			name:    "RunFromShubOK",
-			command: "run",
-			argv:    []string{"--bind", bind, "shub://singularityhub/busybox", size},
-			exit:    0,
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "RunFromShubOK",
+		// 	command: "run",
+		// 	argv:    []string{"--bind", bind, "shub://singularityhub/busybox", size},
+		// 	exit:    0,
+		// },
 		{
 			name:    "RunFromOrasOK",
 			command: "run",
@@ -474,12 +477,13 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 			argv:    []string{"--bind", bind, "library://busybox:latest", "0"},
 			exit:    1,
 		},
-		{
-			name:    "RunFromShubKO",
-			command: "run",
-			argv:    []string{"--bind", bind, "shub://singularityhub/busybox", "0"},
-			exit:    1,
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "RunFromShubKO",
+		// 	command: "run",
+		// 	argv:    []string{"--bind", bind, "shub://singularityhub/busybox", "0"},
+		// 	exit:    1,
+		// },
 		{
 			name:    "RunFromOrasKO",
 			command: "run",
@@ -500,12 +504,13 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 			argv:    []string{"library://busybox:latest", "true"},
 			exit:    0,
 		},
-		{
-			name:    "ExecTrueShub",
-			command: "exec",
-			argv:    []string{"shub://singularityhub/busybox", "true"},
-			exit:    0,
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "ExecTrueShub",
+		// 	command: "exec",
+		// 	argv:    []string{"shub://singularityhub/busybox", "true"},
+		// 	exit:    0,
+		// },
 		{
 			name:    "ExecTrueOras",
 			command: "exec",
@@ -524,12 +529,13 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 			argv:    []string{"library://busybox:latest", "false"},
 			exit:    1,
 		},
-		{
-			name:    "ExecFalseShub",
-			command: "exec",
-			argv:    []string{"shub://singularityhub/busybox", "false"},
-			exit:    1,
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "ExecFalseShub",
+		// 	command: "exec",
+		// 	argv:    []string{"shub://singularityhub/busybox", "false"},
+		// 	exit:    1,
+		// },
 		{
 			name:    "ExecFalseOras",
 			command: "exec",
@@ -550,12 +556,13 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 			argv:    []string{"--userns", "library://busybox:latest", "true"},
 			exit:    0,
 		},
-		{
-			name:    "ExecTrueShubUserns",
-			command: "exec",
-			argv:    []string{"--userns", "shub://singularityhub/busybox", "true"},
-			exit:    0,
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "ExecTrueShubUserns",
+		// 	command: "exec",
+		// 	argv:    []string{"--userns", "shub://singularityhub/busybox", "true"},
+		// 	exit:    0,
+		// },
 		{
 			name:    "ExecTrueOrasUserns",
 			command: "exec",
@@ -574,12 +581,13 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 			argv:    []string{"--userns", "library://busybox:latest", "false"},
 			exit:    1,
 		},
-		{
-			name:    "ExecFalseShubUserns",
-			command: "exec",
-			argv:    []string{"--userns", "shub://singularityhub/busybox", "false"},
-			exit:    1,
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name:    "ExecFalseShubUserns",
+		// 	command: "exec",
+		// 	argv:    []string{"--userns", "shub://singularityhub/busybox", "false"},
+		// 	exit:    1,
+		// },
 		{
 			name:    "ExecFalseOrasUserns",
 			command: "exec",

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -33,8 +33,10 @@ func (c *imgBuildTests) buildFrom(t *testing.T) {
 		{"Debootstrap", "debootstrap", "../examples/debian/Singularity", true},
 		{"DockerURI", "", "docker://busybox", true},
 		{"DockerDefFile", "", "../examples/docker/Singularity", true},
-		{"ShubURI", "", "shub://GodloveD/busybox", true},
-		{"ShubDefFile", "", "../examples/shub/Singularity", true},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"ShubURI", "", "shub://GodloveD/busybox", true},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"ShubDefFile", "", "../examples/shub/Singularity", true},
 		{"LibraryDefFile", "", "../examples/library/Singularity", true},
 		{"OrasURI", "", "oras://localhost:5000/oras_test_sif:latest", true},
 		{"Yum", "yum", "../examples/centos/Singularity", true},

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -208,10 +208,11 @@ func (c *ctx) testInstanceFromURI(t *testing.T) {
 			name: "test_from_library",
 			uri:  "library://busybox",
 		},
-		{
-			name: "test_from_shub",
-			uri:  "shub://singularityhub/busybox",
-		},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {
+		// 	name: "test_from_shub",
+		// 	uri:  "shub://singularityhub/busybox",
+		// },
 	}
 
 	for _, i := range instances {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -174,13 +174,14 @@ var tests = []struct {
 		unauthenticated: false,
 		expectSuccess:   true,
 	},
-	{
-		desc:            "image from shub",
-		srcURI:          "shub://GodloveD/busybox",
-		force:           true,
-		unauthenticated: false,
-		expectSuccess:   true,
-	},
+	// TODO(mem): reenable this; disabled while shub is down
+	// {
+	// 	desc:            "image from shub",
+	// 	srcURI:          "shub://GodloveD/busybox",
+	// 	force:           true,
+	// 	unauthenticated: false,
+	// 	expectSuccess:   true,
+	// },
 	{
 		desc:            "oras transport for SIF from registry",
 		srcURI:          "oras://localhost:5000/pull_test_sif:latest",

--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -68,6 +68,8 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 
 // TestSandboxAssemblerShub sees if we can build a sandbox from an image from a Singularity registry
 func TestSandboxAssemblerShub(t *testing.T) {
+	// TODO(mem): reenable this; disabled while shub is down
+	t.Skip("Skipping tests that access singularity hub")
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/internal/pkg/build/assemblers/assembler_sif_test.go
+++ b/internal/pkg/build/assemblers/assembler_sif_test.go
@@ -77,6 +77,8 @@ func TestSIFAssemblerDocker(t *testing.T) {
 
 // TestSIFAssemblerShub sees if we can build a SIF image from an image from a Singularity registry
 func TestSIFAssemblerShub(t *testing.T) {
+	// TODO(mem): reenable this; disabled while shub is down
+	t.Skip("Skipping tests that access singularity hub")
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/internal/pkg/build/sources/conveyorPacker_shub_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub_test.go
@@ -19,6 +19,8 @@ const (
 
 // TestShubConveyor tests if we can pull an image from singularity hub
 func TestShubConveyor(t *testing.T) {
+	// TODO(mem): reenable this; disabled while shub is down
+	t.Skip("Skipping tests that access singularity hub")
 
 	if testing.Short() {
 		t.SkipNow()
@@ -49,6 +51,8 @@ func TestShubConveyor(t *testing.T) {
 
 // TestShubPacker checks if we can create a Bundle from the pulled image
 func TestShubPacker(t *testing.T) {
+	// TODO(mem): reenable this; disabled while shub is down
+	t.Skip("Skipping tests that access singularity hub")
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestShub(t *testing.T) {
+	// TODO(mem): reenable this; disabled while shub is down
+	t.Skip("Skipping tests that access singularity hub")
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
@@ -56,6 +58,8 @@ func TestShub(t *testing.T) {
 }
 
 func TestShubImageExists(t *testing.T) {
+	// TODO(mem): reenable this; disabled while shub is down
+	t.Skip("Skipping tests that access singularity hub")
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/pkg/build/legacy/parser/deffile_test.go
+++ b/pkg/build/legacy/parser/deffile_test.go
@@ -31,7 +31,8 @@ func TestScanDefinitionFile(t *testing.T) {
 		{"Docker", "testdata_good/docker/docker", "testdata_good/docker/docker_sections.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage_sections.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch_sections.json"},
-		{"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum_sections.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper_sections.json"},
 	}
@@ -170,7 +171,8 @@ func TestParseDefinitionFile(t *testing.T) {
 		{"Docker", "testdata_good/docker/docker", "testdata_good/docker/docker.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch.json"},
-		{"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub.json"},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper.json"},
 		{"NoHeader", "testdata_good/noheader/noheader", "testdata_good/noheader/noheader.json"},
@@ -322,7 +324,8 @@ func TestIsValidDefinition(t *testing.T) {
 		{"Docker", "testdata_good/docker/docker", "testdata_good/docker/docker_sections.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage_sections.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch_sections.json"},
-		{"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum_sections.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper_sections.json"},
 	}

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -31,7 +31,8 @@ func TestScanDefinitionFile(t *testing.T) {
 		{"Docker", "testdata_good/docker/docker", "testdata_good/docker/docker_sections.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage_sections.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch_sections.json"},
-		{"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum_sections.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper_sections.json"},
 	}
@@ -170,7 +171,8 @@ func TestParseDefinitionFile(t *testing.T) {
 		{"Docker", "testdata_good/docker/docker", "testdata_good/docker/docker.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch.json"},
-		{"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub.json"},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper.json"},
 		{"NoHeader", "testdata_good/noheader/noheader", "testdata_good/noheader/noheader.json"},
@@ -334,7 +336,8 @@ func TestIsValidDefinition(t *testing.T) {
 		{"Docker", "testdata_good/docker/docker", "testdata_good/docker/docker_sections.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage_sections.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch_sections.json"},
-		{"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
+		// TODO(mem): reenable this; disabled while shub is down
+		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum_sections.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper_sections.json"},
 	}

--- a/pkg/client/shub/pull_test.go
+++ b/pkg/client/shub/pull_test.go
@@ -19,6 +19,8 @@ const (
 
 // TestDownloadImage tests if we can pull an image from Singularity Hub
 func TestDownloadImage(t *testing.T) {
+	// TODO(mem): reenable this; disabled while shub is down
+	t.Skip("Skipping tests that access singularity hub")
 
 	if testing.Short() {
 		t.SkipNow()


### PR DESCRIPTION
While singularity hub is down, disable the tests that try to access it.
Every disabled test or test case has been marked with a comment
indicating the reason for disabling it is the fact that singularity hub
is down. This is done in order to avoid confusion in case the code is
reworked before the tests can be reenabled again.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>