### PR TITLE
Separate Cache Clean Test

### DIFF
--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -243,6 +243,7 @@ func (c *Handle) cleanAllCaches() {
 		"blob":    c.OciBlob,
 		"shub":    c.Shub,
 		"oras":    c.Oras,
+		"net":     c.Net,
 	}
 
 	for name, dir := range cacheDirs {

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -169,28 +169,6 @@ func (c *Handle) GetBasedir() string {
 	return c.baseDir
 }
 
-// Root is the root location where all of singularity caching happens. Library, Shub,
-// and oci image formats supported by containers/image repository will be cached inside
-//
-// Defaults to ${HOME}/.singularity/cache
-func (c *Handle) Root() string {
-	updateCacheRoot(c)
-
-	return c.rootDir
-}
-
-func updateCacheRoot(c *Handle) {
-	if d := os.Getenv(DirEnv); d != "" && d != syfs.ConfigDir() {
-		c.rootDir = d
-	} else {
-		c.rootDir = path.Join(syfs.ConfigDir(), CacheDir)
-	}
-
-	if err := initCacheDir(c.rootDir); err != nil {
-		sylog.Fatalf("Unable to initialize caching directory: %v", err)
-	}
-}
-
 // updateCacheSubdir update/create a sub-cache (directory) within the cache,
 // for example, the 'shub' cache.
 func updateCacheSubdir(c *Handle, subdir string) (string, error) {

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -142,8 +142,8 @@ func TestRoot(t *testing.T) {
 				t.Fatalf("failed to create new image cache: %s", err)
 			}
 
-			root := imgCache.Root()
-			if root == tt.expectedResult {
+			root := imgCache.rootDir
+			if root != tt.expectedResult {
 				t.Fatalf("test %s returned %s instead of %s", tt.name, root, tt.expectedResult)
 			}
 

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/syfs"
 )
 
@@ -20,7 +21,7 @@ const cacheCustom = "/tmp/customcachedir"
 var expectedCacheCustomRoot = filepath.Join(cacheCustom, CacheDir)
 var cacheDefault = filepath.Join(syfs.ConfigDir(), CacheDir)
 
-func TestCleanAllCaches(t *testing.T) {
+func TestNewHandle(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
@@ -47,13 +48,54 @@ func TestCleanAllCaches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
-			/* This is evil: if the cache is the default cache, we clean it */
-			defer c.cleanAllCaches()
 
 			if r := c.rootDir; r != tt.expected {
 				t.Errorf("Unexpected result: %s (expected %s)", r, tt.expected)
 			}
 		})
+	}
+}
+
+func TestCleanAllCaches(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	imageCacheDir, err := ioutil.TempDir("", "image-cache-")
+	if err != nil {
+		t.Fatalf("failed to create a temporary image cache")
+	}
+	defer os.RemoveAll(imageCacheDir)
+
+	c, err := NewHandle(imageCacheDir)
+	if err != nil {
+		t.Fatalf("failed to create new image cache handle: %s", err)
+	}
+
+	// list of subdirs to iterate over
+	cacheDirs := map[string]string{
+		"library": c.Library,
+		"oci":     c.OciTemp,
+		"blob":    c.OciBlob,
+		"shub":    c.Shub,
+		"oras":    c.Oras,
+		"net":     c.Net,
+	}
+
+	testfile := "test"
+	for _, dir := range cacheDirs {
+		if err := fs.Touch(filepath.Join(dir, testfile)); err != nil {
+			t.Fatalf("Failed to create file in test cache: %v", err)
+		}
+	}
+
+	// clean out our cache
+	c.cleanAllCaches()
+
+	for name, dir := range cacheDirs {
+		_, err := os.Stat(filepath.Join(dir, testfile))
+		if !os.IsNotExist(err) {
+			t.Errorf("Failed to clean %q cache at: %s", name, dir)
+		}
 	}
 }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Separates `cleanAllCaches()` testing from test where it could potentially remove user cached data
- adds `net` as a directory to be cleaned in the above method
- removes the `Root()` method that changes the cache location behind the scenes
- update `TestRoot()` to fail if the root doesn't match the expected location


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
