### PR TITLE
Sif encryption cleanup

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -29,6 +29,7 @@ var (
 	VMRAM           string
 	VMCPU           string
 	ContainLibsPath []string
+	encryptionKey   string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -258,6 +259,16 @@ var actionContainLibsFlag = cmdline.Flag{
 	Hidden:       true,
 	EnvKeys:      []string{"CONTAINLIBS"},
 	ExcludedOS:   []string{cmdline.Darwin},
+}
+
+// hidden flag to handle SINGULARITY_ENCRYPTION_KEY environment variable
+var commonEncryptFlag = cmdline.Flag{
+	ID:           "actionEncryptionKey",
+	Value:        &encryptionKey,
+	DefaultValue: "",
+	Name:         "encryption-key",
+	Hidden:       true,
+	EnvKeys:      []string{"ENCRYPTION_KEY"},
 }
 
 // hidden flags to handle docker credentials
@@ -649,6 +660,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&actionDropCapsFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionAllowSetuidFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionPwdFlag, actionsCmd...)
+	cmdManager.RegisterFlagForCmd(&commonEncryptFlag, actionsCmd...)
 
 	for _, cmd := range actionsCmd {
 		plugin.AddFlagHooks(cmd.Flags())

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -238,6 +238,8 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		BindPaths = append(BindPaths, nvidia.IpcsPath(userPath)...)
 	}
 
+	engineConfig.SetEncryptionKey(encryptionKey)
+
 	engineConfig.SetBindPath(BindPaths)
 	engineConfig.SetNetwork(Network)
 	engineConfig.SetDNS(DNS)

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	remote         bool
-	encrypt        bool
+	encryptionKey  string
 	builderURL     string
 	detached       bool
 	libraryURL     string
@@ -122,12 +122,12 @@ var buildRemoteFlag = cmdline.Flag{
 // -e|--encrypt
 var buildEncryptFlag = cmdline.Flag{
 	ID:           "buildEncryptFlag",
-	Value:        &encrypt,
-	DefaultValue: false,
-	Name:         "encrypt",
+	Value:        &encryptionKey,
+	DefaultValue: "",
+	Name:         "encryption-key",
 	ShortHand:    "e",
-	Usage:        "Encrypt the file system after building (requires root)",
-	EnvKeys:      []string{"ENCRYPT"},
+	Usage:        "Key for encrypting the filesystem after building (requires root)",
+	EnvKeys:      []string{"ENCRYPTION_KEY"},
 }
 
 // -d|--detached

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -25,7 +25,6 @@ import (
 
 var (
 	remote         bool
-	encryptionKey  string
 	builderURL     string
 	detached       bool
 	libraryURL     string
@@ -119,17 +118,6 @@ var buildRemoteFlag = cmdline.Flag{
 	EnvKeys:      []string{"REMOTE"},
 }
 
-// -e|--encrypt
-var buildEncryptFlag = cmdline.Flag{
-	ID:           "buildEncryptFlag",
-	Value:        &encryptionKey,
-	DefaultValue: "",
-	Name:         "encryption-key",
-	ShortHand:    "e",
-	Usage:        "Key for encrypting the filesystem after building (requires root)",
-	EnvKeys:      []string{"ENCRYPTION_KEY"},
-}
-
 // -d|--detached
 var buildDetachedFlag = cmdline.Flag{
 	ID:           "buildDetachedFlag",
@@ -214,7 +202,6 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&buildNoHTTPSFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildNoTestFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildRemoteFlag, BuildCmd)
-	cmdManager.RegisterFlagForCmd(&buildEncryptFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSandboxFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSectionFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&buildTmpdirFlag, BuildCmd)
@@ -224,6 +211,8 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&actionDockerUsernameFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&actionDockerPasswordFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&actionDockerLoginFlag, BuildCmd)
+
+	cmdManager.RegisterFlagForCmd(&commonEncryptFlag, BuildCmd)
 }
 
 // BuildCmd represents the build command

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -227,7 +227,7 @@ func run(cmd *cobra.Command, args []string) {
 					LibraryURL:       libraryURL,
 					LibraryAuthToken: authToken,
 					DockerAuthConfig: authConf,
-					Encrypted:        encrypt,
+					EncryptionKey:    encryptionKey,
 				},
 			})
 		if err != nil {

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -199,12 +199,6 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 			return fmt.Errorf("unable to encrypt filesystem at %s: %+v", fsPath, err)
 		}
 
