### PR TITLE
Add e2e tests for the run command of encrypted containers

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -830,12 +830,13 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 		expectedStderr = ""
 	}
 
-	// First with the command line argument
+	// First with the command line argument, only using --passphrase
 	passphraseInput := []e2e.SingularityConsoleOp{
 		e2e.ConsoleSendLine(e2e.Passphrase),
 	}
-	imgPath1 := filepath.Join(tempDir, "encrypted_cmdline_option.sif")
-	cmdArgs := []string{"--passphrase", imgPath1, "library://alpine:latest"}
+	cmdlineTestImgPath := filepath.Join(tempDir, "encrypted_cmdline_option.sif")
+	// The image is deleted during cleanup of the tempdir
+	cmdArgs := []string{"--passphrase", cmdlineTestImgPath, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("passphrase flag"),
@@ -850,15 +851,12 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	)
 	// If the command was supposed to succeed, we check the image
 	if expectedExitCode == 0 {
-		c.ensureImageIsEncrypted(t, imgPath1)
-	}
-	err = os.Remove(imgPath1)
-	if err != nil {
-		t.Fatalf("failed to delete image: %s", err)
+		c.ensureImageIsEncrypted(t, cmdlineTestImgPath)
 	}
 
-	// First with the command line argument
-	cmdArgs = []string{"--encrypt", "--passphrase", imgPath1, "library://alpine:latest"}
+	// With the command line argument, using --encrypt and --passphrase
+	cmdlineTest2ImgPath := filepath.Join(tempDir, "encrypted_cmdline2_option.sif")
+	cmdArgs = []string{"--encrypt", "--passphrase", cmdlineTest2ImgPath, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("encrypt and passphrase flags"),
@@ -873,13 +871,13 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	)
 	// If the command was supposed to succeed, we check the image
 	if expectedExitCode == 0 {
-		c.ensureImageIsEncrypted(t, imgPath1)
+		c.ensureImageIsEncrypted(t, cmdlineTest2ImgPath)
 	}
 
-	// Second with the environment variable
+	// With the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PASSPHRASE", e2e.Passphrase)
-	imgPath2 := filepath.Join(tempDir, "encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", imgPath2, "library://alpine:latest"}
+	envvarImgPath := filepath.Join(tempDir, "encrypted_env_var.sif")
+	cmdArgs = []string{"--encrypt", envvarImgPath, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("passphrase env var"),
@@ -894,12 +892,12 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	)
 	// If the command was supposed to succeed, we check the image
 	if expectedExitCode == 0 {
-		c.ensureImageIsEncrypted(t, imgPath2)
+		c.ensureImageIsEncrypted(t, envvarImgPath)
 	}
 
 	// Finally a test that must fail: try to specify the passphrase on the command line
-	imgPath3 := filepath.Join(tempDir, "dummy_encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, imgPath3, "library://alpine:latest"}
+	dummyImgPath := filepath.Join(tempDir, "dummy_encrypted_env_var.sif")
+	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, dummyImgPath, "library://alpine:latest"}
 	c.env.RunSingularity(
 		t,
 		e2e.AsSubtest("passphrase on cmdline"),

--- a/e2e/internal/e2e/encrypt.go
+++ b/e2e/internal/e2e/encrypt.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/util/bin"
+	"github.com/sylabs/singularity/pkg/util/crypt"
+)
+
+const (
+	// Passphrase used for passphrase-based encryption tests
+	Passphrase = "e2e-passphrase"
+)
+
+// CheckCryptsetupVersion checks the version of cryptsetup and returns
+// an error if the version is not compatible; nil otherwise
+func CheckCryptsetupVersion() error {
+	cryptsetup, err := bin.Cryptsetup()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(cryptsetup, "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run cryptsetup --version: %s", err)
+	}
+
+	if !strings.Contains(string(out), "cryptsetup 2.") {
+		return fmt.Errorf("incompatible cryptsetup version")
+	}
+
+	return nil
+}
+
+// GeneratePemFile creates a new PEM file for testing purposes.
+func GeneratePemFiles(t *testing.T, basedir string) (string, string) {
+	// Temporary file to save the PEM public file. The caller is in charge of cleanup
+	tempPemPubFile, err := ioutil.TempFile(basedir, "pem-pub-")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %s", err)
+	}
+	tempPemPubFile.Close()
+
+	// Temporary file to save the PEM file. The caller is in charge of cleanup
+	tempPemPrivFile, err := ioutil.TempFile(basedir, "pem-priv-")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %s", err)
+	}
+	tempPemPrivFile.Close()
+
+	rsaKey, err := crypt.GenerateRSAKey(2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %s", err)
+	}
+
+	err = crypt.SavePublicPEM(tempPemPubFile.Name(), rsaKey)
+	if err != nil {
+		t.Fatalf("failed to generate PEM public file: %s", err)
+	}
+
+	err = crypt.SavePrivatePEM(tempPemPrivFile.Name(), rsaKey)
+	if err != nil {
+		t.Fatalf("failed to generate PEM private file: %s", err)
+	}
+
+	return tempPemPubFile.Name(), tempPemPrivFile.Name()
+}

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -147,7 +147,7 @@ func (c *ctx) testRunPassphraseEncrypted(t *testing.T) {
 		e2e.WithArgs(cmdArgs...),
 		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
 		e2e.ExpectExit(
-			0,
+			expectedExitCode,
 			e2e.ExpectError(e2e.ContainMatch, expectedStderr),
 		),
 	)

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -6,6 +6,7 @@
 package run
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -51,6 +52,121 @@ func (c *ctx) testRun555Cache(t *testing.T) {
 	)
 }
 
