### PR TITLE
Add the `no_output_timeout` option to the `Run E2E tests` step in the `e2e_tests` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ jobs:
             sudo make -C ./builddir install
       - run:
           name: Run E2E tests
+          no_output_timeout: 45m
           command: |-
             cd $HOME/go/singularity
             make -C ./builddir integration-test e2e-test


### PR DESCRIPTION
Add the `no_output_timeout` option to the `Run E2E tests` step in the `e2e_tests` job.

A `step` will fail if the `command` runs for a set time without any output.

This is controlled by the `no_output_timeout` option, which defaults to 10m.

Increase this to 45m based on our test expectations.

Fixes #3881 