### PR TITLE
Skip PersistentOverlay test if mkfs.ext3 is not available

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	stdexec "os/exec"
 	"strconv"
 	"testing"
 
@@ -617,6 +618,10 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 // PersistentOverlay test the --overlay function
 func (c *actionTests) PersistentOverlay(t *testing.T) {
 	const squashfsImage = "squashfs.simg"
+
+	if _, err := stdexec.LookPath("mkfs.ext3"); err != nil {
+		t.Skip("mkfs.ext3 not found")
+	}
 
 	dir, err := ioutil.TempDir(c.env.TestDir, "overlay_test")
 	if err != nil {


### PR DESCRIPTION
This test will fail if mkfs.ext3 is not found in PATH, which is the case
if mkfs.ext3 is installed in /sbin or /usr/sbin and the user does not
have those directories in their PATH, or if e2fsprogs is not installed
(which should never be the case, as it contains fsck.ext3, too).

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>