### PR TITLE
Fail if trying to push to a unsupported transport type

### DIFF
--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -94,6 +94,8 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")
+		default:
+			sylog.Fatalf("Unsupported transport type: %s", transport)
 		}
 	},
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes the issue when trying to push a image to a unsupported transport.

### This fixes or addresses the following GitHub issues:

- Fixes #4296

<br>
