### PR TITLE
Ensure descr type for verification

### DIFF
--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -199,6 +199,16 @@ func Sign(cpath string, id uint32, isGroup bool, keyIdx int) error {
 	return nil
 }
 
+func filterSigDescrs(sigs []*sif.Descriptor) []*sif.Descriptor {
+	var filtered []*sif.Descriptor
+	for _, s := range sigs {
+		if s.Datatype == sif.DataSignature {
+			filtered = append(filtered, s)
+		}
+	}
+	return filtered
+}
+
 // return all signatures for the primary partition
 func getSigsPrimPart(fimg *sif.FileImage) (sigs []*sif.Descriptor, descr []*sif.Descriptor, err error) {
 	descr = make([]*sif.Descriptor, 1)
@@ -208,10 +218,13 @@ func getSigsPrimPart(fimg *sif.FileImage) (sigs []*sif.Descriptor, descr []*sif.
 		return nil, nil, fmt.Errorf("no primary partition found")
 	}
 
-	sigs, _, err = fimg.GetFromLinkedDescr(descr[0].ID)
+	linkDescrs, _, err := fimg.GetFromLinkedDescr(descr[0].ID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("no signatures found for system partition")
 	}
+
+	// filter descriptor list to only contain signatures
+	sigs = filterSigDescrs(linkDescrs)
 
 	return
 }
@@ -225,10 +238,13 @@ func getSigsDescr(fimg *sif.FileImage, id uint32) (sigs []*sif.Descriptor, descr
 		return nil, nil, fmt.Errorf("no descriptor found for id %v", id)
 	}
 
-	sigs, _, err = fimg.GetFromLinkedDescr(id)
+	linkDescrs, _, err := fimg.GetFromLinkedDescr(id)
 	if err != nil {
 		return nil, nil, fmt.Errorf("no signatures found for id %v", id)
 	}
+
+	// filter descriptor list to only contain signatures
+	sigs = filterSigDescrs(linkDescrs)
 
 	return
 }


### PR DESCRIPTION
Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

**Description of the Pull Request (PR):**

Previously we were only checking for descriptors linked to the system partition and assuming they were signatures, now that we have linked partitions to store other information, that assumption is no longer correct and we need to filter linked descriptor results to only `DataSignature` types.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
