### PR TITLE
Change ALL error messages to un-cap

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -182,10 +182,10 @@ func checkSections() error {
 	}
 
 	if all && len(sections) > 1 {
-		return fmt.Errorf("Section specification error: Cannot have all and any other option")
+		return fmt.Errorf("section specification error: cannot have all and any other option")
 	}
 	if none && len(sections) > 1 {
-		return fmt.Errorf("Section specification error: Cannot have none and any other option")
+		return fmt.Errorf("section specification error: cannot have none and any other option")
 	}
 
 	return nil

--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -963,11 +963,11 @@ func verifyFile(t *testing.T, original, copy string) error {
 	}
 
 	if ofi.Size() != cfi.Size() {
-		return fmt.Errorf("Incorrect file sizes. Original: %v, Copy: %v", ofi.Size(), cfi.Size())
+		return fmt.Errorf("incorrect file sizes. original: %v, copy: %v", ofi.Size(), cfi.Size())
 	}
 
 	if ofi.Mode() != cfi.Mode() {
-		return fmt.Errorf("Incorrect file modes. Original: %v, Copy: %v", ofi.Mode(), cfi.Mode())
+		return fmt.Errorf("incorrect file modes. original: %v, copy: %v", ofi.Mode(), cfi.Mode())
 	}
 
 	o, err := ioutil.ReadFile(original)
@@ -981,7 +981,7 @@ func verifyFile(t *testing.T, original, copy string) error {
 	}
 
 	if !bytes.Equal(o, c) {
-		return fmt.Errorf("Incorrect file content")
+		return fmt.Errorf("incorrect file content")
 	}
 
 	return nil
