### PR TITLE
Added public/private key support for encryption (first attempt)

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	remote         bool
-	encrypt        bool
+	encrypt        string
 	builderURL     string
 	detached       bool
 	libraryURL     string
@@ -123,7 +123,7 @@ var buildRemoteFlag = cmdline.Flag{
 var buildEncryptFlag = cmdline.Flag{
 	ID:           "buildEncryptFlag",
 	Value:        &encrypt,
-	DefaultValue: false,
+	DefaultValue: "",
 	Name:         "encrypt",
 	ShortHand:    "e",
 	Usage:        "Encrypt the file system after building (requires root)",

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -31,6 +31,10 @@ func run(cmd *cobra.Command, args []string) {
 	dest := args[0]
 	spec := args[1]
 
+	if encrypt == "" {
+		sylog.Fatalf("encrypt flag needs path of file containing public key")
+	}
+
 	// check if target collides with existing file
 	if ok := checkBuildTarget(dest, update); !ok {
 		os.Exit(1)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -31,10 +31,6 @@ func run(cmd *cobra.Command, args []string) {
 	dest := args[0]
 	spec := args[1]
 
-	if encrypt == "" {
-		sylog.Fatalf("encrypt flag needs path of file containing public key")
-	}
-
 	// check if target collides with existing file
 	if ok := checkBuildTarget(dest, update); !ok {
 		os.Exit(1)
@@ -161,7 +157,7 @@ func run(cmd *cobra.Command, args []string) {
 					LibraryAuthToken: authToken,
 					DockerAuthConfig: authConf,
 					Fakeroot:         fakeroot,
-					Encrypted:        encrypt,
+					PubKeyFile:       encrypt,
 				},
 			})
 		if err != nil {

--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -238,7 +238,7 @@ func getPluginObjDescr(objPath string) (sif.DescriptorInput, error) {
 	objInput.Size = fstat.Size()
 
 	// populate objInput.Extra with appropriate Fstype & Parttype
-	err = objInput.SetPartExtra(sif.FsRaw, sif.PartData, sif.GetSIFArch(runtime.GOARCH))
+	err = objInput.SetPartExtra(sif.FsRaw, sif.PartData, sif.GetSIFArch(runtime.GOARCH), []byte{0})
 	if err != nil {
 		return sif.DescriptorInput{}, err
 	}

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -204,16 +204,13 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		return fmt.Errorf("While running mksquashfs: %v: %s", err, strings.Replace(string(errOut), "\n", " ", -1))
 	}
 
-	//TODO: I am using the field from the old code (Encrypted) to pass the keyfile.
-	// The field needs to be renamed
-
-	if b.Opts.Encrypted != "" {
+	if b.Opts.PubKeyFile != "" {
 
 		// A dm-crypt device needs to be created with squashfs
 		cryptDev := &crypt.Device{}
 
 		randomStr, _ := getRandomString(32)
-		publicKey, err := crypt.GetPublicKey(b.Opts.Encrypted)
+		publicKey, err := crypt.GetPublicKey(b.Opts.PubKeyFile)
 		if err != nil {
 			sylog.Debugf("Error parsing public key %s", err)
 			return err

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -105,8 +105,8 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		}
 
 		s := stage{}
-		if conf.Opts.Encrypted != "" {
-			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild")
+		if conf.Opts.PubKeyFile != "" {
+			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild", conf.Opts.PubKeyFile)
 		} else {
 			s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")
 		}

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -105,7 +105,7 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		}
 
 		s := stage{}
-		if conf.Opts.Encrypted {
+		if conf.Opts.Encrypted != "" {
 			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild")
 		} else {
 			s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")

--- a/internal/pkg/plugin/binary.go
+++ b/internal/pkg/plugin/binary.go
@@ -464,6 +464,7 @@ type sifReader interface {
 	GetFsType(name string) (sif.Fstype, error)
 	GetPartType(name string) (sif.Parttype, error)
 	GetData(name string) []byte
+	GetCipher(name string) ([]byte, error)
 }
 
 type sifFileImageReader struct {
@@ -494,6 +495,11 @@ func (r *sifFileImageReader) GetFsType(name string) (sif.Fstype, error) {
 func (r *sifFileImageReader) GetPartType(name string) (sif.Parttype, error) {
 	n := r.descriptors[name]
 	return r.fi.DescrArr[n].GetPartType()
+}
+
+func (r *sifFileImageReader) GetCipher(name string) ([]byte, error) {
+	n := r.descriptors[name]
+	return r.fi.DescrArr[n].GetCipher()
 }
 
 func (r *sifFileImageReader) GetData(name string) []byte {

--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -39,6 +39,7 @@ type MountArgs struct {
 type CryptArgs struct {
 	Offset  uint64
 	Loopdev string
+	Cipher  []byte
 }
 
 // ChrootArgs defines the arguments to chroot.

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -35,11 +35,12 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 }
 
 // Decrypt calls the DeCrypt RPC using the supplied arguments.
-func (t *RPC) Decrypt(offset uint64, path string) (string, error) {
+func (t *RPC) Decrypt(offset uint64, path string, cipher []byte) (string, error) {
 	loopdev := filepath.Base(path)
 	arguments := &args.CryptArgs{
 		Offset:  offset,
 		Loopdev: loopdev,
+		Cipher:  cipher,
 	}
 
 	var reply string

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -53,7 +53,7 @@ type Options struct {
 	// contains docker credentials if specified
 	DockerAuthConfig *ocitypes.DockerAuthConfig
 	// Encrypted specifies if the filesystem needs to be encrypteded
-	Encrypted string `json:"encrypt"`
+	PubKeyFile string `json:"pubKeyFile"`
 	// noTest indicates if build should skip running the test script
 	NoTest bool `json:"noTest"`
 	// force automatically deletes an existing container at build destination while performing build
@@ -72,7 +72,7 @@ type Options struct {
 }
 
 // Common code between NewBundle and NewEncryptedBundle
-func bundleCommon(encrypted string, bundleDir, bundlePrefix string) (b *Bundle, err error) {
+func bundleCommon(keyFile string, bundleDir, bundlePrefix string) (b *Bundle, err error) {
 	b = &Bundle{}
 	b.JSONObjects = make(map[string][]byte)
 
@@ -90,7 +90,7 @@ func bundleCommon(encrypted string, bundleDir, bundlePrefix string) (b *Bundle, 
 		"rootfs": "fs",
 	}
 
-	b.Opts.Encrypted = encrypted
+	b.Opts.PubKeyFile = keyFile
 
 	for _, fso := range b.FSObjects {
 		if err = os.MkdirAll(filepath.Join(b.Path, fso), 0755); err != nil {
@@ -103,8 +103,8 @@ func bundleCommon(encrypted string, bundleDir, bundlePrefix string) (b *Bundle, 
 }
 
 // NewEncryptedBundle creates an Encrypted Bundle environment
-func NewEncryptedBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
-	return bundleCommon("", bundleDir, bundlePrefix)
+func NewEncryptedBundle(bundleDir, bundlePrefix string, pubKeyFile string) (b *Bundle, err error) {
+	return bundleCommon(pubKeyFile, bundleDir, bundlePrefix)
 }
 
 // NewBundle creates a Bundle environment

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -53,7 +53,7 @@ type Options struct {
 	// contains docker credentials if specified
 	DockerAuthConfig *ocitypes.DockerAuthConfig
 	// Encrypted specifies if the filesystem needs to be encrypteded
-	Encrypted bool `json:"encrypt"`
+	Encrypted string `json:"encrypt"`
 	// noTest indicates if build should skip running the test script
 	NoTest bool `json:"noTest"`
 	// force automatically deletes an existing container at build destination while performing build
@@ -72,7 +72,7 @@ type Options struct {
 }
 
 // Common code between NewBundle and NewEncryptedBundle
-func bundleCommon(encrypted bool, bundleDir, bundlePrefix string) (b *Bundle, err error) {
+func bundleCommon(encrypted string, bundleDir, bundlePrefix string) (b *Bundle, err error) {
 	b = &Bundle{}
 	b.JSONObjects = make(map[string][]byte)
 
@@ -104,12 +104,12 @@ func bundleCommon(encrypted bool, bundleDir, bundlePrefix string) (b *Bundle, er
 
 // NewEncryptedBundle creates an Encrypted Bundle environment
 func NewEncryptedBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
-	return bundleCommon(true, bundleDir, bundlePrefix)
+	return bundleCommon("", bundleDir, bundlePrefix)
 }
 
 // NewBundle creates a Bundle environment
 func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
-	return bundleCommon(false, bundleDir, bundlePrefix)
+	return bundleCommon("", bundleDir, bundlePrefix)
 }
 
 // Rootfs give the path to the root filesystem in the Bundle

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -58,6 +58,7 @@ type Section struct {
 	Offset uint64 `json:"offset"`
 	Type   uint32 `json:"type"`
 	Name   string `json:"name"`
+	Cipher []byte `json:"cipher"`
 }
 
 // Image describes an image object, an image is composed of one

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -74,10 +74,16 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 		if err != nil {
 			continue
 		}
+
 		if ptype != sif.PartPrimSys {
 			continue
 		}
 		fstype, err := desc.GetFsType()
+		if err != nil {
+			continue
+		}
+
+		cipher, err := desc.GetCipher()
 		if err != nil {
 			continue
 		}
@@ -87,6 +93,7 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 				Offset: uint64(desc.Fileoff),
 				Size:   uint64(desc.Filelen),
 				Name:   RootFs,
+				Cipher: cipher,
 			},
 		}
 
@@ -122,10 +129,16 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 			if err != nil {
 				continue
 			}
+			cipher, err := desc.GetCipher()
+			if err != nil {
+				continue
+			}
+			sylog.Debugf("Non primary cipher is %s", string(cipher))
 			partition := Section{
 				Offset: uint64(desc.Fileoff),
 				Size:   uint64(desc.Filelen),
 				Name:   desc.GetName(),
+				Cipher: cipher,
 			}
 			switch fstype {
 			case sif.FsSquash:

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -6,6 +6,9 @@
 package crypt
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -68,6 +71,56 @@ func (crypt *Device) CloseCryptDevice(path string) error {
 	}
 
 	return nil
+}
+
+// GetPublicKey returns public key in the file at path
+func GetPublicKey(path string) (*rsa.PublicKey, error) {
+
+	dat, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to read public key file: %s", path)
+	}
+
+	block, _ := pem.Decode(dat)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block containing public key")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		sylog.Debugf("Can't parse using ParsePCKS1PublicKey ")
+		return nil, err
+	}
+	pub1, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		sylog.Debugf("Not of type rsa.PublicKey")
+	}
+
+	return pub1, nil
+}
+
+// GetPrivateKey returns private key in the file at path
+func GetPrivateKey(path string) (*rsa.PrivateKey, error) {
+
+	dat, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to read private key file: %s", path)
+	}
+
+	block, _ := pem.Decode(dat)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block containing private key")
+	}
+
+	pri, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		sylog.Debugf("Can't parse using ParsePCKS1PrivateKey ")
+		return nil, err
+	}
+
+	return pri, nil
 }
 
 // ReadKeyFromStdin reads key from terminal and returns it

--- a/vendor/github.com/sylabs/sif/internal/app/siftool/modif.go
+++ b/vendor/github.com/sylabs/sif/internal/app/siftool/modif.go
@@ -139,7 +139,7 @@ func Add(containerFile, dataFile string, opts AddOptions) error {
 			return fmt.Errorf("usage")
 		}
 
-		err := input.SetPartExtra(sif.Fstype(*opts.Partfs), sif.Parttype(*opts.Parttype), a)
+		err := input.SetPartExtra(sif.Fstype(*opts.Partfs), sif.Parttype(*opts.Parttype), a, []byte{0})
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/sylabs/sif/pkg/sif/create.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/create.go
@@ -68,6 +68,7 @@ func getUserIDs() (int64, int64, error) {
 
 // Fill all of the fields of a Descriptor
 func fillDescriptor(fimg *FileImage, index int, input DescriptorInput) (err error) {
+
 	descr := &fimg.DescrArr[index]
 
 	curoff, err := fimg.Fp.Seek(0, 1)
@@ -430,7 +431,7 @@ func (fimg *FileImage) DeleteObject(id uint32, flags int) error {
 }
 
 // SetPartExtra serializes the partition and fs type info into a binary buffer
-func (di *DescriptorInput) SetPartExtra(fs Fstype, part Parttype, arch string) error {
+func (di *DescriptorInput) SetPartExtra(fs Fstype, part Parttype, arch string, cipher []byte) error {
 	extra := Partition{
 		Fstype:   fs,
 		Parttype: part,
@@ -439,6 +440,7 @@ func (di *DescriptorInput) SetPartExtra(fs Fstype, part Parttype, arch string) e
 		return fmt.Errorf("architecture not supported: %v", arch)
 	}
 	copy(extra.Arch[:], arch[:])
+	copy(extra.Cipher[:], cipher[:])
 
 	// serialize the partition data for integration with the base descriptor input
 	if err := binary.Write(&di.Extra, binary.LittleEndian, extra); err != nil {

--- a/vendor/github.com/sylabs/sif/pkg/sif/lookup.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/lookup.go
@@ -277,6 +277,20 @@ func (descr *Descriptor) GetFsType() (Fstype, error) {
 	return pinfo.Fstype, nil
 }
 
+// GetCipher extracts the cipher from the partition descriptor
+func (descr *Descriptor) GetCipher() ([]byte, error) {
+	if descr.Datatype != DataPartition {
+		return []byte{0}, fmt.Errorf("expected DataPartition, got %v", descr.Datatype)
+	}
+	var pinfo Partition
+	b := bytes.NewReader(descr.Extra[:])
+	if err := binary.Read(b, binary.LittleEndian, &pinfo); err != nil {
+		return []byte{0}, fmt.Errorf("while extracting Partition extra info: %s", err)
+	}
+
+	return []byte(pinfo.Cipher[:]), nil
+}
+
 // GetPartType extracts the Parttype field from the Extra field of a Partition Descriptor
 func (descr *Descriptor) GetPartType() (Parttype, error) {
 	if descr.Datatype != DataPartition {

--- a/vendor/github.com/sylabs/sif/pkg/sif/sif.go
+++ b/vendor/github.com/sylabs/sif/pkg/sif/sif.go
@@ -215,6 +215,7 @@ type Envvar struct {
 type Partition struct {
 	Fstype   Fstype
 	Parttype Parttype
+	Cipher   [128]byte
 	Arch     [HdrArchLen]byte // arch the image is built for
 }
 
@@ -300,6 +301,7 @@ type DescriptorInput struct {
 	Link      uint32   // link to be set for new descriptor
 	Size      int64    // size of the data object for the new descriptor
 	Alignment int      // Align requirement for data object
+	Cipher    []byte   // Cipher if encrypted
 
 	Fname string    // file containing data associated with the new descriptor
 	Fp    io.Reader // file pointer to opened 'fname'


### PR DESCRIPTION
First attempt at public/private key encryption

This PR is doing the following things:
**Build time:**

1. Generate a 32 byte random string to use as LUKS key to encrypt and decrypt the root file system inside the SIF
2. Use public key (needs to be supplied from command line) to encrypt the LUKS key and generate a cipher
3. Store the cipher inside SIF's partition header

**Runtime**
1. Use the private key to decrypt the cipher
2. Use the key generated from step 1 to decrypt the file system

**Usage:**
**Build**
sudo singularity -d build -e /home/vagrant/mykey.pub  /home/vagrant/sif/test.sif /home/vagrant/sif/test.recipe

/home/vagrant/mykey.pub contains the public key in the following format

-----BEGIN PUBLIC KEY-----
MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDbHSyeQ78J71M/SIF0C3hGG1lt
XSyhasJKMpweks8Fn6sdekOnsVgfflZOT9p1WHmu68uhGwgJqVfDoORJbg1C8sHs
gNM3wd1qyxzHbiWY2FKU8EV6C6IrMFqzGY6QW2hN1UHMWrjRZxam85MSlSzNxYDW
FJ11t94KXTiIlwooUwIDAQAB
-----END PUBLIC KEY-----

**Runtime**

singularity -d shell ~/sif/test.sif
This should automatically read the cipher and decrypt the FS

**TODOs**
1. A lot of error checking. This code most likely doesn't work with default case.
2. I am allocating 128 bytes in partition header for the key. Need to check if that's the right number.
3. The way I am passing the cipher during runtime is using mnt.InternalOptions and the cipher is encoded as a string. I had to use base64 encoding to avoid characters in cipher such as "," which can cause further issues. Need to check if there in a more efficient way to pass this info around.
4. Move to code t appropriate files and functions
5. Hardcoded the location of private key in Decrypt() function. This is most likely the place to add the TPM integration. If not, at least get the file location from some config file. The current hardcoded path for private key is /home/vagrant/mykey.pem

Private key looks like this:

-----BEGIN RSA PRIVATE KEY-----
MIICXgIBAAKBgQDbHSyeQ78J71M/SIF0C3hGG1ltXSyhasJKMpweks8Fn6sdekOn
sVgfflZOT9p1WHmu68uhGwgJqVfDoORJbg1C8sHsgNM3wd1qyxzHbiWY2FKU8EV6
C6IrMFqzGY6QW2hN1UHMWrjRZxam85MSlSzNxYDWFJ11t94KXTiIlwooUwIDAQAB
AoGBAKUg8XU8fQaRtF0m2ViJJFVBWz3OUEo92LpuNbXc0ePdFuoaME56mnzxiz1t
dKemy92FmmqJop8VXizyXdjw9VAv2IzXUmR9NNC0rQnjkf6zs3+lImvBL2mbQjxx
56+CxY3+v2utiRNy772ysLPnL8zKXpec/TtzUR1/DEFwrNWBAkEA9EIsAMuczEe+
RhjIlmcW7F+9sfJPsyU8ToAqoO67O8+nR062lq1Bep0KrOdCONXmdHq7w9a6X7mu
T0/l/pDScwJBAOWlk117c5w6sr37DoDaXwTzlIgs3fewsv3dWrPWQm98M3bgdvJO
i5SCZd7ene2rJun2rXWansV+uEtaIpXpeqECQQCBIWaP+RTo7ljKSBnrYY694hOw
OpEl/V53hcyDjhJQGYSu7w8ac3f1cYaOSCg7UeHm3GfdreyT5N8hMPU/cqK/AkEA
3IIVs7DDvSL72MKGFaIZlTaSzANRC/JGnM98tawp1MUM4bv9WwOisXJYgR1/xeQP
FJ8Bxig3Bmp8ahZdmVc8oQJAJKEb3SjzgSfa6MaF2uvTmEULTN6vBjt2aCjhcS6o
L526iRq23mgoH2kIIracfxlPoAsAcCnLSVT76jSEPOo1rg==
-----END RSA PRIVATE KEY-----



Attn: @singularity-maintainers
