### PR TITLE
Changed SINGULARITY_NAME => SINGULARITY_PULL_NAME

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -79,7 +79,7 @@ var pullNameFlag = cmdline.Flag{
 	Name:         "name",
 	Hidden:       true,
 	Usage:        "specify a custom image name",
-	EnvKeys:      []string{"NAME"},
+	EnvKeys:      []string{"PULL_NAME"},
 }
 
 // --dir


### PR DESCRIPTION
## Description of the Pull Request (PR):

This variable name was interfering will 'SINGULARITY_NAME' when shell-ing into a container. This is a problem if you are running singularity in a singularity container, because every time you pull a container, it will be the name of the container you are shelling into, (unexpected behavior)

Besides, `SINGULARITY_NAME` is kinda undescriptive for the pull name.

<br>
