### PR TITLE
Add stack traces to test errors

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/internal/pkg/test/tool/exec"
 )
@@ -243,8 +244,9 @@ func (c *actionTests) actionShell(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	hostname, err := os.Hostname()
+	err = errors.Wrap(err, "getting hostname")
 	if err != nil {
-		t.Fatalf("could not get hostname: %s", err)
+		t.Fatalf("could not get hostname: %+v", err)
 	}
 
 	tests := []struct {

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/buger/jsonparser"
+	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 )
 
@@ -117,8 +118,9 @@ func (c *ctx) singularityInspect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Inspect the container, and get the output
 			out, err := c.runInspectCommand(tt.insType)
+			err = errors.Wrap(err, "running inspect command")
 			if err != nil {
-				t.Fatalf("unexpected failure: %s: %s", string(out), err)
+				t.Fatalf("unexpected failure: %s: %+v", string(out), err)
 			}
 
 			// Parse the output

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 )
 
@@ -99,8 +100,9 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 	// Create and populate a temporary file.
 	tempFile := filepath.Join(dir, fileName)
 	err = ioutil.WriteFile(tempFile, fileContents, 0644)
+	err = errors.Wrapf(err, "creating temporary test file %s", tempFile)
 	if err != nil {
-		t.Fatalf("Failed to create file %s: %v", tempFile, err)
+		t.Fatalf("Failed to create file: %+v", err)
 	}
 
 	// Start an instance with the temporary directory as the home directory.

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const dockerInstanceName = "e2e-docker-instance"
@@ -66,6 +68,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 		retry := 0
 		for {
 			conn, err := net.Dial("tcp", "127.0.0.1:5111")
+			err = errors.Wrap(err, "connecting to test endpoint in docker registry container")
 			if err == nil {
 				conn.Close()
 				break
@@ -73,7 +76,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 			time.Sleep(100 * time.Millisecond)
 			retry++
 			if retry == 100 {
-				t.Fatalf("docker registry unreachable after 10 seconds: %s", err)
+				t.Fatalf("docker registry unreachable after 10 seconds: %+v", err)
 			}
 		}
 

--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
@@ -47,15 +48,17 @@ func WriteTempFile(dir, pattern, content string) (string, error) {
 func MakeCacheDirs(baseDir string) error {
 	if cacheDirPriv == "" {
 		dir, err := fs.MakeTmpDir(baseDir, "privcache-", 0755)
+		err = errors.Wrapf(err, "creating temporary privileged cache directory at %s", baseDir)
 		if err != nil {
-			return fmt.Errorf("failed to create privileged cache directory: %s", err)
+			return fmt.Errorf("failed to create privileged cache directory: %+v", err)
 		}
 		cacheDirPriv = dir
 	}
 	if cacheDirUnpriv == "" {
 		dir, err := fs.MakeTmpDir(baseDir, "unprivcache-", 0755)
+		err = errors.Wrapf(err, "creating temporary unprivileged cache directory at %s", baseDir)
 		if err != nil {
-			return fmt.Errorf("failed to create unprivileged cache directory: %s", err)
+			return fmt.Errorf("failed to create unprivileged cache directory: %+v", err)
 		}
 		cacheDirUnpriv = dir
 		os.Setenv(cache.DirEnv, cacheDirUnpriv)

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 )
 
@@ -28,12 +29,14 @@ func (c *ctx) testPushCmd(t *testing.T) {
 	// setup file and dir to use as invalid sources
 	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")
 	if err != nil {
-		t.Fatalf("unable to create src dir for push tests: %v", err)
+		err = errors.Wrap(err, "creating oras temporary directory")
+		t.Fatalf("unable to create src dir for push tests: %+v", err)
 	}
 
 	orasInvalidFile, err := e2e.WriteTempFile(orasInvalidDir, "oras_invalid_image-", "Invalid Image Contents")
 	if err != nil {
-		t.Fatalf("unable to create src file for push tests: %v", err)
+		err = errors.Wrap(err, "creating oras temporary file")
+		t.Fatalf("unable to create src file for push tests: %+v", err)
 	}
 
 	tests := []struct {

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/buger/jsonparser"
+	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 )
 
@@ -84,7 +85,8 @@ func (c *ctx) singularityVerifyKeyNum(t *testing.T) {
 			// Get the Signatures and compare it
 			eNum, err := jsonparser.GetInt(r.Stdout, keyNumPath...)
 			if err != nil {
-				t.Fatalf("unable to get expected output from json: %s", err)
+				err = errors.Wrap(err, "getting key number from JSON")
+				t.Fatalf("unable to get expected output from json: %+v", err)
 			}
 			if eNum != tt.expectNumOut {
 				t.Fatalf("unexpected failure: got: '%d', expecting: '%d'", eNum, tt.expectNumOut)
@@ -218,7 +220,8 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 			for keyNum, vo := range tt.expectOutput {
 				eName, err := jsonparser.GetString(r.Stdout, getNameJSON(keyNum)...)
 				if err != nil {
-					t.Fatalf("unable to get expected output from json: %s", err)
+					err = errors.Wrap(err, "getting string from JSON")
+					t.Fatalf("unable to get expected output from json: %+v", err)
 				}
 				if eName != vo.name {
 					t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", eName, vo.name)
@@ -227,7 +230,8 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 				// Get the Fingerprint and compare it
 				eFingerprint, err := jsonparser.GetString(r.Stdout, getFingerprintJSON(keyNum)...)
 				if err != nil {
-					t.Fatalf("unable to get expected output from json: %s", err)
+					err = errors.Wrap(err, "getting string from JSON")
+					t.Fatalf("unable to get expected output from json: %+v", err)
 				}
 				if eFingerprint != vo.fingerprint {
 					t.Fatalf("unexpected failure: got: '%s', expecting: '%s'", eFingerprint, vo.fingerprint)
@@ -236,7 +240,8 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 				// Get the Local and compare it
 				eLocal, err := jsonparser.GetBoolean(r.Stdout, getLocalJSON(keyNum)...)
 				if err != nil {
-					t.Fatalf("unable to get expected output from json: %s", err)
+					err = errors.Wrap(err, "getting boolean from JSON")
+					t.Fatalf("unable to get expected output from json: %+v", err)
 				}
 				if eLocal != vo.local {
 					t.Fatalf("unexpected failure: got: '%v', expecting: '%v'", eLocal, vo.local)
@@ -245,7 +250,8 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 				// Get the KeyCheck and compare it
 				eKeyCheck, err := jsonparser.GetBoolean(r.Stdout, getKeyCheckJSON(keyNum)...)
 				if err != nil {
-					t.Fatalf("unable to get expected output from json: %s", err)
+					err = errors.Wrap(err, "getting boolean from JSON")
+					t.Fatalf("unable to get expected output from json: %+v", err)
 				}
 				if eKeyCheck != vo.keyCheck {
 					t.Fatalf("unexpected failure: got: '%v', expecting: '%v'", eKeyCheck, vo.keyCheck)
@@ -254,7 +260,8 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 				// Get the DataCheck and compare it
 				eDataCheck, err := jsonparser.GetBoolean(r.Stdout, getDataCheckJSON(keyNum)...)
 				if err != nil {
-					t.Fatalf("unable to get expected output from json: %s", err)
+					err = errors.Wrap(err, "getting boolean from JSON")
+					t.Fatalf("unable to get expected output from json: %+v", err)
 				}
 				if eDataCheck != vo.dataCheck {
 					t.Fatalf("unexpected failure: got: '%v', expecting: '%v'", eDataCheck, vo.dataCheck)

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 )
 
@@ -62,17 +63,19 @@ func (c *ctx) testEqualVersion(t *testing.T) {
 			outputVer = strings.TrimSpace(outputVer)
 			semanticVersion, err := semver.Make(outputVer)
 			if err != nil {
-				t.Log(semanticVersion)
-				t.Fatalf("FAIL: no semantic version valid for %s command", tt.name)
+				err = errors.Wrapf(err, "creating semver version from %q", outputVer)
+				t.Fatalf("Creating semver version: %+v", err)
 			}
 			if tmpVersion != "" {
 				versionTmp, err := semver.Make(tmpVersion)
 				if err != nil {
-					t.Fatalf("FAIL: %s", err)
+					err = errors.Wrapf(err, "creating semver version from %q", tmpVersion)
+					t.Fatalf("Creating semver version: %+v", err)
 				}
 				//compare versions and see if they are equal
 				if semanticVersion.Compare(versionTmp) != 0 {
-					t.Fatalf("FAIL: singularity version command and singularity --version give a non-matching version result")
+					err = errors.Wrapf(err, "comparing versions %q and %q", outputVer, tmpVersion)
+					t.Fatalf("singularity version command and singularity --version give a non-matching version result: %+v", err)
 				}
 			} else {
 				tmpVersion = outputVer


### PR DESCRIPTION
In order to make it easier to understand what's failing, use
github.com/pkg/errors to record the closest location to where an error
was reported and use that when calling t.Fatal or equivalent functions.
In this way a stack is captured at the location where the error is
receving and it's printed out as part of the error message.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
