### PR TITLE
Json output for 'verify'

### DIFF
--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ var (
 	sifGroupID  uint32 // -g groupid specification
 	sifDescID   uint32 // -i id specification
 	localVerify bool   // -l flag
+	jsonVerify  bool   // -j flag
 )
 
 // -u|--url
@@ -64,6 +66,16 @@ var verifyLocalFlag = cmdline.Flag{
 	EnvKeys:      []string{"LOCAL_VERIFY"},
 }
 
+// -j|--json
+var verifyJSONFlag = cmdline.Flag{
+	ID:           "verifyJsonFlag",
+	Value:        &jsonVerify,
+	DefaultValue: false,
+	Name:         "json",
+	ShortHand:    "j",
+	Usage:        "output json",
+}
+
 func init() {
 	cmdManager.RegisterCmd(VerifyCmd)
 
@@ -71,6 +83,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&verifySifGroupIDFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifySifDescIDFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifyLocalFlag, VerifyCmd)
+	cmdManager.RegisterFlagForCmd(&verifyJSONFlag, VerifyCmd)
 }
 
 // VerifyCmd singularity verify
@@ -115,7 +128,8 @@ func doVerifyCmd(cpath, url string) {
 		id = sifDescID
 	}
 
-	_, err := signing.Verify(cpath, url, id, isGroup, authToken, localVerify, false, false)
+	author, _, err := signing.Verify(cpath, url, id, isGroup, authToken, localVerify, jsonVerify)
+	fmt.Printf("%s", author)
 	if err == signing.ErrVerificationFail {
 		sylog.Fatalf("Failed to verify: %s", cpath)
 	} else if err != nil {

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -107,7 +107,7 @@ func LibraryPull(imgCache *cache.Handle, name, ref, transport, fullURI, libraryU
 
 	// check if we pulled from the library, if so; is it signed?
 	if !unauthenticated {
-		imageSigned, err := signing.IsSigned(name, keyServerURL, 0, false, authToken, true)
+		imageSigned, err := signing.IsSigned(name, keyServerURL, 0, false, authToken)
 		if err != nil {
 			sylog.Errorf("%v", err)
 		}

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -62,7 +62,7 @@ func LibraryPush(file, dest, authToken, libraryURI, keyServerURL, remoteWarning 
 
 	if !unauthenticated {
 		// check if the container is signed
-		imageSigned, err := signing.IsSigned(file, keyServerURL, 0, false, authToken, true)
+		imageSigned, err := signing.IsSigned(file, keyServerURL, 0, false, authToken)
 		if err != nil {
 			// err will be: "unable to verify container: %v", err
 			sylog.Warningf("%v", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds a flag to `verify` to provider a json output.

#### Example

```bash
$ singularity verify -j alpine_latest.sif 
[
  {
    "Signer": {
      "Name": "Sylabs Admin \u003csupport@sylabs.io\u003e",
      "Fingerprint": "8883491F4268F173C6E5DC49EDECE4F3F38D871E",
      "Local": true,
      "KeyCheck": true,
      "DataCheck": true
    }
  }
]
INFO:    Container verified: alpine_latest.sif
```

_NOTE: The `INFO` is not part of the json output, so you can pipe this output to `jq` without a problem._

## This fixes or addresses the following GitHub issues:

- Fixes: https://github.com/sylabs/singularity/issues/3905

- Related to: https://github.com/sylabs/singularity/issues/3919

<br>
