### PR TITLE
Add another apt lock file to wait for before continuing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - run:
          name: Wait until apt completion
          command: |-
-           i=0 ; while fuser /var/lib/dpkg/lock > /dev/null 2>&1 ; do echo 'Waiting for dpkg lock...' ; let i=i+1 ; if test $i -ge 30 ; then echo 'Waiting for too long. Abort.' ; exit 1 ; fi ; sleep 1 ; done
+           i=0 ; while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock > /dev/null 2>&1 ; do echo 'Waiting for locks...' ; let i=i+1 ; if test $i -ge 30 ; then echo 'Waiting for too long. Abort.' ; exit 1 ; fi ; sleep 1 ; done
       - run:
           name: Fetch deps
           working_directory: /tmp


### PR DESCRIPTION
CircleCI is continuously failing at the following step with the following error:

```
#!/bin/bash -eo pipefail
mkdir -p ${GOBIN}
sudo apt-get update -y && sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev

E: Could not get lock /var/lib/apt/lists/lock - open (11: Resource temporarily unavailable)
E: Unable to lock directory /var/lib/apt/lists/
Exited with code 100
```

So we will try and wait for that lock file in the previous step.