### PR TITLE
Fix integer overflow on 32 bits system in fakeroot package

### DIFF
--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -25,11 +25,11 @@ const (
 	// SubGIDFile is the default path to the subgid file.
 	SubGIDFile = "/etc/subgid"
 	// validRangeCount is the valid fakeroot range count.
-	validRangeCount = 65536
+	validRangeCount = uint32(65536)
 	// StartMax is the maximum possible range start.
-	startMax = 4294967296 - validRangeCount
+	startMax = uint32(4294967296 - 65536)
 	// StartMin is the minimum possible range start.
-	startMin = 65536
+	startMin = uint32(65536)
 	// disabledPrefix is the character prefix marking an entry as disabled.
 	disabledPrefix = '!'
 	// fieldSeparator is the character separating entry's fields.
@@ -207,7 +207,7 @@ func (c *Config) AddUser(username string) error {
 		return fmt.Errorf("could not retrieve user information for %s: %s", username, err)
 	}
 	for i := startMax; i >= startMin; i -= validRangeCount {
-		current := uint32(i)
+		current := i
 		available := true
 		for _, entry := range c.entries {
 			if entry.invalid {

--- a/internal/pkg/fakeroot/fakeroot_test.go
+++ b/internal/pkg/fakeroot/fakeroot_test.go
@@ -157,8 +157,8 @@ func createConfig(t *testing.T) string {
 
 	var buf bytes.Buffer
 
-	base := 10
-	size := 10
+	base := uint32(10)
+	size := uint32(10)
 
 	// valid users
 	for i := base; i < base+size; i++ {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix constant variable typed `int` instead of `uint32`

**This fixes or addresses the following GitHub issues:**

- Fixes #4005


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
