### PR TITLE
Cache Shub images by commit hash

### DIFF
--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -142,16 +142,27 @@ func PullShub(imgCache *cache.Handle, filePath string, shubRef string, force, no
 		}
 	}
 
+	shubURI, err := shub.ShubParseReference(shubRef)
+	if err != nil {
+		return fmt.Errorf("failed to parse shub uri: %s", err)
+	}
+
+	// Get the image manifest
+	manifest, err := shub.GetManifest(shubURI, noHTTPS)
+	if err != nil {
+		return fmt.Errorf("failed to get manifest from shub: %s", err)
+	}
+
 	imageName := uri.GetName(shubRef)
-	imagePath := imgCache.ShubImage("hash", imageName)
+	imagePath := imgCache.ShubImage(manifest.Commit, imageName)
 
 	if noCache {
 		// Dont use cached image
-		if err := shub.DownloadImage(filePath, shubRef, true, noHTTPS); err != nil {
+		if err := shub.DownloadImage(manifest, filePath, shubRef, true, noHTTPS); err != nil {
 			return err
 		}
 	} else {
-		exists, err := imgCache.ShubImageExists("hash", imageName)
+		exists, err := imgCache.ShubImageExists(manifest.Commit, imageName)
 		if err != nil {
 			return fmt.Errorf("unable to check if %v exists: %v", imagePath, err)
 		}
@@ -159,7 +170,7 @@ func PullShub(imgCache *cache.Handle, filePath string, shubRef string, force, no
 			sylog.Infof("Downloading shub image")
 			go interruptCleanup(imagePath)
 
-			err := shub.DownloadImage(imagePath, shubRef, true, noHTTPS)
+			err := shub.DownloadImage(manifest, imagePath, shubRef, true, noHTTPS)
 			if err != nil {
 				return err
 			}

--- a/pkg/client/shub/api.go
+++ b/pkg/client/shub/api.go
@@ -44,12 +44,12 @@ type ShubAPIResponse struct {
 	Name    string `json:"name"`
 	Tag     string `json:"tag"`
 	Version string `json:"version"`
+	Commit  string `json:"commit"`
 }
 
-// getManifest will return the image manifest for a container uri
+// GetManifest will return the image manifest for a container uri
 // from Singularity Hub.
-func getManifest(uri ShubURI, noHTTPS bool) (ShubAPIResponse, error) {
-
+func GetManifest(uri ShubURI, noHTTPS bool) (ShubAPIResponse, error) {
 	// Create a new http Hub client
 	httpc := http.Client{
 		Timeout: 30 * time.Second,

--- a/pkg/client/shub/pull.go
+++ b/pkg/client/shub/pull.go
@@ -23,7 +23,7 @@ const pullTimeout = 7200
 
 // DownloadImage image will download a shub image to a path. This will not try
 // to cache it, or use cache.
-func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
+func DownloadImage(manifest ShubAPIResponse, filePath, shubRef string, force, noHTTPS bool) error {
 	sylog.Debugf("Downloading container from Shub")
 	if !force {
 		if _, err := os.Stat(filePath); err == nil {
@@ -36,20 +36,14 @@ func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 		sylog.Fatalf("Invalid shub URI")
 	}
 
-	ShubURI, err := shubParseReference(shubRef)
+	shubURI, err := ShubParseReference(shubRef)
 	if err != nil {
 		return fmt.Errorf("failed to parse shub uri: %v", err)
 	}
 
 	if filePath == "" {
-		filePath = fmt.Sprintf("%s_%s.simg", ShubURI.container, ShubURI.tag)
+		filePath = fmt.Sprintf("%s_%s.simg", shubURI.container, shubURI.tag)
 		sylog.Infof("Download filename not provided. Downloading to: %s\n", filePath)
-	}
-
-	// Get the image manifest
-	manifest, err := getManifest(ShubURI, noHTTPS)
-	if err != nil {
-		return fmt.Errorf("failed to get manifest from shub: %v", err)
 	}
 
 	// Get the image based on the manifest
@@ -121,7 +115,7 @@ func DownloadImage(filePath, shubRef string, force, noHTTPS bool) error {
 
 	bar.Finish()
 
-	sylog.Debugf("Download complete\n")
+	sylog.Debugf("Download complete: %s\n", filePath)
 
 	return nil
 }

--- a/pkg/client/shub/pull_test.go
+++ b/pkg/client/shub/pull_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	shubURI     = "shub://ikaneshiro/singularityhub:latest"
-	shubImgPath = "/tmp/shub-test_img.simg"
+	shubImageURI = "shub://ikaneshiro/singularityhub:latest"
+	shubImgPath  = "/tmp/shub-test_img.simg"
 )
 
 // TestDownloadImage tests if we can pull an image from Singularity Hub
@@ -29,12 +29,23 @@ func TestDownloadImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	err := DownloadImage(shubImgPath, shubURI, false, false)
+	shubURI, err := ShubParseReference(shubImageURI)
+	if err != nil {
+		t.Fatalf("failed to parse shub uri: %v", err)
+	}
+
+	// Get the image manifest
+	manifest, err := GetManifest(shubURI, false)
+	if err != nil {
+		t.Fatalf("failed to get manifest from shub: %s", err)
+	}
+
+	err = DownloadImage(manifest, shubImgPath, shubImageURI, false, false)
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
 	}
 
-	//clean up
+	// clean up
 	err = os.Remove(shubImgPath)
 	if err != nil {
 		t.Fatalf("failed to clean up test environment: %v", err)

--- a/pkg/client/shub/util.go
+++ b/pkg/client/shub/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -34,10 +34,10 @@ func isShubPullRef(shubRef string) bool {
 	return shubRef == found
 }
 
-// shubParseReference accepts a valid Shub reference string and parses its content
+// ShubParseReference accepts a valid Shub reference string and parses its content
 // It will return an error if the given URI is not valid,
 // otherwise it will parse the contents into a ShubURI struct
-func shubParseReference(src string) (uri ShubURI, err error) {
+func ShubParseReference(src string) (uri ShubURI, err error) {
 	ShubRef := strings.TrimPrefix(src, "shub://")
 	refParts := strings.Split(ShubRef, "/")
 

--- a/pkg/client/shub/util_test.go
+++ b/pkg/client/shub/util_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -81,7 +81,7 @@ func TestShubParser(t *testing.T) {
 	for _, uri := range validShubURIs {
 		t.Run(fmt.Sprintf("Valid URI: %v", uri),
 			func(t *testing.T) {
-				sURI, err := shubParseReference(uri)
+				sURI, err := ShubParseReference(uri)
 				if err != nil {
 					t.Fatalf("failed to parse valid URI: %v", uri)
 				}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes caching for shub by caching by the commit hash instead of the container name.

### This fixes or addresses the following GitHub issues:

- Fixes: #4027 

<br>
