### PR TITLE
Better handle the path to the Singularity system configuration file

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/env"
 	"github.com/sylabs/singularity/internal/pkg/util/exec"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	singularityConfig "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 )
@@ -132,7 +133,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	engineConfig := singularityConfig.NewConfig()
 
-	configurationFile := buildcfg.SYSCONFDIR + "/singularity/singularity.conf"
+	configurationFile := files.GetSysConfigFile()
 	if err := config.Parser(configurationFile, engineConfig.File); err != nil {
 		sylog.Fatalf("Unable to parse singularity.conf file: %s", err)
 	}

--- a/cmd/singularity/cli_test.go
+++ b/cmd/singularity/cli_test.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 )
 
 var (
@@ -52,7 +52,7 @@ func run(m *testing.M) int {
 	cmdPath = path
 
 	// Ensure config is installed
-	if fi, err := os.Stat(buildcfg.SYSCONFDIR + "/singularity/singularity.conf"); err != nil {
+	if fi, err := os.Stat(files.GetSysConfigFile()); err != nil {
 		log.Fatalf("singularity config is not installed on this system: %v", err)
 	} else if !fi.Mode().IsRegular() {
 		log.Fatalf("singularity config is not a regular file")

--- a/cmd/singularity/security_test.go
+++ b/cmd/singularity/security_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 )
 
 // testSecurityUnpriv tests security flag fuctionality for singularity exec without elevated privileges
@@ -91,7 +91,7 @@ func testSecurityPriv(t *testing.T) {
 
 // testSecurityConfOwnership tests checks on config files ownerships
 func testSecurityConfOwnership(t *testing.T) {
-	configFile := buildcfg.SYSCONFDIR + "/singularity/singularity.conf"
+	configFile := files.GetSysConfigFile()
 	// Change file ownership (do not try this at home)
 	err := os.Chown(configFile, 1001, 0)
 	if err != nil {

--- a/internal/pkg/runtime/engines/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engines/fakeroot/engine_linux.go
@@ -9,12 +9,10 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"syscall"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	fakerootutil "github.com/sylabs/singularity/internal/pkg/fakeroot"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/starter"
@@ -23,6 +21,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/security/seccomp"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 	singularity "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 	"github.com/sylabs/singularity/pkg/util/capabilities"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
@@ -48,7 +47,7 @@ func (e *EngineOperations) Config() config.EngineConfig {
 func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	g := generate.Generator{Config: &specs.Spec{}}
 
-	configurationFile := filepath.Join(buildcfg.SYSCONFDIR, "/singularity/singularity.conf")
+	configurationFile := files.GetSysConfigFile()
 
 	// check for ownership of singularity.conf
 	if starterConfig.GetIsSUID() && !fs.IsOwner(configurationFile, 0) {

--- a/internal/pkg/runtime/engines/singularity/create_linux.go
+++ b/internal/pkg/runtime/engines/singularity/create_linux.go
@@ -10,9 +10,9 @@ import (
 	"net"
 	"net/rpc"
 
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/singularity/rpc/client"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 	singularityConfig "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 )
 
@@ -26,7 +26,7 @@ func (engine *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error
 		return nil
 	}
 
-	configurationFile := buildcfg.SYSCONFDIR + "/singularity/singularity.conf"
+	configurationFile := files.GetSysConfigFile()
 	if err := config.Parser(configurationFile, engine.EngineConfig.File); err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}

--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/syecl"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 	"github.com/sylabs/singularity/internal/pkg/util/mainthread"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/image"
@@ -720,7 +721,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		return fmt.Errorf("bad engine configuration provided")
 	}
 
-	configurationFile := buildcfg.SYSCONFDIR + "/singularity/singularity.conf"
+	configurationFile := files.GetSysConfigFile()
 	if err := config.Parser(configurationFile, e.EngineConfig.File); err != nil {
 		return fmt.Errorf("Unable to parse singularity.conf file: %s", err)
 	}

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/internal/pkg/util/fs/files"
 	singularity "github.com/sylabs/singularity/pkg/runtime/engines/singularity/config"
 )
 
@@ -35,7 +36,7 @@ var (
 // returns a non-nil error.
 func Cryptsetup() (string, error) {
 	cache.Do(func() {
-		cfgpath := filepath.Join(buildcfg.SINGULARITY_CONFDIR, "singularity.conf")
+		cfgpath := files.GetSysConfigFile()
 		cache.cryptsetup, cache.err = cryptsetup(cfgpath)
 		sylog.Debugf("Using cryptsetup at %q", cache.cryptsetup)
 	})


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Better handle the path to the Singularity system configuration file by calling a specific API instead of the creation of a string (which did not even use `filepath.Join()`).


**This fixes or addresses the following GitHub issues:**

- Fixes #3976 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers