### PR TITLE
Do not set blkio cgroup limits during test

### DIFF
--- a/internal/pkg/cgroups/example/cgroups.toml
+++ b/internal/pkg/cgroups/example/cgroups.toml
@@ -53,18 +53,18 @@
 
 
 # BlockIO restriction configuration
-[blockIO]
+# [blockIO]
   # Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, CFQ scheduler only
-  leafWeight = 10
+  # leafWeight = 10
 
   # Specifies per cgroup weight
-  weight = 10
+  # weight = 10
 
   # Weight per cgroup per device, can override BlkioWeight
   # - major is the device's major number.
   # - minor is the device's minor number.
   # - weight is the bandwidth rate for the device.
-	# - leafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, CFQ scheduler only
+  # - leafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, CFQ scheduler only
   # [[blockIO.weightDevice]]
   #   major = 7
   #   minor = 0
@@ -72,9 +72,9 @@
   #   leafWeight = 10
 
   # IO read rate limit per cgroup per device, bytes per second
-	# - major is the device's major number.
-	# - minor is the device's minor number.
-	# - rate is the IO rate limit per cgroup per device
+  # - major is the device's major number.
+  # - minor is the device's minor number.
+  # - rate is the IO rate limit per cgroup per device
   # [[blockIO.throttleReadBpsDevice]]
   #   major = 7
   #   minor = 0


### PR DESCRIPTION
blkio requires an IO scheduler, and there's no gurantee one is available
when running tests (recent kernels disable the IO scheduler when the
block device is a virtual disk, e.g. vda, as it's the case with some
virtual machines). Trying to make this conditional on the existance of
an IO scheduler seems more complicated than what it's worth, as the
TestCgroups test is testing more whether it can load the configuration
file and less that everything in that file is applied correctly (if it
checks anything, it's only the stuff directly related to CPU). Most of
the logic that applies the configuration file is already tested as part
of the cgroups package anyways.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
