### PR TITLE
[3.4] Fix issue when exporting a key and the keyring files do not exist

### DIFF
--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -858,6 +858,10 @@ func RecryptKey(k *openpgp.Entity, passphrase []byte) error {
 
 // ExportPrivateKey Will export a private key into a file (kpath).
 func (keyring *Handle) ExportPrivateKey(kpath string, armor bool) error {
+	if err := keyring.PathsCheck(); err != nil {
+		return err
+	}
+
 	localEntityList, err := loadKeyring(keyring.SecretPath())
 	if err != nil {
 		return fmt.Errorf("unable to load private keyring: %v", err)
@@ -908,6 +912,10 @@ func (keyring *Handle) ExportPrivateKey(kpath string, armor bool) error {
 
 // ExportPubKey Will export a public key into a file (kpath).
 func (keyring *Handle) ExportPubKey(kpath string, armor bool) error {
+	if err := keyring.PathsCheck(); err != nil {
+		return err
+	}
+
 	localEntityList, err := loadKeyring(keyring.PublicPath())
 	if err != nil {
 		return fmt.Errorf("unable to open local keyring: %v", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes the issue when export a key, and the keyring files do not exist

### This fixes or addresses the following GitHub issues:

- Fixes #4072

<br>