@@ -995,7 +995,7 @@ func verifyHelp(t *testing.T, fileName string, contents []string) error {
 
 	// do perm check
 	if fi.Mode().Perm() != 0644 {
-		return fmt.Errorf("Incorrect help script perms: %v", fi.Mode().Perm())
+		return fmt.Errorf("incorrect help script perms: %v", fi.Mode().Perm())
 	}
 
 	s, err := ioutil.ReadFile(fileName)
@@ -1006,7 +1006,7 @@ func verifyHelp(t *testing.T, fileName string, contents []string) error {
 	helpScript := string(s)
 	for _, c := range contents {
 		if !strings.Contains(helpScript, c) {
-			return fmt.Errorf("Missing help script content")
+			return fmt.Errorf("missing help script content")
 		}
 	}
 
@@ -1021,7 +1021,7 @@ func verifyScript(t *testing.T, fileName string, contents []string) error {
 
 	// do perm check
 	if fi.Mode().Perm() != 0755 {
-		return fmt.Errorf("Incorrect script perms: %v", fi.Mode().Perm())
+		return fmt.Errorf("incorrect script perms: %v", fi.Mode().Perm())
 	}
 
 	s, err := ioutil.ReadFile(fileName)
@@ -1032,7 +1032,7 @@ func verifyScript(t *testing.T, fileName string, contents []string) error {
 	script := string(s)
 	for _, c := range contents {
 		if !strings.Contains(script, c) {
-			return fmt.Errorf("Missing script content")
+			return fmt.Errorf("missing script content")
 		}
 	}
 
@@ -1063,7 +1063,7 @@ func verifyEnv(t *testing.T, imagePath string, env []string, flags []string) err
 
 	for _, e := range env {
 		if !strings.Contains(out, e) {
-			return fmt.Errorf("Environment is missing: %v", e)
+			return fmt.Errorf("environment is missing: %v", e)
 		}
 	}
 
@@ -1084,7 +1084,7 @@ func verifyLabels(t *testing.T, imagePath string, labels map[string]string) erro
 
 	for k, v := range labels {
 		if l, ok := fileLabels[k]; !ok || v != l {
-			return fmt.Errorf("Missing label: %v:%v", k, v)
+			return fmt.Errorf("missing label: %v:%v", k, v)
 		}
 	}
 
@@ -1097,7 +1097,7 @@ func verifyLabels(t *testing.T, imagePath string, labels map[string]string) erro
 
 	for _, l := range defaultLabels {
 		if _, ok := fileLabels[l]; !ok {
-			return fmt.Errorf("Missing label: %v", l)
+			return fmt.Errorf("missing label: %v", l)
 		}
 	}
 
@@ -1118,7 +1118,7 @@ func verifyAppLabels(t *testing.T, imagePath, appName string, labels map[string]
 
 	for k, v := range labels {
 		if l, ok := fileLabels[k]; !ok || v != l {
-			return fmt.Errorf("Missing label: %v:%v", k, v)
+			return fmt.Errorf("missing label: %v:%v", k, v)
 		}
 	}
 

--- a/internal/app/singularity/oci_create_linux.go
+++ b/internal/app/singularity/oci_create_linux.go
@@ -51,7 +51,7 @@ func OciCreate(containerID string, args *OciArgs) error {
 	configJSON := filepath.Join(absBundle, "config.json")
 	fb, err := os.Open(configJSON)
 	if err != nil {
-		return fmt.Errorf("OCI specification file %q is missing or cannot be read", configJSON)
+		return fmt.Errorf("oci specification file %q is missing or cannot be read", configJSON)
 	}
 
 	data, err := ioutil.ReadAll(fb)

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -38,7 +38,7 @@ func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("No Remote configurations")
+			return fmt.Errorf("no remote configurations")
 		}
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -426,7 +426,7 @@ func copy(src, dst string) error {
 	copy.Stderr = &stderr
 	sylog.Debugf("Copying %v to %v", src, dst)
 	if err := copy.Run(); err != nil {
-		return fmt.Errorf("While copying %v to %v: %v: %v", src, dst, err, stderr.String())
+		return fmt.Errorf("while copying %v to %v: %v: %v", src, dst, err, stderr.String())
 	}
 
 	return nil

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the URIs of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/assembler.go
+++ b/internal/pkg/build/assembler.go
@@ -32,5 +32,5 @@ func IsValidAssembler(c string) (valid bool, err error) {
 		return true, nil
 	}
 
-	return false, fmt.Errorf("Invalid Assembler %s", c)
+	return false, fmt.Errorf("invalid assembler %s", c)
 }

--- a/internal/pkg/build/assembler.go
+++ b/internal/pkg/build/assembler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/assemblers/assembler_sandbox.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox.go
@@ -34,7 +34,7 @@ func (a *SandboxAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	cmd := exec.Command("mv", b.Rootfs(), path)
 	cmd.Stderr = &stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("Sandbox Assemble Failed: %v: %v", err, stderr.String())
+		return fmt.Errorf("sandbox assemble failed: %v: %v", err, stderr.String())
 	}
 
 	return nil

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -150,7 +150,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 
 	mksquashfs, err := getMksquashfsPath()
 	if err != nil {
-		return fmt.Errorf("While searching for mksquashfs: %v", err)
+		return fmt.Errorf("while searching for mksquashfs: %v", err)
 	}
 	f, err := ioutil.TempFile(b.Path, "squashfs-")
 	fsPath = f.Name()
@@ -166,20 +166,20 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 	mksquashfsCmd := exec.Command(mksquashfs, args...)
 	stderr, err := mksquashfsCmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("While setting up stderr pipe: %v", err)
+		return fmt.Errorf("while setting up stderr pipe: %v", err)
 	}
 
 	if err := mksquashfsCmd.Start(); err != nil {
-		return fmt.Errorf("While starting mksquashfs: %v", err)
+		return fmt.Errorf("while starting mksquashfs: %v", err)
 	}
 
 	errOut, err := ioutil.ReadAll(stderr)
 	if err != nil {
-		return fmt.Errorf("While reading mksquashfs stderr: %v", err)
+		return fmt.Errorf("while reading mksquashfs stderr: %v", err)
 	}
 
 	if err := mksquashfsCmd.Wait(); err != nil {
-		return fmt.Errorf("While running mksquashfs: %v: %s", err, strings.Replace(string(errOut), "\n", " ", -1))
+		return fmt.Errorf("while running mksquashfs: %v: %s", err, strings.Replace(string(errOut), "\n", " ", -1))
 	}
 
 	if b.Opts.Encrypted {
@@ -210,7 +210,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 
 	err = createSIF(path, b.Recipe.Raw, b.JSONObjects["oci-config"], fsPath, b.Opts.Encrypted)
 	if err != nil {
-		return fmt.Errorf("While creating SIF: %v", err)
+		return fmt.Errorf("while creating sif: %v", err)
 	}
 
 	return

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -24,43 +24,43 @@ func (s *stage) insertMetadata() (err error) {
 	// insert help
 	err = insertHelpScript(s.b)
 	if err != nil {
-		return fmt.Errorf("While inserting help script: %v", err)
+		return fmt.Errorf("while inserting help script: %v", err)
 	}
 
 	// insert labels
 	err = insertLabelsJSON(s.b)
 	if err != nil {
-		return fmt.Errorf("While inserting labels JSON: %v", err)
+		return fmt.Errorf("while inserting labels json: %v", err)
 	}
 
 	// insert definition
 	err = insertDefinition(s.b)
 	if err != nil {
-		return fmt.Errorf("While inserting definition: %v", err)
+		return fmt.Errorf("while inserting definition: %v", err)
 	}
 
 	// insert environment
 	err = insertEnvScript(s.b)
 	if err != nil {
-		return fmt.Errorf("While inserting environment script: %v", err)
+		return fmt.Errorf("while inserting environment script: %v", err)
 	}
 
 	// insert startscript
 	err = insertStartScript(s.b)
 	if err != nil {
-		return fmt.Errorf("While inserting startscript: %v", err)
+		return fmt.Errorf("while inserting startscript: %v", err)
 	}
 
 	// insert runscript
 	err = insertRunScript(s.b)
 	if err != nil {
-		return fmt.Errorf("While inserting runscript: %v", err)
+		return fmt.Errorf("while inserting runscript: %v", err)
 	}
 
 	// insert test script
 	err = insertTestScript(s.b)
 	if err != nil {
-		return fmt.Errorf("While inserting test script: %v", err)
+		return fmt.Errorf("while inserting test script: %v", err)
 	}
 
 	return

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -77,12 +77,12 @@ func (cp *ArchConveyorPacker) Get(b *types.Bundle) (err error) {
 
 	instList, err := getPacmanBaseList()
 	if err != nil {
-		return fmt.Errorf("While generating the installation list: %v", err)
+		return fmt.Errorf("while generating the installation list: %v", err)
 	}
 
 	pacConf, err := cp.getPacConf(pacmanConfURL)
 	if err != nil {
-		return fmt.Errorf("While getting pacman config: %v", err)
+		return fmt.Errorf("while getting pacman config: %v", err)
 	}
 
 	args := []string{"-C", pacConf, "-c", "-d", "-G", "-M", cp.b.Rootfs(), "haveged"}
@@ -94,7 +94,7 @@ func (cp *ArchConveyorPacker) Get(b *types.Bundle) (err error) {
 	sylog.Debugf("\n\tPacstrap Path: %s\n\tPac Conf: %s\n\tRootfs: %s\n\tInstall List: %s\n", pacstrapPath, pacConf, cp.b.Rootfs(), instList)
 
 	if err = pacCmd.Run(); err != nil {
-		return fmt.Errorf("While pacstrapping: %v", err)
+		return fmt.Errorf("while pacstrapping: %v", err)
 	}
 
 	//Pacman package signing setup
@@ -102,7 +102,7 @@ func (cp *ArchConveyorPacker) Get(b *types.Bundle) (err error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While setting up package signing: %v", err)
+		return fmt.Errorf("while setting up package signing: %v", err)
 	}
 
 	//Clean up haveged
@@ -110,7 +110,7 @@ func (cp *ArchConveyorPacker) Get(b *types.Bundle) (err error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While cleaning up packages: %v", err)
+		return fmt.Errorf("while cleaning up packages: %v", err)
 	}
 
 	return nil
@@ -120,12 +120,12 @@ func (cp *ArchConveyorPacker) Get(b *types.Bundle) (err error) {
 func (cp *ArchConveyorPacker) Pack() (b *types.Bundle, err error) {
 	err = cp.insertBaseEnv()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting base environment: %v", err)
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	err = cp.insertRunScript()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting runscript: %v", err)
+		return nil, fmt.Errorf("while inserting runscript: %v", err)
 	}
 
 	return cp.b, nil
@@ -161,7 +161,7 @@ func (cp *ArchConveyorPacker) getPacConf(pacmanConfURL string) (pacConf string, 
 
 	resp, err := http.Get(pacmanConfURL)
 	if err != nil {
-		return "", fmt.Errorf("While performing http request: %v", err)
+		return "", fmt.Errorf("while performing http request: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -172,7 +172,7 @@ func (cp *ArchConveyorPacker) getPacConf(pacmanConfURL string) (pacConf string, 
 
 	//Simple check to make sure file received is the correct size
 	if bytesWritten != resp.ContentLength {
-		return "", fmt.Errorf("File received is not the right size. Supposed to be: %v  Actually: %v", resp.ContentLength, bytesWritten)
+		return "", fmt.Errorf("file received is not the right size. supposed to be: %v actually: %v", resp.ContentLength, bytesWritten)
 	}
 
 	return pacConfFile.Name(), nil

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -35,22 +35,22 @@ func (c *BusyBoxConveyor) Get(b *types.Bundle) (err error) {
 	// get mirrorURL, OSVerison, and Includes components to definition
 	mirrorurl, ok := b.Recipe.Header["mirrorurl"]
 	if !ok {
-		return fmt.Errorf("Invalid busybox header, no MirrurURL specified")
+		return fmt.Errorf("invalid busybox header, no mirrur url specified")
 	}
 
 	err = c.insertBaseEnv()
 	if err != nil {
-		return fmt.Errorf("While inserting base environment: %v", err)
+		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	err = c.insertBaseFiles()
 	if err != nil {
-		return fmt.Errorf("While inserting files: %v", err)
+		return fmt.Errorf("while inserting files: %v", err)
 	}
 
 	busyBoxPath, err := c.insertBusyBox(mirrorurl)
 	if err != nil {
-		return fmt.Errorf("While inserting busybox: %v", err)
+		return fmt.Errorf("while inserting busybox: %v", err)
 	}
 
 	cmd := exec.Command(busyBoxPath, `--install`, filepath.Join(c.b.Rootfs(), "/bin"))
@@ -59,7 +59,7 @@ func (c *BusyBoxConveyor) Get(b *types.Bundle) (err error) {
 
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("While performing busybox install: %v", err)
+		return fmt.Errorf("while performing busybox install: %v", err)
 	}
 
 	return nil
@@ -69,7 +69,7 @@ func (c *BusyBoxConveyor) Get(b *types.Bundle) (err error) {
 func (cp *BusyBoxConveyorPacker) Pack() (b *types.Bundle, err error) {
 	err = cp.insertRunScript()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting base environment: %v", err)
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	return cp.b, nil
@@ -96,7 +96,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 
 	resp, err := http.Get(mirrorurl)
 	if err != nil {
-		return "", fmt.Errorf("While performing http request: %v", err)
+		return "", fmt.Errorf("while performing http request: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -113,7 +113,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 
 	//Simple check to make sure file received is the correct size
 	if bytesWritten != resp.ContentLength {
-		return "", fmt.Errorf("File received is not the right size. Supposed to be: %v  Actually: %v", resp.ContentLength, bytesWritten)
+		return "", fmt.Errorf("file received is not the right size. supposed to be: %v actually: %v", resp.ContentLength, bytesWritten)
 	}
 
 	err = os.Chmod(f.Name(), 0755)

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -39,7 +39,7 @@ func (cp *DebootstrapConveyorPacker) Get(b *types.Bundle) (err error) {
 	}
 
 	if os.Getuid() != 0 {
-		return fmt.Errorf("You must be root to build with debootstrap")
+		return fmt.Errorf("you must be root to build with debootstrap")
 	}
 
 	// run debootstrap command
@@ -51,7 +51,7 @@ func (cp *DebootstrapConveyorPacker) Get(b *types.Bundle) (err error) {
 
 	// run debootstrap
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While debootstrapping: %v", err)
+		return fmt.Errorf("while debootstrapping: %v", err)
 	}
 
 	return nil
@@ -62,17 +62,17 @@ func (cp *DebootstrapConveyorPacker) Pack() (*types.Bundle, error) {
 
 	//change root directory permissions to 0755
 	if err := os.Chmod(cp.b.Rootfs(), 0755); err != nil {
-		return nil, fmt.Errorf("While changing bundle rootfs perms: %v", err)
+		return nil, fmt.Errorf("while changing bundle rootfs perms: %v", err)
 	}
 
 	err := cp.insertBaseEnv(cp.b)
 	if err != nil {
-		return nil, fmt.Errorf("While inserting base environtment: %v", err)
+		return nil, fmt.Errorf("while inserting base environtment: %v", err)
 	}
 
 	err = cp.insertRunScript(cp.b)
 	if err != nil {
-		return nil, fmt.Errorf("While inserting runscript: %v", err)
+		return nil, fmt.Errorf("while inserting runscript: %v", err)
 	}
 
 	return cp.b, nil
@@ -84,12 +84,12 @@ func (cp *DebootstrapConveyorPacker) getRecipeHeaderInfo() (err error) {
 	//get mirrorURL, OSVerison, and Includes components to definition
 	cp.mirrorurl, ok = cp.b.Recipe.Header["mirrorurl"]
 	if !ok {
-		return fmt.Errorf("Invalid debootstrap header, no MirrorURL specified")
+		return fmt.Errorf("invalid debootstrap header, no mirrorurl specified")
 	}
 
 	cp.osversion, ok = cp.b.Recipe.Header["osversion"]
 	if !ok {
-		return fmt.Errorf("Invalid debootstrap header, no OSVersion specified")
+		return fmt.Errorf("invalid debootstrap header, no osversion specified")
 	}
 
 	include := cp.b.Recipe.Header["include"]

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -38,7 +38,7 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 	authToken := b.Opts.LibraryAuthToken
 
 	if err = makeBaseEnv(cp.b.Rootfs()); err != nil {
-		return fmt.Errorf("While inserting base environment: %v", err)
+		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	// check for custom library from definition
@@ -78,19 +78,19 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 		sylog.Infof("Downloading library image")
 
 		if err = library.DownloadImageNoProgress(context.TODO(), libraryClient, imagePath, imageRef); err != nil {
-			return fmt.Errorf("unable to Download Image: %v", err)
+			return fmt.Errorf("unable to download image: %v", err)
 		}
 
 		if cacheFileHash, err := client.ImageHash(imagePath); err != nil {
-			return fmt.Errorf("Error getting ImageHash: %v", err)
+			return fmt.Errorf("error getting image hash: %v", err)
 		} else if cacheFileHash != libraryImage.Hash {
-			return fmt.Errorf("Cached File Hash(%s) and Expected Hash(%s) does not match", cacheFileHash, libraryImage.Hash)
+			return fmt.Errorf("cached file hash(%s) and expected Hash(%s) does not match", cacheFileHash, libraryImage.Hash)
 		}
 	}
 
 	// insert base metadata before unpacking fs
 	if err = makeBaseEnv(cp.b.Rootfs()); err != nil {
-		return fmt.Errorf("While inserting base environment: %v", err)
+		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	cp.LocalPacker, err = GetLocalPacker(imagePath, cp.b)

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -88,7 +88,7 @@ func GetLocalPacker(src string, b *types.Bundle) (LocalPacker, error) {
 func (cp *LocalConveyorPacker) Get(b *types.Bundle) (err error) {
 	// insert base metadata before unpacking fs
 	if err = makeBaseEnv(b.Rootfs()); err != nil {
-		return fmt.Errorf("While inserting base environment: %v", err)
+		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	cp.src = filepath.Clean(b.Recipe.Header["from"])

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -113,11 +113,11 @@ func (cp *OCIConveyorPacker) Get(b *sytypes.Bundle) (err error) {
 		}
 
 	default:
-		return fmt.Errorf("OCI ConveyorPacker does not support %s", b.Recipe.Header["bootstrap"])
+		return fmt.Errorf("oci conveyorPacker does not support %s", b.Recipe.Header["bootstrap"])
 	}
 
 	if err != nil {
-		return fmt.Errorf("Invalid image source: %v", err)
+		return fmt.Errorf("invalid image source: %v", err)
 	}
 
 	// Grab the modified source ref from the cache
@@ -147,27 +147,27 @@ func (cp *OCIConveyorPacker) Get(b *sytypes.Bundle) (err error) {
 func (cp *OCIConveyorPacker) Pack() (*sytypes.Bundle, error) {
 	err := cp.unpackTmpfs()
 	if err != nil {
-		return nil, fmt.Errorf("While unpacking tmpfs: %v", err)
+		return nil, fmt.Errorf("while unpacking tmpfs: %v", err)
 	}
 
 	err = cp.insertBaseEnv()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting base environment: %v", err)
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	err = cp.insertRunScript()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting runscript: %v", err)
+		return nil, fmt.Errorf("while inserting runscript: %v", err)
 	}
 
 	err = cp.insertEnv()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting docker specific environment: %v", err)
+		return nil, fmt.Errorf("while inserting docker specific environment: %v", err)
 	}
 
 	err = cp.insertOCIConfig()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting oci config: %v", err)
+		return nil, fmt.Errorf("while inserting oci config: %v", err)
 	}
 
 	return cp.b, nil

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -54,7 +54,7 @@ func (cp *OrasConveyorPacker) Get(b *types.Bundle) (err error) {
 
 	// insert base metadata before unpacking fs
 	if err = makeBaseEnv(b.Rootfs()); err != nil {
-		return fmt.Errorf("While inserting base environment: %v", err)
+		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	cp.LocalPacker, err = GetLocalPacker(cacheImagePath, b)

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -35,12 +35,12 @@ func (c *ScratchConveyor) Get(b *types.Bundle) (err error) {
 func (cp *ScratchConveyorPacker) Pack() (b *types.Bundle, err error) {
 	err = cp.insertBaseEnv()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting base environment: %v", err)
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	err = cp.insertRunScript()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting runscript: %v", err)
+		return nil, fmt.Errorf("while inserting runscript: %v", err)
 	}
 
 	return cp.b, nil

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -46,7 +46,7 @@ func (cp *ShubConveyorPacker) Get(b *types.Bundle) (err error) {
 
 	// insert base metadata before unpacking fs
 	if err = makeBaseEnv(cp.b.Rootfs()); err != nil {
-		return fmt.Errorf("While inserting base environment: %v", err)
+		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	cp.LocalPacker, err = GetLocalPacker(cp.b.FSObjects["shubImg"], cp.b)

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -53,28 +53,28 @@ func (c *YumConveyor) Get(b *types.Bundle) (err error) {
 	} else if installCommandPath, err = exec.LookPath("yum"); err == nil {
 		sylog.Debugf("Found yum at: %v", installCommandPath)
 	} else {
-		return fmt.Errorf("Neither yum nor dnf in PATH")
+		return fmt.Errorf("neither yum nor dnf in path")
 	}
 
 	// check for rpm on system
 	err = c.getRPMPath()
 	if err != nil {
-		return fmt.Errorf("While checking rpm path: %v", err)
+		return fmt.Errorf("while checking rpm path: %v", err)
 	}
 
 	err = c.getBootstrapOptions()
 	if err != nil {
-		return fmt.Errorf("While getting bootstrap options: %v", err)
+		return fmt.Errorf("while getting bootstrap options: %v", err)
 	}
 
 	err = c.genYumConfig()
 	if err != nil {
-		return fmt.Errorf("While generating Yum config: %v", err)
+		return fmt.Errorf("while generating yum config: %v", err)
 	}
 
 	err = c.copyPseudoDevices()
 	if err != nil {
-		return fmt.Errorf("While copying pseudo devices: %v", err)
+		return fmt.Errorf("while copying pseudo devices: %v", err)
 	}
 
 	args := []string{`--noplugins`, `-c`, filepath.Join(c.b.Rootfs(), yumConf), `--installroot`, c.b.Rootfs(), `--releasever=` + c.osversion, `-y`, `install`}
@@ -86,7 +86,7 @@ func (c *YumConveyor) Get(b *types.Bundle) (err error) {
 	// cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While bootstrapping: %v", err)
+		return fmt.Errorf("while bootstrapping: %v", err)
 	}
 
 	// clean up bootstrap packages
@@ -99,12 +99,12 @@ func (c *YumConveyor) Get(b *types.Bundle) (err error) {
 func (cp *YumConveyorPacker) Pack() (b *types.Bundle, err error) {
 	err = cp.insertBaseEnv()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting base environment: %v", err)
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	err = cp.insertRunScript()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting runscript: %v", err)
+		return nil, fmt.Errorf("while inserting runscript: %v", err)
 	}
 
 	return cp.b, nil
@@ -115,7 +115,7 @@ func (c *YumConveyor) getRPMPath() (err error) {
 
 	c.rpmPath, err = exec.LookPath("rpm")
 	if err != nil {
-		return fmt.Errorf("RPM is not in PATH: %v", err)
+		return fmt.Errorf("rpm is not in path: %v", err)
 	}
 
 	cmd := exec.Command("rpm", "--showrc")
@@ -139,7 +139,7 @@ func (c *YumConveyor) getRPMPath() (err error) {
 	}
 
 	if rpmDBPath == "" {
-		return fmt.Errorf("Could not find dbpath")
+		return fmt.Errorf("could not find dbpath")
 	} else if rpmDBPath != `%{_var}/lib/rpm` {
 		return fmt.Errorf("RPM database is using a weird path: %s\n"+
 			"You are probably running this bootstrap on Debian or Ubuntu.\n"+
@@ -166,7 +166,7 @@ func (c *YumConveyor) getBootstrapOptions() (err error) {
 	// get mirrorURL, updateURL, OSVerison, and Includes components to definition
 	c.mirrorurl, ok = c.b.Recipe.Header["mirrorurl"]
 	if !ok {
-		return fmt.Errorf("Invalid yum header, no MirrorURL specified")
+		return fmt.Errorf("invalid yum header, no mirrorurl specified")
 	}
 
 	c.updateurl = c.b.Recipe.Header["updateurl"]
@@ -176,7 +176,7 @@ func (c *YumConveyor) getBootstrapOptions() (err error) {
 	if regex.MatchString(c.mirrorurl) || regex.MatchString(c.updateurl) {
 		c.osversion, ok = c.b.Recipe.Header["osversion"]
 		if !ok {
-			return fmt.Errorf("Invalid yum header, OSVersion referenced in mirror but no OSVersion specified")
+			return fmt.Errorf("invalid yum header, osversion referenced in mirror but no osversion specified")
 		}
 		c.mirrorurl = regex.ReplaceAllString(c.mirrorurl, c.osversion)
 		c.updateurl = regex.ReplaceAllString(c.updateurl, c.osversion)
@@ -252,19 +252,19 @@ func (c *YumConveyor) genYumConfig() (err error) {
 
 	err = os.Mkdir(filepath.Join(c.b.Rootfs(), "/etc"), 0775)
 	if err != nil {
-		return fmt.Errorf("While creating %v: %v", filepath.Join(c.b.Rootfs(), "/etc"), err)
+		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.Rootfs(), "/etc"), err)
 	}
 
 	err = ioutil.WriteFile(filepath.Join(c.b.Rootfs(), yumConf), []byte(fileContent), 0664)
 	if err != nil {
-		return fmt.Errorf("While creating %v: %v", filepath.Join(c.b.Rootfs(), yumConf), err)
+		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.Rootfs(), yumConf), err)
 	}
 
 	// if gpg key is specified, import it
 	if c.gpg != "" {
 		err = c.importGPGKey()
 		if err != nil {
-			return fmt.Errorf("While importing GPG key: %v", err)
+			return fmt.Errorf("while importing gpg key: %v", err)
 		}
 	} else {
 		sylog.Infof("Skipping GPG Key Import")
@@ -278,26 +278,26 @@ func (c *YumConveyor) importGPGKey() (err error) {
 
 	// make sure gpg is being imported over https
 	if !strings.HasPrefix(c.gpg, "https://") {
-		return fmt.Errorf("GPG key must be fetched with https")
+		return fmt.Errorf("gpg key must be fetched with https")
 	}
 
 	// make sure curl is installed so rpm can import gpg key
 	if _, err = exec.LookPath("curl"); err != nil {
-		return fmt.Errorf("Neither yum nor dnf in PATH")
+		return fmt.Errorf("neither yum nor dnf in path")
 	}
 
 	cmd := exec.Command(c.rpmPath, "--root", c.b.Rootfs(), "--initdb")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While initializing new rpm db: %v", err)
+		return fmt.Errorf("while initializing new rpm db: %v", err)
 	}
 
 	cmd = exec.Command(c.rpmPath, "--root", c.b.Rootfs(), "--import", c.gpg)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While importing GPG key with rpm: %v", err)
+		return fmt.Errorf("while importing gpg key with rpm: %v", err)
 	}
 
 	sylog.Infof("GPG key import complete!")
@@ -308,7 +308,7 @@ func (c *YumConveyor) importGPGKey() (err error) {
 func (c *YumConveyor) copyPseudoDevices() (err error) {
 	err = os.Mkdir(filepath.Join(c.b.Rootfs(), "/dev"), 0775)
 	if err != nil {
-		return fmt.Errorf("While creating %v: %v", filepath.Join(c.b.Rootfs(), "/dev"), err)
+		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.Rootfs(), "/dev"), err)
 	}
 
 	devs := []string{"/dev/null", "/dev/zero", "/dev/random", "/dev/urandom"}
@@ -320,7 +320,7 @@ func (c *YumConveyor) copyPseudoDevices() (err error) {
 		if err = cmd.Run(); err != nil {
 			f, err := os.Create(c.b.Rootfs() + "/.singularity.d/runscript")
 			if err != nil {
-				return fmt.Errorf("While creating %v: %v", filepath.Join(c.b.Rootfs(), dev), err)
+				return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.Rootfs(), dev), err)
 			}
 
 			defer f.Close()

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -49,7 +49,7 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 	// get mirrorURL, OSVerison, and Includes components to definition
 	mirrorurl, ok := cp.b.Recipe.Header["mirrorurl"]
 	if !ok {
-		return fmt.Errorf("Invalid zypper header, no MirrorURL specified")
+		return fmt.Errorf("invalid zypper header, no mirrorurl specified")
 	}
 
 	// look for an OS version if the mirror specifies it
@@ -58,7 +58,7 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 	if regex.MatchString(mirrorurl) {
 		osversion, ok = cp.b.Recipe.Header["osversion"]
 		if !ok {
-			return fmt.Errorf("Invalid zypper header, OSVersion referenced in mirror but no OSVersion specified")
+			return fmt.Errorf("invalid zypper header, osversion referenced in mirror but no osversion specified")
 		}
 		mirrorurl = regex.ReplaceAllString(mirrorurl, osversion)
 	}
@@ -77,12 +77,12 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 	// Create the main portion of zypper config
 	err = cp.genZypperConfig()
 	if err != nil {
-		return fmt.Errorf("While generating Zypper config: %v", err)
+		return fmt.Errorf("while generating zypper config: %v", err)
 	}
 
 	err = cp.copyPseudoDevices()
 	if err != nil {
-		return fmt.Errorf("While copying pseudo devices: %v", err)
+		return fmt.Errorf("while copying pseudo devices: %v", err)
 	}
 
 	// Add mirrorURL as repo
@@ -90,7 +90,7 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While adding zypper mirror: %v", err)
+		return fmt.Errorf("while adding zypper mirror: %v", err)
 	}
 
 	// Refreshing gpg keys
@@ -98,7 +98,7 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While refreshing gpg keys: %v", err)
+		return fmt.Errorf("while refreshing gpg keys: %v", err)
 	}
 
 	args := []string{`--non-interactive`, `-c`, filepath.Join(cp.b.Rootfs(), zypperConf), `--root`, cp.b.Rootfs(), `--releasever=` + osversion, `-n`, `install`, `--auto-agree-with-licenses`, `--download-in-advance`}
@@ -113,7 +113,7 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 
 	// run zypper
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("While bootstrapping from zypper: %v", err)
+		return fmt.Errorf("while bootstrapping from zypper: %v", err)
 	}
 
 	return nil
@@ -123,12 +123,12 @@ func (cp *ZypperConveyorPacker) Get(b *types.Bundle) (err error) {
 func (cp *ZypperConveyorPacker) Pack() (b *types.Bundle, err error) {
 	err = cp.insertBaseEnv()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting base environment: %v", err)
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	err = cp.insertRunScript()
 	if err != nil {
-		return nil, fmt.Errorf("While inserting runscript: %v", err)
+		return nil, fmt.Errorf("while inserting runscript: %v", err)
 	}
 
 	return cp.b, nil
@@ -171,7 +171,7 @@ func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
 func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
 	err = os.MkdirAll(filepath.Join(cp.b.Rootfs(), "/etc/zypp"), 0775)
 	if err != nil {
-		return fmt.Errorf("While creating %v: %v", filepath.Join(cp.b.Rootfs(), "/etc/zypp"), err)
+		return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.Rootfs(), "/etc/zypp"), err)
 	}
 
 	err = ioutil.WriteFile(filepath.Join(cp.b.Rootfs(), zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0664)
@@ -185,7 +185,7 @@ func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
 func (cp *ZypperConveyorPacker) copyPseudoDevices() (err error) {
 	err = os.Mkdir(filepath.Join(cp.b.Rootfs(), "/dev"), 0775)
 	if err != nil {
-		return fmt.Errorf("While creating %v: %v", filepath.Join(cp.b.Rootfs(), "/dev"), err)
+		return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.Rootfs(), "/dev"), err)
 	}
 
 	devs := []string{"/dev/null", "/dev/zero", "/dev/random", "/dev/urandom"}
@@ -197,7 +197,7 @@ func (cp *ZypperConveyorPacker) copyPseudoDevices() (err error) {
 		if err = cmd.Run(); err != nil {
 			f, err := os.Create(cp.b.Rootfs() + "/.singularity.d/runscript")
 			if err != nil {
-				return fmt.Errorf("While creating %v: %v", filepath.Join(cp.b.Rootfs(), dev), err)
+				return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.Rootfs(), dev), err)
 			}
 
 			defer f.Close()

--- a/internal/pkg/build/sources/packer_ext3_linux.go
+++ b/internal/pkg/build/sources/packer_ext3_linux.go
@@ -36,7 +36,7 @@ func (p *Ext3Packer) Pack() (*types.Bundle, error) {
 func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs string) error {
 	tmpmnt, err := ioutil.TempDir(p.b.Path, "mnt")
 	if err != nil {
-		return fmt.Errorf("While making tmp mount point: %v", err)
+		return fmt.Errorf("while making tmp mount point: %v", err)
 	}
 
 	var number int
@@ -54,7 +54,7 @@ func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs strin
 	sylog.Debugf("Mounting loop device %s to %s\n", path, tmpmnt)
 	err = syscall.Mount(path, tmpmnt, "ext3", syscall.MS_NOSUID|syscall.MS_RDONLY|syscall.MS_NODEV, "errors=remount-ro")
 	if err != nil {
-		return fmt.Errorf("While mounting image: %v", err)
+		return fmt.Errorf("while mounting image: %v", err)
 	}
 	defer syscall.Unmount(tmpmnt, 0)
 
@@ -64,7 +64,7 @@ func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs strin
 	cmd := exec.Command("cp", "-r", tmpmnt+`/.`, b.Rootfs())
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("While copying files: %v: %v", err, stderr.String())
+		return fmt.Errorf("while copying files: %v: %v", err, stderr.String())
 	}
 
 	return err

--- a/internal/pkg/build/sources/packer_sif_linux.go
+++ b/internal/pkg/build/sources/packer_sif_linux.go
@@ -70,7 +70,7 @@ func (p *SIFPacker) unpackSIF(b *types.Bundle, srcfile string) (err error) {
 		sylog.Debugf("Ext3 partition detected, mounting to extract.")
 		err = unpackImagePartition(img.File, b.Rootfs(), "ext3", info)
 		if err != nil {
-			return fmt.Errorf("While copying partition data to bundle: %v", err)
+			return fmt.Errorf("while copying partition data to bundle: %v", err)
 		}
 	default:
 		return fmt.Errorf("unrecognized partition format")

--- a/internal/pkg/build/sources/packer_squashfs.go
+++ b/internal/pkg/build/sources/packer_squashfs.go
@@ -43,7 +43,7 @@ func (p *SquashfsPacker) unpackSquashfs(b *types.Bundle, info *loop.Info64, root
 
 	trimfile, err := ioutil.TempFile(p.b.Path, "trim.squashfs")
 	if err != nil {
-		return fmt.Errorf("While making tmp file: %v", err)
+		return fmt.Errorf("while making tmp file: %v", err)
 	}
 
 	// trim header
@@ -51,7 +51,7 @@ func (p *SquashfsPacker) unpackSquashfs(b *types.Bundle, info *loop.Info64, root
 	cmd := exec.Command("dd", "bs="+strconv.Itoa(int(info.Offset)), "skip=1", "if="+rootfs, "of="+trimfile.Name())
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("Trimming header Failed: %v: %v", err, stderr.String())
+		return fmt.Errorf("trimming header failed: %v: %v", err, stderr.String())
 	}
 
 	// copy filesystem into bundle rootfs

--- a/internal/pkg/client/oci/oci.go
+++ b/internal/pkg/client/oci/oci.go
@@ -82,7 +82,7 @@ func (t *ImageReference) newImageSource(ctx context.Context, sys *types.SystemCo
 func ParseImageName(imgCache *cache.Handle, uri string, sys *types.SystemContext) (types.ImageReference, error) {
 	ref, err := parseURI(uri)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse image name %v: %v", uri, err)
+		return nil, fmt.Errorf("unable to parse image name %v: %v", uri, err)
 	}
 
 	return ConvertReference(imgCache, ref, sys)
@@ -108,7 +108,7 @@ func parseURI(uri string) (types.ImageReference, error) {
 func ImageSHA(uri string, sys *types.SystemContext) (string, error) {
 	ref, err := parseURI(uri)
 	if err != nil {
-		return "", fmt.Errorf("Unable to parse image name %v: %v", uri, err)
+		return "", fmt.Errorf("unable to parse image name %v: %v", uri, err)
 	}
 
 	return calculateRefHash(ref, sys)

--- a/internal/pkg/plugin/binary.go
+++ b/internal/pkg/plugin/binary.go
@@ -592,7 +592,7 @@ func List(libexecdir string) ([]*Meta, error) {
 	pattern := filepath.Join(pluginDir, "*.meta")
 	entries, err := filepath.Glob(pattern)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot list plugins in directory %q", pluginDir)
+		return nil, fmt.Errorf("cannot list plugins in directory %q", pluginDir)
 	}
 
 	metas := []*Meta{}

--- a/internal/pkg/runtime/engines/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engines/config/starter/starter_linux.go
@@ -217,7 +217,7 @@ func (c *Config) AddUIDMappings(uids []specs.LinuxIDMapping) error {
 
 	l := len(uidMap)
 	if l >= C.MAX_MAP_SIZE-1 {
-		return fmt.Errorf("UID map too big")
+		return fmt.Errorf("uid map too big")
 	}
 
 	if l > 0 {
@@ -240,7 +240,7 @@ func (c *Config) AddGIDMappings(gids []specs.LinuxIDMapping) error {
 
 	l := len(gidMap)
 	if l >= C.MAX_MAP_SIZE-1 {
-		return fmt.Errorf("GID map too big")
+		return fmt.Errorf("gid map too big")
 	}
 
 	if l > 0 {

--- a/internal/pkg/runtime/engines/oci/create_linux.go
+++ b/internal/pkg/runtime/engines/oci/create_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/runtime/engines/oci/create_linux.go
+++ b/internal/pkg/runtime/engines/oci/create_linux.go
@@ -488,7 +488,7 @@ func (c *container) addCgroups(pid int, system *mount.System) error {
 	manager := &cgroups.Manager{Path: cgroupsPath, Pid: pid}
 
 	if err := manager.ApplyFromSpec(c.engine.EngineConfig.OciConfig.Linux.Resources); err != nil {
-		return fmt.Errorf("Failed to apply cgroups resources restriction: %s", err)
+		return fmt.Errorf("failed to apply cgroups resources restriction: %s", err)
 	}
 
 	if c.cgroupIndex >= 0 {

--- a/internal/pkg/runtime/engines/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engines/oci/prepare_linux.go
@@ -28,27 +28,27 @@ var (
 func (e *EngineOperations) checkCapabilities() error {
 	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Permitted {
 		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("Unrecognized capabilities %s", cap)
+			return fmt.Errorf("unrecognized capabilities %s", cap)
 		}
 	}
 	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Effective {
 		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("Unrecognized capabilities %s", cap)
+			return fmt.Errorf("unrecognized capabilities %s", cap)
 		}
 	}
 	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Inheritable {
 		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("Unrecognized capabilities %s", cap)
+			return fmt.Errorf("unrecognized capabilities %s", cap)
 		}
 	}
 	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Bounding {
 		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("Unrecognized capabilities %s", cap)
+			return fmt.Errorf("unrecognized capabilities %s", cap)
 		}
 	}
 	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Ambient {
 		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("Unrecognized capabilities %s", cap)
+			return fmt.Errorf("unrecognized capabilities %s", cap)
 		}
 	}
 	return nil
@@ -65,7 +65,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	}
 
 	if starterConfig.GetIsSUID() {
-		return fmt.Errorf("SUID workflow disabled by administrator")
+		return fmt.Errorf("suid workflow disabled by administrator")
 	}
 
 	if e.EngineConfig.OciConfig.Process == nil {

--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -208,7 +208,7 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 			cgroupPath := filepath.Join("/singularity", strconv.Itoa(pid))
 			manager := &cgroups.Manager{Pid: pid, Path: cgroupPath}
 			if err := manager.ApplyFromFile(path); err != nil {
-				return fmt.Errorf("Failed to apply cgroups resources restriction: %s", err)
+				return fmt.Errorf("failed to apply cgroups resources restriction: %s", err)
 			}
 			engine.EngineConfig.Cgroups = manager
 		}
@@ -608,7 +608,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 		cryptDev, err := c.rpcOps.Decrypt(offset, path)
 
 		if err != nil {
-			return fmt.Errorf("Unable to decrypt the file system: %s", err)
+			return fmt.Errorf("unable to decrypt the file system: %s", err)
 		}
 
 		path = cryptDev
@@ -1025,7 +1025,7 @@ func (c *container) addDevMount(system *mount.System) error {
 
 		if c.engine.EngineConfig.File.MountDevPts {
 			if _, err := os.Stat("/dev/pts/ptmx"); os.IsNotExist(err) {
-				return fmt.Errorf("Multiple devpts instances unsupported and /dev/pts configured")
+				return fmt.Errorf("multiple devpts instances unsupported and /dev/pts configured")
 			}
 
 			sylog.Debugf("Creating temporary staged /dev/pts")
@@ -1037,7 +1037,7 @@ func (c *container) addDevMount(system *mount.System) error {
 			if !c.userNS {
 				group, err := user.GetGrNam("tty")
 				if err != nil {
-					return fmt.Errorf("Problem resolving 'tty' group GID: %s", err)
+					return fmt.Errorf("problem resolving 'tty' group gid: %s", err)
 				}
 				options = fmt.Sprintf("%s,gid=%d", options, group.GID)
 
@@ -1310,7 +1310,7 @@ func (c *container) addHomeMount(system *mount.System) error {
 
 	// check if user attempt to mount a custom home when not allowed to
 	if c.engine.EngineConfig.GetCustomHome() && !c.engine.EngineConfig.File.UserBindControl {
-		return fmt.Errorf("Not mounting user requested home: user bind control is disallowed")
+		return fmt.Errorf("not mounting user requested home: user bind control is disallowed")
 	}
 
 	source, dest, err := c.getHomePaths()

--- a/internal/pkg/runtime/engines/singularity/create_linux.go
+++ b/internal/pkg/runtime/engines/singularity/create_linux.go
@@ -28,7 +28,7 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 
 	configurationFile := buildcfg.SYSCONFDIR + "/singularity/singularity.conf"
 	if err := config.Parser(configurationFile, engine.EngineConfig.File); err != nil {
-		return fmt.Errorf("Unable to parse singularity.conf file: %s", err)
+		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
 
 	rpcOps := &client.RPC{

--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -439,7 +439,7 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 	// 2. a user must use SUID workflow to join an instance
 	//    started without user namespace
 	if starterConfig.GetIsSUID() && !suidRequired {
-		return fmt.Errorf("joining user namespace with SUID workflow is not allowed")
+		return fmt.Errorf("joining user namespace with suid workflow is not allowed")
 	} else if !starterConfig.GetIsSUID() && suidRequired {
 		return fmt.Errorf("a setuid installation is required to join this instance")
 	}
@@ -698,7 +698,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	}
 
 	if !e.EngineConfig.File.AllowSetuid && starterConfig.GetIsSUID() {
-		return fmt.Errorf("SUID workflow disabled by administrator")
+		return fmt.Errorf("suid workflow disabled by administrator")
 	}
 
 	if starterConfig.GetIsSUID() {
@@ -900,21 +900,21 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 		if authorized, err := imgObject.AuthorizedPath(e.EngineConfig.File.LimitContainerPaths); err != nil {
 			return nil, err
 		} else if !authorized {
-			return nil, fmt.Errorf("Singularity image is not in an allowed configured path")
+			return nil, fmt.Errorf("singularity image is not in an allowed configured path")
 		}
 	}
 	if len(e.EngineConfig.File.LimitContainerGroups) != 0 {
 		if authorized, err := imgObject.AuthorizedGroup(e.EngineConfig.File.LimitContainerGroups); err != nil {
 			return nil, err
 		} else if !authorized {
-			return nil, fmt.Errorf("Singularity image is not owned by required group(s)")
+			return nil, fmt.Errorf("singularity image is not owned by required group(s)")
 		}
 	}
 	if len(e.EngineConfig.File.LimitContainerOwners) != 0 {
 		if authorized, err := imgObject.AuthorizedOwner(e.EngineConfig.File.LimitContainerOwners); err != nil {
 			return nil, err
 		} else if !authorized {
-			return nil, fmt.Errorf("Singularity image is not owned by required user(s)")
+			return nil, fmt.Errorf("singularity image is not owned by required user(s)")
 		}
 	}
 

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -40,7 +40,7 @@ func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) 
 
 	key, err := cryptDev.ReadKeyFromStdin(false)
 	if err != nil {
-		return fmt.Errorf("Unable to read key from stdin")
+		return fmt.Errorf("unable to read key from stdin")
 	}
 	cryptName, err := cryptDev.GetCryptDevice(key, arguments.Loopdev)
 

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/security/security.go
+++ b/internal/pkg/security/security.go
@@ -20,7 +20,7 @@ import (
 func Configure(config *specs.Spec) error {
 	if config.Process != nil {
 		if config.Process.SelinuxLabel != "" && config.Process.ApparmorProfile != "" {
-			return fmt.Errorf("You can't specify both an apparmor profile and a SELinux label")
+			return fmt.Errorf("you can't specify both an apparmor profile and a selinux label")
 		}
 		if config.Process.SelinuxLabel != "" {
 			if selinux.Enabled() {

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -203,7 +203,7 @@ func shouldRun(ecl *EclConfig, fp *os.File) (ok bool, err error) {
 		return checkBlackList(fp, egroup)
 	}
 
-	return false, fmt.Errorf("ECL config file invalid")
+	return false, fmt.Errorf("ecl config file invalid")
 }
 
 // ShouldRun determines if a container should run according to its execgroup rules

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -580,7 +580,7 @@ func (p *Points) AddImage(tag AuthorizedTag, source string, dest string, fstype 
 		return fmt.Errorf("source must be an absolute path")
 	}
 	if flags&(syscall.MS_BIND|syscall.MS_REMOUNT|syscall.MS_REC) != 0 {
-		return fmt.Errorf("MS_BIND, MS_REC or MS_REMOUNT are not valid flags for image mount points")
+		return fmt.Errorf("ms_bind, ms_rec or ms_remount are not valid flags for image mount points")
 	}
 	if _, ok := authorizedImage[fstype]; !ok {
 		return fmt.Errorf("mount %s image is not authorized", fstype)
@@ -640,7 +640,7 @@ func (p *Points) GetAllBinds() []Point {
 // AddOverlay adds an overlay mount point
 func (p *Points) AddOverlay(tag AuthorizedTag, dest string, flags uintptr, lowerdir string, upperdir string, workdir string) error {
 	if flags&(syscall.MS_BIND|syscall.MS_REMOUNT|syscall.MS_REC) != 0 {
-		return fmt.Errorf("MS_BIND, MS_REC or MS_REMOUNT are not valid flags for overlay mount points")
+		return fmt.Errorf("ms_bind, ms_rec or ms_remount are not valid flags for overlay mount points")
 	}
 	if lowerdir == "" {
 		return fmt.Errorf("overlay mount point %s should have at least lowerdir option", dest)
@@ -688,7 +688,7 @@ func (p *Points) AddFS(tag AuthorizedTag, dest string, fstype string, flags uint
 // AddFSWithSource adds a filesystem mount point
 func (p *Points) AddFSWithSource(tag AuthorizedTag, source string, dest string, fstype string, flags uintptr, options string) error {
 	if flags&(syscall.MS_BIND|syscall.MS_REMOUNT|syscall.MS_REC) != 0 {
-		return fmt.Errorf("MS_BIND, MS_REC or MS_REMOUNT are not valid flags for FS mount points")
+		return fmt.Errorf("ms_bind, ms_rec or ms_remount are not valid flags for fs mount points")
 	}
 	if _, ok := authorizedFS[fstype]; !ok {
 		return fmt.Errorf("mount %s file system is not authorized", fstype)

--- a/internal/pkg/util/uri/uri.go
+++ b/internal/pkg/util/uri/uri.go
@@ -43,14 +43,14 @@ func IsValid(source string) (valid bool, err error) {
 	u := strings.SplitN(source, ":", 2)
 
 	if len(u) != 2 {
-		return false, fmt.Errorf("Invalid URI %s", source)
+		return false, fmt.Errorf("invalid uri %s", source)
 	}
 
 	if _, ok := validURIs[u[0]]; ok {
 		return true, nil
 	}
 
-	return false, fmt.Errorf("Invalid URI %s", source)
+	return false, fmt.Errorf("invalid uri %s", source)
 }
 
 // GetName turns a transport:ref URI into a name containing the top-level identifier

--- a/pkg/client/net/pull.go
+++ b/pkg/client/net/pull.go
@@ -35,7 +35,7 @@ func IsNetPullRef(libraryRef string) bool {
 func DownloadImage(filePath string, libraryURL string, Force bool) error {
 
 	if !IsNetPullRef(libraryURL) {
-		return fmt.Errorf("Not a valid url reference: %s", libraryURL)
+		return fmt.Errorf("not a valid url reference: %s", libraryURL)
 	}
 	if filePath == "" {
 		refParts := strings.Split(libraryURL, "/")
@@ -70,7 +70,7 @@ func DownloadImage(filePath string, libraryURL string, Force bool) error {
 	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("The requested image was not found in the library")
+		return fmt.Errorf("the requested image was not found in the library")
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/pkg/client/net/pull.go
+++ b/pkg/client/net/pull.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/pkg/client/shub/api.go
+++ b/pkg/client/shub/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/pkg/client/shub/api.go
+++ b/pkg/client/shub/api.go
@@ -80,10 +80,10 @@ func getManifest(uri ShubURI, noHTTPS bool) (manifest ShubAPIResponse, err error
 	// Do the request, if status isn't success, return error
 	res, err := httpc.Do(req)
 	if res == nil {
-		return ShubAPIResponse{}, fmt.Errorf("No response received from singularity hub")
+		return ShubAPIResponse{}, fmt.Errorf("no response received from singularity hub")
 	}
 	if res.StatusCode == http.StatusNotFound {
-		return ShubAPIResponse{}, fmt.Errorf("The requested manifest was not found in singularity hub")
+		return ShubAPIResponse{}, fmt.Errorf("the requested manifest was not found in singularity hub")
 	}
 	sylog.Debugf("%s response received, beginning manifest download\n", res.Status)
 

--- a/pkg/client/shub/pull.go
+++ b/pkg/client/shub/pull.go
@@ -38,7 +38,7 @@ func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 
 	ShubURI, err := shubParseReference(shubRef)
 	if err != nil {
-		return fmt.Errorf("Failed to parse shub URI: %v", err)
+		return fmt.Errorf("failed to parse shub uri: %v", err)
 	}
 
 	if filePath == "" {
@@ -49,7 +49,7 @@ func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 	// Get the image manifest
 	manifest, err := getManifest(ShubURI, noHTTPS)
 	if err != nil {
-		return fmt.Errorf("Failed to get manifest from Shub: %v", err)
+		return fmt.Errorf("failed to get manifest from shub: %v", err)
 	}
 
 	// Get the image based on the manifest
@@ -116,7 +116,7 @@ func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 	}
 	// Simple check to make sure image received is the correct size
 	if bytesWritten != resp.ContentLength {
-		return fmt.Errorf("Image received is not the right size. Supposed to be: %v  Actually: %v", resp.ContentLength, bytesWritten)
+		return fmt.Errorf("image received is not the right size. supposed to be: %v  actually: %v", resp.ContentLength, bytesWritten)
 	}
 
 	bar.Finish()

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -24,7 +24,7 @@ type sifFormat struct{}
 
 func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	if fileinfo.IsDir() {
-		return fmt.Errorf("not a SIF file image")
+		return fmt.Errorf("not a sif file image")
 	}
 	b := make([]byte, bufferSize)
 	if n, err := img.File.Read(b); err != nil || n != bufferSize {

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -134,7 +134,7 @@ func Sign(cpath string, id uint32, isGroup bool, keyIdx int) error {
 	// load the container
 	fimg, err := sif.LoadContainer(cpath, false)
 	if err != nil {
-		return fmt.Errorf("failed to load SIF container file: %s", err)
+		return fmt.Errorf("failed to load sif container file: %s", err)
 	}
 	defer fimg.UnloadContainer()
 
@@ -277,7 +277,7 @@ func Verify(cpath, keyServiceURI string, id uint32, isGroup bool, authToken stri
 
 	fimg, err := sif.LoadContainer(cpath, true)
 	if err != nil {
-		return false, fmt.Errorf("failed to load SIF container file: %s", err)
+		return false, fmt.Errorf("failed to load sif container file: %s", err)
 	}
 	defer fimg.UnloadContainer()
 

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -211,13 +211,13 @@ func (crypt *Device) FormatCryptDevice(path, key string) (string, string, error)
 func copyDeviceContents(source, dest string, size int64) error {
 	sourceFd, err := syscall.Open(source, syscall.O_RDWR, 0777)
 	if err != nil {
-		return fmt.Errorf("Unable to open the file %s", source)
+		return fmt.Errorf("unable to open the file %s", source)
 	}
 	defer syscall.Close(sourceFd)
 
 	destFd, err := syscall.Open(dest, syscall.O_RDWR, 0777)
 	if err != nil {
-		return fmt.Errorf("Unable to open the file: %s", dest)
+		return fmt.Errorf("unable to open the file: %s", dest)
 	}
 	defer syscall.Close(destFd)
 
@@ -227,11 +227,11 @@ func copyDeviceContents(source, dest string, size int64) error {
 	for writtenSoFar < size {
 		numRead, err := syscall.Read(sourceFd, buffer)
 		if err != nil {
-			return fmt.Errorf("Unable to read the the file %s", source)
+			return fmt.Errorf("unable to read the the file %s", source)
 		}
 		numWritten, err := syscall.Write(destFd, buffer)
 		if err != nil {
-			return fmt.Errorf("Unable to write to destination %s", dest)
+			return fmt.Errorf("unable to write to destination %s", dest)
 		}
 
 		if numRead != numWritten {

--- a/pkg/util/loop/loop_linux.go
+++ b/pkg/util/loop/loop_linux.go
@@ -102,7 +102,7 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 	}
 
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdSetStatus64, uintptr(unsafe.Pointer(loop.Info))); err != 0 {
-		return fmt.Errorf("Failed to set loop flags on loop device: %s", syscall.Errno(err))
+		return fmt.Errorf("failed to set loop flags on loop device: %s", syscall.Errno(err))
 	}
 
 	return nil
@@ -123,7 +123,7 @@ func GetStatusFromFd(fd uintptr) (*Info64, error) {
 	info := &Info64{}
 	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, CmdGetStatus64, uintptr(unsafe.Pointer(info)))
 	if err != syscall.ENXIO && err != 0 {
-		return nil, fmt.Errorf("Failed to get loop flags for loop device: %s", err.Error())
+		return nil, fmt.Errorf("failed to get loop flags for loop device: %s", err.Error())
 	}
 	return info, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR updates **ALL** the return error messages (in our source code) to un-caps.

For anyone else wanting to do the same, heres what I did:

```bash
$ for f in $(find -type f | grep -v "vendor" grep -v "examples" | grep -v ".git" | grep -v "etc" | grep -v "makeit" | grep -v "scripts" | grep -v "dist" | grep -v "mlocal" | grep -v "docs" | grep -v "builddir" | grep -v "e2e"); do error_detect.sh $f; done 

$ cat /usr/local/bin/error_detect.sh 
#!/bin/bash

errs=`cat $1 | grep "fmt.Errorf" | cut -f 2 -d \" | cut -c1`

for e in $errs; do
    if [[ "$e" =~ [a-z] ]]; then
       echo "ERROR: already lowercase"
    elif [[ "$e" =~ [A-Z] ]]; then
        echo "UPPERCASE! IN FILE: $1"
        old_err=`cat $1 | grep "fmt.Errorf" | cut -f 2 -d \" | grep "$e" | head -1`
        echo Old err: $old_err
        new_err=`echo "${old_err,,}"`
        echo New err: $new_err
        replace "$old_err" "$new_err" -- $1
        echo
    else
        echo "ERROR: non-alphabetic"
    fi
done
```

## This fixes or addresses the following GitHub issues:

- Fixes #

<br>
