### PR TITLE
Move call to e2e.EnsureImage to the tests that need it

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -24,6 +24,8 @@ type actionTests struct {
 
 // run tests min fuctionality for singularity run
 func (c *actionTests) actionRun(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	tests := []struct {
 		name string
 		argv []string
@@ -69,6 +71,8 @@ func (c *actionTests) actionRun(t *testing.T) {
 
 // exec tests min fuctionality for singularity exec
 func (c *actionTests) actionExec(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	user := e2e.CurrentUser(t)
 
 	// Create a temp testfile
@@ -236,6 +240,8 @@ func (c *actionTests) actionExec(t *testing.T) {
 
 // Shell interaction tests
 func (c *actionTests) actionShell(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		t.Fatalf("could not get hostname: %s", err)
@@ -298,6 +304,8 @@ func (c *actionTests) actionShell(t *testing.T) {
 
 // STDPipe tests pipe stdin/stdout to singularity actions cmd
 func (c *actionTests) STDPipe(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	stdinTests := []struct {
 		name    string
 		command string
@@ -617,6 +625,8 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 
 // PersistentOverlay test the --overlay function
 func (c *actionTests) PersistentOverlay(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	const squashfsImage = "squashfs.simg"
 
 	if _, err := stdexec.LookPath("mkfs.ext3"); err != nil {

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -62,6 +62,8 @@ func (c *ctx) testNoInstances(t *testing.T) {
 // Test that a basic echo server instance can be started, communicated with,
 // and stopped.
 func (c *ctx) testBasicEchoServer(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	const instanceName = "echo1"
 	// Start the instance.
 	_, _, err := c.startInstance(startOpts{}, c.env.ImagePath, instanceName, strconv.Itoa(instanceStartPort))
@@ -79,6 +81,8 @@ func (c *ctx) testBasicEchoServer(t *testing.T) {
 
 // Test creating many instances, but don't stop them.
 func (c *ctx) testCreateManyInstances(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	const n = 10
 	// Start n instances.
 	for i := 0; i < n; i++ {
@@ -109,6 +113,8 @@ func (c *ctx) testStopAll(t *testing.T) {
 // Test basic options like mounting a custom home directory, changing the
 // hostname, etc.
 func (c *ctx) testBasicOptions(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	const fileName = "hello"
 	const instanceName = "testbasic"
 	const testHostname = "echoserver99"
@@ -161,6 +167,8 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 
 // Test that contain works.
 func (c *ctx) testContain(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	const instanceName = "testcontain"
 	const fileName = "thegreattestfile"
 	// Create a temporary directory to serve as a contain directory.

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -20,6 +20,8 @@ type ctx struct {
 }
 
 func (c *ctx) testPushCmd(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
 	// setup file and dir to use as invalid sources
 	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")
 	if err != nil {

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -114,7 +114,7 @@ func Run(t *testing.T) {
 	testenv.ImagePath = imagePath
 	defer os.Remove(imagePath)
 
-	// XXX(mem): Please DO NOT add a call to e2e.EnsureImage here.
+	// WARNING(Sylabs-team): Please DO NOT add a call to e2e.EnsureImage here.
 	// If you need the test image, add the call at the top of your
 	// own test.
 

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -114,8 +114,9 @@ func Run(t *testing.T) {
 	testenv.ImagePath = imagePath
 	defer os.Remove(imagePath)
 
-	// build test image
-	singularitye2e.EnsureImage(t, testenv)
+	// XXX(mem): Please DO NOT add a call to e2e.EnsureImage here.
+	// If you need the test image, add the call at the top of your
+	// own test.
 
 	// Start registry for tests
 	singularitye2e.PrepRegistry(t, name, testenv.ImagePath)


### PR DESCRIPTION
EnsureImage creates the test image if it's missing. This is done to
avoid creating the image multiple times for each test.

The call to EnsureImage MUST be in the tests that require said image in
order to avoid paying the cost of creating the image when it is not
required: many tests do not require this image and can operate without
it, and while developing a test or working on individual failure cases
it's useful to be able to run a single test repeatedly. If said test
requires the image, there's no way around it, but if the test does not
require the test image it does not make sense to build it over and over
again.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>