### PR TITLE
Fix --contain issues. Fix bind destination creation

### DIFF
--- a/internal/pkg/runtime/engines/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/create_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -70,22 +70,19 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 	}
 
 	sylog.Debugf("Mounting image directory %s\n", rootfs)
-	_, err = rpcOps.Mount(rootfs, sessionPath, "", syscall.MS_BIND, "errors=remount-ro")
-	if err != nil {
+	if err := rpcOps.Mount(rootfs, sessionPath, "", syscall.MS_BIND, "errors=remount-ro"); err != nil {
 		return fmt.Errorf("failed to mount directory filesystem %s: %s", rootfs, err)
 	}
 
 	dest := filepath.Join(sessionPath, "tmp")
 	sylog.Debugf("Mounting /tmp at %s\n", dest)
-	_, err = rpcOps.Mount("/tmp", dest, "", syscall.MS_BIND, "")
-	if err != nil {
+	if err := rpcOps.Mount("/tmp", dest, "", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("mount /tmp failed: %s", err)
 	}
 
 	dest = filepath.Join(sessionPath, "var", "tmp")
 	sylog.Debugf("Mounting /var/tmp at %s\n", dest)
-	_, err = rpcOps.Mount("/var/tmp", dest, "", syscall.MS_BIND, "")
-	if err != nil {
+	if err := rpcOps.Mount("/var/tmp", dest, "", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("mount /var/tmp failed: %s", err)
 	}
 
@@ -104,59 +101,50 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 
 	dest = filepath.Join(sessionPath, "proc")
 	sylog.Debugf("Mounting /proc at %s\n", dest)
-	_, err = rpcOps.Mount("/proc", dest, "", flags, "")
-	if err != nil {
+	if err := rpcOps.Mount("/proc", dest, "", flags, ""); err != nil {
 		return fmt.Errorf("mount proc failed: %s", err)
 	}
 	if !insideUserNs {
-		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-		if err != nil {
+		if err := rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, ""); err != nil {
 			return fmt.Errorf("remount proc failed: %s", err)
 		}
 	}
 
 	dest = filepath.Join(sessionPath, "sys")
 	sylog.Debugf("Mounting /sys at %s\n", dest)
-	_, err = rpcOps.Mount("/sys", dest, "", flags, "")
-	if err != nil {
+	if err := rpcOps.Mount("/sys", dest, "", flags, ""); err != nil {
 		return fmt.Errorf("mount sys failed: %s", err)
 	}
 	if !insideUserNs {
-		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-		if err != nil {
+		if err := rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, ""); err != nil {
 			return fmt.Errorf("remount sys failed: %s", err)
 		}
 	}
 
 	dest = filepath.Join(sessionPath, "dev")
 	sylog.Debugf("Mounting /dev at %s\n", dest)
-	_, err = rpcOps.Mount("/dev", dest, "", syscall.MS_BIND|syscall.MS_REC, "")
-	if err != nil {
+	if err := rpcOps.Mount("/dev", dest, "", syscall.MS_BIND|syscall.MS_REC, ""); err != nil {
 		return fmt.Errorf("mount /dev failed: %s", err)
 	}
 
 	dest = filepath.Join(sessionPath, "etc", "resolv.conf")
 	sylog.Debugf("Mounting /etc/resolv.conf at %s\n", dest)
-	_, err = rpcOps.Mount("/etc/resolv.conf", dest, "", flags, "")
-	if err != nil {
+	if err := rpcOps.Mount("/etc/resolv.conf", dest, "", flags, ""); err != nil {
 		return fmt.Errorf("mount /etc/resolv.conf failed: %s", err)
 	}
 	if !insideUserNs {
-		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-		if err != nil {
+		if err := rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, ""); err != nil {
 			return fmt.Errorf("remount /etc/resolv.conf failed: %s", err)
 		}
 	}
 
 	dest = filepath.Join(sessionPath, "etc", "hosts")
 	sylog.Debugf("Mounting /etc/hosts at %s\n", dest)
-	_, err = rpcOps.Mount("/etc/hosts", dest, "", flags, "")
-	if err != nil {
+	if err := rpcOps.Mount("/etc/hosts", dest, "", flags, ""); err != nil {
 		return fmt.Errorf("mount /etc/hosts failed: %s", err)
 	}
 	if !insideUserNs {
-		_, err = rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, "")
-		if err != nil {
+		if err := rpcOps.Mount("", dest, "", syscall.MS_REMOUNT|flags, ""); err != nil {
 			return fmt.Errorf("remount /etc/hosts failed: %s", err)
 		}
 	}
@@ -168,8 +156,7 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 	}
 
 	sylog.Debugf("Set RPC mount propagation flag to PRIVATE")
-	_, err = rpcOps.Mount("", "/", "", syscall.MS_PRIVATE|syscall.MS_REC, "")
-	if err != nil {
+	if err := rpcOps.Mount("", "/", "", syscall.MS_PRIVATE|syscall.MS_REC, ""); err != nil {
 		return err
 	}
 

--- a/internal/pkg/runtime/engines/oci/create_linux.go
+++ b/internal/pkg/runtime/engines/oci/create_linux.go
@@ -627,7 +627,7 @@ func (c *container) addRootfsMount(system *mount.System) error {
 
 	sylog.Debugf("Parent rootfs: %s", parentRootfs)
 
-	if _, err := c.rpcOps.Mount("", parentRootfs, "", syscall.MS_PRIVATE, ""); err != nil {
+	if err := c.rpcOps.Mount("", parentRootfs, "", syscall.MS_PRIVATE, ""); err != nil {
 		return err
 	}
 	if err := system.Points.AddBind(mount.RootfsTag, c.rootfs, c.rootfs, flags); err != nil {
@@ -709,7 +709,7 @@ func (c *container) addDefaultDevices(system *mount.System) error {
 				if _, err := c.rpcOps.Touch(path); err != nil {
 					return fmt.Errorf("could not create file %s: %s", path, err)
 				}
-				if _, err := c.rpcOps.Mount(device.path, path, "", syscall.MS_BIND, ""); err != nil {
+				if err := c.rpcOps.Mount(device.path, path, "", syscall.MS_BIND, ""); err != nil {
 					return fmt.Errorf("could not mount %s to %s: %s", device.path, path, err)
 				}
 			} else {
@@ -959,7 +959,7 @@ func (c *container) mount(point *mount.Point) error {
 		sylog.Debugf("Mount %s to %s : %s [%s]", source, dest, point.Type, optsString)
 	}
 
-	_, err := c.rpcOps.Mount(source, dest, point.Type, flags, optsString)
+	err := c.rpcOps.Mount(source, dest, point.Type, flags, optsString)
 	if err != nil {
 		sylog.Debugf("RPC mount error: %s", err)
 	}

--- a/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/server/server_linux.go
@@ -27,11 +27,11 @@ var diskGID = -1
 type Methods int
 
 // Mount performs a mount with the specified arguments.
-func (t *Methods) Mount(arguments *args.MountArgs, reply *int) (err error) {
+func (t *Methods) Mount(arguments *args.MountArgs, mountErr *error) (err error) {
 	mainthread.Execute(func() {
-		err = syscall.Mount(arguments.Source, arguments.Target, arguments.Filesystem, arguments.Mountflags, arguments.Data)
+		*mountErr = syscall.Mount(arguments.Source, arguments.Target, arguments.Filesystem, arguments.Mountflags, arguments.Data)
 	})
-	return err
+	return nil
 }
 
 // DeCrypt decrypts the loop device

--- a/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -47,6 +47,11 @@ func (o *Overlay) Add(session *layout.Session, system *mount.System) error {
 	o.lowerDirs = append(o.lowerDirs, path)
 
 	return system.RunBeforeTag(mount.LayerTag, o.createOverlay)
+}
+
+// Dir returns absolute overlay directory within session
+func (o *Overlay) Dir() string {
+	return lowerDir
 }
 
 func (o *Overlay) createOverlay(system *mount.System) error {

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -44,6 +44,11 @@ func (u *Underlay) Add(session *layout.Session, system *mount.System) error {
 		return err
 	}
 	return system.RunBeforeTag(mount.PreLayerTag, u.createUnderlay)
+}
+
+// Dir returns absolute underlay directory within session
+func (u *Underlay) Dir() string {
+	return underlayDir
 }
 
 func (u *Underlay) createUnderlay(system *mount.System) error {

--- a/internal/pkg/util/fs/layout/session_linux.go
+++ b/internal/pkg/util/fs/layout/session_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,8 +7,10 @@ package layout
 
 import (
 	"fmt"
+	"path/filepath"
 	"syscall"
 
+	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/fs/mount"
 )
 
@@ -24,6 +26,7 @@ type Session struct {
 // Layer describes a layer interface added on top of session layout
 type layer interface {
 	Add(*Session, *mount.System) error
+	Dir() string
 }
 
 // NewSession creates and returns a session directory layout manager
@@ -75,6 +78,16 @@ func (s *Session) FinalPath() string {
 	return s.RootFsPath()
 }
 
+// OverrideDir overrides a path in the session directory, it simulates
+// a bind mount.
+func (s *Session) OverrideDir(path string, realpath string) {
+	p := path
+	if s.Layer != nil {
+		p = filepath.Join(s.Layer.Dir(), path)
+	}
+	s.overrideDir(p, realpath)
+}
+
 // RootFsPath returns the full path to session rootfs directory
 func (s *Session) RootFsPath() string {
 	path, _ := s.GetPath(rootFsDir)
@@ -82,5 +95,57 @@ func (s *Session) RootFsPath() string {
 }
 
 func (s *Session) createLayout(system *mount.System) error {
+	st := new(syscall.Stat_t)
+
+	// create directory for registered overrided directory
+	for _, tag := range mount.GetTagList() {
+		for _, point := range system.Points.GetByTag(tag) {
+			if point.Source == "" {
+				continue
+			}
+
+			// search until we find a parent overrided directory
+			overrided := false
+			for baseDir := filepath.Dir(point.Destination); baseDir != "/"; {
+				if _, err := s.GetOverridePath(baseDir); err == nil {
+					overrided = true
+					break
+				}
+				baseDir = filepath.Dir(baseDir)
+			}
+			if !overrided {
+				continue
+			}
+
+			dest := point.Destination
+			if _, err := s.GetPath(dest); err == nil {
+				continue
+			}
+			flags, _ := mount.ConvertOptions(point.Options)
+
+			// ignore anything which is not a bind mount point
+			if flags&syscall.MS_BIND == 0 {
+				continue
+			}
+
+			// check if the bind source exists
+			if err := syscall.Stat(point.Source, st); err != nil {
+				sylog.Warningf("skipping mount of: %s: %s", point.Source, err)
+				continue
+			}
+
+			switch st.Mode & syscall.S_IFMT {
+			case syscall.S_IFDIR:
+				if err := s.AddDir(dest); err != nil {
+					return err
+				}
+			default:
+				if err := s.AddFile(dest, nil); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	return s.Create()
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Fix --contain issue with both overlay/underlay and writable flags.
- Introduces overrideDir in session manager to simulate a bind mount during directories/files/symlinks creation, it should address many issues related to binding giving error like "no such file directory" during mount call.
- Nested binds are already allowed, with `overrideDir` destination directories will be automatically created.
- Fix RPC mount error type to now return `syscall.Errno` type

**This fixes or addresses the following GitHub issues:**

- Fixes #3949


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
