### PR TITLE
[3.3] Fixed issue when exporting key and 'sypgp' does not exist

### DIFF
--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -799,6 +799,7 @@ func ExportPrivateKey(kpath string, armor bool) error {
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	if !armor {
 		// Export the key to the file
@@ -811,7 +812,6 @@ func ExportPrivateKey(kpath string, armor bool) error {
 		}
 		file.WriteString(keyText)
 	}
-	defer file.Close()
 
 	if err != nil {
 		return fmt.Errorf("unable to serialize private key: %v", err)
@@ -847,6 +847,7 @@ func ExportPubKey(kpath string, armor bool) error {
 	if err != nil {
 		return fmt.Errorf("unable to create file: %v", err)
 	}
+	defer file.Close()
 
 	if !armor {
 		err = entityToExport.Serialize(file)
@@ -859,7 +860,6 @@ func ExportPubKey(kpath string, armor bool) error {
 	if err != nil {
 		return fmt.Errorf("unable to serialize public key: %v", err)
 	}
-	defer file.Close()
 	fmt.Printf("Public key with fingerprint %X correctly exported to file: %s\n", entityToExport.PrimaryKey.Fingerprint, kpath)
 
 	return nil

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -768,6 +768,9 @@ func LoadKeyringFromFile(path string) (openpgp.EntityList, error) {
 
 // ExportPrivateKey Will export a private key into a file (kpath).
 func ExportPrivateKey(kpath string, armor bool) error {
+	if err := PathsCheck(); err != nil {
+		return err
+	}
 
 	f, err := os.OpenFile(SecretPath(), os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
@@ -820,10 +823,10 @@ func ExportPrivateKey(kpath string, armor bool) error {
 
 // ExportPubKey Will export a public key into a file (kpath).
 func ExportPubKey(kpath string, armor bool) error {
-	file, err := os.Create(kpath)
-	if err != nil {
-		return fmt.Errorf("unable to create file: %v", err)
+	if err := PathsCheck(); err != nil {
+		return err
 	}
+
 	f, err := os.OpenFile(PublicPath(), os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return fmt.Errorf("unable to open local keyring: %v", err)
@@ -838,6 +841,11 @@ func ExportPubKey(kpath string, armor bool) error {
 	entityToExport, err := SelectPubKey(localEntityList)
 	if err != nil {
 		return err
+	}
+
+	file, err := os.Create(kpath)
+	if err != nil {
+		return fmt.Errorf("unable to create file: %v", err)
 	}
 
 	if !armor {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixed issue when trying to export a key when `sypgp` dir does not exist.

### This fixes or addresses the following GitHub issues:

- Fixes #3993 

<br>
