### PR TITLE
Check overlay lower/upper filesystem compatibility for sandbox images

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,3 +34,7 @@ issues:
   max-per-linter: 0
   max-same-issues: 0
 
+  exclude-rules:
+    - path: internal/pkg/util/fs/overlay/
+      linters:
+        - misspell

--- a/internal/pkg/util/fs/overlay/overlay.go
+++ b/internal/pkg/util/fs/overlay/overlay.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package overlay
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// statfs is the function pointing to unix.Statfs and
+// also used by unit tests for mocking.
+var statfs = unix.Statfs
+
+type dir uint8
+
+const (
+	_ dir = iota << 1
+	lowerDir
+	upperDir
+)
+
+type fs struct {
+	name       string
+	overlayDir dir
+}
+
+const (
+	nfs    int64 = 0x6969
+	fuse         = 0x65735546
+	ecrypt       = 0xF15F
+	lustre       = 0x0BD00BD0
+)
+
+var incompatibleFs = map[int64]fs{
+	// NFS filesystem
+	nfs: {
+		name:       "NFS",
+		overlayDir: upperDir,
+	},
+	// FUSE filesystem
+	fuse: {
+		name:       "FUSE",
+		overlayDir: upperDir,
+	},
+	// ECRYPT filesystem
+	ecrypt: {
+		name:       "ECRYPT",
+		overlayDir: lowerDir | upperDir,
+	},
+	// LUSTRE filesystem
+	lustre: {
+		name:       "LUSTRE",
+		overlayDir: lowerDir | upperDir,
+	},
+}
+
+func check(path string, d dir) error {
+	stfs := &unix.Statfs_t{}
+
+	if err := statfs(path, stfs); err != nil {
+		return fmt.Errorf("could not retrieve underlying filesystem information for %s: %s", path, err)
+	}
+
+	fs, ok := incompatibleFs[stfs.Type]
+	if !ok || (ok && fs.overlayDir&d == 0) {
+		return nil
+	}
+
+	return &errIncompatibleFs{
+		path: path,
+		name: fs.name,
+		dir:  d,
+	}
+}
+
+// CheckUpper checks if the underlying filesystem of the
+// provided path can be used as an upper overlay directory.
+func CheckUpper(path string) error {
+	return check(path, upperDir)
+}
+
+// CheckLower checks if the underlying filesystem of the
+// provided path can be used as lower overlay directory.
+func CheckLower(path string) error {
+	return check(path, lowerDir)
+}
+
+type errIncompatibleFs struct {
+	path string
+	name string
+	dir  dir
+}
+
+func (e *errIncompatibleFs) Error() string {
+	overlayDir := "lower"
+	if e.dir == upperDir {
+		overlayDir = "upper"
+	}
+	return fmt.Sprintf(
+		"%s is located on a %s filesystem incompatible as overlay %s directory",
+		e.path, e.name, overlayDir,
+	)
+}
+
+// IsIncompatible returns if the error corresponds to
+// an incompatible filesystem error.
+func IsIncompatible(err error) bool {
+	if _, ok := err.(*errIncompatibleFs); ok {
+		return true
+	}
+	return false
+}

--- a/internal/pkg/util/fs/overlay/overlay_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package overlay
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCheckLowerUpper(t *testing.T) {
+	tests := []struct {
+		name                  string
+		path                  string
+		fsName                string
+		fsType                int64
+		dir                   dir
+		expectedSuccess       bool
+		expectIncompatibleErr bool
+	}{
+		{
+			name:                  "Root filesystem lower",
+			path:                  "/",
+			fsName:                "none",
+			dir:                   lowerDir,
+			expectedSuccess:       true,
+			expectIncompatibleErr: false,
+		},
+		{
+			name:                  "Root filesystem upper",
+			path:                  "/",
+			fsName:                "none",
+			dir:                   upperDir,
+			expectedSuccess:       true,
+			expectIncompatibleErr: false,
+		},
+		{
+			name:                  "Non existent path lower",
+			path:                  "/non/existent/path",
+			fsName:                "none",
+			dir:                   lowerDir,
+			expectedSuccess:       false,
+			expectIncompatibleErr: false,
+		},
+		{
+			name:                  "Non existent path upper",
+			path:                  "/non/existent/path",
+			fsName:                "none",
+			dir:                   upperDir,
+			expectedSuccess:       false,
+			expectIncompatibleErr: false,
+		},
+		{
+			name:                  "NFS mock lower",
+			path:                  "/",
+			fsName:                "NFS",
+			dir:                   lowerDir,
+			fsType:                nfs,
+			expectedSuccess:       true,
+			expectIncompatibleErr: false,
+		},
+		{
+			name:                  "NFS mock upper",
+			path:                  "/",
+			fsName:                "NFS",
+			dir:                   upperDir,
+			fsType:                nfs,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "FUSE mock lower",
+			path:                  "/",
+			fsName:                "FUSE",
+			dir:                   lowerDir,
+			fsType:                fuse,
+			expectedSuccess:       true,
+			expectIncompatibleErr: false,
+		},
+		{
+			name:                  "FUSE mock upper",
+			path:                  "/",
+			fsName:                "FUSE",
+			dir:                   upperDir,
+			fsType:                fuse,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "ECRYPT mock lower",
+			path:                  "/",
+			fsName:                "ECRYPT",
+			dir:                   lowerDir,
+			fsType:                ecrypt,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "ECRYPT mock upper",
+			path:                  "/",
+			fsName:                "ECRYPT",
+			dir:                   upperDir,
+			fsType:                ecrypt,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "LUSTRE mock lower",
+			path:                  "/",
+			fsName:                "LUSTRE",
+			dir:                   lowerDir,
+			fsType:                lustre,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "LUSTRE mock upper",
+			path:                  "/",
+			fsName:                "LUSTRE",
+			dir:                   upperDir,
+			fsType:                lustre,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+	}
+
+	if IsIncompatible(nil) {
+		t.Errorf("IsIncompatible with nil error returned true")
+	}
+
+	for _, tt := range tests {
+		var err error
+
+		// mock statfs
+		if tt.fsType > 0 {
+			statfs = func(path string, st *unix.Statfs_t) error {
+				st.Type = tt.fsType
+				return nil
+			}
+		} else {
+			statfs = unix.Statfs
+		}
+
+		switch tt.dir {
+		case lowerDir:
+			err = CheckLower(tt.path)
+		case upperDir:
+			err = CheckUpper(tt.path)
+		}
+
+		if err != nil && tt.expectedSuccess {
+			t.Errorf("unexpected error for %q: %s", tt.name, err)
+		} else if err == nil && !tt.expectedSuccess {
+			t.Errorf("unexpected success for %q", tt.name)
+		} else if err != nil && !tt.expectedSuccess {
+			if !tt.expectIncompatibleErr {
+				continue
+			}
+			expectedError := &errIncompatibleFs{
+				path: tt.path,
+				name: tt.fsName,
+				dir:  tt.dir,
+			}
+			if IsIncompatible(err) {
+				if expectedError.Error() == err.Error() {
+					continue
+				}
+			}
+			t.Errorf("unexpected error for %q: %q instead of %q", tt.name, err, expectedError)
+		} else if err == nil && tt.expectedSuccess {
+			// test PASS without error
+		}
+	}
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Some filesystems are not compatible either with lower or upper overlay directories or both, this PR adds a package easing detection for those filesystems. This PR also adds an automatic fallback in runtime to use underlay if the sandbox image is on a filesystem incompatible with overlay.

**This fixes or addresses the following GitHub issues:**

- Fixes #4035
- Fixes #3977
- Fixes #3887


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
