### PR TITLE
[e2e] Add a test for the SINGULARITY_DISABLE_CACHE environment variable

### DIFF
--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -9,7 +9,6 @@ package e2e
 // from specifying which Singularity binary to use to controlling how Singularity
 // environment variables will be set.
 type TestEnv struct {
-	RunDisabled   bool
 	CmdPath       string // Path to the Singularity binary to use for the execution of a Singularity command
 	ImagePath     string // Path to the image that has to be used for the execution of a Singularity command
 	OrasTestImage string
@@ -17,4 +16,6 @@ type TestEnv struct {
 	TestRegistry  string
 	KeyringDir    string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using SINGULARITY_SYPGPDIR which should be avoided when running e2e tests)
 	ImgCacheDir   string // ImgCacheDir sets the location of the image cache to be used by the Singularity command to be executed (instead of using SINGULARITY_CACHE_DIR which should be avoided when running e2e tests)
+	RunDisabled   bool
+	DisableCache  bool // DisableCache can be set to disable the cache during the execution of a e2e command
 }

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -398,74 +398,6 @@ func ExpectExit(code int, resultOps ...SingularityCmdResultOp) SingularityCmdOp 
 	}
 }
 
-func (env TestEnv) setCmdEnvVars(t *testing.T, s *singularityCmd, cmd *exec.Cmd) {
-	// Each command gets by default a clean temporary image cache.
-	// If it is needed to share an image cache between tests, or to manually
-	// set the directory to be used, one shall set the ImgCacheDir of the test
-	// environment. Doing so will overwrite the default creation of an image cache
-	// for the command to be executed. In that context, it is the developer's
-	// responsibility to ensure that the directory is correctly deleted upon successful
-	// or unsuccessful completion of the test.
-	if env.ImgCacheDir != "" {
-		s.cacheDir = env.ImgCacheDir
-	}
-
-	if s.cacheDir == "" {
-		// cleanCache is a function that will delete the image cache
-		// and fail the test if it cannot be deleted.
-		imgCacheDir, cleanCache := MakeCacheDir(t, "")
-		s.cacheDir = imgCacheDir
-		defer func() {
-			// Tests may switch back and forth between privileged
-			// and unprivileged mode so if this specific test is
-			// privileged, we ensure that we delete the image cache
-			// with privileged rights.
-			if s.privileged {
-				cleanCache = Privileged(cleanCache)
-			}
-			cleanCache(t)
-		}()
-	}
-	cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, s.cacheDir)
-	cmd.Env = append(cmd.Env, cacheDirEnv)
-
-	// Each command gets by default a clean temporary PGP keyring.
-	// If it is needed to share a keyring between tests, or to manually
-	// set the directory to be used, one shall set the KeyringDir of the
-	// test environment. Doing so will overwrite the default creation of
-	// a keyring for the command to be executed/ In that context, it is
-	// the developer's responsibility to ensure that the directory is
-	// correctly deleted upon successful or unsuccessful completion of the
-	// test.
-	if env.KeyringDir != "" {
-		s.sypgpDir = env.KeyringDir
-	}
-
-	if s.sypgpDir == "" {
-		// cleanKeyring is a function that will delete the temporary
-		// PGP keyring and fail the test if it cannot be deleted.
-		keyringDir, cleanSyPGPDir := MakeSyPGPDir(t, "")
-		s.sypgpDir = keyringDir
-		defer func() {
-			// Tests may switch back and forth between privileged and
-			// unprivileged mode so if this specific test is
-			// privileged, we ensure that we delete the temporary
-			// keyring with privileged rights.
-			if s.privileged {
-				cleanSyPGPDir = Privileged(cleanSyPGPDir)
-			}
-			cleanSyPGPDir(t)
-		}()
-	}
-	sypgpDirEnv := fmt.Sprintf("%s=%s", "SINGULARITY_SYPGPDIR", s.sypgpDir)
-	cmd.Env = append(cmd.Env, sypgpDirEnv)
-
-	// We check if we need to disable the cache
-	if env.DisableCache {
-		cmd.Env = append(cmd.Env, "SINGULARITY_DISABLE_CACHE=1")
-	}
-}
-
 // RunSingularity executes a singularity command within a test execution
 // context.
 //
@@ -502,7 +434,71 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 			cmd.Env = os.Environ()
 		}
 
