### PR TITLE
Remove call to e2e.PrepRegistry from toplevel test

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -440,6 +440,8 @@ func (c *actionTests) STDPipe(t *testing.T) {
 
 // RunFromURI tests min fuctionality for singularity run/exec URI://
 func (c *actionTests) RunFromURI(t *testing.T) {
+	e2e.PrepRegistry(t, c.env)
+
 	runScript := "testdata/runscript.sh"
 	bind := fmt.Sprintf("%s:/.singularity.d/runscript", runScript)
 
@@ -478,7 +480,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "RunFromOrasOK",
 			command: "run",
-			argv:    []string{"--bind", bind, "oras://localhost:5000/oras_test_sif:latest", size},
+			argv:    []string{"--bind", bind, c.env.OrasTestImage, size},
 			exit:    0,
 		},
 		{
@@ -503,7 +505,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "RunFromOrasKO",
 			command: "run",
-			argv:    []string{"--bind", bind, "oras://localhost:5000/oras_test_sif:latest", "0"},
+			argv:    []string{"--bind", bind, c.env.OrasTestImage, "0"},
 			exit:    1,
 		},
 
@@ -530,7 +532,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecTrueOras",
 			command: "exec",
-			argv:    []string{"oras://localhost:5000/oras_test_sif:latest", "true"},
+			argv:    []string{c.env.OrasTestImage, "true"},
 			exit:    0,
 		},
 		{
@@ -555,7 +557,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecFalseOras",
 			command: "exec",
-			argv:    []string{"oras://localhost:5000/oras_test_sif:latest", "false"},
+			argv:    []string{c.env.OrasTestImage, "false"},
 			exit:    1,
 		},
 
@@ -582,7 +584,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecTrueOrasUserns",
 			command: "exec",
-			argv:    []string{"--userns", "oras://localhost:5000/oras_test_sif:latest", "true"},
+			argv:    []string{"--userns", c.env.OrasTestImage, "true"},
 			exit:    0,
 		},
 		{
@@ -607,7 +609,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecFalseOrasUserns",
 			command: "exec",
-			argv:    []string{"--userns", "oras://localhost:5000/oras_test_sif:latest", "false"},
+			argv:    []string{"--userns", c.env.OrasTestImage, "false"},
 			exit:    1,
 		},
 	}

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -318,6 +318,8 @@ func (c *ctx) testDockerDefFile(t *testing.T) {
 }
 
 func (c *ctx) testDockerRegistry(t *testing.T) {
+	e2e.PrepRegistry(t, c.env)
+
 	if _, err := stdexec.LookPath("docker"); err != nil {
 		t.Skip("docker not installed")
 	}
@@ -329,17 +331,17 @@ func (c *ctx) testDockerRegistry(t *testing.T) {
 	}{
 		{"BusyBox", true, e2e.DefFileDetails{
 			Bootstrap: "docker",
-			From:      "localhost:5000/my-busybox",
+			From:      fmt.Sprintf("%s/my-busybox", c.env.TestRegistry),
 		}},
 		{"BusyBoxRegistry", true, e2e.DefFileDetails{
 			Bootstrap: "docker",
 			From:      "my-busybox",
-			Registry:  "localhost:5000",
+			Registry:  c.env.TestRegistry,
 		}},
 		{"BusyBoxNamespace", false, e2e.DefFileDetails{
 			Bootstrap: "docker",
 			From:      "my-busybox",
-			Registry:  "localhost:5000",
+			Registry:  c.env.TestRegistry,
 			Namespace: "not-a-namespace",
 		}},
 	}

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -23,6 +23,8 @@ type imgBuildTests struct {
 }
 
 func (c *imgBuildTests) buildFrom(t *testing.T) {
+	e2e.PrepRegistry(t, c.env)
+
 	tests := []struct {
 		name       string
 		dependency string
@@ -38,7 +40,7 @@ func (c *imgBuildTests) buildFrom(t *testing.T) {
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"ShubDefFile", "", "../examples/shub/Singularity", true},
 		{"LibraryDefFile", "", "../examples/library/Singularity", true},
-		{"OrasURI", "", "oras://localhost:5000/oras_test_sif:latest", true},
+		{"OrasURI", "", c.env.OrasTestImage, true},
 		{"Yum", "yum", "../examples/centos/Singularity", true},
 		{"Zypper", "zypper", "../examples/opensuse/Singularity", true},
 	}

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -6,8 +6,10 @@
 package e2e
 
 type TestEnv struct {
-	RunDisabled bool
-	CmdPath     string
-	TestDir     string
-	ImagePath   string
+	RunDisabled   bool
+	CmdPath       string
+	ImagePath     string
+	OrasTestImage string
+	TestDir       string
+	TestRegistry  string
 }

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -184,7 +184,7 @@ var tests = []struct {
 	// },
 	{
 		desc:            "oras transport for SIF from registry",
-		srcURI:          "oras://localhost:5000/pull_test_sif:latest",
+		srcURI:          "oras://localhost:5000/pull_test_sif:latest", // TODO(mem): obtain registry from context
 		force:           true,
 		unauthenticated: false,
 		expectSuccess:   true,
@@ -193,13 +193,13 @@ var tests = []struct {
 	// pulling of invalid images with oras
 	{
 		desc:          "oras pull of non SIF file",
-		srcURI:        "oras://localhost:5000/pull_test_:latest",
+		srcURI:        "oras://localhost:5000/pull_test_:latest", // TODO(mem): obtain registry from context
 		force:         true,
 		expectSuccess: false,
 	},
 	{
 		desc:          "oras pull of packed dir",
-		srcURI:        "oras://localhost:5000/pull_test_invalid_file:latest",
+		srcURI:        "oras://localhost:5000/pull_test_invalid_file:latest", // TODO(mem): obtain registry from context
 		force:         true,
 		expectSuccess: false,
 	},
@@ -266,6 +266,7 @@ func getImageNameFromURI(imgURI string) string {
 
 func (c *ctx) setup(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
+	e2e.PrepRegistry(t, c.env)
 
 	// setup file and dir to use as invalid images
 	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")
@@ -287,15 +288,15 @@ func (c *ctx) setup(t *testing.T) {
 	}{
 		{
 			srcPath: c.env.ImagePath,
-			uri:     "localhost:5000/pull_test_sif:latest",
+			uri:     fmt.Sprintf("%s/pull_test_sif:latest", c.env.TestRegistry),
 		},
 		{
 			srcPath: orasInvalidDir,
-			uri:     "localhost:5000/pull_test_dir:latest",
+			uri:     fmt.Sprintf("%s/pull_test_dir:latest", c.env.TestRegistry),
 		},
 		{
 			srcPath: orasInvalidFile,
-			uri:     "localhost:5000/pull_test_invalid_file:latest",
+			uri:     fmt.Sprintf("%s/pull_test_invalid_file:latest", c.env.TestRegistry),
 		},
 	}
 

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -7,6 +7,7 @@
 package push
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ type ctx struct {
 
 func (c *ctx) testPushCmd(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
+	e2e.PrepRegistry(t, c.env)
 
 	// setup file and dir to use as invalid sources
 	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")
@@ -42,25 +44,25 @@ func (c *ctx) testPushCmd(t *testing.T) {
 		{
 			desc:          "non existent image",
 			imagePath:     filepath.Join(orasInvalidDir, "not_an_existing_file.sif"),
-			dstURI:        "oras://localhost:5000/non_existent:test",
+			dstURI:        fmt.Sprintf("oras://%s/non_existent:test", c.env.TestRegistry),
 			expectSuccess: false,
 		},
 		{
 			desc:          "non SIF file",
 			imagePath:     orasInvalidFile,
-			dstURI:        "oras://localhost:5000/non_sif:test",
+			dstURI:        fmt.Sprintf("oras://%s/non_sif:test", c.env.TestRegistry),
 			expectSuccess: false,
 		},
 		{
 			desc:          "directory",
 			imagePath:     orasInvalidDir,
-			dstURI:        "oras://localhost:5000/directory:test",
+			dstURI:        fmt.Sprintf("oras://%s/directory:test", c.env.TestRegistry),
 			expectSuccess: false,
 		},
 		{
 			desc:          "standard SIF push",
 			imagePath:     c.env.ImagePath,
-			dstURI:        "oras://localhost:5000/standard_sif:test",
+			dstURI:        fmt.Sprintf("oras://%s/standard_sif:test", c.env.TestRegistry),
 			expectSuccess: true,
 		},
 	}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -7,6 +7,7 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -118,8 +119,15 @@ func Run(t *testing.T) {
 	// If you need the test image, add the call at the top of your
 	// own test.
 
-	// Start registry for tests
-	singularitye2e.PrepRegistry(t, name, testenv.ImagePath)
+	testenv.TestRegistry = "localhost:5000"
+	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
+
+	// WARNING(Sylabs-team): Please DO NOT add a call to
+	// e2e.PrepRegistry here. If you need to access the local
+	// registry, add the call at the top of your own test.
+	//
+	// e2e.KillRegistry is called here to ensure that the registry
+	// is stopped after tests run.
 	defer singularitye2e.KillRegistry(t)
 
 	// RunE2ETests by functionality


### PR DESCRIPTION
Just like with e2e.EnsureImage, the call to e2e.PrepRegistry should not
be in the toplevel test. Instead each test that needs to access the
registry MUST call this function to make sure the registry is ready for
use.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>