### PR TITLE
Prevent build engine from mixing container and host libraries

### DIFF
--- a/e2e/regressions/build.go
+++ b/e2e/regressions/build.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package regressions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+type regressionsTests struct {
+	env e2e.TestEnv
+}
+
+// This test will build an image from a multi-stage definition
+// file, the first stage compile a bad NSS library containing
+// a constructor forcing program to exit with code 255 when loaded,
+// the second stage will copy the bad NSS library in its root filesytem
+// to check that the post section executed by the build engine doesn't
+// load the bad NSS library from container image.
+// Most if not all NSS services point to the bad NSS library in
+// order to catch all the potential calls which could occur from
+// Go code inside the build engine, singularity engine is also tested.
+func (c *regressionsTests) issue4203(t *testing.T) {
+	image := filepath.Join(c.env.TestDir, "issue_4203.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithPrivileges(true),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(image, "testdata/regressions/issue_4203.def"),
+		e2e.PostRun(func(t *testing.T) {
+			defer os.Remove(image)
+
+			if t.Failed() {
+				return
+			}
+
+			// also execute the image to check that singularity
+			// engine doesn't try to load a NSS library from
+			// container image
+			c.env.RunSingularity(
+				t,
+				e2e.WithPrivileges(false),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs(image, "true"),
+				e2e.ExpectExit(0),
+			)
+		}),
+		e2e.ExpectExit(0),
+	)
+}
+
+// RunE2ETests is the main func to trigger the test suite
+func RunE2ETests(env e2e.TestEnv) func(*testing.T) {
+	c := &regressionsTests{
+		env: env,
+	}
+
+	return func(t *testing.T) {
+		// https://github.com/sylabs/singularity/issues/4203
+		t.Run("Issue4203", c.issue4203)
+	}
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sylabs/singularity/e2e/oci"
 	"github.com/sylabs/singularity/e2e/pull"
 	"github.com/sylabs/singularity/e2e/push"
+	"github.com/sylabs/singularity/e2e/regressions"
 	"github.com/sylabs/singularity/e2e/remote"
 	"github.com/sylabs/singularity/e2e/sign"
 	"github.com/sylabs/singularity/e2e/verify"
@@ -130,23 +131,24 @@ func Run(t *testing.T) {
 	// RunE2ETests by functionality
 
 	suites := map[string]func(*testing.T){
-		"ACTIONS":    actions.RunE2ETests(testenv),
-		"BUILD":      imgbuild.RunE2ETests(testenv),
-		"CACHE":      cache.RunE2ETests(testenv),
-		"CMDENVVARS": cmdenvvars.RunE2ETests(testenv),
-		"DOCKER":     docker.RunE2ETests(testenv),
-		"ENV":        singularityenv.RunE2ETests(testenv),
-		"HELP":       help.RunE2ETests(testenv),
-		"INSPECT":    inspect.RunE2ETests(testenv),
-		"INSTANCE":   instance.RunE2ETests(testenv),
-		"KEY":        key.RunE2ETests(testenv),
-		"OCI":        oci.RunE2ETests(testenv),
-		"PULL":       pull.RunE2ETests(testenv),
-		"PUSH":       push.RunE2ETests(testenv),
-		"REMOTE":     remote.RunE2ETests(testenv),
-		"SIGN":       sign.RunE2ETests(testenv),
-		"VERIFY":     verify.RunE2ETests(testenv),
-		"VERSION":    version.RunE2ETests(testenv),
+		"ACTIONS":     actions.RunE2ETests(testenv),
+		"BUILD":       imgbuild.RunE2ETests(testenv),
+		"CACHE":       cache.RunE2ETests(testenv),
+		"CMDENVVARS":  cmdenvvars.RunE2ETests(testenv),
+		"DOCKER":      docker.RunE2ETests(testenv),
+		"ENV":         singularityenv.RunE2ETests(testenv),
+		"HELP":        help.RunE2ETests(testenv),
+		"INSPECT":     inspect.RunE2ETests(testenv),
+		"INSTANCE":    instance.RunE2ETests(testenv),
+		"KEY":         key.RunE2ETests(testenv),
+		"OCI":         oci.RunE2ETests(testenv),
+		"PULL":        pull.RunE2ETests(testenv),
+		"PUSH":        push.RunE2ETests(testenv),
+		"REMOTE":      remote.RunE2ETests(testenv),
+		"SIGN":        sign.RunE2ETests(testenv),
+		"VERIFY":      verify.RunE2ETests(testenv),
+		"VERSION":     version.RunE2ETests(testenv),
+		"REGRESSIONS": regressions.RunE2ETests(testenv),
 	}
 
 	for name, fn := range suites {

--- a/e2e/testdata/regressions/issue_4203.def
+++ b/e2e/testdata/regressions/issue_4203.def
@@ -1,0 +1,47 @@
+bootstrap: docker
+from: ubuntu:16.04
+stage: build
+
+%post
+    apt-get update
+    apt-get install -y --no-install-recommends gcc libc6-dev
+
+    cat > /bad.c <<EOF
+#include <stdio.h>
+#include <unistd.h>
+
+void __attribute__ ((constructor)) setup(void) {
+    fprintf(stderr, "BAD NSS CALL\n");
+    _exit(255);
+}
+EOF
+
+    gcc -Wall -shared -fPIC -o /bad.so -Wl,-soname,libnss_bad.so.2 /bad.c
+
+    cat > /nsswitch.conf <<EOF
+aliases:        bad
+passwd:         bad
+group:          bad
+initgroups:     bad
+publickey:      bad
+shadow:         bad
+gshadow:        bad
+hosts:          bad
+networks:       bad
+protocols:      bad
+services:       bad
+ethers:         bad
+rpc:            bad
+netgroup:       bad
+EOF
+
+bootstrap: docker
+from: ubuntu:16.04
+stage: final
+
+%files from build
+    /bad.so /lib/x86_64-linux-gnu/libnss_bad.so.2
+    /nsswitch.conf /etc/nsswitch.conf
+
+%post
+    true

--- a/internal/pkg/runtime/engines/imgbuild/process_linux.go
+++ b/internal/pkg/runtime/engines/imgbuild/process_linux.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/user"
 	"strings"
 	"syscall"
 
@@ -80,14 +79,12 @@ func (e *EngineOperations) cleanEnv() {
 	// clean environment
 	e.EngineConfig.OciConfig.Spec.Process.Env = nil
 
-	// During image build process (run typically as root), home destination
-	// is /root
+	// during image build process, home destination is /root as
+	// build engine is usable only by root or fakeroot, fakeroot
+	// already take care of binding the real user home directory
+	// to /root, so we don't need to query user database to determine
+	// home directory as it's always /root
 	homeDest := "/root"
-	usr, err := user.Current()
-
-	if err == nil {
-		homeDest = usr.HomeDir
-	}
 
 	// add relevant environment variables back
 	env.SetContainerEnv(&generator, environment, true, homeDest)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Remove unecessary call to `user.Current` in `cleanEnv` to prevent Go from loading and mixing NSS libraries with container image and host libc leading to error shown in #4247

**This fixes or addresses the following GitHub issues:**

- Fixes #4203 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
