### PR TITLE
Write wget output to /dev/null

### DIFF
--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -17,7 +17,7 @@ from: registry:2.7.1
     dockerd --iptables=false --ip-forward=false --ip-masq=false --storage-driver=vfs &
     /.singularity.d/runscript &
     # wait until docker registry is up
-    while ! wget 127.0.0.1:5000 >/dev/null 2>&1; do sleep 0.2; done
+    while ! wget -O /dev/null 127.0.0.1:5000 >/dev/null 2>&1 ; do sleep 0.2; done
     if [ ! -z "${DELETE_BRIDGE}" ]; then
         ip link set docker0 down || kill -TERM 1
         brctl delbr docker0

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -17,7 +17,7 @@ from: registry:2.7.1
     dockerd --iptables=false --ip-forward=false --ip-masq=false --storage-driver=vfs &
     /.singularity.d/runscript &
     # wait until docker registry is up
-    while ! wget -O /dev/null 127.0.0.1:5000 >/dev/null 2>&1 ; do sleep 0.2; done
+    while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.2; done
     if [ ! -z "${DELETE_BRIDGE}" ]; then
         ip link set docker0 down || kill -TERM 1
         brctl delbr docker0


### PR DESCRIPTION
At least in once case wget was failing because the file index.html
already existed and it refused to overwrite it. By sending it to
/dev/null we make sure we avoid this issue.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
