### PR TITLE
Fixed panic when 'key search' on a open-keyserver

### DIFF
--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -596,7 +596,7 @@ func formatMROutput(mrString string) (int, []byte, error) {
 			}
 			if n == "pub" {
 				// The fingerprint is located at nk[1], and we only want the last 8 chars
-				fmt.Fprintf(tw, "%s\t", nk[1][32:])
+				fmt.Fprintf(tw, "%s\t", nk[1][len(nk[1])-8:])
 				// The key size (bits) is located at nk[3]
 				fmt.Fprintf(tw, "%s\t", nk[3])
 				count++


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes the issue when searching from non-sylabs openpgp-keyserver, caused by some keys do not have the full 40 char fingerprint length.

### This fixes or addresses the following GitHub issues:

- Fixes #4193
- Related to: https://github.com/sylabs/singularity/pull/4121

<br>

