### PR TITLE
Fix scratch mount and remove false skipping mount warning

### DIFF
--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -167,7 +167,7 @@ func (m *Manager) overrideDir(path string, realpath string) {
 
 // GetOverridePath returns the real path for the session path
 func (m *Manager) GetOverridePath(path string) (string, error) {
-	if p, ok := m.ovDirs[path]; !ok {
+	if p, ok := m.ovDirs[path]; ok {
 		return p, nil
 	}
 	return "", fmt.Errorf("no override directory %s", path)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

A bug was introduced in #3970 generating false warning message like `skipping mount of: ...`, this PR fixes that and also fixes scratch mount and allow to create sub-directories for bind mount

**This fixes or addresses the following GitHub issues:**

- Fixes #4052 
- Related to #4023


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
