### PR TITLE
Fix cryptsetup hang when running from a container IPC namespace

### DIFF
--- a/internal/pkg/runtime/engines/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/args.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -37,9 +37,10 @@ type MountArgs struct {
 
 // CryptArgs defines the arguments to mount.
 type CryptArgs struct {
-	Offset  uint64
-	Loopdev string
-	Key     []byte
+	Offset    uint64
+	Loopdev   string
+	Key       []byte
+	MasterPid int
 }
 
 // ChrootArgs defines the arguments to chroot.

--- a/internal/pkg/runtime/engines/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engines/singularity/rpc/client/client.go
@@ -43,11 +43,12 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 }
 
 // Decrypt calls the DeCrypt RPC using the supplied arguments.
-func (t *RPC) Decrypt(offset uint64, path string, key []byte) (string, error) {
+func (t *RPC) Decrypt(offset uint64, path string, key []byte, masterPid int) (string, error) {
 	arguments := &args.CryptArgs{
-		Offset:  offset,
-		Loopdev: path,
-		Key:     key,
+		Offset:    offset,
+		Loopdev:   path,
+		Key:       key,
+		MasterPid: masterPid,
 	}
 
 	var reply string


### PR DESCRIPTION
**Description of the Pull Request (PR):**

For decryption step `cryptsetup` is actually run by RPC server, but the RPC server can potentially live in the container IPC namespace if `--ipc` is requested or use with instance, as `cryptsetup` requires to run in the host IPC namespace to work correctly, the execution of `cryptsetup` must be done in the host IPC namespace. This PR fixes that by joining the host IPC namespace before executing `cryptsetup` and returns to the container IPC namespace once `cryptsetup` command execution terminates.


**This fixes or addresses the following GitHub issues:**

- Fixes #4059


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
