### PR TITLE
Detect errors due an incompatible version of cryptsetup

### DIFF
--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -172,6 +172,9 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 	if err != nil {
 		err = checkCryptsetupVersion(cryptsetup)
 		if err == ErrUnsupportedCryptsetupVersion {
+			// Special case of unsupported version of cryptsetup. We return the raw error
+			// so it can propagate up and a user-friendly message be displayed. This error
+			// should trigger an error at the CLI level.
 			return "", err
 		}
 		return "", fmt.Errorf("unable to format crypt device: %s: %s", cryptF.Name(), string(out))
@@ -287,6 +290,9 @@ func (crypt *Device) Open(key []byte, path string) (string, error) {
 			}
 			err = checkCryptsetupVersion(cryptsetup)
 			if err == ErrUnsupportedCryptsetupVersion {
+				// Special case of unsupported version of cryptsetup. We return the raw error
+				// so it can propagate up and a user-friendly message be displayed. This error
+				// should trigger an error at the CLI level.
 				return "", err
 			}
 

--- a/pkg/util/crypt/crypt_dev_test.go
+++ b/pkg/util/crypt/crypt_dev_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
@@ -105,23 +104,20 @@ func TestEncrypt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			devPath, err := dev.EncryptFilesystem(tt.path, tt.key)
-			needCleanup := true
 			if tt.shallPass && err != nil {
-				// cryptsetup is currently creating issues with our CI so
-				// if it is only that, we assume it is fine until we can precisely
-				// figure out why it is not working.
-				if !strings.Contains(err.Error(), "--luks2-metadata-size: unknown option") &&
-					!strings.Contains(err.Error(), "--type: unknown option") &&
-					!strings.Contains(err.Error(), "Unrecognized metadata device type luks2") {
-					t.Fatalf("test %s expected to succeed but failed: %s", tt.name, err)
+				if err == ErrUnsupportedCryptsetupVersion {
+					t.Skip("the version of cryptsetup available is not compatible")
 				} else {
-					needCleanup = false
+					t.Fatalf("test %s expected to succeed but failed: %s", tt.name, err)
 				}
 			}
+
 			if !tt.shallPass && err == nil {
 				t.Fatalf("test %s expected to fail but succeeded", tt.name)
 			}
-			if tt.shallPass && needCleanup {
+
+			// Clean up successful tests
+			if tt.shallPass {
 				devName, err := dev.Open(tt.key, devPath)
 				if err != nil {
 					t.Fatalf("failed to open encrypted device: %s", err)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Detect errors due to an incompatible version of cryptsetup and update the unit test to skip when the cryptsetup version available is not compatible. This will allow us to avoid having tons of failures with CI on platforms that do not have the correct version of cryptsetup, without having to implement work arounds in the unit tests.

This does *not* include the required changes to have a more useful error message displayed to users.

**This fixes or addresses the following GitHub issues:**

- Addresses #3983 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers