### PR TITLE
[E2E] create a clean temporary image cache by default to each test

### DIFF
--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -7,6 +7,7 @@ package e2e
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -38,12 +39,17 @@ func WriteTempFile(dir, pattern, content string) (string, error) {
 //
 // This function shall not set the environment variable to specify the
 // image cache location since it would create thread safety problems.
-func MakeCacheDir(t *testing.T, baseDir string) string {
-	dir, err := fs.MakeTmpDir(baseDir, "imgcache-", 0755)
+func MakeCacheDir(t *testing.T, baseDir string) (string, func(t *testing.T)) {
+	dir, err := fs.MakeTmpDir(baseDir, "e2e-imgcache-", 0755)
 	err = errors.Wrapf(err, "creating temporary image cache directory at %s", baseDir)
 	if err != nil {
 		t.Fatalf("failed to create image cache directory: %+v", err)
 	}
 
-	return dir
+	return dir, func(t *testing.T) {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Fatalf("failed to delete temporary image cache: %s", err)
+		}
+	}
 }

--- a/e2e/internal/e2e/priv_linux.go
+++ b/e2e/internal/e2e/priv_linux.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/sylabs/singularity/internal/pkg/client/cache"
 )
 
 var (
@@ -38,9 +37,6 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 			err = errors.Wrap(err, "changing group ID to 0")
 			t.Fatalf("privileges escalation failed: %+v", err)
 		}
-		// NEED FIX: it shouldn't be set/restored globally, only
-		// when executing singularity command with privileges.
-		os.Setenv(cache.DirEnv, cacheDirPriv)
 
 		defer func() {
 			if err := syscall.Setresgid(origGID, origGID, 0); err != nil {
@@ -51,8 +47,6 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 				err = errors.Wrapf(err, "changing group ID to %d", origGID)
 				t.Fatalf("privileges drop failed: %+v", err)
 			}
-			// NEED FIX: see above comment
-			os.Setenv(cache.DirEnv, cacheDirUnpriv)
 			runtime.UnlockOSThread()
 		}()
 

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -115,10 +115,6 @@ func Run(t *testing.T) {
 	}
 	testenv.TestDir = name
 
-	if err := singularitye2e.MakeCacheDirs(name); err != nil {
-		t.Fatal(err)
-	}
-
 	// Build a base image for tests
 	imagePath := path.Join(name, "test.sif")
 	t.Log(imagePath)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This set of modifications ensures that each e2e test will have its own image clean cache by default. This fixes potential problems when running concurrent tests as well as giving us a fine grain control over the context of the test execution since we ensure that the cache will be clean by default.

**This fixes or addresses the following GitHub issues:**

- Fixes #3987 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
