### PR TITLE
Show unsquashfs command failure output

### DIFF
--- a/pkg/image/unpacker/squashfs.go
+++ b/pkg/image/unpacker/squashfs.go
@@ -64,8 +64,8 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) error 
 	if stdin {
 		cmd.Stdin = reader
 	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("extract command failed: %s", err)
+	if o, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("extract command failed: %s: %s", string(o), err)
 	}
 	return nil
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Actually during extraction only the exit status is reported which doesn't give any useful hints to end user, this PR now show combined output when the extraction failed.

**This fixes or addresses the following GitHub issues:**

- Fixes #4012
- Fixes #3996

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
