### PR TITLE
Use newuidmap/newgidmap as fakeroot fallback

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -126,14 +126,6 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	syscall.Umask(0022)
 
-	starter := filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter-suid")
-	// setuid workflow is not required for root user or if we
-	// are already running inside a user namespace
-	if uid == 0 || insideUserNs {
-		starter = filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter")
-	}
-	sylog.Debugf("Use starter binary %s", starter)
-
 	engineConfig := singularityConfig.NewConfig()
 
 	configurationFile := buildcfg.SYSCONFDIR + "/singularity/singularity.conf"
@@ -201,6 +193,30 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			sylog.Fatalf("Failed to determine image absolute path for %s: %s", image, err)
 		}
 		engineConfig.SetImage(abspath)
+	}
+
+	starter := filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter-suid")
+	// singularity was compiled with '--without-suid' option
+	if buildcfg.SINGULARITY_SUID_INSTALL == 0 {
+		starter = filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter")
+	}
+
+	// use non privileged starter binary:
+	// - if we are the root user
+	// - if we are already running inside a user namespace
+	// - if user namespace is requested
+	// - if 'allow setuid = no' is set in singularity.conf
+	if uid == 0 || insideUserNs || UserNamespace || !engineConfig.File.AllowSetuid {
+		starter = filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter")
+		if buildcfg.SINGULARITY_SUID_INSTALL == 1 && !engineConfig.File.AllowSetuid {
+			sylog.Verbosef("'allow setuid' set to 'no' by configuration, fallback to user namespace")
+			UserNamespace = true
+		}
+	}
+
+	sylog.Debugf("Use starter binary %s", starter)
+	if _, err := os.Stat(starter); os.IsNotExist(err) {
+		sylog.Fatalf("%s not found, please check your installation", starter)
 	}
 
 	if !NoNvidia && (Nvidia || engineConfig.File.AlwaysUseNv) {
@@ -283,6 +299,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	homeFlag := cobraCmd.Flag("home")
 	engineConfig.SetCustomHome(homeFlag.Changed)
 
+	if !homeFlag.Changed && IsFakeroot {
+		engineConfig.SetCustomHome(true)
+		HomePath = fmt.Sprintf("%s:/root", HomePath)
+	}
+
 	// set home directory for the targeted UID if it exists on host system
 	if !homeFlag.Changed && targetUID != 0 {
 		if targetUID > 500 {
@@ -335,7 +356,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		engineConfig.SetHomeDest(homeSlice[1])
 	}
 
-	if !engineConfig.File.AllowSetuid || IsFakeroot {
+	if IsFakeroot {
 		UserNamespace = true
 	}
 
@@ -378,6 +399,17 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	if NetNamespace {
 		if IsFakeroot && Network != "none" {
 			engineConfig.SetNetwork("fakeroot")
+
+			// unprivileged installation could not use fakeroot
+			// network because it requires a setuid installation
+			// so we fallback to none
+			if buildcfg.SINGULARITY_SUID_INSTALL == 0 || !engineConfig.File.AllowSetuid {
+				sylog.Warningf(
+					"fakeroot with unprivileged installation or 'allow setuid = no' " +
+						"could not use 'fakeroot' network, fallback to 'none' network",
+				)
+				engineConfig.SetNetwork("none")
+			}
 		}
 		generator.AddOrReplaceLinuxNamespace("network", "")
 	}
@@ -402,7 +434,6 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		generator.AddOrReplaceLinuxNamespace("user", "")
 
 		if !IsFakeroot {
-			starter = filepath.Join(buildcfg.LIBEXECDIR, "/singularity/bin/starter")
 			generator.AddLinuxUIDMapping(uid, uid, 1)
 			generator.AddLinuxGIDMapping(gid, gid, 1)
 		}

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -230,7 +230,7 @@ var BuildCmd = &cobra.Command{
 }
 
 func preRun(cmd *cobra.Command, args []string) {
-	if fakeroot {
+	if fakeroot && !remote {
 		fakerootExec(args)
 	}
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -31,13 +31,14 @@ import (
 )
 
 func fakerootExec(cmdArgs []string) {
-	if remote {
-		return
-	}
-
 	starter := filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter-suid")
-	if _, err := os.Stat(starter); err != nil {
-		sylog.Fatalf("fakeroot feature requires a setuid installation")
+
+	// singularity was compiled with '--without-suid' option
+	if buildcfg.SINGULARITY_SUID_INSTALL == 0 {
+		starter = filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter")
+	}
+	if _, err := os.Stat(starter); os.IsNotExist(err) {
+		sylog.Fatalf("%s not found, please check your installation", starter)
 	}
 
 	short := "-" + buildFakerootFlag.ShortHand

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -21,9 +21,10 @@
 
 #define MAX_JSON_SIZE       128*1024
 #define MAX_MAP_SIZE        4096
-#define MAX_NS_PATH_SIZE    PATH_MAX
+#define MAX_PATH_SIZE       PATH_MAX
 #define MAX_GID             32
 #define MAX_STARTER_FDS     1024
+#define MAX_CMD_SIZE        MAX_PATH_SIZE+MAX_MAP_SIZE+64
 
 #ifndef PR_SET_NO_NEW_PRIVS
 #define PR_SET_NO_NEW_PRIVS 38
@@ -94,13 +95,13 @@ struct namespace {
     bool bringLoopbackInterface;
 
     /* namespaces inodes paths used to join namespaces */
-    char network[MAX_NS_PATH_SIZE];
-    char mount[MAX_NS_PATH_SIZE];
-    char user[MAX_NS_PATH_SIZE];
-    char ipc[MAX_NS_PATH_SIZE];
-    char uts[MAX_NS_PATH_SIZE];
-    char cgroup[MAX_NS_PATH_SIZE];
-    char pid[MAX_NS_PATH_SIZE];
+    char network[MAX_PATH_SIZE];
+    char mount[MAX_PATH_SIZE];
+    char user[MAX_PATH_SIZE];
+    char ipc[MAX_PATH_SIZE];
+    char uts[MAX_PATH_SIZE];
+    char cgroup[MAX_PATH_SIZE];
+    char pid[MAX_PATH_SIZE];
 };
 
 /* container privileges */
@@ -112,6 +113,10 @@ struct privileges {
     char uidMap[MAX_MAP_SIZE];
     char gidMap[MAX_MAP_SIZE];
     bool allowSetgroups;
+
+    /* path to external newuidmap/newgidmap binaries */
+    char newuidmapPath[MAX_PATH_SIZE];
+    char newgidmapPath[MAX_PATH_SIZE];
 
     /* uid/gids set for container process execution */
     uid_t targetUID;

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,12 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
 
+	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/syfs"
 )
 
@@ -80,21 +80,21 @@ func getPath(username string, subDir string) (string, error) {
 
 	var u *user.User
 	if username == "" {
-		u, err = user.Current()
+		u, err = user.CurrentOriginal()
 	} else {
-		u, err = user.Lookup(username)
+		u, err = user.GetPwNam(username)
 	}
 
 	if err != nil {
 		return "", err
 	}
 
-	configDir, err := syfs.ConfigDirForUsername(u.Username)
+	configDir, err := syfs.ConfigDirForUsername(u.Name)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(configDir, instancePath, subDir, hostname, u.Username), nil
+	return filepath.Join(configDir, instancePath, subDir, hostname, u.Name), nil
 }
 
 // GetDir returns directory where instances file will be stored

--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -202,7 +202,7 @@ func create(engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 		}
 	}
 
-	if os.Geteuid() == 0 {
+	if os.Geteuid() == 0 && !c.userNS {
 		path := engine.EngineConfig.GetCgroupsPath()
 		if path != "" {
 			cgroupPath := filepath.Join("/singularity", strconv.Itoa(pid))
@@ -1239,7 +1239,7 @@ func (c *container) getHomePaths() (source string, dest string, err error) {
 		dest = filepath.Clean(c.engine.EngineConfig.GetHomeDest())
 		source, err = filepath.Abs(filepath.Clean(c.engine.EngineConfig.GetHomeSource()))
 	} else {
-		pw, err := user.GetPwUID(uint32(os.Getuid()))
+		pw, err := user.Current()
 		if err == nil {
 			dest = pw.Dir
 			source = pw.Dir
@@ -1638,7 +1638,8 @@ func (c *container) addLibsMount(system *mount.System) error {
 }
 
 func (c *container) addIdentityMount(system *mount.System) error {
-	if os.Geteuid() == 0 && c.engine.EngineConfig.GetTargetUID() == 0 {
+	if (os.Geteuid() == 0 && c.engine.EngineConfig.GetTargetUID() == 0) ||
+		c.engine.EngineConfig.GetFakeroot() {
 		sylog.Verbosef("Not updating passwd/group files, running as root!")
 		return nil
 	}

--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -21,7 +21,7 @@ import (
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
-	"github.com/sylabs/singularity/internal/pkg/fakeroot"
+	fakerootutil "github.com/sylabs/singularity/internal/pkg/fakeroot"
 	"github.com/sylabs/singularity/internal/pkg/instance"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/starter"
@@ -49,8 +49,7 @@ var nsProcName = map[specs.LinuxNamespaceType]string{
 
 // prepareUserCaps is responsible for checking that user's requested
 // capabilities are authorized
-func (e *EngineOperations) prepareUserCaps() error {
-	uid := os.Getuid()
+func (e *EngineOperations) prepareUserCaps(enforced bool) error {
 	commonCaps := make([]string, 0)
 	commonUnauthorizedCaps := make([]string, 0)
 
@@ -67,7 +66,7 @@ func (e *EngineOperations) prepareUserCaps() error {
 		return fmt.Errorf("while parsing capability config data: %s", err)
 	}
 
-	pw, err := user.GetPwUID(uint32(uid))
+	pw, err := user.Current()
 	if err != nil {
 		return err
 	}
@@ -78,34 +77,38 @@ func (e *EngineOperations) prepareUserCaps() error {
 	}
 	caps = append(caps, e.EngineConfig.OciConfig.Process.Capabilities.Permitted...)
 
-	authorizedCaps, unauthorizedCaps := capConfig.CheckUserCaps(pw.Name, caps)
-	if len(authorizedCaps) > 0 {
-		sylog.Debugf("User capabilities %s added", strings.Join(authorizedCaps, ","))
-		commonCaps = authorizedCaps
-	}
-	if len(unauthorizedCaps) > 0 {
-		commonUnauthorizedCaps = append(commonUnauthorizedCaps, unauthorizedCaps...)
-	}
-
-	groups, err := os.Getgroups()
-	if err != nil {
-		return err
-	}
-
-	for _, g := range groups {
-		gr, err := user.GetGrGID(uint32(g))
-		if err != nil {
-			sylog.Debugf("Ignoring group %d: %s", g, err)
-			continue
-		}
-		authorizedCaps, unauthorizedCaps := capConfig.CheckGroupCaps(gr.Name, caps)
+	if enforced {
+		authorizedCaps, unauthorizedCaps := capConfig.CheckUserCaps(pw.Name, caps)
 		if len(authorizedCaps) > 0 {
-			sylog.Debugf("%s group capabilities %s added", gr.Name, strings.Join(authorizedCaps, ","))
-			commonCaps = append(commonCaps, authorizedCaps...)
+			sylog.Debugf("User capabilities %s added", strings.Join(authorizedCaps, ","))
+			commonCaps = authorizedCaps
 		}
 		if len(unauthorizedCaps) > 0 {
 			commonUnauthorizedCaps = append(commonUnauthorizedCaps, unauthorizedCaps...)
 		}
+
+		groups, err := os.Getgroups()
+		if err != nil {
+			return err
+		}
+
+		for _, g := range groups {
+			gr, err := user.GetGrGID(uint32(g))
+			if err != nil {
+				sylog.Debugf("Ignoring group %d: %s", g, err)
+				continue
+			}
+			authorizedCaps, unauthorizedCaps := capConfig.CheckGroupCaps(gr.Name, caps)
+			if len(authorizedCaps) > 0 {
+				sylog.Debugf("%s group capabilities %s added", gr.Name, strings.Join(authorizedCaps, ","))
+				commonCaps = append(commonCaps, authorizedCaps...)
+			}
+			if len(unauthorizedCaps) > 0 {
+				commonUnauthorizedCaps = append(commonUnauthorizedCaps, unauthorizedCaps...)
+			}
+		}
+	} else {
+		commonCaps = caps
 	}
 
 	commonCaps = capabilities.RemoveDuplicated(commonCaps)
@@ -343,7 +346,8 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 			return err
 		}
 	} else {
-		if err := e.prepareUserCaps(); err != nil {
+		enforced := starterConfig.GetIsSUID()
+		if err := e.prepareUserCaps(enforced); err != nil {
 			return err
 		}
 	}
@@ -355,24 +359,41 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 	}
 
 	if e.EngineConfig.GetFakeroot() {
-		baseID := e.EngineConfig.File.FakerootBaseID
-		allowedUsers := e.EngineConfig.File.FakerootAllowedUsers
-		idRange, err := fakeroot.GetIDRange(baseID, allowedUsers)
-		if err != nil {
-			return err
+		if !starterConfig.GetIsSUID() {
+			// no SUID workflow, check if newuidmap/newgidmap are present
+			sylog.Verbosef("Fakeroot requested with unprivileged workflow, fallback to newuidmap/newgidmap")
+			sylog.Debugf("Search for newuidmap binary")
+			if err := starterConfig.SetNewUIDMapPath(); err != nil {
+				return err
+			}
+			sylog.Debugf("Search for newgidmap binary")
+			if err := starterConfig.SetNewGIDMapPath(); err != nil {
+				return err
+			}
 		}
+
+		uid := uint32(os.Getuid())
+		gid := uint32(os.Getgid())
+
+		e.EngineConfig.OciConfig.AddLinuxUIDMapping(uid, 0, 1)
+		idRange, err := fakerootutil.GetIDRange(fakerootutil.SubUIDFile, uid)
+		if err != nil {
+			return fmt.Errorf("could not use fakeroot: %s", err)
+		}
+		e.EngineConfig.OciConfig.AddLinuxUIDMapping(idRange.HostID, idRange.ContainerID, idRange.Size)
+		starterConfig.AddUIDMappings(e.EngineConfig.OciConfig.Linux.UIDMappings)
+
+		e.EngineConfig.OciConfig.AddLinuxGIDMapping(gid, 0, 1)
+		idRange, err = fakerootutil.GetIDRange(fakerootutil.SubGIDFile, uid)
+		if err != nil {
+			return fmt.Errorf("could not use fakeroot: %s", err)
+		}
+		e.EngineConfig.OciConfig.AddLinuxGIDMapping(idRange.HostID, idRange.ContainerID, idRange.Size)
+		starterConfig.AddGIDMappings(e.EngineConfig.OciConfig.Linux.GIDMappings)
 
 		e.EngineConfig.OciConfig.SetupPrivileged(true)
 
 		e.EngineConfig.OciConfig.AddOrReplaceLinuxNamespace(specs.UserNamespace, "")
-
-		e.EngineConfig.OciConfig.AddLinuxUIDMapping(uint32(os.Getuid()), 0, 1)
-		e.EngineConfig.OciConfig.AddLinuxUIDMapping(idRange.HostID, idRange.ContainerID, idRange.Size)
-		starterConfig.AddUIDMappings(e.EngineConfig.OciConfig.Linux.UIDMappings)
-
-		e.EngineConfig.OciConfig.AddLinuxGIDMapping(uint32(os.Getgid()), 0, 1)
-		e.EngineConfig.OciConfig.AddLinuxGIDMapping(idRange.HostID, idRange.ContainerID, idRange.Size)
-		starterConfig.AddGIDMappings(e.EngineConfig.OciConfig.Linux.GIDMappings)
 
 		starterConfig.SetHybridWorkflow(true)
 		starterConfig.SetAllowSetgroups(true)
@@ -575,22 +596,19 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 		}
 	}
 
-	// get starter binary in use
-	dest, err := mainthread.Readlink("/proc/self/exe")
+	path, err = filepath.Abs("comm")
 	if err != nil {
-		return fmt.Errorf("failed to read /proc/self/exe link: %s", err)
+		return fmt.Errorf("failed to determine absolute path for comm: %s", err)
 	}
-	// should be either starter-suid or starter
-	exe := filepath.Base(dest)
-	path = filepath.Join("..", strconv.Itoa(file.PPid), "comm")
-	b, err := ioutil.ReadFile(path)
+
+	// we must read "sinit\n"
+	b, err := ioutil.ReadFile("comm")
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %s", path, err)
 	}
-	// check that the right starter binary is used according
-	// to namespace configuration and joined instance
-	if exe != strings.Trim(string(b), "\n") {
-		return fmt.Errorf("%s not found in %s, wrong instance process", exe, path)
+	// check that we are currently joining sinit process
+	if "sinit" != strings.Trim(string(b), "\n") {
+		return fmt.Errorf("sinit not found in %s, wrong instance process", path)
 	}
 
 	// tell starter that we are joining an instance
@@ -632,10 +650,20 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 			return err
 		}
 	} else {
-		if err := e.prepareUserCaps(); err != nil {
+		if err := e.prepareUserCaps(suidRequired); err != nil {
 			return err
 		}
 	}
+
+	// set UID/GID for the fakeroot context
+	if instanceEngineConfig.GetFakeroot() {
+		starterConfig.SetTargetUID(0)
+		starterConfig.SetTargetGID([]int{0})
+	}
+
+	// restore HOME environment variable to match the
+	// one set during instance start
+	e.EngineConfig.OciConfig.AddProcessEnv("HOME", instanceEngineConfig.GetHomeDest())
 
 	// restore apparmor profile or apply a new one if provided
 	param := security.GetParam(e.EngineConfig.GetSecurity(), "apparmor")

--- a/internal/pkg/runtime/engines/singularity/process_linux.go
+++ b/internal/pkg/runtime/engines/singularity/process_linux.go
@@ -370,7 +370,6 @@ func (engine *EngineOperations) PostStartProcess(pid int) error {
 	sylog.Debugf("Post start process")
 
 	if engine.EngineConfig.GetInstance() {
-		uid := os.Getuid()
 		name := engine.CommonConfig.ContainerID
 
 		if err := os.Chdir("/"); err != nil {
@@ -382,7 +381,7 @@ func (engine *EngineOperations) PostStartProcess(pid int) error {
 			return err
 		}
 
-		pw, err := user.GetPwUID(uint32(uid))
+		pw, err := user.CurrentOriginal()
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/util/user/identity.go
+++ b/internal/pkg/util/user/identity.go
@@ -1,15 +1,17 @@
-/*
-  Copyright (c) 2018, Sylabs, Inc. All rights reserved.
-
-  This software is licensed under a 3-clause BSD license.  Please
-  consult LICENSE.md file distributed with the sources of this project regarding
-  your rights to use or distribute this software.
-*/
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
 
 package user
 
-import "strconv"
-import osuser "os/user"
+import (
+	"os"
+	osuser "os/user"
+	"strconv"
+
+	"github.com/sylabs/singularity/pkg/util/namespaces"
+)
 
 // User represents an Unix user account information
 type User struct {
@@ -89,4 +91,22 @@ func GetGrNam(name string) (*Group, error) {
 		return nil, err
 	}
 	return convertGroup(g)
+}
+
+// Current returns a pointer to User structure associated with current
+// user
+func Current() (*User, error) {
+	return GetPwUID(uint32(os.Getuid()))
+}
+
+// CurrentOriginal returns a pointer to User structure associated with the
+// original current user, if current user is inside a user namespace with a
+// custom user mappings, it will returns information about the original user
+// otherwise it returns information about the current user
+func CurrentOriginal() (*User, error) {
+	uid, err := namespaces.HostUID()
+	if err != nil {
+		return nil, err
+	}
+	return GetPwUID(uint32(uid))
 }

--- a/internal/pkg/util/user/identity_test.go
+++ b/internal/pkg/util/user/identity_test.go
@@ -1,14 +1,12 @@
-/*
-  Copyright (c) 2018, Sylabs, Inc. All rights reserved.
-
-  This software is licensed under a 3-clause BSD license.  Please
-  consult LICENSE.md file distributed with the sources of this project regarding
-  your rights to use or distribute this software.
-*/
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
 
 package user
 
 import (
+	"os"
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
@@ -18,11 +16,11 @@ func TestGetPwUID(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	user, err := GetPwUID(0)
+	u, err := GetPwUID(0)
 	if err != nil {
 		t.Fatalf("Failed to retrieve information for UID 0")
 	}
-	if user.Name != "root" {
+	if u.Name != "root" {
 		t.Fatalf("UID 0 doesn't correspond to root user")
 	}
 }
@@ -31,11 +29,11 @@ func TestGetPwNam(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	user, err := GetPwNam("root")
+	u, err := GetPwNam("root")
 	if err != nil {
 		t.Fatalf("Failed to retrieve information for root user")
 	}
-	if user.UID != 0 {
+	if u.UID != 0 {
 		t.Fatalf("root user doesn't have UID 0")
 	}
 }
@@ -64,4 +62,46 @@ func TestGetGrNam(t *testing.T) {
 	if group.GID != 0 {
 		t.Fatalf("root group doesn't have GID 0")
 	}
+}
+
+func testCurrent(t *testing.T, fn func() (*User, error)) {
+	uid := os.Getuid()
+
+	u, err := fn()
+	if err != nil {
+		t.Fatalf("Failed to retrieve information for current user")
+	}
+	if u.UID != uint32(uid) {
+		t.Fatalf("returned UID (%d) doesn't match current UID (%d)", uid, u.UID)
+	}
+}
+
+func TestCurrent(t *testing.T) {
+	// as a regular user
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	testCurrent(t, Current)
+
+	// as root
+	test.ResetPrivilege(t)
+
+	testCurrent(t, Current)
+}
+
+func TestCurrentOriginal(t *testing.T) {
+	// as a regular user
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	// to fully test CurrentOriginal, we would need
+	// to execute it from a user namespace, actually
+	// we just ensure that current user informations
+	// are returned
+	testCurrent(t, CurrentOriginal)
+
+	// as root
+	test.ResetPrivilege(t)
+
+	testCurrent(t, CurrentOriginal)
 }

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -41,6 +41,7 @@ config_add_def SINGULARITY_CONFDIR SYSCONFDIR \"/singularity\"
 config_add_def CAPABILITY_FILE SINGULARITY_CONFDIR \"/capability.json\"
 config_add_def ECL_FILE SINGULARITY_CONFDIR \"/ecl.toml\"
 config_add_def SESSIONDIR LOCALSTATEDIR \"/singularity/mnt/session\"
+config_add_def SINGULARITY_SUID_INSTALL $with_suid
 
 build_runtime=0
 if [ "$host" = "unix" ]; then

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -36,7 +36,6 @@ type FileConfig struct {
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
 	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
 	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
-	FakerootBaseID          uint64   `default:"4227858432" directive:"fakeroot base id"`
 	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
 	EnableOverlay           string   `default:"try" authorized:"yes,no,try" directive:"enable overlay"`
 	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
@@ -44,7 +43,6 @@ type FileConfig struct {
 	LimitContainerGroups    []string `directive:"limit container groups"`
 	LimitContainerPaths     []string `directive:"limit container paths"`
 	AutofsBugPath           []string `directive:"autofs bug path"`
-	FakerootAllowedUsers    []string `directive:"fakeroot allowed users"`
 	RootDefaultCapabilities string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
 	MemoryFSType            string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
 	CniConfPath             string   `directive:"cni configuration path"`

--- a/pkg/runtime/engines/singularity/config/data/singularity.conf
+++ b/pkg/runtime/engines/singularity/config/data/singularity.conf
@@ -250,34 +250,3 @@ memory fs type = {{ .MemoryFSType }}
 # Allow to share same images associated with loop devices to minimize loop
 # usage and optimize kernel cache (useful for MPI)
 shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }}
-
-# FAKEROOT BASE ID: [INT] 131072 <= BASE <= 4294901760
-# DEFAULT: 4227858432
-# This is the start of allocatable UID/GID in containers for fakeroot users.
-# Each user will be allocated a range of 65535 UID/GID based on this base,
-# eg:
-# the first user in the list of allowed users will get a UID/GID range starting at:
-# (BASE_ID)+(65536*0) -> 4227858432:4227923967
-# the second user in the list of allowed users will get a UID/GID range starting at:
-# (BASE_ID)+(65536*1) -> 4227923968:4227989503
-#
-# The default value of 4227858432 should be fine with most environment and
-# only changed if some users UID/GID on your system may overlap with the
-# allocated ranges. DON'T CHANGE IT IF USERS ALREADY USE THE FEATURE.
-# The default value enables the configuration of up to 1024 users; if you need to
-# configure more users, you must decrease this value, basically by 65536 to
-# add one user and so on.
-# Additionally this value must be a multiple of 65536.
-fakeroot base id = {{ .FakerootBaseID }}
-
-# FAKEROOT ALLOWED USERS: [STRING]
-# DEFAULT: Undefined
-# This is the list of users allowed to use the fakeroot feature.
-# User position will determine the allocated ID range based on the
-# formula above, so you will need to be very careful when manipulating
-# the user list in order to not swap a range between users
-#fakeroot allowed users = foo, bar
-{{ range $index, $users := .FakerootAllowedUsers }}
-fakeroot allowed users = 
-{{ if $index }}, {{ end }}{{$users}}
-{{- end }}

--- a/pkg/util/namespaces/user_unsupported.go
+++ b/pkg/util/namespaces/user_unsupported.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package namespaces
+
+import "os"
+
+// IsInsideUserNamespace checks if a process is already running in a
+// user namespace and also returns if the process has permissions to use
+// setgroups in this user namespace.
+func IsInsideUserNamespace(pid int) (bool, bool) {
+	return false, false
+}
+
+// HostUID attempts to find the original host UID if the current
+// process is running inside a user namespace, if it doesn't it
+// simply returns the current UID
+func HostUID() (int, error) {
+	return os.Getuid(), nil
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Use newuidmap/newgidmap as fakeroot fallback for unprivileged installation.
- Fakeroot configuration is now handled by /etc/subxid files.
- Introduce new SINGULARITY_SUID_INSTALL constant to
ease setup detection and use starter binary accordingly.
- Fix fakeroot issues:
  - fix home directory (previously used user home directory)
  - HOME environment variable while joining an instance

**This fixes or addresses the following GitHub issues:**

- Related to discussion in #3891


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
