### PR TITLE
Support for E2e coverage reports

### DIFF
--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -6,55 +6,278 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/sylabs/singularity/cmd/internal/cli"
 )
 
-type Cmd struct {
-	Name     string
-	Options  []string
-	Children []Cmd
+/*
+ * This tool aims at gathering the list of Singularity commands and optionaly
+ * the list of commands covered by the E2E tests. When gathering the list of
+ * E2E tests, we also calculate the coverage compared to all the Singularity
+ * commands.
+ *
+ * Note that the list of all the commands has some limitations. Since we create
+ * the list with Cobra, the following assumptions are made:
+ * - Commands are based on the following scheme (which is not matching reality at 100%):
+ *		singularity <cmd> [[--<cmd-opt>] [<sub-cmd> [--<subcmd-opt]]]
+ * - Cobra does not actually create a tree of commands/sub-commands/options but rather
+ * a list of commands and sub-list of sub-commands and options. As a result, it is not
+ * possible to track sub-command that are specific to a command option; and therefore
+ * not possible to get all the actual Singularity commands.
+ * - the e2e tests are using the long version of the option, not the short version. At
+ * the moment, we have no way to associate short and long versions of options.
+ */
+
+// Global variable to track the total number of tested commands.
+var tested = 0
+
+type singularityCmd struct {
+	name     string
+	options  []string
+	children []singularityCmd
 }
 
-func (c *Cmd) AddCmd(cmd Cmd) {
-	c.Children = append(c.Children, cmd)
+func checkCmd(sCmd string, e2eCmds string, resultFile *os.File) error {
+	currentCmd := sCmd
+	currentOpt := ""
+	if strings.Index(sCmd, "--") > 0 {
+		cmdElts := strings.Split(sCmd, "--")
+		if len(cmdElts) != 2 {
+			return fmt.Errorf("Wrong number of options: %d", len(cmdElts))
+		}
+		currentCmd = strings.Trim(cmdElts[0], " ")
+		currentOpt = strings.Trim("--"+cmdElts[1], " ")
+	}
+
+	isTested := false
+	for _, e2eCmd := range strings.Split(e2eCmds, "\n") {
+		e2eCmd = strings.Trim(e2eCmd, " ")
+		if e2eCmd == "" {
+			continue
+		}
+
+		if e2eCmd != "" && strings.Contains(e2eCmd, currentCmd) {
+			if currentOpt == "" || (currentOpt != "" && strings.Contains(e2eCmd, currentOpt)) {
+				isTested = true
+				break
+			}
+		}
+	}
+
+	str := fmt.Sprintf("UNTESTED: %s\n", sCmd)
+	if isTested {
+		fmt.Printf("%s%s%s\n", "\x1b[32m", sCmd, "\x1b[0m")
+		str = fmt.Sprintf("TESTED: %s\n", sCmd)
+		tested++
+	} else {
+		fmt.Printf("%s%s%s\n", "\x1b[31m", sCmd, "\x1b[0m")
+	}
+	resultFile.WriteString(str)
+
+	return nil
 }
 
-func (c *Cmd) AddOpt(opt string) {
-	c.Options = append(c.Options, opt)
+func loadData(singularityCmdsFile, e2eCmdsFile string) (string, string, error) {
+	e2eData, err := ioutil.ReadFile(e2eCmdsFile)
+	if err != nil {
+		return "", "", err
+	}
+	e2eCmds := string(e2eData)
+
+	singularityData, err := ioutil.ReadFile(singularityCmdsFile)
+	if err != nil {
+		return "", "", err
+	}
+	singularityCmds := string(singularityData)
+
+	return singularityCmds, e2eCmds, nil
 }
 
-func buildTree(root *cobra.Command) Cmd {
+func analyseData(singularityCmds string, e2eCmds string) (string, error) {
+	resultFile, err := ioutil.TempFile("", "singularity-cmd-coverage-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create file to store coverage results: %s", err)
+	}
+	defer resultFile.Close()
+
+	for _, singularityCmd := range strings.Split(singularityCmds, "\n") {
+		if singularityCmd != "" {
+			err = checkCmd(singularityCmd, e2eCmds, resultFile)
+			if err != nil {
+				return "", fmt.Errorf("failed to check cmd %s", singularityCmd)
+			}
+		}
+	}
+
+	totalCmds := len(strings.Split(singularityCmds, "\n"))
+	ratio := tested * 100 / totalCmds
+	fmt.Printf("Coverage: %d/%d (%d%%)\n", tested, totalCmds, ratio)
+
+	return resultFile.Name(), nil
+}
+
+func parseCmd(cmd singularityCmd, outputFile *os.File) error {
+	str := fmt.Sprintf("%s", cmd)
+	cmds := strings.Split(str, "singularity")
+	for _, cmdStr := range cmds { // This may be a command with sub-commands
+		if cmdStr != "{" { // Going down the tree, we may be at the bottom with an empty list
+
+			// We clean up the command
+			cmdStr = strings.Replace(cmdStr, "[]}", "", -1)
+			cmdStr = strings.Replace(cmdStr, "{", "", -1)
+			cmdStr = strings.Replace(cmdStr, "]}", "", -1)
+			cmdStr = strings.Replace(cmdStr, "] [", "]", -1)
+			cmdStr = strings.Replace(cmdStr, "[{", "", -1)
+
+			// We check whether the command has options to handle
+			subcmds := strings.Split(cmdStr, "[")
+			if len(subcmds) == 2 { // Options are associated to the command
+				opts := subcmds[1]
+				opts = strings.Replace(opts, "]", "", -1)
+				// Handle each option separately
+				for _, opt := range strings.Split(opts, " ") {
+					if strings.Trim(opt, " \t") != "" {
+						// Command with option
+						str = fmt.Sprintf("singularity %s --%s\n", strings.Trim(subcmds[0], " \t"), strings.Trim(opt, " \t"))
+						outputFile.WriteString(str)
+					}
+				}
+			} else {
+				// Command without option or sub-commands
+				str = fmt.Sprintf("singularity %s\n", cmdStr)
+				outputFile.WriteString(str)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *singularityCmd) addCmd(cmd singularityCmd, outputFile *os.File) error {
+	c.children = append(c.children, cmd)
+	return parseCmd(cmd, outputFile)
+}
+
+func (c *singularityCmd) addOpt(opt string) {
+	c.options = append(c.options, opt)
+}
+
+func buildTree(root *cobra.Command, outputFile *os.File) singularityCmd {
 	root.InitDefaultHelpFlag()
 
-	tree := Cmd{Name: root.CommandPath(), Options: nil, Children: nil}
+	tree := singularityCmd{name: root.CommandPath(), options: nil, children: nil}
 
 	root.Flags().VisitAll(func(flag *pflag.Flag) {
-		tree.AddOpt(flag.Name)
+		tree.addOpt(flag.Name)
 	})
 
 	for _, c := range root.Commands() {
-		tree.AddCmd(buildTree(c))
+		tree.addCmd(buildTree(c, outputFile), outputFile)
 	}
 
 	return tree
 }
 
-func main() {
+func createCmdsFiles() (string, string, error) {
+	jsonFile, err := ioutil.TempFile("", "singularityCmdsJSON-")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create command JSON file: %s", err)
+	}
+	defer jsonFile.Close()
+
+	textFile, err := ioutil.TempFile("", "singularityCmds-")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create command text file: %s", err)
+	}
+	defer textFile.Close()
 	cli.SingularityCmd.InitDefaultHelpCmd()
 	cli.SingularityCmd.InitDefaultVersionFlag()
 
-	tree := buildTree(cli.SingularityCmd)
+	buildTree(cli.SingularityCmd, textFile)
+	tree := buildTree(cli.SingularityCmd, textFile)
 
 	json, err := json.MarshalIndent(tree, "", "  ")
 	if err != nil {
-		log.Fatal(err)
+		return "", "", fmt.Errorf("failed to marshal data: %s", err)
 	}
 
-	fmt.Println(string(json))
+	jsonFile.WriteString(string(json))
+
+	return jsonFile.Name(), textFile.Name(), nil
+}
+
+func runE2ETests() (string, error) {
+	tempCoverageFileStr, err := ioutil.TempFile("", "e2e-cmds-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create file to store e2e-cmds: %s", err)
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %s", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("make", "-C", "builddir", "e2e-test")
+	coverageFileStr := "SINGULARITY_E2E_COVERAGE=" + tempCoverageFileStr.Name()
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), coverageFileStr)
+	cmd.Dir = filepath.Join(dir, "../../..")
+	err = cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to run E2E tests - stderr: %s; stdout: %s", stderr.String(), stdout.String())
+	}
+
+	return tempCoverageFileStr.Name(), nil
+}
+
+func main() {
+	verbose := flag.Bool("v", false, "Enable verbose mode")
+	coverage := flag.Bool("coverage", false, "Analyze the results")
+
+	flag.Parse()
+
+	jsonFilePath, textFilePath, err := createCmdsFiles()
+	if err != nil {
+		log.Fatalf("failed to gather all the Singularity commands: %s", err)
+	}
+
+	resultFilePath := ""
+	e2eCmdsFilePath := ""
+	if *coverage {
+		e2eCmdsFilePath, err = runE2ETests()
+		if err != nil {
+			log.Fatalf("failed to run E2E tests: %s", err)
+		}
+		singularityCmds, e2eCmds, err := loadData(textFilePath, e2eCmdsFilePath)
+		if err != nil {
+			log.Fatalf("failed to load data: %s", err)
+		}
+		resultFilePath, err = analyseData(singularityCmds, e2eCmds)
+		if err != nil {
+			log.Fatalf("failed to analyze data: %s", err)
+		}
+	}
+
+	if *verbose {
+		fmt.Printf("List of all the Singularity commands (JSON) is in: %s\n", jsonFilePath)
+		fmt.Printf("List of all the Singularity commands (text) is in: %s\n", textFilePath)
+		if *coverage {
+			fmt.Printf("List of all the Singularity commands currently tested by E2E: %s\n", e2eCmdsFilePath)
+			fmt.Printf("Coverage results are saved in: %s\n", resultFilePath)
+		}
+	}
 }

--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -48,9 +48,9 @@ import (
 var tested = 0
 
 type singularityCmd struct {
-	name     string
-	options  []string
-	children []singularityCmd
+	Name     string           `json:"name"`
+	Options  []string         `json:"options"`
+	Children []singularityCmd `json:"children"`
 }
 
 func checkCmd(sCmd string, e2eCmds string, resultFile *os.File) error {
@@ -179,18 +179,18 @@ func parseCmd(cmd singularityCmd, outputFile *os.File) error {
 }
 
 func (c *singularityCmd) addCmd(cmd singularityCmd, outputFile *os.File) error {
-	c.children = append(c.children, cmd)
+	c.Children = append(c.Children, cmd)
 	return parseCmd(cmd, outputFile)
 }
 
 func (c *singularityCmd) addOpt(opt string) {
-	c.options = append(c.options, opt)
+	c.Options = append(c.Options, opt)
 }
 
 func buildTree(root *cobra.Command, outputFile *os.File) singularityCmd {
 	root.InitDefaultHelpFlag()
 
-	tree := singularityCmd{name: root.CommandPath(), options: nil, children: nil}
+	tree := singularityCmd{Name: root.CommandPath(), Options: nil, Children: nil}
 
 	root.Flags().VisitAll(func(flag *pflag.Flag) {
 		tree.addOpt(flag.Name)

--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -134,6 +134,7 @@ func analyseData(singularityCmds string, e2eCmds string) (string, error) {
 
 func parseCmd(cmd singularityCmd, outputFile *os.File) error {
 	str := fmt.Sprintf("%s", cmd)
+
 	// When creating the tree of commands, it includes elements such as:
 	//		{singularity cache [help] [{singularity cache clean [force help name type] []} {singularity cache list [help type verbose] []}]}
 	// The fact that the element includes "[{" means that the first part is a command to
@@ -217,7 +218,6 @@ func createCmdsFiles() (string, string, error) {
 	cli.SingularityCmd.InitDefaultHelpCmd()
 	cli.SingularityCmd.InitDefaultVersionFlag()
 
-	buildTree(cli.SingularityCmd, textFile)
 	tree := buildTree(cli.SingularityCmd, textFile)
 
 	json, err := json.MarshalIndent(tree, "", "  ")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -6,6 +6,9 @@
 package e2e
 
 import (
+	"io/ioutil"
+	"log"
+	"os"
 	"testing"
 
 	// This import will execute a CGO section with the help of a C
@@ -20,5 +23,18 @@ import (
 )
 
 func TestE2E(t *testing.T) {
+	targetCoverageFilePath := os.Getenv("SINGULARITY_E2E_COVERAGE")
+	if targetCoverageFilePath != "" {
+		logFile, err := os.OpenFile(targetCoverageFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			log.Fatalf("failed to create log file: %s", err)
+		}
+		defer logFile.Close()
+		log.SetOutput(logFile)
+		log.Println("List of commands called by E2E")
+	} else {
+		log.SetOutput(ioutil.Discard)
+	}
+
 	RunE2ETests(t)
 }

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -477,7 +478,11 @@ func RunSingularity(t *testing.T, cmdPath string, cmdOps ...SingularityCmdOp) {
 			defer s.postFn(t)
 		}
 
+		if os.Getenv("SINGULARITY_E2E_COVERAGE") != "" {
+			log.Printf("COVERAGE: %q", s.result.FullCmd)
+		}
 		t.Logf("Running command %q", s.result.FullCmd)
+
 		if err := cmd.Start(); err != nil {
 			err = errors.Wrapf(err, "running command %q", s.result.FullCmd)
 			t.Errorf("command execution of %q failed: %+v", s.result.FullCmd, err)

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -454,7 +455,11 @@ func RunSingularity(t *testing.T, cmdPath string, cmdOps ...SingularityCmdOp) {
 			defer s.postFn(t)
 		}
 
+		if os.Getenv("SINGULARITY_E2E_COVERAGE") != "" {
+			log.Printf("COVERAGE: %q", s.result.FullCmd)
+		}
 		t.Logf("Running command %q", s.result.FullCmd)
+
 		if err := cmd.Start(); err != nil {
 			t.Errorf("command execution of %q failed: %s", s.result.FullCmd, err)
 			return

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -17,4 +17,5 @@ sudo \
 		PATH=$PATH \
 		HOME=$HOME \
 		SINGULARITY_E2E=1 \
+		SINGULARITY_E2E_COVERAGE=$SINGULARITY_E2E_COVERAGE \
 	scripts/go-test "$@" ./e2e


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Provide a coverage tool for the E2E framework:
- Create a new special log file when running E2E that will store the executed commands. The path to the file and the mechanism can be activated by setting the SINGULARITY_E2E_COVERAGE environment variable.
- Extend the `cmds` tool
  - Generate both a son and plain text file with all the Singularity commands
  - Add a `coverage` option that will automatically run the E2E tests, gather the list of all the commands that have been executed and compare it to the list of all Singularity commands to generate a coverage report


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
