### PR TITLE
Add unit test for pkg/util/crypt

### DIFF
--- a/pkg/util/crypt/key_test.go
+++ b/pkg/util/crypt/key_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package crypt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/sylabs/singularity/internal/pkg/test"
+)
+
+const (
+	unsupportedURI = "test://justarandominvaliduri"
+	invalidPem     = "pem://nothing"
+)
+
+func TestNewPlaintextKey(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tests := []struct {
+		name          string
+		keyURI        string
+		expectedError error
+	}{
+		{
+			name:          "empty URI",
+			keyURI:        "",
+			expectedError: nil,
+		},
+		{
+			name:          "unsupported URI",
+			keyURI:        unsupportedURI,
+			expectedError: ErrUnsupportedKeyURI,
+		},
+		{
+			name:          "invalid pem",
+			keyURI:        invalidPem,
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPlaintextKey(tt.keyURI)
+			// We do not always use predefined errors so when dealing with errors, we compare the text associated
+			// to the error.
+			if (err != nil && tt.expectedError != nil && err.Error() != tt.expectedError.Error()) ||
+				((err == nil || tt.expectedError == nil) && err != tt.expectedError) {
+				t.Fatalf("test %s returned an unexpected error: %s vs. %s", tt.name, err, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestEncryptKey(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tests := []struct {
+		name          string
+		keyURI        string
+		plaintext     []byte
+		expectedError error
+	}{
+		{
+			name:          "empty URI",
+			keyURI:        "",
+			plaintext:     []byte(""),
+			expectedError: nil,
+		},
+		{
+			name:          "unsupported URI",
+			keyURI:        unsupportedURI,
+			plaintext:     []byte(""),
+			expectedError: ErrUnsupportedKeyURI,
+		},
+		{
+			name:          "invalid pem",
+			keyURI:        invalidPem,
+			plaintext:     []byte(""),
+			expectedError: errors.Wrap(fmt.Errorf("open : no such file or directory"), "loading public key for key encryption"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := EncryptKey(tt.keyURI, tt.plaintext)
+			// We do not always use predefined errors so when dealing with errors, we compare the text associated
+			// to the error.
+			if (err != nil && tt.expectedError != nil && err.Error() != tt.expectedError.Error()) ||
+				((err == nil || tt.expectedError == nil) && err != tt.expectedError) {
+				t.Fatalf("test %s returned an unexpected error: %s vs. %s", tt.name, err, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestPlaintextKey(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	// TestPlaintestKey reads a key from an image. Creating an image does not
+	// fit with unit tests testing so we only test error cases here.
+	const (
+		noimage = ""
+	)
+
+	tests := []struct {
+		name          string
+		keyURI        string
+		expectedError error
+	}{
+		{
+			name:          "empty URI",
+			keyURI:        "",
+			expectedError: nil,
+		},
+		{
+			name:          "unsupported URI",
+			keyURI:        unsupportedURI,
+			expectedError: ErrUnsupportedKeyURI,
+		},
+		{
+			name:          "invalid pem",
+			keyURI:        invalidPem,
+			expectedError: errors.Wrap(fmt.Errorf("open : no such file or directory"), "loading private key for key decryption"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PlaintextKey(tt.keyURI, noimage)
+			// We do not always use predefined errors so when dealing with errors, we compare the text associated
+			// to the error.
+			if (err != nil && tt.expectedError != nil && err.Error() != tt.expectedError.Error()) ||
+				((err == nil || tt.expectedError == nil) && err != tt.expectedError) {
+				t.Fatalf("test %s returned an unexpected error: %s vs. %s", tt.name, err, tt.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add unit test for `pkg/util/crypt`, at the moment mainly the error cases


**This fixes or addresses the following GitHub issues:**

- Addresses #3971 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
