### PR TITLE
Check SIF squashfs/ext3 partitions at load time

### DIFF
--- a/pkg/image/ext3.go
+++ b/pkg/image/ext3.go
@@ -50,15 +50,15 @@ func CheckExt3Header(b []byte) (uint64, error) {
 	einfo := &extFSInfo{}
 
 	if uintptr(offset)+unsafe.Sizeof(einfo) >= uintptr(len(b)) {
-		return offset, fmt.Errorf("can't find ext3 information header")
+		return offset, debugError("can't find ext3 information header")
 	}
 	buffer := bytes.NewReader(b[offset:])
 
 	if err := binary.Read(buffer, binary.LittleEndian, einfo); err != nil {
-		return offset, fmt.Errorf("can't read the top of the image")
+		return offset, debugError("can't read the top of the image")
 	}
 	if !bytes.Equal(einfo.Magic[:], []byte(extMagic)) {
-		return offset, fmt.Errorf(notValidExt3ImageMessage)
+		return offset, debugError(notValidExt3ImageMessage)
 	}
 	if einfo.Compat&compatHasJournal == 0 {
 		return offset, fmt.Errorf(notValidExt3ImageMessage)
@@ -75,11 +75,11 @@ func CheckExt3Header(b []byte) (uint64, error) {
 
 func (f *ext3Format) initializer(img *Image, fileinfo os.FileInfo) error {
 	if fileinfo.IsDir() {
-		return fmt.Errorf("not an ext3 image")
+		return debugError("not an ext3 image")
 	}
 	b := make([]byte, bufferSize)
 	if n, err := img.File.Read(b); err != nil || n != bufferSize {
-		return fmt.Errorf("can't read first %d bytes: %s", bufferSize, err)
+		return debugErrorf("can't read first %d bytes: %s", bufferSize, err)
 	}
 	offset, err := CheckExt3Header(b)
 	if err != nil {

--- a/pkg/image/sandbox.go
+++ b/pkg/image/sandbox.go
@@ -6,7 +6,6 @@
 package image
 
 import (
-	"fmt"
 	"os"
 )
 
@@ -16,7 +15,7 @@ func (f *sandboxFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	if fileinfo.IsDir() {
 		img.Type = SANDBOX
 	} else {
-		return fmt.Errorf("not a directory image")
+		return debugError("not a directory image")
 	}
 	img.Partitions = []Section{
 		{

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 
 	"github.com/sylabs/sif/pkg/sif"
-	"github.com/sylabs/singularity/internal/pkg/sylog"
 )
 
 const (
@@ -22,16 +21,41 @@ const (
 
 type sifFormat struct{}
 
+func checkPartitionType(img *Image, fstype sif.Fstype, offset int64) (uint32, error) {
+	header := make([]byte, bufferSize)
+
+	if _, err := img.File.ReadAt(header, offset); err != nil {
+		return 0, fmt.Errorf("failed to read SIF partition at offset %d: %s", offset, err)
+	}
+
+	switch fstype {
+	case sif.FsSquash:
+		if _, err := CheckSquashfsHeader(header[:]); err != nil {
+			return 0, fmt.Errorf("error while checking squashfs header: %s", err)
+		}
+		return SQUASHFS, nil
+	case sif.FsExt3:
+		if _, err := CheckExt3Header(header[:]); err != nil {
+			return 0, fmt.Errorf("error while checking ext3 header: %s", err)
+		}
+		return EXT3, nil
+	case sif.FsEncryptedSquashfs:
+		return ENCRYPTSQUASHFS, nil
+	}
+
+	return 0, fmt.Errorf("unknown filesystem type %v", fstype)
+}
+
 func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	if fileinfo.IsDir() {
-		return fmt.Errorf("not a sif file image")
+		return debugError("not a sif file image")
 	}
 	b := make([]byte, bufferSize)
 	if n, err := img.File.Read(b); err != nil || n != bufferSize {
-		return fmt.Errorf("can't read first %d bytes: %s", bufferSize, err)
+		return debugErrorf("can't read first %d bytes: %s", bufferSize, err)
 	}
 	if !bytes.Contains(b, []byte(sifMagic)) {
-		return fmt.Errorf("SIF magic not found")
+		return debugError("SIF magic not found")
 	}
 
 	// Load the SIF file
@@ -55,9 +79,7 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	// runtime, which is not 100% compliant with the intended workflow.
 	sifArch := string(fimg.Header.Arch[:sif.HdrArchLen-1])
 	if sifArch != sif.HdrArchUnknown && sifArch != sif.GetSIFArch(runtime.GOARCH) {
-		err := fmt.Errorf("the image's architecture (%s) is incompatible with the host's (%s)", sif.GetGoArch(sifArch), runtime.GOARCH)
-		sylog.Errorf("%s", err)
-		return err
+		return fmt.Errorf("the image's architecture (%s) is incompatible with the host's (%s)", sif.GetGoArch(sifArch), runtime.GOARCH)
 	}
 
 	groupID := -1
@@ -82,22 +104,24 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 			continue
 		}
 
+		// checks if the partition length is greater that the file
+		// size which may reveal a corrupted image (see issue #3996)
+		if fimg.Filesize < desc.Filelen+desc.Fileoff {
+			return fmt.Errorf("SIF image %s is corrupted: wrong partition size", img.File.Name())
+		}
+
+		htype, err := checkPartitionType(img, fstype, desc.Fileoff)
+		if err != nil {
+			return fmt.Errorf("while checking system partition header: %s", err)
+		}
+
 		img.Partitions = []Section{
 			{
 				Offset: uint64(desc.Fileoff),
 				Size:   uint64(desc.Filelen),
 				Name:   RootFs,
+				Type:   htype,
 			},
-		}
-
-		if fstype == sif.FsSquash {
-			img.Partitions[0].Type = SQUASHFS
-		} else if fstype == sif.FsExt3 {
-			img.Partitions[0].Type = EXT3
-		} else if fstype == sif.FsEncryptedSquashfs {
-			img.Partitions[0].Type = ENCRYPTSQUASHFS
-		} else {
-			return fmt.Errorf("unknown file system type: %v", fstype)
 		}
 
 		groupID = int(desc.Groupid)
@@ -122,18 +146,21 @@ func (f *sifFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 			if err != nil {
 				continue
 			}
+
+			if fimg.Filesize < desc.Filelen+desc.Fileoff {
+				return fmt.Errorf("SIF image %s is corrupted: wrong partition size", img.File.Name())
+			}
+
+			htype, err := checkPartitionType(img, fstype, desc.Fileoff)
+			if err != nil {
+				return fmt.Errorf("while checking data partition header: %s", err)
+			}
+
 			partition := Section{
 				Offset: uint64(desc.Fileoff),
 				Size:   uint64(desc.Filelen),
 				Name:   desc.GetName(),
-			}
-			switch fstype {
-			case sif.FsSquash:
-				partition.Type = SQUASHFS
-			case sif.FsExt3:
-				partition.Type = EXT3
-			default:
-				partition.Type = uint32(fstype)
+				Type:   htype,
 			}
 			img.Partitions = append(img.Partitions, partition)
 		} else if desc.Datatype != 0 {

--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package image
+
+import (
+	"bytes"
+	"os"
+	"runtime"
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
+)
+
+const testSquash = "./testdata/squashfs.v4"
+
+func createSIF(t *testing.T, inputDesc []sif.DescriptorInput, corrupted bool) string {
+	sifFile, err := fs.MakeTmpFile("", "sif-", 0644)
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %s", err)
+	}
+	sifFile.Close()
+
+	for _, d := range inputDesc {
+		if f, ok := d.Fp.(*os.File); ok {
+			f.Seek(0, 0)
+		}
+	}
+
+	cinfo := sif.CreateInfo{
+		Pathname:   sifFile.Name(),
+		Launchstr:  sif.HdrLaunch,
+		Sifversion: sif.HdrVersion,
+		ID:         uuid.NewV4(),
+		InputDescr: inputDesc,
+	}
+
+	fp, err := sif.CreateContainer(cinfo)
+	if err != nil {
+		t.Fatalf("failed to create empty SIF")
+	}
+	fp.UnloadContainer()
+
+	if corrupted {
+		f, err := os.OpenFile(sifFile.Name(), os.O_WRONLY, 0)
+		if err != nil {
+			t.Fatalf("failed to open %s: %s", sifFile.Name(), err)
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatalf("failed to stat on %s: %s", sifFile.Name(), err)
+		}
+		if err := f.Truncate(fi.Size() - 4096); err != nil {
+			t.Fatalf("failed to truncate file to %d: %s", fi.Size()-4096, err)
+		}
+	}
+
+	return sifFile.Name()
+}
+
+func TestSIFInitializer(t *testing.T) {
+	fp1, err := os.Open(testSquash)
+	if err != nil {
+		t.Fatalf("failed to open %s: %s", testSquash, err)
+	}
+	defer fp1.Close()
+
+	fp2, err := os.Open(testSquash)
+	if err != nil {
+		t.Fatalf("failed to open %s: %s", testSquash, err)
+	}
+	defer fp2.Close()
+
+	onePart := sif.DescriptorInput{
+		Datatype: sif.DataPartition,
+		Groupid:  sif.DescrDefaultGroup,
+		Link:     sif.DescrUnusedLink,
+		Fname:    "onePart",
+		Fp:       fp1,
+		Extra: *bytes.NewBuffer([]byte{
+			0x01, 0x00, 0x00, 0x00, // fstype
+			0x01, 0x00, 0x00, 0x00, // part type
+		}),
+	}
+
+	oneSection := sif.DescriptorInput{
+		Datatype: sif.DataGeneric,
+		Groupid:  sif.DescrDefaultGroup,
+		Link:     sif.DescrUnusedLink,
+		Fname:    "oneSection",
+		Fp:       fp1,
+	}
+
+	primPartNoArch := sif.DescriptorInput{
+		Datatype: sif.DataPartition,
+		Groupid:  sif.DescrDefaultGroup,
+		Link:     sif.DescrUnusedLink,
+		Fname:    "primPart",
+		Fp:       fp1,
+		Extra: *bytes.NewBuffer([]byte{
+			0x01, 0x00, 0x00, 0x00, // fstype
+			0x02, 0x00, 0x00, 0x00, // part type
+		}),
+	}
+
+	primPart := sif.DescriptorInput{
+		Datatype: sif.DataPartition,
+		Groupid:  sif.DescrDefaultGroup,
+		Link:     sif.DescrUnusedLink,
+		Fname:    "primPart",
+		Fp:       fp1,
+		Extra: *bytes.NewBuffer([]byte{
+			0x01, 0x00, 0x00, 0x00, // fstype
+			0x02, 0x00, 0x00, 0x00, // part type
+		}),
+	}
+	primPart.Extra.WriteString(sif.GetSIFArch(runtime.GOARCH))
+
+	overlayPart := sif.DescriptorInput{
+		Datatype: sif.DataPartition,
+		Groupid:  sif.DescrDefaultGroup,
+		Link:     sif.DescrUnusedLink,
+		Fname:    "overlayPart",
+		Fp:       fp2,
+		Extra: *bytes.NewBuffer([]byte{
+			0x01, 0x00, 0x00, 0x00, // fstype
+			0x04, 0x00, 0x00, 0x00, // part type
+		}),
+	}
+
+	tests := []struct {
+		name               string
+		path               string
+		writable           bool
+		expectedSuccess    bool
+		expectedPartitions int
+		expectedSections   int
+	}{
+		{
+			name:               "NoPartitionSIF",
+			path:               createSIF(t, nil, false),
+			writable:           false,
+			expectedSuccess:    false,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+		{
+			name:               "UnkownPartitionSIF",
+			path:               createSIF(t, []sif.DescriptorInput{onePart}, false),
+			writable:           false,
+			expectedSuccess:    true,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+		{
+			name:               "PrimaryPartitionNoArchSIF",
+			path:               createSIF(t, []sif.DescriptorInput{primPartNoArch}, false),
+			writable:           false,
+			expectedSuccess:    false,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+		{
+			name:               "PrimaryPartitionSIF",
+			path:               createSIF(t, []sif.DescriptorInput{primPart}, false),
+			writable:           false,
+			expectedSuccess:    true,
+			expectedPartitions: 1,
+			expectedSections:   0,
+		},
+		{
+			name:               "PrimaryPartitionCorruptedSIF",
+			path:               createSIF(t, []sif.DescriptorInput{primPart}, true),
+			writable:           false,
+			expectedSuccess:    false,
+			expectedPartitions: 0,
+			expectedSections:   0,
+		},
+		{
+			name:               "PrimaryAndOverlayPartitionsSIF",
+			path:               createSIF(t, []sif.DescriptorInput{primPart, overlayPart}, false),
+			writable:           false,
+			expectedSuccess:    true,
+			expectedPartitions: 2,
+			expectedSections:   0,
+		},
+		{
+			name:               "SectionSIF",
+			path:               createSIF(t, []sif.DescriptorInput{oneSection}, false),
+			writable:           false,
+			expectedSuccess:    true,
+			expectedPartitions: 0,
+			expectedSections:   1,
+		},
+		{
+			name:               "PartitionAndSectionSIF",
+			path:               createSIF(t, []sif.DescriptorInput{primPart, oneSection}, false),
+			writable:           false,
+			expectedSuccess:    true,
+			expectedPartitions: 1,
+			expectedSections:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		var err error
+
+		sifFmt := new(sifFormat)
+		mode := sifFmt.openMode(tt.writable)
+
+		img := &Image{
+			Path: tt.path,
+			Name: tt.path,
+		}
+
+		img.Writable = true
+		img.File, err = os.OpenFile(tt.path, mode, 0)
+		if err != nil {
+			t.Fatalf("cannot open image's file: %s\n", err)
+		}
+		defer img.File.Close()
+
+		fileinfo, err := img.File.Stat()
+		if err != nil {
+			t.Fatalf("cannot stat the image file: %s\n", err)
+		}
+
+		err = sifFmt.initializer(img, fileinfo)
+		os.Remove(tt.path)
+
+		if err != nil && tt.expectedSuccess {
+			t.Fatalf("unexpected error for %q: %s\n", tt.name, err)
+		} else if err == nil && !tt.expectedSuccess {
+			t.Fatalf("unexpected success for %q", tt.name)
+		} else if tt.expectedPartitions != len(img.Partitions) {
+			t.Fatalf("unexpected partitions number: %d instead of %d", len(img.Partitions), tt.expectedPartitions)
+		} else if tt.expectedSections != len(img.Sections) {
+			t.Fatalf("unexpected sections number: %d instead of %d", len(img.Sections), tt.expectedSections)
+		}
+	}
+}
+
+func TestSIFOpenMode(t *testing.T) {
+	var sifFmt sifFormat
+
+	if sifFmt.openMode(true) != os.O_RDWR {
+		t.Fatal("openMode(true) returned the wrong value")
+	}
+	if sifFmt.openMode(false) != os.O_RDONLY {
+		t.Fatal("openMode(false) returned the wrong value")
+	}
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Actually SIF squashfs/ext3 partitions are not checked, this PR add checks for both squashfs/ext3 system/data partitions

**This fixes or addresses the following GitHub issues:**

- Related to #3996 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
