### PR TITLE
Abort suid install if not root

### DIFF
--- a/mlocal/frags/build_runtime_suid.mk
+++ b/mlocal/frags/build_runtime_suid.mk
@@ -11,7 +11,7 @@ $(starter_suid): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starte
 		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go
 
 $(starter_suid_INSTALL): $(starter_suid)
-	@if [ `id -u` -ne 0 ] ; then \
+	@if [ `id -u` -ne 0 -a -z "${RPM_BUILD_ROOT}" ] ; then \
 		echo "SUID binary requires to execute make install as root, use sudo make install to finish installation"; \
 		exit 1 ; \
 	fi

--- a/mlocal/frags/build_runtime_suid.mk
+++ b/mlocal/frags/build_runtime_suid.mk
@@ -12,7 +12,7 @@ $(starter_suid): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starte
 
 $(starter_suid_INSTALL): $(starter_suid)
 	@if [ `id -u` -ne 0 ] ; then \
-		echo "SUID is useful when running as root only, aborting"; \
+		echo "SUID binary requires to execute make install as root, use sudo make install to finish installation"; \
 		exit 1 ; \
 	fi
 	@echo " INSTALL SUID" $@

--- a/mlocal/frags/build_runtime_suid.mk
+++ b/mlocal/frags/build_runtime_suid.mk
@@ -11,6 +11,10 @@ $(starter_suid): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starte
 		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go
 
 $(starter_suid_INSTALL): $(starter_suid)
+	@if [ `id -u` -ne 0 ] ; then \
+		echo "SUID is useful when running as root only, aborting"; \
+		exit 1 ; \
+	fi
 	@echo " INSTALL SUID" $@
 	$(V)install -d $(@D)
 	$(V)install -m 4755 $(starter_suid) $(starter_suid_INSTALL)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds a small effective uid check during starter installation. If euid is not 0 then this installation doesn't make sense. It is better to abort it then to install with wrong suid bit.

**This fixes or addresses the following GitHub issues:** 

- Fixes #4227

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
