### PR TITLE
Build a sif from a sif without root

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -12,14 +12,14 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/sylabs/singularity/internal/pkg/util/fs"
-
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/internal/pkg/build"
 	"github.com/sylabs/singularity/internal/pkg/build/remotebuilder"
 	scs "github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/build/types"
+	"github.com/sylabs/singularity/pkg/image"
 )
 
 func run(cmd *cobra.Command, args []string) {
@@ -111,7 +111,7 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("failed to create an image cache handle")
 		}
 
-		if syscall.Getuid() != 0 && !fakeroot && fs.IsFile(spec) {
+		if syscall.Getuid() != 0 && !fakeroot && fs.IsFile(spec) && !isImage(spec) {
 			sylog.Fatalf("You must be the root user, however you can use --remote or --fakeroot to build from a Singularity recipe file")
 		}
 
@@ -189,6 +189,11 @@ func checkSections() error {
 	}
 
 	return nil
+}
+
+func isImage(spec string) bool {
+	_, err := image.Init(spec, false)
+	return err == nil
 }
 
 // standard builds should just warn and fall back to CLI default if we cannot resolve library URL

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -256,7 +256,7 @@ func engineRequired(def types.Definition) bool {
 // runBuildEngine creates an imgbuild engine and creates a container out of our bundle in order to execute %post %setup scripts in the bundle
 func runBuildEngine(b *types.Bundle) error {
 	if syscall.Getuid() != 0 && !b.Opts.Fakeroot {
-		return fmt.Errorf("Attempted to build with scripts as non-root user or without --fakeroot")
+		return fmt.Errorf("attempted to build with scripts as non-root user or without --fakeroot")
 	}
 
 	sylog.Debugf("Starting build engine")


### PR DESCRIPTION
## Description of the Pull Request (PR):

Re-able to build a sif from a sif image. In v3.2.1 this works, but in 3.3-rc-1, it was not possible.

#### Example

**3.2.1**
```bash
$ ./singularity version
3.2.1

$ ./singularity build foo.sif alpine_latest.sif 
INFO:    Starting build...
INFO:    Creating SIF file...
INFO:    Build complete: foo.sif
```

**This PR**
```bash
$ singularity build foo.sif alpine_latest.sif 
INFO:    Starting build...
INFO:    Creating SIF file...
INFO:    Build complete: foo.sif

# If you try to build from a def file without root:
$ singularity build foo.sif test.def 
INFO:    Starting build...
FATAL:   You must be the root user, however you can use --remote or --fakeroot to build from a Singularity recipe file
```

**Before this PR**
```bash
$ singularity build foo.sif alpine_latest.sif 
FATAL:   You must be the root user, however you can use --remote or --fakeroot to build from a Singularity recipe file

# I'm not even building from a def file!!!
```

## This fixes or addresses the following GitHub issues:

- Fixes #

<br>