### PR TITLE
Remove output order requirement in TestExpandPath

### DIFF
--- a/internal/pkg/build/files/files_test.go
+++ b/internal/pkg/build/files/files_test.go
@@ -10,7 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -58,6 +58,22 @@ files-test-dir/
 ├── file
 └── .file
 */
+
+func formatSlice(slice []string) (s string) {
+	for _, elm := range slice {
+		s += strconv.Quote(elm) + "\n"
+	}
+	return s
+}
+
+func contains(slice []string, s string) bool {
+	for _, elm := range slice {
+		if elm == s {
+			return true
+		}
+	}
+	return false
+}
 
 func createTestDirLayout(t *testing.T) string {
 	testDirName, err := ioutil.TempDir("", "files-test-dir-")
@@ -226,10 +242,13 @@ func TestExpandPath(t *testing.T) {
 				correct = append(correct, testDir+"/"+c)
 			}
 
-			if !reflect.DeepEqual(files, correct) {
-				t.Logf("Generated %d results: %s", len(files), files)
-				t.Logf("Correct %d results: %s", len(correct), correct)
-				t.Errorf("matched files are not correct")
+			for _, c := range correct {
+				if !contains(files, c) {
+					t.Logf("Generated %d results: %s", len(files), formatSlice(files))
+					t.Logf("Correct %d results: %s", len(correct), formatSlice(correct))
+					t.Errorf("matched files are not correct")
+					break
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

**This fixes or addresses the following GitHub issues:**

- Fixes #3956


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
