### PR TITLE
Add root to override paths

### DIFF
--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -247,8 +247,9 @@ func (m *Manager) sync() error {
 			if e == d {
 				path = m.rootPath + p
 				if ovDir, ok := m.ovDirs[p]; ok {
-					if _, err := os.Stat(ovDir); err != nil {
-						path = ovDir
+					ovPath := m.rootPath + ovDir
+					if _, err := os.Stat(ovPath); err != nil {
+						path = ovPath
 					}
 				}
 				break


### PR DESCRIPTION
**Description of the Pull Request (PR):**

In #4198 I first noticed that the override paths being applied did not add on the root path.  @gvallee made issue #4208 about it, but instead of fixing the issue I thought I found @cclerget fixed it in a different way.  I didn't want the issue to be forgotten, so here is a proposed way to fix it.  This code was introduced recently in #3970.

I don't know enough about the problem addressed by #3970 to find a test case to demonstrate a problem that this PR fixes, but hopefully @cclerget will understand.


**This fixes or addresses the following GitHub issues:**

- Fixes #4208


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
