### PR TITLE
[E2E] Let a developer specify the value of SINGULARRITY_SYPGPDIR

### DIFF
--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -87,9 +87,8 @@ func (c *ctx) testSingularitySypgpDir(t *testing.T) {
 		}
 	}()
 
-	// Create a new pair of keys. We make sure we use RunSingularity to ensure that
-	// it does the expected things.
-	cmdArgs := []string{"list"} // The command will actually not do much but create the keyring
+	// Run 'key list' to initialize the keyring.
+	cmdArgs := []string{"list"}
 	c.env.KeyringDir = keyringDir
 	c.env.RunSingularity(
 		t,

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -438,7 +438,7 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 		// If it is needed to share an image cache between tests, or to manually
 		// set the directory to be used, one shall set the ImgCacheDir of the test
 		// environment. Doing so will overwrite the default creation of an image cache
-		// for the command to be executed.In that context, it is the developer's
+		// for the command to be executed. In that context, it is the developer's
 		// responsibility to ensure that the directory is correctly deleted upon successful
 		// or unsuccessful completion of the test.
 		if env.ImgCacheDir != "" {
@@ -465,9 +465,17 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 		cmd.Env = append(cmd.Env, cacheDirEnv)
 
 		// Each command gets by default a clean temporary PGP keyring.
-		// If it is needed to share a keyring between tests, one shall
-		// update the test configuration and set s.sypgpDir and make
-		// sure the directory is properly deleted once the test completed.
+		// If it is needed to share a keyring between tests, or to manually
+		// set the directory to be used, one shall set the KeyringDir of the
+		// test environment. Doing so will overwrite the default creation of
+		// a keyring for the command to be executed/ In that context, it is
+		// the developer's responsibility to ensure that the directory is
+		// correctly deleted upon successful or unsuccessful completion of the
+		// test.
+		if env.KeyringDir != "" {
+			s.sypgpDir = env.KeyringDir
+		}
+
 		if s.sypgpDir == "" {
 			// cleanKeyring is a function that will delete the temporary
 			// PGP keyring and fail the test if it cannot be deleted.


### PR DESCRIPTION

**Description of the Pull Request (PR):**

[E2E] Modifications to let a developer specify the value of `SINGULARITY_SYPGPDIR`

This is similar to PR #4165 but for `SINGULARITY_SYPGPDIR`.

**This fixes or addresses the following GitHub issues:**

- Fixes #4137 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers