### PR TITLE
Fix #4264 use compatible scs-library-client 0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/sylabs/json-resp v0.5.0
 	github.com/sylabs/scs-build-client v0.0.4
 	github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec
-	github.com/sylabs/scs-library-client v0.4.1
+	github.com/sylabs/scs-library-client v0.4.2
 	github.com/sylabs/sif v1.0.8
 	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e // indirect
 	github.com/urfave/cli v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec h1:dX97dpv
 github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec/go.mod h1:nMF8PplFD5ZmDz//GHjaip7+MlQ0z4Qe0RCzaT5Xjes=
 github.com/sylabs/scs-library-client v0.4.1 h1:D9tMqVBs7M2mTfpGrRlHFxp6iL0Ri9PgrjvuPxmjwb4=
 github.com/sylabs/scs-library-client v0.4.1/go.mod h1:89vH+0RQemCEcOnaUUQwnsRVQQmupVh8VQlBbW0ZHss=
+github.com/sylabs/scs-library-client v0.4.2 h1:h1w37fbphEkWLVjSoh8YLxjTUJ4VZQlJOw0/WHE3YYc=
+github.com/sylabs/scs-library-client v0.4.2/go.mod h1:89vH+0RQemCEcOnaUUQwnsRVQQmupVh8VQlBbW0ZHss=
 github.com/sylabs/sif v1.0.8 h1:BK55XU0UhUsbimCr1Sl1tCLDrFsB71EDYDcHRfPpw8k=
 github.com/sylabs/sif v1.0.8/go.mod h1:/W42wtEREMjfQCNz1HhqD2PHW8ZPqjiU7Z2pZQXTRqI=
 github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e h1:QjF5rxNgRSLHJDwKUvfYP3qOx1vTDzUi/+oSC8FXnCI=

--- a/vendor/github.com/sylabs/scs-library-client/client/push.go
+++ b/vendor/github.com/sylabs/scs-library-client/client/push.go
@@ -284,7 +284,6 @@ func (c *Client) postFileV2(ctx context.Context, r io.Reader, fileSize int64, im
 
 	req.ContentLength = fileSize
 	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("x-amz-meta-client-md5sum", metadata["md5sum"])
 
 	// redirect log output from retryablehttp to our logger
 	l := loggingAdapter{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -329,7 +329,7 @@ github.com/sylabs/json-resp
 github.com/sylabs/scs-build-client/client
 # github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec
 github.com/sylabs/scs-key-client/client
-# github.com/sylabs/scs-library-client v0.4.1
+# github.com/sylabs/scs-library-client v0.4.2
 github.com/sylabs/scs-library-client/client
 # github.com/sylabs/sif v1.0.8
 github.com/sylabs/sif/pkg/siftool


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This fixes #4264 by using scs-library-client 0.4.2 which reverts a
change in that repo which was incompatible with upstream libraries using
the Minio client SDK internally.



**This fixes or addresses the following GitHub issues:**

- Fixes #4264 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)

Attn: @singularity-maintainers
