### PR TITLE
warn admin about priv escalation possibility with capability add 

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -334,7 +334,10 @@ Enterprise Performance Computing (EPC)`
   Capabilities allow you to have fine grained control over the permissions that
   your containers need to run.
 
-  NOTE: capability add/drop commands requires root to run.`
+  NOTE: capability add/drop commands require root to run. Granting capabilities 
+  to users allows them to escalate privilege inside the container and will
+  likely give them a route to priviledge escalation on the host system as well.
+  Do not add capabilities to users who should not have root on the host system.`
 	CapabilityExample string = `
   All group commands have their own help output:
 

--- a/docs/content.go
+++ b/docs/content.go
@@ -336,7 +336,7 @@ Enterprise Performance Computing (EPC)`
 
   NOTE: capability add/drop commands require root to run. Granting capabilities 
   to users allows them to escalate privilege inside the container and will
-  likely give them a route to priviledge escalation on the host system as well.
+  likely give them a route to privilege escalation on the host system as well.
   Do not add capabilities to users who should not have root on the host system.`
 	CapabilityExample string = `
   All group commands have their own help output:

--- a/pkg/util/capabilities/config.go
+++ b/pkg/util/capabilities/config.go
@@ -95,6 +95,8 @@ func (c *Config) AddUserCaps(user string, caps []string) error {
 		}
 		if !present {
 			c.Users[user] = append(c.Users[user], cap)
+			sylog.Warningf("Adding '%s' capability will likely allow user %s to escalate privilege on the host", cap, user)
+			sylog.Warningf("Use 'singularity capability drop --user %s %s' to reverse this action if necessary", user, cap)
 		} else {
 			sylog.Warningf("Won't add capability '%s', already assigned to user %s", cap, user)
 		}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Admins should know that using the `capability add` command will allow users to have elevated privs within a container, and that carries the risk of breakout and priv escalation on the host.

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
