### PR TITLE
Pull no longer fails while pulling unsigned images

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -132,6 +132,7 @@ var pullAllowUnsignedFlag = cmdline.Flag{
 	ShortHand:    "U",
 	Usage:        "do not require a signed container",
 	EnvKeys:      []string{"ALLOW_UNSIGNED"},
+	Deprecated:   `pull no longer exits with an error code in case of unsigned image. Now the flag only suppress warning message.`,
 }
 
 // --allow-unauthenticated
@@ -220,10 +221,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 	case LibraryProtocol, "":
 		handlePullFlags(cmd)
 		err := singularity.LibraryPull(imgCache, name, args[i], pullLibraryURI, keyServerURL, authToken, force, unauthenticatedPull, disableCache)
-		if err == singularity.ErrLibraryPullUnsigned {
-			os.Exit(10)
-		}
-		if err != nil {
+		if err != nil && err != singularity.ErrLibraryPullUnsigned {
 			sylog.Fatalf("While pulling library image: %v", err)
 		}
 	case ShubProtocol:

--- a/cmd/singularity/pull_test.go
+++ b/cmd/singularity/pull_test.go
@@ -114,7 +114,7 @@ func TestPull(t *testing.T) {
 			library:         "",
 			pullDir:         "",
 			imagePath:       imagePath,
-			success:         false,
+			success:         true,
 		},
 		{
 			name:            "Unsigned_image",
@@ -125,16 +125,6 @@ func TestPull(t *testing.T) {
 			pullDir:         "",
 			imagePath:       imagePath,
 			success:         true,
-		},
-		{
-			name:            "Unsigned_image_fail",
-			sourceSpec:      "library://sylabs/tests/unsigned:1.0.0",
-			force:           true,
-			unauthenticated: false,
-			library:         "",
-			pullDir:         "",
-			imagePath:       imagePath,
-			success:         false,
 		},
 		{
 			name:            "NotDefault",

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -84,7 +84,7 @@ var tests = []testStruct{
 		srcURI:           "library://sylabs/tests/unsigned:1.0.0",
 		force:            true,
 		unauthenticated:  false,
-		expectedExitCode: 10,
+		expectedExitCode: 0,
 	},
 
 	// test version specifications

--- a/internal/app/singularity/pull.go
+++ b/internal/app/singularity/pull.go
@@ -120,7 +120,7 @@ func LibraryPull(imgCache *cache.Handle, name, fullURI, libraryURI, keyServerURL
 	if !unauthenticated {
 		imageSigned, err := signing.IsSigned(name, keyServerURL, 0, false, authToken)
 		if err != nil {
-			sylog.Errorf("%v", err)
+			sylog.Warningf("%v", err)
 		}
 		if !imageSigned {
 			return ErrLibraryPullUnsigned


### PR DESCRIPTION
closes https://github.com/sylabs/singularity/issues/4123

**Mark  Pull `-U|--allow-unsigned` flag as deprecated**