### PR TITLE
e2e: add match type argument for ExpectOutput and ExpectError

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -402,7 +402,7 @@ func (c *actionTests) STDPipe(t *testing.T) {
 			name:    "AppsFoo",
 			command: "run",
 			argv:    []string{"--app", "foo", c.env.ImagePath},
-			output:  "FOO",
+			output:  "RUNNING FOO",
 			exit:    0,
 		},
 		{
@@ -416,7 +416,7 @@ func (c *actionTests) STDPipe(t *testing.T) {
 			name:    "Arguments",
 			command: "run",
 			argv:    []string{c.env.ImagePath, "foo"},
-			output:  "foo",
+			output:  "Running command: foo",
 			exit:    127,
 		},
 		{
@@ -433,7 +433,10 @@ func (c *actionTests) STDPipe(t *testing.T) {
 			tt.name,
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
-			e2e.ExpectExit(tt.exit, e2e.ExpectOutput(tt.output)),
+			e2e.ExpectExit(
+				tt.exit,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.output),
+			),
 		)
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds: 
- a match type argument for ExpectOutput and ExpectError to allow three type of match: contain, exact and regex.
- ExpectOutputf and ExpectErrorf methods

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
