### PR TITLE
Skip e2e tests for pull requests based on their changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           step-name: Check changes
           custom-logic: |
             echo "Circle branch: $CIRCLE_BRANCH"
-            echo "Commit range: $COMMIT_RANGE"
+            echo "Commit range: '${COMMIT_RANGE}'"
 
             # Skip if there were no changes to the e2e or vendor directories and the branch is not master
             if [[ ! $(git diff "$COMMIT_RANGE" --name-status | grep -e "^e2e" -e "^vendor") && "$CIRCLE_BRANCH" != "master" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,8 @@ jobs:
       - run:
           name: Setup environment
           command: |-
+            pwd
+            ls
             echo 'export GOPATH=$HOME/go' >> $BASH_ENV
             echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
             echo 'export GOBIN=$HOME/go/bin' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  circle-compare-url: iynere/compare-url@1.2.0
+  compare-url: iynere/compare-url@1.2.0
 
 defaults: &defaults
   working_directory: /go/singularity
@@ -143,18 +143,18 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/go
-      - circle-compare-url/reconstruct
-      - circle-compare-url/use:
-        step-name: Check changes
-        custom-logic: |
-          echo "Circle branch: $CIRCLE_BRANCH"
-          echo "Commit range: $COMMIT_RANGE"
+      - compare-url/reconstruct
+      - compare-url/use:
+          step-name: Check changes
+          custom-logic: |
+            echo "Circle branch: $CIRCLE_BRANCH"
+            echo "Commit range: $COMMIT_RANGE"
 
-          # Skip if there were no changes to the e2e or vendor directories and the branch is not master
-          if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "^e2e" -e "^vendor") && "$CIRCLE_BRANCH" != "master" ]]; then
-            echo "Skipping e2e tests"
-            circleci step halt
-          fi
+            # Skip if there were no changes to the e2e or vendor directories and the branch is not master
+            if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "^e2e" -e "^vendor") && "$CIRCLE_BRANCH" != "master" ]]; then
+              echo "Skipping e2e tests"
+              circleci step halt
+            fi
       - run:
           name: Setup environment
           command: |-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
           at: ~/go
       - circle-compare-url/reconstruct
       - circle-compare-url/use:
+        step-name: Check changes
         custom-logic: |
           echo "Circle branch: $CIRCLE_BRANCH"
           echo "Commit range: $COMMIT_RANGE"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  circle-compe-url: iynere/compare-url@1.2.0
+
 defaults: &defaults
   working_directory: /go/singularity
 
@@ -140,6 +143,19 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/go
+      - circle-compare-url/reconstruct
+      - circle-compare-url/use:
+        step-name: Check changes
+        custom-logic: |
+          echo "Circle branch: $CIRCLE_BRANCH"
+          echo "Commit range: $COMMIT_RANGE"
+
+          # Skip if there were no changes to the e2e or vendor directories and the branch is not master
+          if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "^e2e" -e "^vendor") && "$CIRCLE_BRANCH" != "master" ]]; then
+            echo "Skipping e2e tests"
+            circleci step halt
+          fi
+      
       - run:
           name: Setup environment
           command: |-
@@ -204,6 +220,3 @@ workflows:
       - e2e_tests:
           requires:
             - get_source
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,6 @@ jobs:
       - run:
           name: Setup environment
           command: |-
-            pwd
-            ls
             echo 'export GOPATH=$HOME/go' >> $BASH_ENV
             echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
             echo 'export GOBIN=$HOME/go/bin' >> $BASH_ENV
@@ -146,10 +144,11 @@ jobs:
       - attach_workspace:
           at: ~/go
       - compare-url/reconstruct:
-          project-path: ~/go/singularity
+          project-path: $HOME/go/singularity
       - compare-url/use:
           step-name: Check changes
           custom-logic: |
+            cd $HOME/go/singularity
             echo "Circle branch: '${CIRCLE_BRANCH}'"
             echo "Commit range: '${COMMIT_RANGE}'"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,11 +143,12 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/go
-      - compare-url/reconstruct
+      - compare-url/reconstruct:
+          project-path: ~/go/singularity
       - compare-url/use:
           step-name: Check changes
           custom-logic: |
-            echo "Circle branch: $CIRCLE_BRANCH"
+            echo "Circle branch: '${CIRCLE_BRANCH}'"
             echo "Commit range: '${COMMIT_RANGE}'"
 
             # Skip if there were no changes to the e2e or vendor directories and the branch is not master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
             echo "Commit range: $COMMIT_RANGE"
 
             # Skip if there were no changes to the e2e or vendor directories and the branch is not master
-            if [[ ! $(git diff $COMMIT_RANGE --name-status | grep -e "^e2e" -e "^vendor") && "$CIRCLE_BRANCH" != "master" ]]; then
+            if [[ ! $(git diff "$COMMIT_RANGE" --name-status | grep -e "^e2e" -e "^vendor") && "$CIRCLE_BRANCH" != "master" ]]; then
               echo "Skipping e2e tests"
               circleci step halt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  circle-compe-url: iynere/compare-url@1.2.0
+  circle-compare-url: iynere/compare-url@1.2.0
 
 defaults: &defaults
   working_directory: /go/singularity
@@ -145,7 +145,6 @@ jobs:
           at: ~/go
       - circle-compare-url/reconstruct
       - circle-compare-url/use:
-        step-name: Check changes
         custom-logic: |
           echo "Circle branch: $CIRCLE_BRANCH"
           echo "Commit range: $COMMIT_RANGE"
@@ -155,7 +154,6 @@ jobs:
             echo "Skipping e2e tests"
             circleci step halt
           fi
-      
       - run:
           name: Setup environment
           command: |-


### PR DESCRIPTION
We only want to run e2e tests under the following condtions:

- Changes are made to the `e2e` directory
- Changes are made to the `vendor` directory
- Merging a pull request into `master`

This requires the use of the `$CIRCLE_COMPARE_URL` environment
variable provided by the orb `iynere/compare-url`.

https://circleci.com/orbs/registry/orb/iynere/compare-url

In earlier versions of circleci, that environment variable was
already present without the need for the orb. Consider this a
short-term fix.

- Fixes #3430
- Fixes #3806
