### PR TITLE
Deactivate a specific crypt_dev unit tests that is creating problems

### DIFF
--- a/pkg/util/crypt/crypt_dev_test.go
+++ b/pkg/util/crypt/crypt_dev_test.go
@@ -86,12 +86,14 @@ func TestEncrypt(t *testing.T) {
 			key:       []byte("dummyKey"),
 			shallPass: false,
 		},
+		/* FIXME: deactivate because it creates too much variability in test results with CI
 		{
 			name:      "empty file",
 			path:      emptyFile.Name(),
 			key:       []byte("dummyKey"),
 			shallPass: false,
 		},
+		*/
 		{
 			name:      "valid file",
 			path:      tempTargetFile.Name(),


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Deactivate a specific crypt_dev unit tests that is creating too many problems. There is a deeper problem with testing crypt_dev (issue 3983)

**This fixes or addresses the following GitHub issues:**

- Addresses #3983 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers