### PR TITLE
Lock ext3 image partitions and prevent them from concurrent writes

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
+	"github.com/sylabs/singularity/pkg/util/fs/lock"
 )
 
 const (
@@ -159,6 +160,46 @@ func (i *Image) HasRootFs() bool {
 		}
 	}
 	return false
+}
+
+// LockSection puts a file byte-range lock on a section to prevent
+// from concurrent writes depending if the image is writable or
+// not. If the image is writable, calling this function will place
+// a write lock for the corresponding section preventing further use
+// if the section is used for writing or reading only, if the image is
+// not writable this function place a read lock to prevent section
+// from being written while the section is used in read-only mode.
+func (i *Image) LockSection(section Section) error {
+	fd := int(i.Fd)
+	start := int64(section.Offset)
+	size := int64(section.Size)
+
+	br := lock.NewByteRange(fd, start, size)
+
+	var err error
+
+	if i.Writable {
+		err = br.Lock()
+	} else {
+		err = br.RLock()
+	}
+
+	if err == lock.ErrByteRangeAcquired {
+		if i.Writable {
+			return fmt.Errorf("can't open %s for writing, currently in use by another process", i.Path)
+		}
+		return fmt.Errorf("can't open %s for reading, currently in use for writing by another process", i.Path)
+	} else if err == lock.ErrLockNotSupported {
+		// ENOLCK means that the underlying filesystem doesn't support
+		// lock, so we simply ignore the error in order to allow ext3
+		// images located on the underlying filesystem to run correctly
+		// and advertise user in log
+		sylog.Verbosef("Could not set lock on %s section %q, underlying filesystem seems to not support lock", i.Path, section.Name)
+		sylog.Verbosef("Data corruptions may occur if %s is open for writing by multiple processes", i.Path)
+		return nil
+	}
+
+	return err
 }
 
 // ResolvePath returns a resolved absolute path.

--- a/pkg/util/fs/lock/const.go
+++ b/pkg/util/fs/lock/const.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package lock
+
+import "golang.org/x/sys/unix"
+
+const (
+	setLk = unix.F_SETLK
+)

--- a/pkg/util/fs/lock/const_linux.go
+++ b/pkg/util/fs/lock/const_linux.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package lock
+
+import "golang.org/x/sys/unix"
+
+const (
+	setLk = unix.F_SETLK64
+)

--- a/pkg/util/fs/lock/lock_test.go
+++ b/pkg/util/fs/lock/lock_test.go
@@ -6,13 +6,15 @@
 package lock
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
-func TestLock(t *testing.T) {
+func TestExclusive(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
@@ -40,5 +42,68 @@ func TestLock(t *testing.T) {
 		}
 	case <-ch:
 		t.Errorf("lock acquired")
+	}
+}
+
+func TestByteRange(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	// test with a wrong file descriptor
+	br := NewByteRange(1111, 0, 0)
+	if err := br.Lock(); err == nil {
+		t.Fatalf("unexpected success with a wrong file descriptor")
+	}
+
+	// create the temporary test file used for locking
+	f, err := ioutil.TempFile("", "byterange-")
+	if err != nil {
+		t.Fatalf("failed to create temporary lock file: %s", err)
+	}
+	testFile := f.Name()
+	defer os.Remove(testFile)
+
+	f.Close()
+
+	// write some content in test file
+	if err := ioutil.WriteFile(testFile, []byte("testing\n"), 0644); err != nil {
+		t.Fatalf("failed to write content in testfile %s: %s", testFile, err)
+	}
+
+	// re-open it and use it for testing
+	f, err = os.OpenFile(testFile, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("failed to open %s: %s", testFile, err)
+	}
+	defer f.Close()
+	// create the byte-range lock
+	br = NewByteRange(int(f.Fd()), 0, 1)
+
+	// acquire the lock, must succeed
+	if err := br.Lock(); err != nil {
+		t.Fatalf("unexpected error while locking file %s: %s", testFile, err)
+	}
+
+	// at this stage we can't test the condition where
+	// the lock is already acquired as we are in the same
+	// process where locks are shared, so we just release it
+	if err := br.Unlock(); err != nil {
+		t.Fatalf("unexpected error while releasing lock: %s", err)
+	}
+
+	// open /dev/null read-only
+	f, err = os.Open("/dev/null")
+	if err != nil {
+		t.Fatalf("failed to open /dev/null: %s", err)
+	}
+	br = NewByteRange(int(f.Fd()), 0, 1)
+
+	// acquire a write lock, must fail
+	if err := br.Lock(); err == nil {
+		t.Fatalf("unexpected success while locking %s", f.Name())
+	}
+	// acquire a read lock, must succeed
+	if err := br.RLock(); err != nil {
+		t.Fatalf("unexpected error while getting lock for %s", f.Name())
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Lock EXT3 image partitions to prevent from concurrent writes

**This fixes or addresses the following GitHub issues:**

- Fixes #4048 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
