### PR TITLE
e2e: Ignore nil SingularityCmdResultOp in ExpectExit to avoid panic

### DIFF
--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -393,7 +393,9 @@ func ExpectExit(code int, resultOps ...SingularityCmdResultOp) SingularityCmdOp 
 		}
 
 		for _, op := range resultOps {
-			op(t, r)
+			if op != nil {
+				op(t, r)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Actually we can't pass a nil `SingularityCmdResultOp` function pointer in `ExpectExit` without panic, this PR just add a check to ignore nil function pointer, may be useful for some tests table which need to mix between output/error check and/or just exit code check.

**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
