### PR TITLE
Enable seccomp during oci mount testing

### DIFF
--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -72,7 +72,7 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 			g.SetProcessTerminal(true)
 			// NEED FIX: disable seccomp for circleci, ubuntu trusty
 			// doesn't support syscalls _llseek and _newselect
-			g.Config.Linux.Seccomp = nil
+			// g.Config.Linux.Seccomp = nil
 
 			err = g.SaveToFile(ociConfig, generate.ExportOptions{})
 			if err != nil {


### PR DESCRIPTION
This was initially disabled because `14.04/trusty` did not support some of the system calls in the default `seccomp` profile