### PR TITLE
Don't warn about inability to create ~/.singularity

### DIFF
--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -196,7 +196,7 @@ func createConfDir(d string) {
 		if os.IsExist(err) {
 			sylog.Debugf("%s already exists. Not creating.", d)
 		} else {
-			sylog.Warningf("Could not create %s: %s", d, err)
+			sylog.Debugf("Could not create %s: %s", d, err)
 		}
 	} else {
 		sylog.Debugf("Created %s", d)


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR changes the warning about not being able to create ~/.singularity into a debug message.  Missing home directories are a common case in batch computing so I don't think it should be a warning.  This was a fatal error in 3.3.0 and recently turned into a warning in #4226.


**This fixes or addresses the following GitHub issues:**

- Fixes #4150


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