-		defer os.Remove(loopPath)
-
-		err = cryptDev.CloseCryptDevice(cryptName)
-		if err != nil {
-			return fmt.Errorf("unable to close crypt device: %s", cryptName)
-		}
 		fsPath = loopPath
 	}
 

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -194,9 +194,9 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		// Detach the following code from the squashfs creation. SIF can be
 		// created first and encrypted after. This gives the flexibility to
 		// encrypt an existing SIF
-		loopPath, cryptName, err := cryptDev.FormatCryptDevice(fsPath, b.Opts.EncryptionKey)
+		loopPath, err := cryptDev.EncryptFilesystem(fsPath, b.Opts.EncryptionKey)
 		if err != nil {
-			return fmt.Errorf("unable to format crypt device: %s", cryptName)
+			return fmt.Errorf("unable to encrypt filesystem at %s: %+v", fsPath, err)
 		}
 
 		defer os.Remove(loopPath)

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -182,7 +182,11 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		return fmt.Errorf("while running mksquashfs: %v: %s", err, strings.Replace(string(errOut), "\n", " ", -1))
 	}
 
-	if b.Opts.Encrypted {
+	encrypted := false
+
+	if b.Opts.EncryptionKey != "" {
+		encrypted = true
+
 		// A dm-crypt device needs to be created with squashfs
 		cryptDev := &crypt.Device{}
 
@@ -190,11 +194,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		// Detach the following code from the squashfs creation. SIF can be
 		// created first and encrypted after. This gives the flexibility to
 		// encrypt an existing SIF
-		key, err := cryptDev.ReadKeyFromStdin(true)
-		if err != nil {
-			return fmt.Errorf("unable to read key from stdin")
-		}
-		loopPath, cryptName, err := cryptDev.FormatCryptDevice(fsPath, key)
+		loopPath, cryptName, err := cryptDev.FormatCryptDevice(fsPath, b.Opts.EncryptionKey)
 		if err != nil {
 			return fmt.Errorf("unable to format crypt device: %s", cryptName)
 		}
@@ -208,7 +208,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) (err error) {
 		fsPath = loopPath
 	}
 
-	err = createSIF(path, b.Recipe.Raw, b.JSONObjects["oci-config"], fsPath, b.Opts.Encrypted)
+	err = createSIF(path, b.Recipe.Raw, b.JSONObjects["oci-config"], fsPath, encrypted)
 	if err != nil {
 		return fmt.Errorf("while creating sif: %v", err)
 	}

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -105,8 +105,8 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		}
 
 		s := stage{}
-		if conf.Opts.Encrypted {
-			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild")
+		if conf.Opts.EncryptionKey != "" {
+			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild", conf.Opts.EncryptionKey)
 		} else {
 			s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")
 		}

--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -39,6 +39,7 @@ type MountArgs struct {
 type CryptArgs struct {
 	Offset  uint64
 	Loopdev string
+	Key     string
 }
 
 // ChrootArgs defines the arguments to chroot.

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -8,7 +8,6 @@ package client
 import (
 	"net/rpc"
 	"os"
-	"path/filepath"
 
 	args "github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc"
 	"github.com/sylabs/singularity/pkg/util/loop"
@@ -36,10 +35,9 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 
 // Decrypt calls the DeCrypt RPC using the supplied arguments.
 func (t *RPC) Decrypt(offset uint64, path string, key string) (string, error) {
-	loopdev := filepath.Base(path)
 	arguments := &args.CryptArgs{
 		Offset:  offset,
-		Loopdev: loopdev,
+		Loopdev: path,
 		Key:     key,
 	}
 

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -35,11 +35,12 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 }
 
 // Decrypt calls the DeCrypt RPC using the supplied arguments.
-func (t *RPC) Decrypt(offset uint64, path string) (string, error) {
+func (t *RPC) Decrypt(offset uint64, path string, key string) (string, error) {
 	loopdev := filepath.Base(path)
 	arguments := &args.CryptArgs{
 		Offset:  offset,
 		Loopdev: loopdev,
+		Key:     key,
 	}
 
 	var reply string

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -146,7 +146,6 @@ func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) error {
 	} else {
 		var err error
 		image, err = os.OpenFile(arguments.Image, arguments.Mode, 0600)
-		defer image.Close()
 		if err != nil {
 			return fmt.Errorf("could not open image file: %v", err)
 		}

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -38,11 +38,7 @@ func (t *Methods) Mount(arguments *args.MountArgs, reply *int) (err error) {
 func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) {
 	cryptDev := &crypt.Device{}
 
-	key, err := cryptDev.ReadKeyFromStdin(false)
-	if err != nil {
-		return fmt.Errorf("unable to read key from stdin")
-	}
-	cryptName, err := cryptDev.GetCryptDevice(key, arguments.Loopdev)
+	cryptName, err := cryptDev.GetCryptDevice(arguments.Key, arguments.Loopdev)
 
 	*reply = "/dev/mapper/" + cryptName
 

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -38,7 +38,7 @@ func (t *Methods) Mount(arguments *args.MountArgs, reply *int) (err error) {
 func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) {
 	cryptDev := &crypt.Device{}
 
-	cryptName, err := cryptDev.GetCryptDevice(arguments.Key, arguments.Loopdev)
+	cryptName, err := cryptDev.Open(arguments.Key, arguments.Loopdev)
 
 	*reply = "/dev/mapper/" + cryptName
 

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -20,53 +20,53 @@ func TestImage(t *testing.T) {
 
 	points := &Points{}
 
-	if err := points.AddImage(RootfsTag, "", "/fake", "ext3", 0, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "", "/fake", "ext3", 0, 0, 10, ""); err == nil {
 		t.Errorf("should have failed with empty source")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "", "ext3", 0, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "", "ext3", 0, 0, 10, ""); err == nil {
 		t.Errorf("should have failed with empty destination")
 	}
 
-	if err := points.AddImage(RootfsTag, "fake", "/", "ext3", 0, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "fake", "/", "ext3", 0, 0, 10, ""); err == nil {
 		t.Errorf("should have failed as source is not an absolute path")
 	}
-	if err := points.AddImage(RootfsTag, "/", "fake", "ext3", 0, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "/", "fake", "ext3", 0, 0, 10, ""); err == nil {
 		t.Errorf("should have failed as destination is not an absolute path")
 	}
 
-	if err := points.AddImage(RootfsTag, "", "/", "ext3", 0, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "", "/", "ext3", 0, 0, 10, ""); err == nil {
 		t.Errorf("should have failed with empty source")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "xfs", 0, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "xfs", 0, 0, 10, ""); err == nil {
 		t.Errorf("should have failed with bad filesystem type")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_BIND, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_BIND, 0, 10, ""); err == nil {
 		t.Errorf("should have failed with bad bind flag")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REMOUNT, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REMOUNT, 0, 10, ""); err == nil {
 		t.Errorf("should have failed with bad remount flag")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REC, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REC, 0, 10, ""); err == nil {
 		t.Errorf("should have failed with bad recursive flag")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/ext3", "ext3", 0, 0, 10); err != nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/ext3", "ext3", 0, 0, 10, ""); err != nil {
 		t.Errorf("should have passed with ext3 filesystem")
 	}
 	points.RemoveAll()
-	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10); err != nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10, ""); err != nil {
 		t.Errorf("should have passed with squashfs filesystem")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", 0, 0, 0); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", 0, 0, 0, ""); err == nil {
 		t.Errorf("should have failed with 0 size limit")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10, ""); err == nil {
 		t.Errorf("nil error returned, should have returned non-nil mount.ErrMountExists")
 	} else if err != ErrMountExists {
 		t.Errorf("non-nil error should have been mount.ErrMountExists")
 	}
 	points.RemoveAll()
 
-	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", syscall.MS_NOSUID, 31, 10); err != nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", syscall.MS_NOSUID, 31, 10, ""); err != nil {
 		t.Fatalf("should have passed with squashfs filesystem")
 	}
 	images := points.GetAllImages()

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -52,8 +52,9 @@ type Options struct {
 	LibraryAuthToken string `json:"libraryAuthToken"`
 	// contains docker credentials if specified
 	DockerAuthConfig *ocitypes.DockerAuthConfig
-	// Encrypted specifies if the filesystem needs to be encrypteded
-	Encrypted bool `json:"encrypt"`
+	// EncryptionKey specifies the key used for filesystem
+	// encryption if applicable
+	EncryptionKey string `json:"encryptionKey"`
 	// noTest indicates if build should skip running the test script
 	NoTest bool `json:"noTest"`
 	// force automatically deletes an existing container at build destination while performing build
@@ -70,7 +71,7 @@ type Options struct {
 }
 
 // Common code between NewBundle and NewEncryptedBundle
-func bundleCommon(encrypted bool, bundleDir, bundlePrefix string) (b *Bundle, err error) {
+func bundleCommon(bundleDir, bundlePrefix, encryptionKey string) (b *Bundle, err error) {
 	b = &Bundle{}
 	b.JSONObjects = make(map[string][]byte)
 
@@ -88,7 +89,7 @@ func bundleCommon(encrypted bool, bundleDir, bundlePrefix string) (b *Bundle, er
 		"rootfs": "fs",
 	}
 
-	b.Opts.Encrypted = encrypted
+	b.Opts.EncryptionKey = encryptionKey
 
 	for _, fso := range b.FSObjects {
 		if err = os.MkdirAll(filepath.Join(b.Path, fso), 0755); err != nil {
@@ -101,13 +102,13 @@ func bundleCommon(encrypted bool, bundleDir, bundlePrefix string) (b *Bundle, er
 }
 
 // NewEncryptedBundle creates an Encrypted Bundle environment
-func NewEncryptedBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
-	return bundleCommon(true, bundleDir, bundlePrefix)
+func NewEncryptedBundle(bundleDir, bundlePrefix, encryptionKey string) (b *Bundle, err error) {
+	return bundleCommon(bundleDir, bundlePrefix, encryptionKey)
 }
 
 // NewBundle creates a Bundle environment
 func NewBundle(bundleDir, bundlePrefix string) (b *Bundle, err error) {
-	return bundleCommon(false, bundleDir, bundlePrefix)
+	return bundleCommon(bundleDir, bundlePrefix, "")
 }
 
 // Rootfs give the path to the root filesystem in the Bundle

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -78,6 +78,7 @@ type JSONConfig struct {
 	Network           string        `json:"network,omitempty"`
 	DNS               string        `json:"dns,omitempty"`
 	Cwd               string        `json:"cwd,omitempty"`
+	EncryptionKey     string        `json:"encryptionKey,omitempty"`
 	TargetUID         int           `json:"targetUID,omitempty"`
 	WritableImage     bool          `json:"writableImage,omitempty"`
 	WritableTmpfs     bool          `json:"writableTmpfs,omitempty"`
@@ -117,6 +118,16 @@ func (e *EngineConfig) SetImage(name string) {
 // GetImage retrieves the container image path.
 func (e *EngineConfig) GetImage() string {
 	return e.JSON.Image
+}
+
+// SetKey sets the key for the image's system partition
+func (e *EngineConfig) SetEncryptionKey(key string) {
+	e.JSON.EncryptionKey = key
+}
+
+// GetKey retrieves the key for image's system partition
+func (e *EngineConfig) GetEncryptionKey() string {
+	return e.JSON.EncryptionKey
 }
 
 // SetWritableImage defines the container image as writable or not.

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/bin"
 	"github.com/sylabs/singularity/pkg/util/fs/lock"
 	"github.com/sylabs/singularity/pkg/util/loop"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Device describes a crypt device
@@ -68,37 +67,6 @@ func (crypt *Device) CloseCryptDevice(path string) error {
 	}
 
 	return nil
-}
-
-// ReadKeyFromStdin reads key from terminal and returns it
-// TODO (schebro): Fix #3816, #3851
-// Currently keys are being read interactively from the terminal.
-// Keys should be non-interactive, preferably in a keyfile that can
-// be passed to cryptsetup utility
-func (crypt *Device) ReadKeyFromStdin(confirm bool) (string, error) {
-
-	fmt.Print("Enter the Key: ")
-	password, err := terminal.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		sylog.Fatalf("Error parsing the key: %s", err)
-	}
-
-	input := string(password)
-	fmt.Println()
-	if confirm {
-		fmt.Print("Confirm the Key: ")
-		password2, err := terminal.ReadPassword(int(syscall.Stdin))
-		if err != nil {
-			sylog.Fatalf("Error parsing the key: %s", err)
-		}
-		input2 := string(password2)
-		fmt.Println()
-		if input != input2 {
-			return "", errors.New("Keys don't match")
-		}
-	}
-
-	return input, nil
 }
 
 // FormatCryptDevice allocates a loop device, encrypts, and returns the loop device name, and encrypted device name

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -69,9 +69,10 @@ func (crypt *Device) CloseCryptDevice(path string) error {
 	return nil
 }
 
-// FormatCryptDevice allocates a loop device, encrypts, and returns the loop device name, and encrypted device name
-func (crypt *Device) FormatCryptDevice(path, key string) (string, string, error) {
-
+// EncryptFilesystem takes the path to a file containing a non-encrypted
+// filesystem, encrypts it using the provided key, and returns a path to
+// a file that can be later used as an encrypted volume with cryptsetup.
+func (crypt *Device) EncryptFilesystem(path, key string) (string, error) {
 	f, err := os.Stat(path)
 	if err != nil {
 		return "", "", fmt.Errorf("failed getting size of %s", path)

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -90,7 +90,7 @@ func (crypt *Device) EncryptFilesystem(path, key string) (string, error) {
 
 	// Truncate the file taking the squashfs size and crypt header into account
 	// Crypt header is around 2MB in size. Slightly over-allocate to be safe
-	devSize := fSize + 16*1024*1024 // 16MB for LUKS header
+	devSize := fSize + 1*1024*1024 // 16MB for LUKS header
 
 	err = os.Truncate(cryptF.Name(), devSize)
 	if err != nil {
@@ -119,7 +119,7 @@ func (crypt *Device) EncryptFilesystem(path, key string) (string, error) {
 		return "", "", err
 	}
 
-	cmd := exec.Command(cryptsetup, "luksFormat", "--batch-mode", "--type", "luks2", "--key-file", "-", loop)
+	cmd := exec.Command(cryptsetup, "luksFormat", "--batch-mode", "--type", "luks2", "--key-file", "-", "--luks2-metadata-size", "64k", "--luks2-keyslots-size", "512k", loop)
 	stdin, err := cmd.StdinPipe()
 
 	if err != nil {

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -217,8 +217,11 @@ func getNextAvailableCryptDevice() string {
 	return (uuid.NewV4()).String()
 }
 
-// GetCryptDevice returns the next available device in /dev/mapper for encryption/decryption
-func (crypt *Device) GetCryptDevice(key, loopDev string) (string, error) {
+// Open opens the encrypted filesystem specified by path (usually a loop
+// device, but any encrypted block device will do) using the given key
+// and returns the name assigned to it that can be later used to close
+// the device.
+func (crypt *Device) Open(key, path string) (string, error) {
 	fd, err := lock.Exclusive("/dev/mapper")
 	if err != nil {
 		sylog.Debugf("Unable to acquire lock on /dev/mapper while decrypting")


### PR DESCRIPTION
This PR contains multiple clean ups done while trying to figure out why I was seeing a corrupted SIF file when trying to use an encrypted container.

* Obtain the key from the environment instead of interactively
* Make sure we are using LUKS 2 crypt devices
* Reduce the space required to create an encrypted container