### PR TITLE
Small fixes for manpages

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -157,8 +157,7 @@ chmod 644 $RPM_BUILD_ROOT%{_sysconfdir}/singularity/actions/*
 %dir %{_localstatedir}/singularity
 %dir %{_localstatedir}/singularity/mnt
 %dir %{_localstatedir}/singularity/mnt/session
-%{_mandir}/man1/singularity.1.gz
-%{_mandir}/man1/singularity-*.1.gz
+%{_mandir}/man1/singularity*
 
 
 %changelog

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -1,7 +1,7 @@
 all: $(ALL)
 
 .PHONY: man
-man:
+man: singularity
 	mkdir -p $(DESTDIR)$(MANDIR)/man1
 	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 		$(SOURCEDIR)/cmd/docs/docs.go man --dir $(DESTDIR)$(MANDIR)/man1


### PR DESCRIPTION
**Description of the Pull Request (PR):**
Fix RPM spec file to include `singularity*` instead of having the `.gz` name for the man pages. Not all older distributions gzip the man pages by default.

Make the `singularity` target a requirement of the `man` build target. It must have been ran, for the `man` target to succeed.

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
