### PR TITLE
Use NewTestConsole instead of NewConsole

### DIFF
--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -319,7 +319,8 @@ func RunSingularity(t *testing.T, name string, cmdOps ...SingularityCmdOp) {
 		if s.consoleFn != nil {
 			var err error
 
-			s.console, err = expect.NewConsole(
+			s.console, err = expect.NewTestConsole(
+				t,
 				expect.WithStdout(cmd.Stdout),
 				expect.WithDefaultTimeout(1*time.Second),
 			)


### PR DESCRIPTION
NewTestConsole will pass the console input and output to the test
logger, so when tests run in verbose mode, the console logs are shown
along with other test information. This makes it much easier to work
with tests that use expect, as the exact inputs and outputs are shown.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>