### PR TITLE
Change the interface to create a new image cache handle 

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -34,10 +34,11 @@ const (
 )
 
 func getCacheHandle() *cache.Handle {
-	h, err := cache.NewHandle(os.Getenv(cache.DirEnv))
+	h, err := cache.NewHandle(cache.Context{BaseDir: os.Getenv(cache.DirEnv)})
 	if err != nil {
 		sylog.Fatalf("Failed to create an image cache handle: %s", err)
 	}
+
 	return h
 }
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -34,7 +34,7 @@ const (
 )
 
 func getCacheHandle() *cache.Handle {
-	h, err := cache.NewHandle(cache.Context{BaseDir: os.Getenv(cache.DirEnv)})
+	h, err := cache.NewHandle(cache.Config{BaseDir: os.Getenv(cache.DirEnv)})
 	if err != nil {
 		sylog.Fatalf("Failed to create an image cache handle: %s", err)
 	}

--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -30,7 +30,7 @@ var testFileContent = "Test file content\n"
 
 func setupCache(t *testing.T) (*cache.Handle, func()) {
 	dir := testCache.MakeDir(t, "")
-	h, err := cache.NewHandle(cache.Context{BaseDir: dir})
+	h, err := cache.NewHandle(cache.Config{BaseDir: dir})
 	if err != nil {
 		testCache.DeleteDir(t, dir)
 		t.Fatalf("failed to create an image cache handle: %s", err)

--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -30,7 +30,7 @@ var testFileContent = "Test file content\n"
 
 func setupCache(t *testing.T) (*cache.Handle, func()) {
 	dir := testCache.MakeDir(t, "")
-	h, err := cache.NewHandle(dir)
+	h, err := cache.NewHandle(cache.Context{BaseDir: dir})
 	if err != nil {
 		testCache.DeleteDir(t, dir)
 		t.Fatalf("failed to create an image cache handle: %s", err)

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -57,7 +57,7 @@ func (c *cacheTests) testCacheClean(t *testing.T) {
 			t,
 			e2e.AsSubtest(tc.name),
 			e2e.PreRun(func(t *testing.T) {
-				h, err := cache.NewHandle(c.env.ImgCacheDir)
+				h, err := cache.NewHandle(cache.Context{BaseDir: c.env.ImgCacheDir})
 				if err != nil {
 					t.Fatalf("Could not create image cache handle: %v", err)
 				}
@@ -73,7 +73,7 @@ func (c *cacheTests) testCacheClean(t *testing.T) {
 				e2e.ConsoleSendLine(tc.send),
 			),
 			e2e.PostRun(func(t *testing.T) {
-				h, err := cache.NewHandle(c.env.ImgCacheDir)
+				h, err := cache.NewHandle(cache.Context{BaseDir: c.env.ImgCacheDir})
 				if err != nil {
 					t.Fatalf("Could not create image cache handle: %v", err)
 				}

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -57,7 +57,7 @@ func (c *cacheTests) testCacheClean(t *testing.T) {
 			t,
 			e2e.AsSubtest(tc.name),
 			e2e.PreRun(func(t *testing.T) {
-				h, err := cache.NewHandle(cache.Context{BaseDir: c.env.ImgCacheDir})
+				h, err := cache.NewHandle(cache.Config{BaseDir: c.env.ImgCacheDir})
 				if err != nil {
 					t.Fatalf("Could not create image cache handle: %v", err)
 				}
@@ -73,7 +73,7 @@ func (c *cacheTests) testCacheClean(t *testing.T) {
 				e2e.ConsoleSendLine(tc.send),
 			),
 			e2e.PostRun(func(t *testing.T) {
-				h, err := cache.NewHandle(cache.Context{BaseDir: c.env.ImgCacheDir})
+				h, err := cache.NewHandle(cache.Config{BaseDir: c.env.ImgCacheDir})
 				if err != nil {
 					t.Fatalf("Could not create image cache handle: %v", err)
 				}

--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -40,7 +40,7 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 	// Create a clean image cache and associate it to the assembler
 	imgCacheDir := testCache.MakeDir(t, "")
 	defer testCache.DeleteDir(t, imgCacheDir)
-	imgCache, err := cache.NewHandle(imgCacheDir)
+	imgCache, err := cache.NewHandle(cache.Context{BaseDir: imgCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}

--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -40,7 +40,7 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 	// Create a clean image cache and associate it to the assembler
 	imgCacheDir := testCache.MakeDir(t, "")
 	defer testCache.DeleteDir(t, imgCacheDir)
-	imgCache, err := cache.NewHandle(cache.Context{BaseDir: imgCacheDir})
+	imgCache, err := cache.NewHandle(cache.Config{BaseDir: imgCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}

--- a/internal/pkg/build/assemblers/assembler_sif_test.go
+++ b/internal/pkg/build/assemblers/assembler_sif_test.go
@@ -55,7 +55,7 @@ func TestSIFAssemblerDocker(t *testing.T) {
 	// set a clean image cache
 	imgCacheDir := testCache.MakeDir(t, "")
 	defer testCache.DeleteDir(t, imgCacheDir)
-	imgCache, err := cache.NewHandle(cache.Context{BaseDir: imgCacheDir})
+	imgCache, err := cache.NewHandle(cache.Config{BaseDir: imgCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}

--- a/internal/pkg/build/assemblers/assembler_sif_test.go
+++ b/internal/pkg/build/assemblers/assembler_sif_test.go
@@ -55,7 +55,7 @@ func TestSIFAssemblerDocker(t *testing.T) {
 	// set a clean image cache
 	imgCacheDir := testCache.MakeDir(t, "")
 	defer testCache.DeleteDir(t, imgCacheDir)
-	imgCache, err := cache.NewHandle(imgCacheDir)
+	imgCache, err := cache.NewHandle(cache.Context{BaseDir: imgCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 
 func setupCache(t *testing.T) (*cache.Handle, func()) {
 	dir := testCache.MakeDir(t, "")
-	h, err := cache.NewHandle(dir)
+	h, err := cache.NewHandle(cache.Context{BaseDir: dir})
 	if err != nil {
 		testCache.DeleteDir(t, dir)
 		t.Fatalf("failed to create an image cache handle: %s", err)

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 
 func setupCache(t *testing.T) (*cache.Handle, func()) {
 	dir := testCache.MakeDir(t, "")
-	h, err := cache.NewHandle(cache.Context{BaseDir: dir})
+	h, err := cache.NewHandle(cache.Config{BaseDir: dir})
 	if err != nil {
 		testCache.DeleteDir(t, dir)
 		t.Fatalf("failed to create an image cache handle: %s", err)

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -38,9 +38,9 @@ const (
 	CacheDir = "cache"
 )
 
-// Context describes the context in which a new handle is created, as defined
-// by the user through command flags and environment variables.
-type Context struct {
+// Config describes the requested configuration requested when a new handle is created,
+// as defined by the user through command flags and environment variables.
+type Config struct {
 	// Location where the user wants the cache to be created.
 	BaseDir string
 }
@@ -95,7 +95,7 @@ type Handle struct {
 // impacting other threads (e.g., while running unit tests). If baseDir is an
 // empty string, the image cache will be located to the default location, i.e.,
 // $HOME/.singularity.
-func NewHandle(ctx Context) (*Handle, error) {
+func NewHandle(cfg Config) (*Handle, error) {
 	newCache := new(Handle)
 
 	// Check whether the cache is disabled by the user.
@@ -114,8 +114,8 @@ func NewHandle(ctx Context) (*Handle, error) {
 		return newCache, nil
 	}
 
-	// ctx is what is requested so we should not change any value that it contains
-	baseDir := ctx.BaseDir
+	// cfg is what is requested so we should not change any value that it contains
+	baseDir := cfg.BaseDir
 	if baseDir == "" {
 		baseDir = getCacheBasedir()
 	}

--- a/internal/pkg/client/cache/dir.go
+++ b/internal/pkg/client/cache/dir.go
@@ -38,6 +38,13 @@ const (
 	CacheDir = "cache"
 )
 
+// Context describes the context in which a new handle is created, as defined
+// by the user through command flags and environment variables.
+type Context struct {
+	// Location where the user wants the cache to be created.
+	BaseDir string
+}
+
 // Handle is an structure representing a cache
 type Handle struct {
 	// basedir is the base directory of the image cache. By default, it is set
@@ -88,7 +95,7 @@ type Handle struct {
 // impacting other threads (e.g., while running unit tests). If baseDir is an
 // empty string, the image cache will be located to the default location, i.e.,
 // $HOME/.singularity.
-func NewHandle(baseDir string) (*Handle, error) {
+func NewHandle(ctx Context) (*Handle, error) {
 	newCache := new(Handle)
 
 	// Check whether the cache is disabled by the user.
@@ -107,6 +114,8 @@ func NewHandle(baseDir string) (*Handle, error) {
 		return newCache, nil
 	}
 
+	// ctx is what is requested so we should not change any value that it contains
+	baseDir := ctx.BaseDir
 	if baseDir == "" {
 		baseDir = getCacheBasedir()
 	}

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -46,7 +46,7 @@ func TestNewHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(Context{BaseDir: tt.dir})
+			c, err := NewHandle(Config{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -70,7 +70,7 @@ func TestCleanAllCaches(t *testing.T) {
 	}
 	defer os.RemoveAll(imageCacheDir)
 
-	c, err := NewHandle(Context{BaseDir: imageCacheDir})
+	c, err := NewHandle(Config{BaseDir: imageCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}
@@ -143,7 +143,7 @@ func TestRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			imgCache, err := NewHandle(Context{BaseDir: tt.basedir})
+			imgCache, err := NewHandle(Config{BaseDir: tt.basedir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache: %s", err)
 			}

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -46,7 +46,7 @@ func TestNewHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(tt.dir)
+			c, err := NewHandle(Context{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -70,7 +70,7 @@ func TestCleanAllCaches(t *testing.T) {
 	}
 	defer os.RemoveAll(imageCacheDir)
 
-	c, err := NewHandle(imageCacheDir)
+	c, err := NewHandle(Context{BaseDir: imageCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}
@@ -143,7 +143,7 @@ func TestRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			imgCache, err := NewHandle(tt.basedir)
+			imgCache, err := NewHandle(Context{BaseDir: tt.basedir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache: %s", err)
 			}

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -44,7 +44,7 @@ func TestLibrary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(tt.dir)
+			c, err := NewHandle(Context{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -71,7 +71,7 @@ func TestLibraryImage(t *testing.T) {
 	}
 	defer os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(tempImageCache)
+	c, err := NewHandle(Context{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}
@@ -144,7 +144,7 @@ func TestLibraryImageExists(t *testing.T) {
 		t.Fatal("failed to create temporary image cache directory")
 	}
 	defer os.RemoveAll(imageCacheDir)
-	c, err := NewHandle(imageCacheDir)
+	c, err := NewHandle(Context{BaseDir: imageCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/library_test.go
+++ b/internal/pkg/client/cache/library_test.go
@@ -44,7 +44,7 @@ func TestLibrary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(Context{BaseDir: tt.dir})
+			c, err := NewHandle(Config{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -71,7 +71,7 @@ func TestLibraryImage(t *testing.T) {
 	}
 	defer os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(Context{BaseDir: tempImageCache})
+	c, err := NewHandle(Config{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}
@@ -144,7 +144,7 @@ func TestLibraryImageExists(t *testing.T) {
 		t.Fatal("failed to create temporary image cache directory")
 	}
 	defer os.RemoveAll(imageCacheDir)
-	c, err := NewHandle(Context{BaseDir: imageCacheDir})
+	c, err := NewHandle(Config{BaseDir: imageCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -42,7 +42,7 @@ func TestNet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(Context{BaseDir: tt.dir})
+			c, err := NewHandle(Config{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -69,7 +69,7 @@ func TestNetImageExists(t *testing.T) {
 	}
 	defer os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(Context{BaseDir: tempImageCache})
+	c, err := NewHandle(Config{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/net_test.go
+++ b/internal/pkg/client/cache/net_test.go
@@ -42,7 +42,7 @@ func TestNet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(tt.dir)
+			c, err := NewHandle(Context{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -69,7 +69,7 @@ func TestNetImageExists(t *testing.T) {
 	}
 	defer os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(tempImageCache)
+	c, err := NewHandle(Context{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -42,7 +42,7 @@ func TestOciBlob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(tt.dir)
+			c, err := NewHandle(Context{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -85,7 +85,7 @@ func TestOciTemp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(tt.dir)
+			c, err := NewHandle(Context{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -112,7 +112,7 @@ func TestOciTempExists(t *testing.T) {
 	}
 	defer os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(tempImageCache)
+	c, err := NewHandle(Context{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/oci_test.go
+++ b/internal/pkg/client/cache/oci_test.go
@@ -42,7 +42,7 @@ func TestOciBlob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(Context{BaseDir: tt.dir})
+			c, err := NewHandle(Config{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -85,7 +85,7 @@ func TestOciTemp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(Context{BaseDir: tt.dir})
+			c, err := NewHandle(Config{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -112,7 +112,7 @@ func TestOciTempExists(t *testing.T) {
 	}
 	defer os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(Context{BaseDir: tempImageCache})
+	c, err := NewHandle(Config{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/oras_test.go
+++ b/internal/pkg/client/cache/oras_test.go
@@ -65,7 +65,7 @@ func TestOrasImage(t *testing.T) {
 	}
 	validImagePath = filepath.Join(newBasedir, validImageName)
 
-	c, err := NewHandle(imageCacheDir)
+	c, err := NewHandle(Context{BaseDir: imageCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/oras_test.go
+++ b/internal/pkg/client/cache/oras_test.go
@@ -65,7 +65,7 @@ func TestOrasImage(t *testing.T) {
 	}
 	validImagePath = filepath.Join(newBasedir, validImageName)
 
-	c, err := NewHandle(Context{BaseDir: imageCacheDir})
+	c, err := NewHandle(Config{BaseDir: imageCacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -44,7 +44,7 @@ func TestShub(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(Context{BaseDir: tt.dir})
+			c, err := NewHandle(Config{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -73,7 +73,7 @@ func TestShubImageExists(t *testing.T) {
 	}
 	os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(Context{BaseDir: tempImageCache})
+	c, err := NewHandle(Config{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create a new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/cache/shub_test.go
+++ b/internal/pkg/client/cache/shub_test.go
@@ -44,7 +44,7 @@ func TestShub(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewHandle(tt.dir)
+			c, err := NewHandle(Context{BaseDir: tt.dir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache handle: %s", err)
 			}
@@ -73,7 +73,7 @@ func TestShubImageExists(t *testing.T) {
 	}
 	os.RemoveAll(tempImageCache)
 
-	c, err := NewHandle(tempImageCache)
+	c, err := NewHandle(Context{BaseDir: tempImageCache})
 	if err != nil {
 		t.Fatalf("failed to create a new image cache handle: %s", err)
 	}

--- a/internal/pkg/client/oci/oci_test.go
+++ b/internal/pkg/client/oci/oci_test.go
@@ -236,7 +236,7 @@ func TestConvertReference(t *testing.T) {
 
 	cacheDir, _, ref := getTestCacheInfo(t)
 	defer os.RemoveAll(cacheDir)
-	imgCache, err := cache.NewHandle(cache.Context{BaseDir: cacheDir})
+	imgCache, err := cache.NewHandle(cache.Config{BaseDir: cacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle")
 	}
@@ -294,7 +294,7 @@ func TestImageNameAndImageSHA(t *testing.T) {
 	// We create a dummy OCI cache to run all our tests
 	cacheDir, _, _ := getTestCacheInfo(t)
 	defer os.RemoveAll(cacheDir)
-	imgCache, err := cache.NewHandle(cache.Context{BaseDir: cacheDir})
+	imgCache, err := cache.NewHandle(cache.Config{BaseDir: cacheDir})
 	if imgCache == nil || err != nil {
 		t.Fatal("failed to create an image cache handle")
 	}
@@ -409,7 +409,7 @@ func TestNewImageSource(t *testing.T) {
 	// We create a minimalistic image reference that is valid enough for testing
 	cacheDir, _, ref := getTestCacheInfo(t)
 	defer os.RemoveAll(cacheDir)
-	imgCache, err := cache.NewHandle(cache.Context{BaseDir: cacheDir})
+	imgCache, err := cache.NewHandle(cache.Config{BaseDir: cacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}

--- a/internal/pkg/client/oci/oci_test.go
+++ b/internal/pkg/client/oci/oci_test.go
@@ -236,7 +236,7 @@ func TestConvertReference(t *testing.T) {
 
 	cacheDir, _, ref := getTestCacheInfo(t)
 	defer os.RemoveAll(cacheDir)
-	imgCache, err := cache.NewHandlecache.Context{BaseDir: cacheDir})
+	imgCache, err := cache.NewHandle(cache.Context{BaseDir: cacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle")
 	}

--- a/internal/pkg/client/oci/oci_test.go
+++ b/internal/pkg/client/oci/oci_test.go
@@ -236,7 +236,7 @@ func TestConvertReference(t *testing.T) {
 
 	cacheDir, _, ref := getTestCacheInfo(t)
 	defer os.RemoveAll(cacheDir)
-	imgCache, err := cache.NewHandle(cacheDir)
+	imgCache, err := cache.NewHandlecache.Context{BaseDir: cacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle")
 	}
@@ -294,7 +294,7 @@ func TestImageNameAndImageSHA(t *testing.T) {
 	// We create a dummy OCI cache to run all our tests
 	cacheDir, _, _ := getTestCacheInfo(t)
 	defer os.RemoveAll(cacheDir)
-	imgCache, err := cache.NewHandle(cacheDir)
+	imgCache, err := cache.NewHandle(cache.Context{BaseDir: cacheDir})
 	if imgCache == nil || err != nil {
 		t.Fatal("failed to create an image cache handle")
 	}
@@ -409,7 +409,7 @@ func TestNewImageSource(t *testing.T) {
 	// We create a minimalistic image reference that is valid enough for testing
 	cacheDir, _, ref := getTestCacheInfo(t)
 	defer os.RemoveAll(cacheDir)
-	imgCache, err := cache.NewHandle(cacheDir)
+	imgCache, err := cache.NewHandle(cache.Context{BaseDir: cacheDir})
 	if err != nil {
 		t.Fatalf("failed to create an image cache handle: %s", err)
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR changes the interface to create a new image cache handle to use a context (extensible structure) instead of a single string for the specification of the base directory. This is required because we now have various ways to impact the cache, namely environment variables (e.g., `SINGULARITY_CACHE_DIR`, `SINGULARITY_DISABLE_CACHE`) and command options (e.g., `singularity pull --disable-cache`). As a result, we need to be able to capture the context in which a new image cache handle is created.

This PR only changes the interface for the creation of a cache handle, in order to ease the its review. The goal here is to only introduce a new struct `Context` that can be used to capture the context in which a cache is created, as well as the changes to the interface to support the context, as well as all the changes necessary.

Extension to the `Context` structure to address #4213 and #4192 will be introduced in future PRs.

**This fixes or addresses the following GitHub issues:**

- Addresses #4213 
- Addresses #4192 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers