### PR TITLE
Add a e2e test for the singularity version --help command

### DIFF
--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -96,6 +96,19 @@ func (c *ctx) testEqualVersion(t *testing.T) {
 	}
 }
 
+// Test the help option
+func (c *ctx) testHelpOption(t *testing.T) {
+	c.env.RunSingularity(
+		t,
+		e2e.WithCommand("version"),
+		e2e.WithArgs("--help"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ContainMatch, "Show the version for Singularity"),
+		),
+	)
+}
+
 // RunE2ETests is the main func to trigger the test suite
 func RunE2ETests(env e2e.TestEnv) func(*testing.T) {
 	c := &ctx{
@@ -105,5 +118,6 @@ func RunE2ETests(env e2e.TestEnv) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("test_semantic_version", c.testSemanticVersion)
 		t.Run("test_equal_version", c.testEqualVersion)
+		t.Run("test_help_option", c.testHelpOption)
 	}
 }

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -104,7 +104,7 @@ func (c *ctx) testHelpOption(t *testing.T) {
 		e2e.WithArgs("--help"),
 		e2e.ExpectExit(
 			0,
-			e2e.ExpectOutput(e2e.ContainMatch, "Show the version for Singularity"),
+			e2e.ExpectOutput(e2e.RegexMatch, "^Show the version for Singularity"),
 		),
 	)
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds a simple test for the `singularity version --help` command. This is only meant to test the successful case in order to have better coverage for the e2e test and make sure there is no regression with the normal cases enabled by the CLI.

**This fixes or addresses the following GitHub issues:**

- Fixes #4102 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
