### PR TITLE
Change "Build complete: <target.sif>" to point to target (instead of cache)

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -241,6 +241,7 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While performing build: %v", err)
 		}
 	}
+	sylog.Infof("Build complete: %s", dest)
 }
 
 func checkSections() error {

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -339,6 +339,7 @@ func OciPull(imgCache *cache.Handle, name, imageURI, tmpDir string, ociAuth *oci
 			if err := convertDockerToSIF(imgCache, imageURI, cachedImgPath, tmpDir, noHTTPS, false, ociAuth); err != nil {
 				return fmt.Errorf("while building SIF from layers: %v", err)
 			}
+			sylog.Infof("Build complete: %s", name)
 		}
 
 		// Perms are 777 *prior* to umask

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -327,7 +327,7 @@ func (b *Build) Full() error {
 		return err
 	}
 
-	sylog.Infof("Build complete: %s", b.Conf.Dest)
+	sylog.Verbosef("Build complete: %s", b.Conf.Dest)
 	return nil
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes the `Build complete: ...` output to point to the actual output image, not the cache.

### This fixes or addresses the following GitHub issues:

- Fixes #4024

<br>
