### PR TITLE
Fix port handling

### DIFF
--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -283,7 +283,7 @@ func (m *Setup) SetArgs(args []string) error {
 				if len(ports) != 1 && len(ports) != 2 {
 					return fmt.Errorf("portmap port argument is badly formatted")
 				}
-				if n, err := strconv.ParseInt(ports[0], 0, 16); err == nil {
+				if n, err := strconv.ParseUint(ports[0], 0, 16); err == nil {
 					pm.HostPort = int(n)
 					if pm.HostPort <= 0 {
 						return fmt.Errorf("host port must be greater than zero")
@@ -292,7 +292,7 @@ func (m *Setup) SetArgs(args []string) error {
 					return fmt.Errorf("can't convert host port '%s': %s", ports[0], err)
 				}
 				if len(ports) == 2 {
-					if n, err := strconv.ParseInt(ports[1], 0, 16); err == nil {
+					if n, err := strconv.ParseUint(ports[1], 0, 16); err == nil {
 						pm.ContainerPort = int(n)
 						if pm.ContainerPort <= 0 {
 							return fmt.Errorf("container port must be greater than zero")

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -285,8 +285,8 @@ func (m *Setup) SetArgs(args []string) error {
 				}
 				if n, err := strconv.ParseUint(ports[0], 0, 16); err == nil {
 					pm.HostPort = int(n)
-					if pm.HostPort <= 0 {
-						return fmt.Errorf("host port must be greater than zero")
+					if pm.HostPort <= 0 || pm.HostPort > 65535 {
+						return fmt.Errorf("host port must be greater than 0 and less than 65535")
 					}
 				} else {
 					return fmt.Errorf("can't convert host port '%s': %s", ports[0], err)
@@ -294,8 +294,8 @@ func (m *Setup) SetArgs(args []string) error {
 				if len(ports) == 2 {
 					if n, err := strconv.ParseUint(ports[1], 0, 16); err == nil {
 						pm.ContainerPort = int(n)
-						if pm.ContainerPort <= 0 {
-							return fmt.Errorf("container port must be greater than zero")
+						if pm.ContainerPort <= 0 || pm.ContainerPort > 65535 {
+							return fmt.Errorf("container port must be greater than 0 and less than 65535")
 						}
 					} else {
 						return fmt.Errorf("can't convert container port '%s': %s", ports[1], err)

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -242,6 +242,16 @@ func testSetArgs(setup *Setup, t *testing.T) {
 			success: true,
 		},
 		{
+			desc:    "good port range",
+			args:    []string{"test-bridge:portmap=65530/tcp"},
+			success: true,
+		},
+		{
+			desc:    "bad port range",
+			args:    []string{"test-bridge:portmap=65550/tcp"},
+			success: false,
+		},
+		{
 			desc:    "ipRange not supported arg",
 			args:    []string{"test-bridge:ipRange=10.1.1.0/16"},
 			success: false,


### PR DESCRIPTION
Looking at the port value was using `ParseInt()` which used a
`int16` value. Change to `ParseUint()` to cover the full range we
require with a `uint16` value.

Fixes: #4028 

Attn: @singularity-maintainers