+func (c *ctx) testRunPEMEncrypted(t *testing.T) {
+	// If the version of cryptsetup is not compatible with Singularity encryption,
+	// the build commands are expected to fail
+	err := e2e.CheckCryptsetupVersion()
+	if err != nil {
+		t.Skip("cryptsetup is not compatible, skipping test")
+	}
+
+	// It is too complicated right now to deal with a PEM file, the Sylabs infrastructure
+	// does not let us attach one to a image in the library, so we generate one.
+	pemPubFile, pemPrivFile := e2e.GeneratePemFiles(t, c.env.TestDir)
+
+	// We create a temporary directory to store the image, making sure tests
+	// will not pollute each other
+	tempDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
+	defer cleanup(t)
+
+	imgPath := filepath.Join(tempDir, "encrypted_cmdline_option.sif")
+	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, "library://alpine:latest"}
+	c.env.RunSingularity(
+		t,
+		e2e.WithCommand("build"),
+		e2e.WithPrivileges(true),
+		e2e.WithArgs(cmdArgs...),
+		e2e.ExpectExit(0),
+	)
+
+	// Using command line
+	cmdArgs = []string{"--pem-path", pemPrivFile, imgPath}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("pem file cmdline"),
+		e2e.WithCommand("run"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.ExpectExit(0),
+	)
+
+	// Using environment variable
+	cmdArgs = []string{imgPath}
+	pemEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PEM_PATH", pemPrivFile)
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("pem file cmdline"),
+		e2e.WithCommand("run"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.WithEnv(append(os.Environ(), pemEnvVar)),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c *ctx) testRunPassphraseEncrypted(t *testing.T) {
+	// Expected results for a successful command execution
+	expectedExitCode := 0
+	expectedStderr := ""
+
+	passphraseEncryptedURL := "library://vallee/default/passphrase_encrypted_alpine"
+	passphraseEncryptedFingerprint := "sha256.e784d01b94e4b5a42d9e9b54bc2c0400630604bb896de1e65d8c77e25ca5b5e7"
+	passphraseInput := []e2e.SingularityConsoleOp{
+		e2e.ConsoleSendLine(e2e.Passphrase),
+	}
+
+	// If the version of cryptsetup is not compatible with Singularity encryption,
+	// the build commands are expected to fail
+	err := e2e.CheckCryptsetupVersion()
+	if err != nil {
+		expectedExitCode = 255
+		// todo: fix the problen with catching stderr, until then we do not do a real check
+		//expectedStderr = "FATAL:   While performing build: unable to encrypt filesystem at /tmp/sbuild-718337349/squashfs-770818633: available cryptsetup is not supported"
+		expectedStderr = ""
+	}
+
+	// Interactive command
+	cmdArgs := []string{"--passphrase", passphraseEncryptedURL + ":" + passphraseEncryptedFingerprint}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("interactive passphrase"),
+		e2e.WithCommand("run"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.ConsoleRun(passphraseInput...),
+		e2e.ExpectExit(
+			expectedExitCode,
+			e2e.ExpectError(e2e.ContainMatch, expectedStderr),
+		),
+	)
+
+	// Using the environment variable to specify the passphrase
+	passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PASSPHRASE", e2e.Passphrase)
+	cmdArgs = []string{passphraseEncryptedURL + ":" + passphraseEncryptedFingerprint}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("env var passphrase"),
+		e2e.WithCommand("run"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectError(e2e.ContainMatch, expectedStderr),
+		),
+	)
+
+	// Specifying the passphrase on the command line should always fail
+	cmdArgs = []string{"--passphrase", e2e.Passphrase, passphraseEncryptedURL + ":" + passphraseEncryptedFingerprint}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("passphrase on cmdline"),
+		e2e.WithCommand("run"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
+		e2e.ExpectExit(
+			255,
+			e2e.ExpectError(e2e.ContainMatch, expectedStderr),
+		),
+	)
+}
+
 // RunE2ETests is the main func to trigger the test suite
 func CmdE2ETests(env e2e.TestEnv) func(*testing.T) {
 	c := &ctx{
@@ -59,5 +175,7 @@ func CmdE2ETests(env e2e.TestEnv) func(*testing.T) {
 
 	return func(t *testing.T) {
 		t.Run("run555cache", c.testRun555Cache)
+		t.Run("runPassphraseEncrypted", c.testRunPassphraseEncrypted)
+		t.Run("runPEMEncrypted", c.testRunPEMEncrypted)
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- Add e2e test for the `run` command with encrypted containers (both passphrase and PEM-file encrypted).
- Update the code for the handling of RSA and PEM secrets.
- Add a new utility file for e2e tests targeting encryption.
- A few update to the `build` e2e tests to reflect code changes and make sure an error case actually fails.

**This fixes or addresses the following GitHub issues:**

- Addresses #4253

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers