### PR TITLE
Basic code for e2e build tests for encryption

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -736,15 +736,15 @@ func (c *imgBuildTests) buildDefinition(t *testing.T) {
 }
 
 func (c *imgBuildTests) ensureImageIsEncrypted(t *testing.T, imgPath string) {
-	sifID := "3" // Which SIF descriptor slots contains encryption information
-	cmdArgs := []string{"list", sifID, imgPath}
+	sifID := "2" // Which SIF descriptor slots contains encryption information
+	cmdArgs := []string{"info", sifID, imgPath}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("sif"),
 		e2e.WithArgs(cmdArgs...),
 		e2e.ExpectExit(
 			0,
-			e2e.ExpectOutput(e2e.RegexMatch, "^something something"),
+			e2e.ExpectOutput(e2e.ContainMatch, "Fstype:    Encrypted squashfs"),
 		),
 	)
 }
@@ -759,6 +759,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
+		e2e.WithPrivileges(true),
 		e2e.WithArgs(cmdArgs...),
 		e2e.ConsoleRun(passphraseInput...),
 		e2e.ExpectExit(0),
@@ -773,6 +774,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 		t,
 		e2e.WithCommand("build"),
 		e2e.WithArgs(cmdArgs...),
+		e2e.WithPrivileges(true),
 		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
 		e2e.ExpectExit(0),
 	)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -771,7 +771,7 @@ func checkCryptsetupVersion() error {
 }
 
 // buildEncryptPassphrase is exercising the build command for encrypted containers
-// while using a passphrase. Not that it covers both the normal case and when the
+// while using a passphrase. Note that it covers both the normal case and when the
 // version of cryptsetup available is not compliant.
 func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// Expected results for a successful command execution

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -741,7 +741,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 		e2e.ConsoleSendLine(passphrase),
 	}
 	imgPath1 := filepath.Join(c.env.TestDir, "encrypted_cmdline_option.sif")
-	cmdArgs := []string{"--passphrase", imgPath1, "library://alpine:latest"}
+	cmdArgs := []string{"-e", "--passphrase", imgPath1, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
@@ -753,7 +753,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// Second with the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PASSPHRASE", passphrase)
 	imgPath2 := filepath.Join(c.env.TestDir, "encrypted_env_var.sif")
-	cmdArgs = []string{imgPath2, "library://alpine:latest"}
+	cmdArgs = []string{"-e", imgPath2, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -838,20 +838,18 @@ func RunE2ETests(env e2e.TestEnv) func(*testing.T) {
 	}
 
 	return func(t *testing.T) {
-		/*
-			// builds from definition file and URI
-			t.Run("From", c.buildFrom)
-			// build and image from an existing image
-			t.Run("FromLocalImage", c.buildLocalImage)
-			// build sifs from non-root
-			t.Run("NonRootBuild", c.nonRootBuild)
-			// try to build from a non existen path
-			t.Run("badPath", c.badPath)
-			// builds from definition template
-			t.Run("Definition", c.buildDefinition)
-			// multistage build from definition templates
-			t.Run("MultiStage", c.buildMultiStageDefinition)
-		*/
+		// builds from definition file and URI
+		t.Run("From", c.buildFrom)
+		// build and image from an existing image
+		t.Run("FromLocalImage", c.buildLocalImage)
+		// build sifs from non-root
+		t.Run("NonRootBuild", c.nonRootBuild)
+		// try to build from a non existen path
+		t.Run("badPath", c.badPath)
+		// builds from definition template
+		t.Run("Definition", c.buildDefinition)
+		// multistage build from definition templates
+		t.Run("MultiStage", c.buildMultiStageDefinition)
 		// build encrypted images
 		t.Run("buildEncryptPassphrase", c.buildEncryptPassphrase)
 	}

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -735,6 +735,20 @@ func (c *imgBuildTests) buildDefinition(t *testing.T) {
 	}
 }
 
+func (c *imgBuildTests) ensureImageIsEncrypted(t *testing.T, imgPath string) {
+	sifID := "3" // Which SIF descriptor slots contains encryption information
+	cmdArgs := []string{"list", sifID, imgPath}
+	c.env.RunSingularity(
+		t,
+		e2e.WithCommand("sif"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.RegexMatch, "^something something"),
+		),
+	)
+}
+
 func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// First with the command line argument
 	passphraseInput := []e2e.SingularityConsoleOp{
@@ -749,6 +763,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 		e2e.ConsoleRun(passphraseInput...),
 		e2e.ExpectExit(0),
 	)
+	c.ensureImageIsEncrypted(t, imgPath1)
 
 	// Second with the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PASSPHRASE", passphrase)
@@ -761,6 +776,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
 		e2e.ExpectExit(0),
 	)
+	c.ensureImageIsEncrypted(t, imgPath2)
 }
 
 // RunE2ETests is the main func to trigger the test suite


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add e2e tests for building encrypted containers. At the moment, only for the `build` command with a pass phrase.
We currently have an issue with getting error messages, which will be fixed separately. At the moment, we implement a work around that basically deactivate checking the error message.

**This fixes or addresses the following GitHub issues:**

- Addresses #4253 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
