### PR TITLE
Replace offline pritunl Arch Linux mirror

### DIFF
--- a/examples/arch/README.md
+++ b/examples/arch/README.md
@@ -11,6 +11,7 @@ docker run -it  --privileged pritunl/archlinux bash
 ```
 
 ```bash
+echo 'Server = https://archive.archlinux.org/repos/2018/08/11/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 pacman -S -y git autoconf libtool automake gcc python make sudo vim arch-install-scripts wget
 git clone https://github.com/sylabs/singularity
 cd singularity


### PR DESCRIPTION
**Description of the Pull Request (PR):**

I replaced the pritunl mirror (`http://mirror.pritunl.com/archlinux/2018/08/11/$repo/os/$arch`) that is not working with an official mirror. Just like the replaced mirror, this mirror is a snapshot of the Arch Linux package archive at a specific date. Seehttps://wiki.archlinux.org/index.php/Arch_Linux_Archive. Right now, the commands don't work as stated because the provided server address returns 403. 

Since this is such a minor change I did not add myself to the contributors file.

Attn: @singularity-maintainers