-		env.setCmdEnvVars(t, s, cmd)
+		// Each command gets by default a clean temporary image cache.
+		// If it is needed to share an image cache between tests, or to manually
+		// set the directory to be used, one shall set the ImgCacheDir of the test
+		// environment. Doing so will overwrite the default creation of an image cache
+		// for the command to be executed. In that context, it is the developer's
+		// responsibility to ensure that the directory is correctly deleted upon successful
+		// or unsuccessful completion of the test.
+		if env.ImgCacheDir != "" {
+			s.cacheDir = env.ImgCacheDir
+		}
+
+		if s.cacheDir == "" {
+			// cleanCache is a function that will delete the image cache
+			// and fail the test if it cannot be deleted.
+			imgCacheDir, cleanCache := MakeCacheDir(t, "")
+			s.cacheDir = imgCacheDir
+			defer func() {
+				// Tests may switch back and forth between privileged
+				// and unprivileged mode so if this specific test is
+				// privileged, we ensure that we delete the image cache
+				// with privileged rights.
+				if s.privileged {
+					cleanCache = Privileged(cleanCache)
+				}
+				cleanCache(t)
+			}()
+		}
+		cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, s.cacheDir)
+		cmd.Env = append(cmd.Env, cacheDirEnv)
+
+		// Each command gets by default a clean temporary PGP keyring.
+		// If it is needed to share a keyring between tests, or to manually
+		// set the directory to be used, one shall set the KeyringDir of the
+		// test environment. Doing so will overwrite the default creation of
+		// a keyring for the command to be executed/ In that context, it is
+		// the developer's responsibility to ensure that the directory is
+		// correctly deleted upon successful or unsuccessful completion of the
+		// test.
+		if env.KeyringDir != "" {
+			s.sypgpDir = env.KeyringDir
+		}
+
+		if s.sypgpDir == "" {
+			// cleanKeyring is a function that will delete the temporary
+			// PGP keyring and fail the test if it cannot be deleted.
+			keyringDir, cleanSyPGPDir := MakeSyPGPDir(t, "")
+			s.sypgpDir = keyringDir
+			defer func() {
+				// Tests may switch back and forth between privileged and
+				// unprivileged mode so if this specific test is
+				// privileged, we ensure that we delete the temporary
+				// keyring with privileged rights.
+				if s.privileged {
+					cleanSyPGPDir = Privileged(cleanSyPGPDir)
+				}
+				cleanSyPGPDir(t)
+			}()
+		}
+		sypgpDirEnv := fmt.Sprintf("%s=%s", "SINGULARITY_SYPGPDIR", s.sypgpDir)
+		cmd.Env = append(cmd.Env, sypgpDirEnv)
+
+		// We check if we need to disable the cache
+		if env.DisableCache {
+			cmd.Env = append(cmd.Env, "SINGULARITY_DISABLE_CACHE=1")
+		}
 
 		cmd.Dir = s.dir
 		cmd.Stdin = s.stdin

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -398,6 +398,74 @@ func ExpectExit(code int, resultOps ...SingularityCmdResultOp) SingularityCmdOp 
 	}
 }
 
+func (env TestEnv) setCmdEnvVars(t *testing.T, s *singularityCmd, cmd *exec.Cmd) {
+	// Each command gets by default a clean temporary image cache.
+	// If it is needed to share an image cache between tests, or to manually
+	// set the directory to be used, one shall set the ImgCacheDir of the test
+	// environment. Doing so will overwrite the default creation of an image cache
+	// for the command to be executed. In that context, it is the developer's
+	// responsibility to ensure that the directory is correctly deleted upon successful
+	// or unsuccessful completion of the test.
+	if env.ImgCacheDir != "" {
+		s.cacheDir = env.ImgCacheDir
+	}
+
+	if s.cacheDir == "" {
+		// cleanCache is a function that will delete the image cache
+		// and fail the test if it cannot be deleted.
+		imgCacheDir, cleanCache := MakeCacheDir(t, "")
+		s.cacheDir = imgCacheDir
+		defer func() {
+			// Tests may switch back and forth between privileged
+			// and unprivileged mode so if this specific test is
+			// privileged, we ensure that we delete the image cache
+			// with privileged rights.
+			if s.privileged {
+				cleanCache = Privileged(cleanCache)
+			}
+			cleanCache(t)
+		}()
+	}
+	cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, s.cacheDir)
+	cmd.Env = append(cmd.Env, cacheDirEnv)
+
+	// Each command gets by default a clean temporary PGP keyring.
+	// If it is needed to share a keyring between tests, or to manually
+	// set the directory to be used, one shall set the KeyringDir of the
+	// test environment. Doing so will overwrite the default creation of
+	// a keyring for the command to be executed/ In that context, it is
+	// the developer's responsibility to ensure that the directory is
+	// correctly deleted upon successful or unsuccessful completion of the
+	// test.
+	if env.KeyringDir != "" {
+		s.sypgpDir = env.KeyringDir
+	}
+
+	if s.sypgpDir == "" {
+		// cleanKeyring is a function that will delete the temporary
+		// PGP keyring and fail the test if it cannot be deleted.
+		keyringDir, cleanSyPGPDir := MakeSyPGPDir(t, "")
+		s.sypgpDir = keyringDir
+		defer func() {
+			// Tests may switch back and forth between privileged and
+			// unprivileged mode so if this specific test is
+			// privileged, we ensure that we delete the temporary
+			// keyring with privileged rights.
+			if s.privileged {
+				cleanSyPGPDir = Privileged(cleanSyPGPDir)
+			}
+			cleanSyPGPDir(t)
+		}()
+	}
+	sypgpDirEnv := fmt.Sprintf("%s=%s", "SINGULARITY_SYPGPDIR", s.sypgpDir)
+	cmd.Env = append(cmd.Env, sypgpDirEnv)
+
+	// We check if we need to disable the cache
+	if env.DisableCache {
+		cmd.Env = append(cmd.Env, "SINGULARITY_DISABLE_CACHE=1")
+	}
+}
+
 // RunSingularity executes a singularity command within a test execution
 // context.
 //
