### PR TITLE
Fix a problem with disabling the image cache

### DIFF
--- a/internal/pkg/client/cache/cache_test.go
+++ b/internal/pkg/client/cache/cache_test.go
@@ -5,9 +5,33 @@
 
 package cache
 
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
 const (
 	validSHASum   = ""
 	invalidSHASum = "not a SHA sum"
 	validPath     = ""
 	invalidPath   = "not an image"
 )
+
+// checkIfCacheDisabled is used throughout the unit tests to check whether the
+// SINGULARITY_DISABLE_CACHE environment variable is set. If it is set, it will
+// skip the current tests since exercising the cache when caching is disabled is
+// not supported.
+func chechIfCacheDisabled(t *testing.T) {
+	envValue := os.Getenv(DisableEnv)
+	if envValue == "" {
+		envValue = "0"
+	}
+	disabled, err := strconv.ParseBool(envValue) // strconv.ParseBool("") raises an error
+	if err != nil {
+		t.Fatalf("failed to parse the %s environment variable: %s", DisableEnv, err)
+	}
+	if disabled {
+		t.Skip("Caching is disabled")
+	}
+}

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -27,7 +27,7 @@ const (
 	DirEnv = "SINGULARITY_CACHEDIR"
 
 	// DisableCacheEnv specifies whether the image should be used
-	DisableCacheEnv = "SINGULARITY_DISABLE_CACHE"
+	DisableEnv = "SINGULARITY_DISABLE_CACHE"
 
 	// CacheDir specifies the name of the directory relative to the
 	// singularity data directory where images are cached in by
@@ -90,7 +90,7 @@ type Handle struct {
 func NewHandle(baseDir string) (*Handle, error) {
 	newCache := new(Handle)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		newCache.disabled = true
 		return newCache, nil
 	}

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -92,10 +92,16 @@ func NewHandle(baseDir string) (*Handle, error) {
 	newCache := new(Handle)
 
 	// Check whether the cache is disabled by the user.
+
+	// strconv.ParseBool("") raises an error so we cannot directly use strconv.ParseBool(os.Getenv(DisableEnv))
+	envCacheDisabled := os.Getenv(DisableEnv)
+	if envCacheDisabled == "" {
+		envCacheDisabled = "0"
+	}
 	var err error
-	newCache.disabled, err = strconv.ParseBool(os.Getenv(DisableEnv)) // strconv.ParseBool() on an empty string returns false
+	newCache.disabled, err = strconv.ParseBool(envCacheDisabled)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse environment variable %s", DisableEnv)
+		return nil, fmt.Errorf("failed to parse environment variable %s: %s", DisableEnv, err)
 	}
 	if newCache.disabled {
 		return newCache, nil

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -13,6 +13,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
@@ -90,12 +91,16 @@ type Handle struct {
 func NewHandle(baseDir string) (*Handle, error) {
 	newCache := new(Handle)
 
-	if os.Getenv(DisableEnv) == "1" {
-		newCache.disabled = true
+	// Check whether the cache is disabled by the user.
+	var err error
+	newCache.disabled, err = strconv.ParseBool(os.Getenv(DisableEnv)) // strconv.ParseBool() on an empty string returns false
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse environment variable %s", DisableEnv)
+	}
+	if newCache.disabled {
 		return newCache, nil
 	}
 
-	newCache.disabled = false
 	if baseDir == "" {
 		baseDir = getCacheBasedir()
 	}

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -26,6 +26,9 @@ const (
 	// for image downloads to be cached in
 	DirEnv = "SINGULARITY_CACHEDIR"
 
+	// DisableCacheEnv specifies whether the image should be used
+	DisableCacheEnv = "SINGULARITY_DISABLE_CACHE"
+
 	// CacheDir specifies the name of the directory relative to the
 	// singularity data directory where images are cached in by
 	// default.
@@ -72,6 +75,9 @@ type Handle struct {
 
 	// Oras provides the location of the ORAS cache
 	Oras string
+
+	// disabled specifies if the test is disabled
+	disabled bool
 }
 
 // NewHandle initializes a new cache within a given directory. It does not set
@@ -82,6 +88,14 @@ type Handle struct {
 // empty string, the image cache will be located to the default location, i.e.,
 // $HOME/.singularity.
 func NewHandle(baseDir string) (*Handle, error) {
+	newCache := new(Handle)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		newCache.disabled = true
+		return newCache, nil
+	}
+
+	newCache.disabled = false
 	if baseDir == "" {
 		baseDir = getCacheBasedir()
 	}
@@ -102,7 +116,6 @@ func NewHandle(baseDir string) (*Handle, error) {
 		return nil, fmt.Errorf("failed initializing caching directory: %s", err)
 	}
 
-	newCache := new(Handle)
 	newCache.baseDir = baseDir
 	newCache.rootDir = rootDir
 	newCache.Library, err = getLibraryCachePath(newCache)
@@ -172,6 +185,11 @@ func (c *Handle) GetBasedir() string {
 	return c.baseDir
 }
 
+// IsDisabled returns true if the cache is disabled
+func (c *Handle) IsDisabled() bool {
+	return c.disabled
+}
+
 // updateCacheSubdir update/create a sub-cache (directory) within the cache,
 // for example, the 'shub' cache.
 func updateCacheSubdir(c *Handle, subdir string) (string, error) {
@@ -218,6 +236,10 @@ func initCacheDir(dir string) error {
 // cleanAllCaches is an utility function that wipes all files in the
 // cache directory, will return a error if one occurs
 func (c *Handle) cleanAllCaches() {
+	if c.disabled {
+		return
+	}
+
 	cacheDirs := map[string]string{
 		"library": c.Library,
 		"oci":     c.OciTemp,

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -25,9 +25,7 @@ func TestNewHandle(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tests := []struct {
 		name     string
@@ -64,9 +62,7 @@ func TestCleanAllCaches(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	imageCacheDir, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {
@@ -111,9 +107,7 @@ func TestRoot(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	scratchDir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -25,6 +25,10 @@ func TestNewHandle(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
+
 	tests := []struct {
 		name     string
 		dir      string
@@ -59,6 +63,10 @@ func TestNewHandle(t *testing.T) {
 func TestCleanAllCaches(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
 
 	imageCacheDir, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {
@@ -102,6 +110,10 @@ func TestCleanAllCaches(t *testing.T) {
 func TestRoot(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
 
 	scratchDir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -25,7 +25,7 @@ func TestNewHandle(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -64,7 +64,7 @@ func TestCleanAllCaches(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -111,7 +111,7 @@ func TestRoot(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 

--- a/internal/pkg/client/cache/library.go
+++ b/internal/pkg/client/cache/library.go
@@ -29,6 +29,10 @@ func getLibraryCachePath(c *Handle) (string, error) {
 
 // LibraryImage creates a directory inside cache.Dir() with the name of the SHA sum of the image.
 func (c *Handle) LibraryImage(sum, name string) string {
+	if c.disabled {
+		return ""
+	}
+
 	_, err := updateCacheSubdir(c, filepath.Join(LibraryDir, sum))
 	if err != nil {
 		return ""
@@ -39,6 +43,10 @@ func (c *Handle) LibraryImage(sum, name string) string {
 
 // LibraryImageExists returns whether the image with the SHA sum exists in the LibraryImage cache.
 func (c *Handle) LibraryImageExists(sum, name string) (bool, error) {
+	if c.disabled {
+		return false, nil
+	}
+
 	imagePath := c.LibraryImage(sum, name)
 	_, err := os.Stat(imagePath)
 	if os.IsNotExist(err) {

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -20,7 +20,7 @@ func TestLibrary(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -65,7 +65,7 @@ func TestLibraryImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -141,7 +141,7 @@ func TestLibraryImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -20,9 +20,7 @@ func TestLibrary(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tests := []struct {
 		name        string
@@ -65,9 +63,7 @@ func TestLibraryImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {
@@ -141,9 +137,7 @@ func TestLibraryImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	imageCacheDir, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -20,6 +20,10 @@ func TestLibrary(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
+
 	tests := []struct {
 		name        string
 		dir         string
@@ -60,6 +64,10 @@ func TestLibrary(t *testing.T) {
 func TestLibraryImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {
@@ -132,6 +140,10 @@ func createValidFakeImageInCache(t *testing.T, c *Handle) (string, string, strin
 func TestLibraryImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
 
 	imageCacheDir, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/net.go
+++ b/internal/pkg/client/cache/net.go
@@ -25,6 +25,10 @@ func Net() string {
 // Net returns the directory inside the cache.Dir() where shub images are
 // cached
 func getNetCachePath(c *Handle) (string, error) {
+	if c.disabled {
+		return "", nil
+	}
+
 	// This function may act on an cache object that is not fully initialized
 	// so it is not a method on a Handle but rather an independent
 	// function
@@ -34,6 +38,10 @@ func getNetCachePath(c *Handle) (string, error) {
 
 // NetImage creates a directory inside cache.Dir() with the name of the SHA sum of the image
 func (c *Handle) NetImage(sum, name string) string {
+	if c.disabled {
+		return ""
+	}
+
 	_, err := updateCacheSubdir(c, filepath.Join(NetDir, sum))
 	if err != nil {
 		return ""
@@ -44,6 +52,10 @@ func (c *Handle) NetImage(sum, name string) string {
 
 // NetImageExists returns whether the image with the SHA sum exists in the net cache
 func (c *Handle) NetImageExists(sum, name string) (bool, error) {
+	if c.disabled {
+		return false, nil
+	}
+
 	_, err := os.Stat(c.NetImage(sum, name))
 	if os.IsNotExist(err) {
 		return false, nil

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -18,6 +18,10 @@ func TestNet(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
+
 	tests := []struct {
 		name        string
 		dir         string
@@ -58,6 +62,10 @@ func TestNet(t *testing.T) {
 func TestNetImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -18,9 +18,7 @@ func TestNet(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tests := []struct {
 		name        string
@@ -63,9 +61,7 @@ func TestNetImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -18,7 +18,7 @@ func TestNet(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -63,7 +63,7 @@ func TestNetImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 

--- a/internal/pkg/client/cache/oci.go
+++ b/internal/pkg/client/cache/oci.go
@@ -38,6 +38,10 @@ func getOciTempCachePath(c *Handle) (string, error) {
 
 // OciTempImage creates a OciTempDir/sum directory and returns the abs path of the image
 func (c *Handle) OciTempImage(sum, name string) string {
+	if c.disabled {
+		return ""
+	}
+
 	_, err := updateCacheSubdir(c, filepath.Join(OciTempDir, sum))
 	if err != nil {
 		return ""
@@ -48,6 +52,10 @@ func (c *Handle) OciTempImage(sum, name string) string {
 
 // OciTempExists returns whether the image with the given sha sum exists in the OciTemp() cache
 func (c *Handle) OciTempExists(sum, name string) (bool, error) {
+	if c.disabled {
+		return false, nil
+	}
+
 	_, err := os.Stat(c.OciTempImage(sum, name))
 	if os.IsNotExist(err) {
 		return false, nil

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -18,6 +18,10 @@ func TestOciBlob(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
+
 	tests := []struct {
 		name        string
 		dir         string
@@ -59,6 +63,10 @@ func TestOciTemp(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
+
 	tests := []struct {
 		name        string
 		dir         string
@@ -99,6 +107,10 @@ func TestOciTemp(t *testing.T) {
 func TestOciTempExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -18,7 +18,7 @@ func TestOciBlob(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -63,7 +63,7 @@ func TestOciTemp(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -108,7 +108,7 @@ func TestOciTempExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -18,9 +18,7 @@ func TestOciBlob(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tests := []struct {
 		name        string
@@ -63,9 +61,7 @@ func TestOciTemp(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tests := []struct {
 		name        string
@@ -108,9 +104,7 @@ func TestOciTempExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/oras.go
+++ b/internal/pkg/client/cache/oras.go
@@ -29,6 +29,10 @@ func getOrasCachePath(c *Handle) (string, error) {
 
 // OrasImage creates a directory inside cache.Dir() with the name of the SHA sum of the image
 func (c *Handle) OrasImage(sum, name string) string {
+	if c.disabled {
+		return ""
+	}
+
 	dir, err := updateCacheSubdir(c, filepath.Join(OrasDir, sum))
 	if err != nil {
 		return ""
@@ -39,6 +43,10 @@ func (c *Handle) OrasImage(sum, name string) string {
 
 // OrasImageExists returns whether the image with the SHA sum exists in the OrasImage cache
 func (c *Handle) OrasImageExists(sum, name string) (bool, error) {
+	if c.disabled {
+		return false, nil
+	}
+
 	imagePath := c.OrasImage(sum, name)
 	_, err := os.Stat(imagePath)
 	if os.IsNotExist(err) {

--- a/internal/pkg/client/cache/oras_test.go
+++ b/internal/pkg/client/cache/oras_test.go
@@ -20,6 +20,10 @@ func TestOrasImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
+
 	// Create a clean empty image cache
 	imageCacheDir, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/oras_test.go
+++ b/internal/pkg/client/cache/oras_test.go
@@ -20,9 +20,7 @@ func TestOrasImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	// Create a clean empty image cache
 	imageCacheDir, err := ioutil.TempDir("", "image-cache-")

--- a/internal/pkg/client/cache/oras_test.go
+++ b/internal/pkg/client/cache/oras_test.go
@@ -20,7 +20,7 @@ func TestOrasImage(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 

--- a/internal/pkg/client/cache/shub.go
+++ b/internal/pkg/client/cache/shub.go
@@ -27,6 +27,10 @@ func getShubCachePath(c *Handle) (string, error) {
 
 // ShubImage creates a directory inside cache.Dir() with the name of the SHA sum of the image
 func (c *Handle) ShubImage(sum, name string) string {
+	if c.disabled {
+		return ""
+	}
+
 	_, err := updateCacheSubdir(c, filepath.Join(ShubDir, sum))
 	if err != nil {
 		return ""
@@ -37,6 +41,10 @@ func (c *Handle) ShubImage(sum, name string) string {
 
 // ShubImageExists returns whether the image with the SHA sum exists in the ShubImage cache
 func (c *Handle) ShubImageExists(sum, name string) (bool, error) {
+	if c.disabled {
+		return false, nil
+	}
+
 	_, err := os.Stat(c.ShubImage(sum, name))
 	if os.IsNotExist(err) {
 		return false, nil

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -20,9 +20,7 @@ func TestShub(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tests := []struct {
 		name        string
@@ -67,9 +65,7 @@ func TestShubImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableEnv) == "1" {
-		t.Skip("Caching is disabled")
-	}
+	chechIfCacheDisabled(t)
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -20,7 +20,7 @@ func TestShub(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 
@@ -67,7 +67,7 @@ func TestShubImageExists(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	if os.Getenv(DisableCacheEnv) == "1" {
+	if os.Getenv(DisableEnv) == "1" {
 		t.Skip("Caching is disabled")
 	}
 

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -20,6 +20,10 @@ func TestShub(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
+
 	tests := []struct {
 		name        string
 		dir         string
@@ -62,6 +66,10 @@ func TestShubImageExists(t *testing.T) {
 	t.Skip("Skipping tests that access singularity hub")
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
+
+	if os.Getenv(DisableCacheEnv) == "1" {
+		t.Skip("Caching is disabled")
+	}
 
 	tempImageCache, err := ioutil.TempDir("", "image-cache-")
 	if err != nil {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

The PR fixes a problem when `SINGULARITY_DISABLE_CACHE` is set. It makes sure that when set, no directory is created in the base directory. So far, the sub-directories of the cache were created (e.g., `cache/library`), even if not used.

The approach implemented in this PR assumes:
- If `SINGULARITY_DISABLE_CACHE` is set `cache.NewHandle()` returns a cache handle that represents a disabled cache. This allows us to easily support disabling the cache without raising an issue and deeply modifying the code.
- The unit tests can only be executed if `SINGULARITY_DISABLE_CACHE` is not set, otherwise the tests are skipped (we cannot really test the image cache capabilities if the environment specifies that no cache should be used).
- We add an internal state to the cache handle (`disabled`) to be able to track if the handle represents a disabled cache. At the moment, that value cannot be changed after the creation of the handle.

**This fixes or addresses the following GitHub issues:**

- Fixes #4189 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers