### PR TITLE
Use session home directory if user home directory doesn't exist

### DIFF
--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -1273,7 +1273,14 @@ func (c *container) addHomeStagingDir(system *mount.System, source string, dest 
 
 	homeStage, _ = c.session.GetPath(dest)
 
-	if !c.engine.EngineConfig.GetContain() || c.engine.EngineConfig.GetCustomHome() {
+	bindSource := !c.engine.EngineConfig.GetContain() || c.engine.EngineConfig.GetCustomHome()
+
+	// use the session home directory is the user home directory doesn't exist (issue #4208)
+	if _, err := os.Stat(source); os.IsNotExist(err) {
+		bindSource = false
+	}
+
+	if bindSource {
 		sylog.Debugf("Staging home directory (%v) at %v\n", source, homeStage)
 
 		if err := system.Points.AddBind(mount.HomeTag, source, homeStage, flags); err != nil {


### PR DESCRIPTION
**Description of the Pull Request (PR):**

If user home directory doesn't exists on host, this patch simply switch and use the session home directory as if `--contain` was passed.

**This fixes or addresses the following GitHub issues:**

- Fixes #4208 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
