### PR TITLE
Update the machine executor image from ubuntu 14.04 to ubuntu 16.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,8 @@ jobs:
             make -j$(sysctl -n hw.logicalcpu) -C ./builddir check
 
   unit_tests:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
       - attach_workspace:
           at: ~/go
@@ -141,7 +142,8 @@ jobs:
             make -j$(nproc) -C ./builddir unit-test
 
   e2e_tests:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
       - attach_workspace:
           at: ~/go


### PR DESCRIPTION
ubuntu 14.04 (the default machine executor image) is end of life

Fixes #4145 