### PR TITLE
Fix buildLocalImage so that it does not step over itself

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -6,6 +6,8 @@
 package imgbuild
 
 import (
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -149,13 +151,18 @@ func (c *imgBuildTests) nonRootBuild(t *testing.T) {
 }
 
 func (c *imgBuildTests) buildLocalImage(t *testing.T) {
-	imagePath1 := path.Join(c.env.TestDir, "container1")
-	imagePath2 := path.Join(c.env.TestDir, "container2")
-	imagePath3 := path.Join(c.env.TestDir, "container3")
+	e2e.EnsureImage(t, c.env)
+
+	tmpdir, err := ioutil.TempDir(c.env.TestDir, "build-local-image.")
+	if err != nil {
+		t.Errorf("Cannot create temporary directory: %+v", err)
+	}
+
+	defer os.RemoveAll(tmpdir)
 
 	liDefFile := e2e.PrepareDefFile(e2e.DefFileDetails{
 		Bootstrap: "localimage",
-		From:      imagePath1,
+		From:      c.env.ImagePath,
 	})
 	defer os.Remove(liDefFile)
 
@@ -163,72 +170,57 @@ func (c *imgBuildTests) buildLocalImage(t *testing.T) {
 	labels["FOO"] = "bar"
 	liLabelDefFile := e2e.PrepareDefFile(e2e.DefFileDetails{
 		Bootstrap: "localimage",
-		From:      imagePath2,
+		From:      c.env.ImagePath,
 		Labels:    labels,
 	})
 	defer os.Remove(liLabelDefFile)
 
-	type testSpec struct {
-		name      string
-		imagePath string
-		buildSpec string
-		force     bool
-		sandbox   bool
-	}
+	sandboxImage := path.Join(tmpdir, "test-sandbox")
+
+	e2e.RunSingularity(
+		t,
+		"test-sandbox",
+		e2e.WithPrivileges(true),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--sandbox", sandboxImage, c.env.ImagePath),
+		e2e.PostRun(func(t *testing.T) {
+			e2e.ImageVerify(t, c.env.CmdPath, sandboxImage)
+		}),
+		e2e.ExpectExit(0),
+	)
+
+	localSandboxDefFile := e2e.PrepareDefFile(e2e.DefFileDetails{
+		Bootstrap: "localimage",
+		From:      sandboxImage,
+		Labels:    labels,
+	})
+	defer os.Remove(localSandboxDefFile)
 
 	tests := []struct {
-		name  string
-		steps []testSpec
+		name      string
+		buildSpec string
 	}{
-		{"SIFToSIF", []testSpec{
-			{"BusyBox", imagePath1, "../examples/busybox/Singularity", false, false},
-			{"SIF", imagePath2, imagePath1, false, false},
-		}},
-		{"SandboxToSIF", []testSpec{
-			{"BusyBoxSandbox", imagePath1, "../examples/busybox/Singularity", false, true},
-			{"SIF", imagePath2, imagePath1, false, false},
-		}},
-		{"LocalImage", []testSpec{
-			{"BusyBox", imagePath1, "../examples/busybox/Singularity", false, false},
-			{"LocalImage", imagePath2, liDefFile, false, false},
-			{"LocalImageLabel", imagePath3, liLabelDefFile, false, false},
-		}},
-		{"LocalImageSandbox", []testSpec{
-			{"BusyBoxSandbox", imagePath2, "../examples/busybox/Singularity", true, true},
-			{"LocalImageLabel", imagePath3, liLabelDefFile, false, false},
-		}},
+		{"SIFToSIF", c.env.ImagePath},
+		{"SandboxToSIF", sandboxImage},
+		{"LocalImage", liDefFile},
+		{"LocalImageLabel", liLabelDefFile},
+		{"LocalImageSandbox", localSandboxDefFile},
 	}
 
-	for _, tt := range tests {
-
-		// prep targets for removal
+	for i, tt := range tests {
+		imagePath := filepath.Join(tmpdir, fmt.Sprintf("image-%d", i))
 		t.Run(tt.name, e2e.Privileged(func(t *testing.T) {
-			for _, ts := range tt.steps {
-				defer os.RemoveAll(ts.imagePath)
-			}
-
-			for _, ts := range tt.steps {
-				args := []string{}
-				if ts.force {
-					args = append([]string{"--force"}, args...)
-				}
-				if ts.sandbox {
-					args = append([]string{"--sandbox"}, args...)
-				}
-				args = append(args, ts.imagePath, ts.buildSpec)
-
-				e2e.RunSingularity(
-					t,
-					tt.name,
-					e2e.WithPrivileges(true),
-					e2e.WithCommand("build"),
-					e2e.WithArgs(args...),
-					e2e.PostRun(func(t *testing.T) {
-						e2e.ImageVerify(t, c.env.CmdPath, ts.imagePath)
-					}),
-					e2e.ExpectExit(0),
-				)
-			}
+			e2e.RunSingularity(
+				t,
+				tt.name,
+				e2e.WithPrivileges(true),
+				e2e.WithCommand("build"),
+				e2e.WithArgs(imagePath, tt.buildSpec),
+				e2e.PostRun(func(t *testing.T) {
+					e2e.ImageVerify(t, c.env.CmdPath, imagePath)
+				}),
+				e2e.ExpectExit(0),
+			)
 		}))
 	}
 }


### PR DESCRIPTION
buildLocalImage is trying to test that building images from several
sources works as intended. It does so by starting with one image and
turning it into a different kind of image. The code is such that it
"knows" when the image it's trying to build is already there and
therefore passes the "--force" flag to avoid an error... except when it
doesn't and the image is already there, which can happen if more than
one of the subtests happen to run at the same time or in a different
order than the test expects them to.

Fix this by removing all the complexity and test what the test is trying
to test in the first place: building a single image out of a
specification file (source, sandbox or definition file). Each subtest
uses either the test image that is already available to all the tests or
a sandbox that is derived from the test image.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
