### PR TITLE
Split up encryption material into two flags

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -12,25 +12,25 @@ import (
 
 // actionflags.go contains flag variables for action-like commands to draw from
 var (
-	AppName         string
-	BindPaths       []string
-	HomePath        string
-	OverlayPath     []string
-	ScratchPath     []string
-	WorkdirPath     string
-	PwdPath         string
-	ShellPath       string
-	Hostname        string
-	Network         string
-	NetworkArgs     []string
-	DNS             string
-	Security        []string
-	CgroupsPath     string
-	VMRAM           string
-	VMCPU           string
-	VMIP            string
-	ContainLibsPath []string
-	encryptionKey   string
+	AppName           string
+	BindPaths         []string
+	HomePath          string
+	OverlayPath       []string
+	ScratchPath       []string
+	WorkdirPath       string
+	PwdPath           string
+	ShellPath         string
+	Hostname          string
+	Network           string
+	NetworkArgs       []string
+	DNS               string
+	Security          []string
+	CgroupsPath       string
+	VMRAM             string
+	VMCPU             string
+	VMIP              string
+	ContainLibsPath   []string
+	encryptionPEMPath string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -48,6 +48,7 @@ var (
 	NoNet           bool
 	IsSyOS          bool
 	disableCache    bool
+	EnterPassphrase bool
 
 	NetNamespace  bool
 	UtsNamespace  bool
@@ -295,14 +296,23 @@ var actionContainLibsFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
-// hidden flag to handle SINGULARITY_ENCRYPTION_KEY environment variable
-var commonEncryptFlag = cmdline.Flag{
-	ID:           "actionEncryptionKey",
-	Value:        &encryptionKey,
+// --passphrase
+var actionPassphraseFlag = cmdline.Flag{
+	ID:           "actionEncryptionPassphrase",
+	Value:        &EnterPassphrase,
+	DefaultValue: false,
+	Name:         "passphrase",
+	Usage:        "Enter a passphrase for an encrypted contaner",
+}
+
+// --pem-path
+var actionPEMPathFlag = cmdline.Flag{
+	ID:           "actionEncryptionPEMPath",
+	Value:        &encryptionPEMPath,
 	DefaultValue: "",
-	Name:         "encryption-key",
-	Hidden:       true,
-	EnvKeys:      []string{"ENCRYPTION_KEY"},
+	Name:         "pem-path",
+	Usage:        "Enter an path to a PEM formated RSA key for an encrypted container",
+	EnvKeys:      []string{"ENCRYPTION_PEM_PATH"},
 }
 
 // hidden flags to handle docker credentials
@@ -697,7 +707,8 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&actionDropCapsFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionAllowSetuidFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionPwdFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&commonEncryptFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionPassphraseFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionPEMPathFlag, actionsInstanceCmd...)
 
 	for _, cmd := range actionsCmd {
 		plugin.AddFlagHooks(cmd.Flags())

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -275,11 +275,13 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		// ensure we have decryption material
 		if img.Partitions[0].Type == imgutil.ENCRYPTSQUASHFS {
 			sylog.Debugf("Encrypted container filesystem detected")
-			if encryptionKey == "" {
-				sylog.Fatalf("Trying to run encrypted container without supplying key material for decryption.")
+
+			keyInfo, err := getEncryptionMaterial(cobraCmd)
+			if err != nil {
+				sylog.Fatalf("While handling encryption material: %v", err)
 			}
 
-			plaintextKey, err := crypt.PlaintextKey(encryptionKey, engineConfig.GetImage())
+			plaintextKey, err := crypt.PlaintextKey(keyInfo, engineConfig.GetImage())
 			if err != nil {
 				sylog.Fatalf("Cannot retrieve key from image %s: %+v", engineConfig.GetImage(), err)
 			}

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -248,7 +248,8 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&actionDockerPasswordFlag, BuildCmd)
 	cmdManager.RegisterFlagForCmd(&actionDockerLoginFlag, BuildCmd)
 
-	cmdManager.RegisterFlagForCmd(&commonEncryptFlag, BuildCmd)
+	cmdManager.RegisterFlagForCmd(&actionPassphraseFlag, BuildCmd)
+	cmdManager.RegisterFlagForCmd(&actionPEMPathFlag, BuildCmd)
 }
 
 // BuildCmd represents the build command

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -27,9 +27,11 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/exec"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/internal/pkg/util/user"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/image"
+	"github.com/sylabs/singularity/pkg/util/crypt"
 )
 
 func fakerootExec(cmdArgs []string) {
@@ -191,15 +193,25 @@ func run(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While performing build: %v", err)
 		}
 	} else {
-		// ensure passphrase or key was supplied with encrypt option
-		if encrypt && !cmd.Flags().Lookup("encryption-key").Changed {
-			sylog.Fatalf("Unable to encrypt container, no passphrase or key path specified.")
-		}
 
-		// ensure we do not build an encrypted container if encrypt option is not specified
-		if !encrypt && cmd.Flags().Lookup("encryption-key").Changed {
-			sylog.Warningf("Encryption key environment variable found, but -e was not specified. NOT encrypting container.")
-			encryptionKey = ""
+		var keyInfo *crypt.KeyInfo
+		if encrypt {
+			if os.Getuid() != 0 {
+				sylog.Fatalf("You must be root to build an encrypted container")
+			}
+
+			k, err := getEncryptionMaterial(cmd)
+			if err != nil {
+				sylog.Fatalf("While handling encryption material: %v", err)
+			}
+			keyInfo = &k
+		} else {
+			passphraseFlag := cmd.Flags().Lookup("passphrase")
+			PEMFlag := cmd.Flags().Lookup("pem-path")
+			_, passphraseOK := os.LookupEnv("SINGULARITY_ENCRYPTION_PASSPHRASE")
+			if PEMFlag.Changed || passphraseFlag.Changed || passphraseOK {
+				sylog.Warningf("Encryption related flags/env vars found, but -e was not specified. NOT encrypting container.")
+			}
 		}
 
 		imgCache := getCacheHandle(cache.Config{})
@@ -242,18 +254,18 @@ func run(cmd *cobra.Command, args []string) {
 				Format:    buildFormat,
 				NoCleanUp: noCleanUp,
 				Opts: types.Options{
-					ImgCache:         imgCache,
-					TmpDir:           tmpDir,
-					NoCache:          disableCache,
-					Update:           update,
-					Force:            force,
-					Sections:         sections,
-					NoTest:           noTest,
-					NoHTTPS:          noHTTPS,
-					LibraryURL:       libraryURL,
-					LibraryAuthToken: authToken,
-					DockerAuthConfig: authConf,
-					EncryptionKey:    encryptionKey,
+					ImgCache:          imgCache,
+					TmpDir:            tmpDir,
+					NoCache:           disableCache,
+					Update:            update,
+					Force:             force,
+					Sections:          sections,
+					NoTest:            noTest,
+					NoHTTPS:           noHTTPS,
+					LibraryURL:        libraryURL,
+					LibraryAuthToken:  authToken,
+					DockerAuthConfig:  authConf,
+					EncryptionKeyInfo: keyInfo,
 				},
 			})
 		if err != nil {
@@ -314,4 +326,49 @@ func handleBuildFlags(cmd *cobra.Command) {
 			sylog.Warningf("Unable to get library service URI: %v", err)
 		}
 	}
+}
+
+// getEncryptionMaterial handles the setting of encryption environment and flag parameters to eventually be
+// passed to the crypt package for handling.
+// This handles the SINGULARITY_ENCRYPTION_PASSPHRASE envvar outside of cobra in order to
+// prevent the need to an odd hidden flag since --passphrase is a boolean for an interactive prompt
+func getEncryptionMaterial(cmd *cobra.Command) (crypt.KeyInfo, error) {
+	passphraseFlag := cmd.Flags().Lookup("passphrase")
+	PEMFlag := cmd.Flags().Lookup("pem-path")
+	passphrase, passphraseOK := os.LookupEnv("SINGULARITY_ENCRYPTION_PASSPHRASE")
+
+	// checks for both envvars/flags being set
+	if !PEMFlag.Changed && !(passphraseFlag.Changed || passphraseOK) {
+		sylog.Fatalf("Trying use container encryption without supplying key or passphrase.")
+	}
+
+	if PEMFlag.Changed && (passphraseFlag.Changed || passphraseOK) {
+		sylog.Warningf("Ignoring option for passphrase as key filepath is supplied")
+	}
+
+	// order of precidence:
+	// 1. PEM flag or envvar(Note flag supersedes envvar)
+	// 2. Passphrase envvar
+	// 3. Passphrase flag
+
+	if PEMFlag.Changed {
+		return crypt.KeyInfo{Format: crypt.PEM, Path: encryptionPEMPath}, nil
+	}
+
+	if passphraseOK {
+		return crypt.KeyInfo{Format: crypt.Passphrase, Material: passphrase}, nil
+	}
+
+	if passphraseFlag.Changed {
+		passphrase, err := interactive.AskQuestionNoEcho("Enter encryption passphrase: ")
+		if err != nil {
+			return crypt.KeyInfo{}, err
+		}
+		if passphrase == "" {
+			sylog.Fatalf("Cannot encrypt container with empty passphrase")
+		}
+		return crypt.KeyInfo{Format: crypt.Passphrase, Material: passphrase}, nil
+	}
+
+	return crypt.KeyInfo{}, nil
 }

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -30,7 +30,7 @@ type SIFAssembler struct {
 }
 
 type encryptionOptions struct {
-	keyURI    string
+	keyInfo   crypt.KeyInfo
 	plaintext []byte
 }
 
@@ -108,7 +108,7 @@ func createSIF(path string, definition, ociConf []byte, squashfile string, encOp
 	cinfo.InputDescr = append(cinfo.InputDescr, parinput)
 
 	if encOpts != nil {
-		data, err := crypt.EncryptKey(encOpts.keyURI, encOpts.plaintext)
+		data, err := crypt.EncryptKey(encOpts.keyInfo, encOpts.plaintext)
 		if err != nil {
 			return fmt.Errorf("while encrypting filesystem key: %s", err)
 		}
@@ -183,8 +183,8 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 
 	var encOpts *encryptionOptions
 
-	if b.Opts.EncryptionKey != "" {
-		plaintext, err := crypt.NewPlaintextKey(b.Opts.EncryptionKey)
+	if b.Opts.EncryptionKeyInfo != nil {
+		plaintext, err := crypt.NewPlaintextKey(*b.Opts.EncryptionKeyInfo)
 		if err != nil {
 			return fmt.Errorf("unable to obtain encryption key: %+v", err)
 		}
@@ -204,7 +204,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 		fsPath = loopPath
 
 		encOpts = &encryptionOptions{
-			keyURI:    b.Opts.EncryptionKey,
+			keyInfo:   *b.Opts.EncryptionKeyInfo,
 			plaintext: plaintext,
 		}
 

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -108,8 +108,8 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		}
 
 		s := stage{}
-		if conf.Opts.EncryptionKey != "" {
-			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild", conf.Opts.EncryptionKey)
+		if conf.Opts.EncryptionKeyInfo != nil {
+			s.b, err = types.NewEncryptedBundle(conf.Opts.TmpDir, "sbuild", conf.Opts.EncryptionKeyInfo)
 		} else {
 			s.b, err = types.NewBundle(conf.Opts.TmpDir, "sbuild")
 		}

--- a/pkg/util/crypt/key_test.go
+++ b/pkg/util/crypt/key_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	unsupportedURI = "test://justarandominvaliduri"
-	invalidPem     = "pem://nothing"
+	invalidPemPath = "nothing"
+	testPassphrase = "test"
 )
 
 func TestNewPlaintextKey(t *testing.T) {
@@ -24,29 +24,29 @@ func TestNewPlaintextKey(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		keyURI        string
+		keyInfo       KeyInfo
 		expectedError error
 	}{
 		{
-			name:          "empty URI",
-			keyURI:        "",
-			expectedError: nil,
-		},
-		{
-			name:          "unsupported URI",
-			keyURI:        unsupportedURI,
+			name:          "unknown format",
+			keyInfo:       KeyInfo{Format: Unknown},
 			expectedError: ErrUnsupportedKeyURI,
 		},
 		{
+			name:          "passphrase",
+			keyInfo:       KeyInfo{Format: Passphrase, Material: testPassphrase},
+			expectedError: nil,
+		},
+		{
 			name:          "invalid pem",
-			keyURI:        invalidPem,
+			keyInfo:       KeyInfo{Format: PEM, Path: invalidPemPath},
 			expectedError: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewPlaintextKey(tt.keyURI)
+			_, err := NewPlaintextKey(tt.keyInfo)
 			// We do not always use predefined errors so when dealing with errors, we compare the text associated
 			// to the error.
 			if (err != nil && tt.expectedError != nil && err.Error() != tt.expectedError.Error()) ||
@@ -63,33 +63,33 @@ func TestEncryptKey(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		keyURI        string
+		keyInfo       KeyInfo
 		plaintext     []byte
 		expectedError error
 	}{
 		{
-			name:          "empty URI",
-			keyURI:        "",
-			plaintext:     []byte(""),
-			expectedError: nil,
-		},
-		{
-			name:          "unsupported URI",
-			keyURI:        unsupportedURI,
+			name:          "unknown format",
+			keyInfo:       KeyInfo{Format: Unknown},
 			plaintext:     []byte(""),
 			expectedError: ErrUnsupportedKeyURI,
 		},
 		{
-			name:          "invalid pem",
-			keyURI:        invalidPem,
+			name:          "passphrase",
+			keyInfo:       KeyInfo{Format: Passphrase, Material: testPassphrase},
 			plaintext:     []byte(""),
-			expectedError: errors.Wrap(fmt.Errorf("open : no such file or directory"), "loading public key for key encryption"),
+			expectedError: nil,
+		},
+		{
+			name:          "invalid pem",
+			keyInfo:       KeyInfo{Format: PEM, Path: invalidPemPath},
+			plaintext:     []byte(""),
+			expectedError: errors.Wrap(fmt.Errorf("open nothing: no such file or directory"), "loading public key for key encryption"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := EncryptKey(tt.keyURI, tt.plaintext)
+			_, err := EncryptKey(tt.keyInfo, tt.plaintext)
 			// We do not always use predefined errors so when dealing with errors, we compare the text associated
 			// to the error.
 			if (err != nil && tt.expectedError != nil && err.Error() != tt.expectedError.Error()) ||
@@ -112,29 +112,29 @@ func TestPlaintextKey(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		keyURI        string
+		keyInfo       KeyInfo
 		expectedError error
 	}{
 		{
-			name:          "empty URI",
-			keyURI:        "",
-			expectedError: nil,
-		},
-		{
-			name:          "unsupported URI",
-			keyURI:        unsupportedURI,
+			name:          "unknown format",
+			keyInfo:       KeyInfo{Format: Unknown},
 			expectedError: ErrUnsupportedKeyURI,
 		},
 		{
+			name:          "passphrase",
+			keyInfo:       KeyInfo{Format: Passphrase, Material: testPassphrase},
+			expectedError: nil,
+		},
+		{
 			name:          "invalid pem",
-			keyURI:        invalidPem,
-			expectedError: errors.Wrap(fmt.Errorf("open : no such file or directory"), "loading private key for key decryption"),
+			keyInfo:       KeyInfo{Format: PEM, Path: invalidPemPath},
+			expectedError: errors.Wrap(fmt.Errorf("open nothing: no such file or directory"), "loading private key for key decryption"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := PlaintextKey(tt.keyURI, noimage)
+			_, err := PlaintextKey(tt.keyInfo, noimage)
 			// We do not always use predefined errors so when dealing with errors, we compare the text associated
 			// to the error.
 			if (err != nil && tt.expectedError != nil && err.Error() != tt.expectedError.Error()) ||


### PR DESCRIPTION
This includes changes to the 'crypt' package to accept a struct in its
external functions instead of a URI to avoid ambiguity for passphrases
that may potentially container a '://' and be incorrectly parsed

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #4242 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
