### PR TITLE
Add e2e test for building encrypted containers with PEM file

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -818,7 +818,7 @@ func (c *imgBuildTests) buildEncryptPemFile(t *testing.T) {
 
 	// First with the command line argument
 	imgPath1 := filepath.Join(tempDir, "encrypted_cmdline_option.sif")
-	cmdArgs := []string{"-e", "--pem-path", pemFile, imgPath1, "library://alpine:latest"}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemFile, imgPath1, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
@@ -837,7 +837,7 @@ func (c *imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	// Second with the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PEM_PATH", pemFile)
 	imgPath2 := filepath.Join(tempDir, "encrypted_env_var.sif")
-	cmdArgs = []string{"-e", imgPath2, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", imgPath2, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
@@ -883,7 +883,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 		e2e.ConsoleSendLine(passphrase),
 	}
 	imgPath1 := filepath.Join(tempDir, "encrypted_cmdline_option.sif")
-	cmdArgs := []string{"-e", "--passphrase", imgPath1, "library://alpine:latest"}
+	cmdArgs := []string{"--encrypt", "--passphrase", imgPath1, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
@@ -903,7 +903,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// Second with the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PASSPHRASE", passphrase)
 	imgPath2 := filepath.Join(tempDir, "encrypted_env_var.sif")
-	cmdArgs = []string{"-e", imgPath2, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", imgPath2, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),
@@ -922,7 +922,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 	// Finally a test that must fail: try to specify the passphrase on the command line
 	imgPath3 := filepath.Join(tempDir, "dummy_encrypted_env_var.sif")
-	cmdArgs = []string{"-e", "--passphrase", passphrase, imgPath3, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", "--passphrase", passphrase, imgPath3, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.WithCommand("build"),

--- a/pkg/util/crypt/rsa.go
+++ b/pkg/util/crypt/rsa.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package crypt
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+)
+
+const (
+	// DefaultKeySize is the default size of the key that is used when a
+	// size is not explicitly specified
+	DefaultKeySize = 2048
+)
+
+// GenerateRSAKey creates a new RSA key of length keySize.
+func GenerateRSAKey(keySize int) (*rsa.PrivateKey, error) {
+	reader := rand.Reader
+
+	if keySize == 0 {
+		keySize = DefaultKeySize
+	}
+
+	key, err := rsa.GenerateKey(reader, keySize)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate RSA key: %v", err)
+	}
+
+	return key, nil
+}
+
+// publicPEM generates a new PEM public key based on a RSA key
+func publicPEM(key *rsa.PrivateKey) (string, error) {
+	var buf bytes.Buffer
+
+	if key == nil {
+		return "", errors.New("cannot encode nil key")
+	}
+
+	err := key.Validate()
+	if err != nil {
+		return "", fmt.Errorf("cannot encode invalid key: %v", err)
+	}
+
+	asn1Bytes, err := asn1.Marshal(key.PublicKey)
+	if err != nil {
+		return "", fmt.Errorf("unable to encode public key: %v", err)
+	}
+
+	var pemkey = &pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: asn1Bytes,
+	}
+
+	err = pem.Encode(&buf, pemkey)
+	if err != nil {
+		return "", fmt.Errorf("error encoding key: %v", err)
+	}
+
+	return buf.String(), nil
+}
+
+// SavePublicPEM saves a public PEM key into a file.
+func SavePublicPEM(fileName string, key *rsa.PrivateKey) error {
+	pem, err := publicPEM(key)
+	if err != nil {
+		return err
+	}
+
+	pemfile, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("unable to create key file: %v", err)
+	}
+	defer pemfile.Close()
+
+	_, err = pemfile.WriteString(pem)
+	if err != nil {
+		return fmt.Errorf("error writing key to file: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Add e2e test for building encrypted containers with PEM file.
- Add a e2e test to capture an invalid case where a user tries to specify a passphrase from the command line.

The overall goal is to capture all the `build` commands that are about to be added to the user documentation.

**This fixes or addresses the following GitHub issues:**

- Addresses #4253 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers