### PR TITLE
Introduce SingularityCmdPath to catch migration errors

### DIFF
--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -6,6 +6,7 @@
 package inspect
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/buger/jsonparser"
@@ -17,6 +18,13 @@ type ctx struct {
 }
 
 const containerTesterSIF = "testdata/inspecter_container.sif"
+
+func (c *ctx) runInspectCommand(inspectType string) ([]byte, error) {
+	argv := []string{"inspect", "--json", inspectType, containerTesterSIF}
+	cmd := exec.Command(string(c.env.CmdPath), argv...)
+
+	return cmd.CombinedOutput()
+}
 
 func (c *ctx) singularityInspect(t *testing.T) {
 	tests := []struct {

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -9,7 +9,7 @@ import "testing"
 
 type TestEnv struct {
 	RunDisabled   bool
-	CmdPath       string
+	CmdPath       SingularityCmdPath
 	ImagePath     string
 	OrasTestImage string
 	TestDir       string

--- a/e2e/internal/e2e/imagepush.go
+++ b/e2e/internal/e2e/imagepush.go
@@ -14,7 +14,7 @@ import (
 
 // ImagePush executes a singularity push command to push
 // an image to the specified URI.
-func ImagePush(t *testing.T, cmdPath, imagePath, imgURI string) (string, []byte, error) {
+func ImagePush(t *testing.T, cmdPath SingularityCmdPath, imagePath, imgURI string) (string, []byte, error) {
 	argv := []string{"push"}
 
 	if imagePath != "" {
@@ -24,7 +24,7 @@ func ImagePush(t *testing.T, cmdPath, imagePath, imgURI string) (string, []byte,
 	argv = append(argv, imgURI)
 
 	cmd := fmt.Sprintf("%s %s", cmdPath, strings.Join(argv, " "))
-	out, err := exec.Command(cmdPath, argv...).CombinedOutput()
+	out, err := exec.Command(string(cmdPath), argv...).CombinedOutput()
 
 	return cmd, out, err
 

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ImageVerify checks for an image integrity
-func ImageVerify(t *testing.T, cmdPath string, imagePath string) {
+func ImageVerify(t *testing.T, cmdPath SingularityCmdPath, imagePath string) {
 	type testSpec struct {
 		name string
 		argv []string
@@ -75,7 +75,7 @@ func ImageVerify(t *testing.T, cmdPath string, imagePath string) {
 	for _, tt := range tests {
 		RunSingularity(
 			t,
-			cmdPath,
+			SingularityCmdPath(cmdPath),
 			AsSubtest(tt.name),
 			WithCommand("exec"),
 			WithArgs(tt.argv...),
@@ -85,7 +85,7 @@ func ImageVerify(t *testing.T, cmdPath string, imagePath string) {
 }
 
 // DefinitionImageVerify checks for image correctness based off off supplied DefFileDetail
-func DefinitionImageVerify(t *testing.T, cmdPath, imagePath string, dfd DefFileDetails) {
+func DefinitionImageVerify(t *testing.T, cmdPath SingularityCmdPath, imagePath string, dfd DefFileDetails) {
 	if dfd.Help != nil {
 		helpPath := filepath.Join(imagePath, `/.singularity.d/runscript.help`)
 		if !fileExists(t, helpPath) {
@@ -355,14 +355,14 @@ func verifyScript(t *testing.T, fileName string, contents []string) error {
 	return nil
 }
 
-func verifyEnv(t *testing.T, cmdPath, imagePath string, env []string, flags []string) error {
+func verifyEnv(t *testing.T, cmdPath SingularityCmdPath, imagePath string, env []string, flags []string) error {
 	args := []string{"exec"}
 	if flags != nil {
 		args = append(args, flags...)
 	}
 	args = append(args, imagePath, "env")
 
-	cmd := exec.Command(cmdPath, args...)
+	cmd := exec.Command(string(cmdPath), args...)
 	res := cmd.Run(t)
 
 	if res.Error != nil {

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -38,6 +38,10 @@ type SingularityCmdResult struct {
 // functions
 type MatchType uint8
 
+// SingularityCmdPath is used to specify the path to the singularity
+// command
+type SingularityCmdPath string
+
 const (
 	// ContainMatch is for contain match
 	ContainMatch MatchType = iota
@@ -401,7 +405,7 @@ func ExpectExit(code int, resultOps ...SingularityCmdResultOp) SingularityCmdOp 
 // cmdPath specifies the path to the singularity binary and cmdOps
 // provides a list of operations to be executed before or after running
 // the command.
-func RunSingularity(t *testing.T, cmdPath string, cmdOps ...SingularityCmdOp) {
+func RunSingularity(t *testing.T, cmdPath SingularityCmdPath, cmdOps ...SingularityCmdOp) {
 	s := new(singularityCmd)
 
 	for _, op := range cmdOps {
@@ -423,7 +427,7 @@ func RunSingularity(t *testing.T, cmdPath string, cmdOps ...SingularityCmdOp) {
 
 		s.t = t
 
-		cmd := exec.Command(cmdPath, s.args...)
+		cmd := exec.Command(string(cmdPath), s.args...)
 
 		cmd.Env = s.envs
 		if len(cmd.Env) == 0 {

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -24,7 +24,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-func checkOciState(t *testing.T, cmdPath, containerID, state string) {
+func checkOciState(t *testing.T, cmdPath e2e.SingularityCmdPath, containerID, state string) {
 	checkStateFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
 		s := &ociruntime.State{}
 		if err := json.Unmarshal(r.Stdout, s); err != nil {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -301,7 +301,7 @@ func (c *ctx) testPullCmd(t *testing.T) {
 	keyringEnv := "SINGULARITY_SYPGPDIR=" + tempKeyringDir
 	c.env.KeyringDir = keyringEnv
 	argv := []string{"key", "pull", sylabsAdminFingerprint}
-	out, err := exec.Command(c.env.CmdPath, argv...).CombinedOutput()
+	out, err := exec.Command(string(c.env.CmdPath), argv...).CombinedOutput()
 	if err != nil {
 		t.Fatalf("Cannot pull key %q: %+v\nCommand:\n%s %s\nOutput:\n%s\n",
 			sylabsAdminFingerprint,

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/sylabs/singularity/e2e/instance"
 
+	"github.com/sylabs/singularity/e2e/internal/e2e"
 	singularitye2e "github.com/sylabs/singularity/e2e/internal/e2e"
 
 	"github.com/sylabs/singularity/e2e/pull"
@@ -71,7 +72,7 @@ func Run(t *testing.T) {
 		log.Fatalf("singularity is not installed on this system: %v", err)
 	}
 
-	testenv.CmdPath = cmdPath
+	testenv.CmdPath = e2e.SingularityCmdPath(cmdPath)
 
 	sysconfdir := func(fn string) string {
 		return filepath.Join(buildcfg.SYSCONFDIR, "singularity", fn)


### PR DESCRIPTION
When the signature of RunSingularity changed from:

	func(*testing.T, string, ...SingularityCmdOps)

to:

	func(*testing.T, string, ...SingularityCmdOps)

the problem is that it didn't change. The only thing that changed was
the meaning of the second argument.

Change the type of the second argument SingularityCmdPath so that the
compiler produces an error with the old code and make it easier to catch
the mistake.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
