### PR TITLE
Don't bind directory set by --pwd flag, use the current instead

### DIFF
--- a/internal/pkg/runtime/engines/singularity/container_linux.go
+++ b/internal/pkg/runtime/engines/singularity/container_linux.go
@@ -1563,8 +1563,6 @@ func (c *container) addScratchMount(system *mount.System) error {
 }
 
 func (c *container) addCwdMount(system *mount.System) error {
-	cwd := ""
-
 	if c.engine.EngineConfig.GetContain() {
 		sylog.Verbosef("Not mounting current directory: container was requested")
 		return nil
@@ -1576,19 +1574,12 @@ func (c *container) addCwdMount(system *mount.System) error {
 	if c.engine.EngineConfig.OciConfig.Process == nil {
 		return nil
 	}
-	cwd = c.engine.EngineConfig.OciConfig.Process.Cwd
-	if err := os.Chdir(cwd); err != nil {
-		if os.IsNotExist(err) {
-			sylog.Debugf("Container working directory %s doesn't exist, will retry after chroot", cwd)
-		} else {
-			sylog.Warningf("Could not set container working directory %s: %s", cwd, err)
-		}
-		return nil
-	}
 	current, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("could not obtain current directory path: %s", err)
 	}
+	sylog.Debugf("Using %s as current working directory", current)
+
 	switch current {
 	case "/", "/etc", "/bin", "/mnt", "/usr", "/var", "/opt", "/sbin", "/lib", "/lib64":
 		sylog.Verbosef("Not mounting CWD within operating system directory: %s", current)
@@ -1599,10 +1590,10 @@ func (c *container) addCwdMount(system *mount.System) error {
 		return nil
 	}
 	flags := uintptr(syscall.MS_BIND | c.suidFlag | syscall.MS_NODEV | syscall.MS_REC)
-	if err := system.Points.AddBind(mount.CwdTag, current, cwd, flags); err == nil {
-		system.Points.AddRemount(mount.CwdTag, cwd, flags)
-		c.checkDest = append(c.checkDest, cwd)
-		sylog.Verbosef("Default mount: %v: to the container", cwd)
+	if err := system.Points.AddBind(mount.CwdTag, current, current, flags); err == nil {
+		system.Points.AddRemount(mount.CwdTag, current, flags)
+		c.checkDest = append(c.checkDest, current)
+		sylog.Verbosef("Default mount: %v: to the container", current)
 	} else {
 		sylog.Warningf("Could not bind CWD to container %s: %s", current, err)
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a wrong behavior introduced in Singularity 3 where `--pwd` value is taken as the current working directory both outside/inside container when it should be only take into account inside container only.

**This fixes or addresses the following GitHub issues:**

- Fixes #4077 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