@@ -434,66 +502,7 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 			cmd.Env = os.Environ()
 		}
 
-		// Each command gets by default a clean temporary image cache.
-		// If it is needed to share an image cache between tests, or to manually
-		// set the directory to be used, one shall set the ImgCacheDir of the test
-		// environment. Doing so will overwrite the default creation of an image cache
-		// for the command to be executed. In that context, it is the developer's
-		// responsibility to ensure that the directory is correctly deleted upon successful
-		// or unsuccessful completion of the test.
-		if env.ImgCacheDir != "" {
-			s.cacheDir = env.ImgCacheDir
-		}
-
-		if s.cacheDir == "" {
-			// cleanCache is a function that will delete the image cache
-			// and fail the test if it cannot be deleted.
-			imgCacheDir, cleanCache := MakeCacheDir(t, "")
-			s.cacheDir = imgCacheDir
-			defer func() {
-				// Tests may switch back and forth between privileged
-				// and unprivileged mode so if this specific test is
-				// privileged, we ensure that we delete the image cache
-				// with privileged rights.
-				if s.privileged {
-					cleanCache = Privileged(cleanCache)
-				}
-				cleanCache(t)
-			}()
-		}
-		cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, s.cacheDir)
-		cmd.Env = append(cmd.Env, cacheDirEnv)
-
-		// Each command gets by default a clean temporary PGP keyring.
-		// If it is needed to share a keyring between tests, or to manually
-		// set the directory to be used, one shall set the KeyringDir of the
-		// test environment. Doing so will overwrite the default creation of
-		// a keyring for the command to be executed/ In that context, it is
-		// the developer's responsibility to ensure that the directory is
-		// correctly deleted upon successful or unsuccessful completion of the
-		// test.
-		if env.KeyringDir != "" {
-			s.sypgpDir = env.KeyringDir
-		}
-
-		if s.sypgpDir == "" {
-			// cleanKeyring is a function that will delete the temporary
-			// PGP keyring and fail the test if it cannot be deleted.
-			keyringDir, cleanSyPGPDir := MakeSyPGPDir(t, "")
-			s.sypgpDir = keyringDir
-			defer func() {
-				// Tests may switch back and forth between privileged and
-				// unprivileged mode so if this specific test is
-				// privileged, we ensure that we delete the temporary
-				// keyring with privileged rights.
-				if s.privileged {
-					cleanSyPGPDir = Privileged(cleanSyPGPDir)
-				}
-				cleanSyPGPDir(t)
-			}()
-		}
-		sypgpDirEnv := fmt.Sprintf("%s=%s", "SINGULARITY_SYPGPDIR", s.sypgpDir)
-		cmd.Env = append(cmd.Env, sypgpDirEnv)
+		env.setCmdEnvVars(t, s, cmd)
 
 		cmd.Dir = s.dir
 		cmd.Stdin = s.stdin


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds everything necessary to the e2e framework to test the `SINGULARITY_DISABLE_CACHE` environment variable.

**This fixes or addresses the following GitHub issues:**

- Fixes #4137 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers