### PR TITLE
Add support for public keys when encrypting images

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/plugin"
 	"github.com/sylabs/singularity/pkg/image"
 	"github.com/sylabs/singularity/pkg/image/unpacker"
+	"github.com/sylabs/singularity/pkg/util/crypt"
 	"github.com/sylabs/singularity/pkg/util/namespaces"
 	"github.com/sylabs/singularity/pkg/util/nvidia"
 
@@ -254,7 +255,12 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		BindPaths = append(BindPaths, nvidia.IpcsPath(userPath)...)
 	}
 
-	engineConfig.SetEncryptionKey(encryptionKey)
+	plaintextKey, err := crypt.PlaintextKey(encryptionKey, engineConfig.GetImage())
+	if err != nil {
+		sylog.Fatalf("Cannot retrieve key from image %s: %+v", engineConfig.GetImage(), err)
+	}
+
+	engineConfig.SetEncryptionKey(plaintextKey)
 
 	engineConfig.SetBindPath(BindPaths)
 	engineConfig.SetNetwork(Network)

--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -689,7 +689,7 @@ func (c *container) addRootfsMount(system *mount.System) error {
 	mountType := ""
 	offset := imageObject.Partitions[0].Offset
 	size := imageObject.Partitions[0].Size
-	key := ""
+	var key []byte
 
 	sylog.Debugf("Image type is %v", imageObject.Partitions[0].Type)
 
@@ -832,13 +832,13 @@ func (c *container) addOverlayMount(system *mount.System) error {
 				ov.AddLowerDir(filepath.Join(dst, "upper"))
 			}
 
-			err = system.Points.AddImage(mount.PreLayerTag, src, dst, "ext3", flags, offset, size, "")
+			err = system.Points.AddImage(mount.PreLayerTag, src, dst, "ext3", flags, offset, size, nil)
 			if err != nil {
 				return fmt.Errorf("while adding ext3 image: %s", err)
 			}
 		case image.SQUASHFS:
 			flags := uintptr(c.suidFlag | syscall.MS_NODEV | syscall.MS_RDONLY)
-			err = system.Points.AddImage(mount.PreLayerTag, src, dst, "squashfs", flags, offset, size, "")
+			err = system.Points.AddImage(mount.PreLayerTag, src, dst, "squashfs", flags, offset, size, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -39,7 +39,7 @@ type MountArgs struct {
 type CryptArgs struct {
 	Offset  uint64
 	Loopdev string
-	Key     string
+	Key     []byte
 }
 
 // ChrootArgs defines the arguments to chroot.

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -34,7 +34,7 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 }
 
 // Decrypt calls the DeCrypt RPC using the supplied arguments.
-func (t *RPC) Decrypt(offset uint64, path string, key string) (string, error) {
+func (t *RPC) Decrypt(offset uint64, path string, key []byte) (string, error) {
 	arguments := &args.CryptArgs{
 		Offset:  offset,
 		Loopdev: path,

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -20,53 +20,53 @@ func TestImage(t *testing.T) {
 
 	points := &Points{}
 
-	if err := points.AddImage(RootfsTag, "", "/fake", "ext3", 0, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "", "/fake", "ext3", 0, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with empty source")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "", "ext3", 0, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "", "ext3", 0, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with empty destination")
 	}
 
-	if err := points.AddImage(RootfsTag, "fake", "/", "ext3", 0, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "fake", "/", "ext3", 0, 0, 10, nil); err == nil {
 		t.Errorf("should have failed as source is not an absolute path")
 	}
-	if err := points.AddImage(RootfsTag, "/", "fake", "ext3", 0, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/", "fake", "ext3", 0, 0, 10, nil); err == nil {
 		t.Errorf("should have failed as destination is not an absolute path")
 	}
 
-	if err := points.AddImage(RootfsTag, "", "/", "ext3", 0, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "", "/", "ext3", 0, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with empty source")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "xfs", 0, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "xfs", 0, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with bad filesystem type")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_BIND, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_BIND, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with bad bind flag")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REMOUNT, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REMOUNT, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with bad remount flag")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REC, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "ext3", syscall.MS_REC, 0, 10, nil); err == nil {
 		t.Errorf("should have failed with bad recursive flag")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/ext3", "ext3", 0, 0, 10, ""); err != nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/ext3", "ext3", 0, 0, 10, nil); err != nil {
 		t.Errorf("should have passed with ext3 filesystem")
 	}
 	points.RemoveAll()
-	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10, ""); err != nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10, nil); err != nil {
 		t.Errorf("should have passed with squashfs filesystem")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", 0, 0, 0, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", 0, 0, 0, nil); err == nil {
 		t.Errorf("should have failed with 0 size limit")
 	}
-	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10, ""); err == nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/squash", "squashfs", 0, 0, 10, nil); err == nil {
 		t.Errorf("nil error returned, should have returned non-nil mount.ErrMountExists")
 	} else if err != ErrMountExists {
 		t.Errorf("non-nil error should have been mount.ErrMountExists")
 	}
 	points.RemoveAll()
 
-	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", syscall.MS_NOSUID, 31, 10, ""); err != nil {
+	if err := points.AddImage(RootfsTag, "/fake", "/", "squashfs", syscall.MS_NOSUID, 31, 10, nil); err != nil {
 		t.Fatalf("should have passed with squashfs filesystem")
 	}
 	images := points.GetAllImages()

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -76,7 +76,7 @@ type JSONConfig struct {
 	Network           string        `json:"network,omitempty"`
 	DNS               string        `json:"dns,omitempty"`
 	Cwd               string        `json:"cwd,omitempty"`
-	EncryptionKey     string        `json:"encryptionKey,omitempty"`
+	EncryptionKey     []byte        `json:"encryptionKey,omitempty"`
 	TargetUID         int           `json:"targetUID,omitempty"`
 	WritableImage     bool          `json:"writableImage,omitempty"`
 	WritableTmpfs     bool          `json:"writableTmpfs,omitempty"`
@@ -119,12 +119,12 @@ func (e *EngineConfig) GetImage() string {
 }
 
 // SetKey sets the key for the image's system partition
-func (e *EngineConfig) SetEncryptionKey(key string) {
+func (e *EngineConfig) SetEncryptionKey(key []byte) {
 	e.JSON.EncryptionKey = key
 }
 
 // GetKey retrieves the key for image's system partition
-func (e *EngineConfig) GetEncryptionKey() string {
+func (e *EngineConfig) GetEncryptionKey() []byte {
 	return e.JSON.EncryptionKey
 }
 

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -8,7 +8,6 @@ package crypt
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -74,7 +73,7 @@ func (crypt *Device) CloseCryptDevice(path string) error {
 // EncryptFilesystem takes the path to a file containing a non-encrypted
 // filesystem, encrypts it using the provided key, and returns a path to
 // a file that can be later used as an encrypted volume with cryptsetup.
-func (crypt *Device) EncryptFilesystem(path, key string) (string, error) {
+func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) {
 	f, err := os.Stat(path)
 	if err != nil {
 		return "", fmt.Errorf("failed getting size of %s", path)
@@ -137,7 +136,7 @@ func (crypt *Device) EncryptFilesystem(path, key string) (string, error) {
 	}
 
 	go func() {
-		io.WriteString(stdin, key)
+		stdin.Write(key)
 		stdin.Close()
 	}()
 
@@ -213,7 +212,7 @@ func getNextAvailableCryptDevice() string {
 // device, but any encrypted block device will do) using the given key
 // and returns the name assigned to it that can be later used to close
 // the device.
-func (crypt *Device) Open(key, path string) (string, error) {
+func (crypt *Device) Open(key []byte, path string) (string, error) {
 	fd, err := lock.Exclusive("/dev/mapper")
 	if err != nil {
 		return "", fmt.Errorf("unable to acquire lock on /dev/mapper")
@@ -243,7 +242,7 @@ func (crypt *Device) Open(key, path string) (string, error) {
 		}
 
 		go func() {
-			io.WriteString(stdin, key)
+			stdin.Write(key)
 			stdin.Close()
 		}()
 

--- a/pkg/util/crypt/key.go
+++ b/pkg/util/crypt/key.go
@@ -18,11 +18,14 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+	"github.com/sylabs/sif/pkg/sif"
 )
 
 var (
-	ErrUnsupportedKeyURI = errors.New("unsupported key URI")
-	ErrNoPEMData         = errors.New("No PEM data")
+	ErrEncryptedKeyNotFound = errors.New("encrypted key not found")
+	ErrUnsupportedKeyURI    = errors.New("unsupported key URI")
+	ErrNoEncryptedKeyData   = errors.New("no encrypted key data")
+	ErrNoPEMData            = errors.New("No PEM data")
 )
 
 func getRandomBytes(size int) ([]byte, error) {
@@ -90,6 +93,60 @@ func EncryptKey(keyURI string, plaintext []byte) ([]byte, error) {
 	}
 }
 
+func PlaintextKey(keyURI, image string) ([]byte, error) {
+	u, err := url.Parse(keyURI)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot parse URI %s", keyURI)
+	}
+
+	switch u.Scheme {
+	case "pem":
+		privateKey, err := loadPEMPrivateKey(u.Path)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading private key for key decryption")
+		}
+
+		pemKey, err := getEncryptionKeyFromImage(image)
+		if err != nil {
+			return nil, errors.Wrapf(err, "loading encrypted key SIF image %s", image)
+		}
+
+		pemBuf := bytes.NewReader(pemKey)
+
+		encKey, err := loadPEMMessage(pemBuf)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unpacking PEM message from SIF image %s", image)
+		}
+
+		plaintext, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, privateKey, encKey, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "decrypting key from image %s", image)
+		}
+
+		return plaintext, nil
+
+	case "":
+		return []byte(u.Path), nil
+
+	default:
+		return nil, ErrUnsupportedKeyURI
+	}
+}
+
+func loadPEMPrivateKey(fn string) (*rsa.PrivateKey, error) {
+	b, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, errors.Wrapf(ErrNoPEMData, "reading %s", fn)
+	}
+
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}
+
 func loadPEMPublicKey(fn string) (*rsa.PublicKey, error) {
 	b, err := ioutil.ReadFile(fn)
 	if err != nil {
@@ -104,6 +161,25 @@ func loadPEMPublicKey(fn string) (*rsa.PublicKey, error) {
 	return x509.ParsePKCS1PublicKey(block.Bytes)
 }
 
+func loadPEMMessage(r io.Reader) ([]byte, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, errors.Wrapf(ErrNoPEMData, "reading PEM block")
+	}
+
+	var buf []byte
+	if _, err := asn1.Unmarshal(block.Bytes, &buf); err != nil {
+		return nil, errors.Wrapf(err, "unmarshalling ASN.1 data")
+	}
+
+	return buf, nil
+}
+
 func savePEMMessage(w io.Writer, msg []byte) error {
 	asn1Bytes, err := asn1.Marshal(msg)
 	if err != nil {
@@ -116,4 +192,44 @@ func savePEMMessage(w io.Writer, msg []byte) error {
 	}
 
 	return pem.Encode(w, b)
+}
+
+func getEncryptionKeyFromImage(fn string) ([]byte, error) {
+	img, err := sif.LoadContainer(fn, true)
+	if err != nil {
+		return nil, errors.Wrapf(err, "loading container image from %s", fn)
+	}
+	defer img.UnloadContainer()
+
+	primDescr, _, err := img.GetPartPrimSys()
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving primary system partition from %s", fn)
+	}
+
+	descr, _, err := img.GetFromLinkedDescr(primDescr.ID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving linked descriptors for primary system partition from %s", fn)
+	}
+
+	for _, d := range descr {
+		if d.Datatype != sif.DataGeneric {
+			continue
+		}
+
+		// TODO(mem): add a specific data type for encrypted
+		// keys. For now, assume the first generic descriptor
+		// linking to the primary system partition contains the
+		// key
+		data := d.GetData(&img)
+		if data == nil {
+			return nil, errors.Wrapf(ErrNoEncryptedKeyData, "retrieving encrypted key data from %s", fn)
+		}
+
+		key := make([]byte, len(data))
+		copy(key, data)
+
+		return key, nil
+	}
+
+	return nil, errors.Wrapf(ErrEncryptedKeyNotFound, "reading from %s", fn)
 }

--- a/pkg/util/crypt/key.go
+++ b/pkg/util/crypt/key.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package crypt
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"io"
+	"io/ioutil"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrUnsupportedKeyURI = errors.New("unsupported key URI")
+	ErrNoPEMData         = errors.New("No PEM data")
+)
+
+func getRandomBytes(size int) ([]byte, error) {
+	buf := make([]byte, size)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func NewPlaintextKey(keyURI string) ([]byte, error) {
+	u, err := url.Parse(keyURI)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot parse URI %s", keyURI)
+	}
+
+	switch u.Scheme {
+	case "pem":
+		// in this case we will generate a random secret and
+		// encrypt it using the PEM key.use the PEM key to
+		// encrypt a secret
+		return getRandomBytes(64)
+
+	case "":
+		// return the original value unmodified
+		return []byte(keyURI), nil
+
+	default:
+		return nil, ErrUnsupportedKeyURI
+	}
+}
+
+func EncryptKey(keyURI string, plaintext []byte) ([]byte, error) {
+	u, err := url.Parse(keyURI)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot parse URI %s", keyURI)
+	}
+
+	switch u.Scheme {
+	case "pem":
+		pubKey, err := loadPEMPublicKey(u.Path)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading public key for key encryption")
+		}
+
+		ciphertext, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, plaintext, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "encrypting key")
+		}
+
+		var buf bytes.Buffer
+
+		if err := savePEMMessage(&buf, ciphertext); err != nil {
+			return nil, errors.Wrap(err, "serializing encrypted key")
+		}
+
+		return buf.Bytes(), nil
+
+	case "":
+		return nil, nil
+
+	default:
+		return nil, ErrUnsupportedKeyURI
+	}
+}
+
+func loadPEMPublicKey(fn string) (*rsa.PublicKey, error) {
+	b, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, errors.Wrapf(ErrNoPEMData, "reading %s", fn)
+	}
+
+	return x509.ParsePKCS1PublicKey(block.Bytes)
+}
+
+func savePEMMessage(w io.Writer, msg []byte) error {
+	asn1Bytes, err := asn1.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	var b = &pem.Block{
+		Type:  "MESSAGE",
+		Bytes: asn1Bytes,
+	}
+
+	return pem.Encode(w, b)
+}


### PR DESCRIPTION
Extend the existing SIF file encryption so that it's possible to specify
a PEM file with a public key instead of a plain text key. When the
public key is specified, a secret will be automatically generated and it
will be encrypted with the specified public key.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
