### PR TITLE
Clean up abandoned files in /tmp

### DIFF
--- a/internal/pkg/build/assemblers/assembler_sandbox_test.go
+++ b/internal/pkg/build/assemblers/assembler_sandbox_test.go
@@ -29,8 +29,9 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 
 	b, err := types.NewBundle("", "sbuild-sandboxAssembler")
 	if err != nil {
-		return
+		t.Fatalf("unable to make bundle: %v", err)
 	}
+	defer os.RemoveAll(b.Path)
 
 	b.Recipe, err = types.NewDefinitionFromURI(assemblerDockerURI)
 	if err != nil {
@@ -76,8 +77,9 @@ func TestSandboxAssemblerShub(t *testing.T) {
 
 	b, err := types.NewBundle("", "sbuild-sandboxAssembler")
 	if err != nil {
-		return
+		t.Fatalf("unable to make bundle: %v", err)
 	}
+	defer os.RemoveAll(b.Path)
 
 	b.Recipe, err = types.NewDefinitionFromURI(assemblerShubURI)
 	if err != nil {

--- a/internal/pkg/build/assemblers/assembler_sif.go
+++ b/internal/pkg/build/assemblers/assembler_sif.go
@@ -200,6 +200,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 		if err != nil {
 			return fmt.Errorf("unable to encrypt filesystem at %s: %+v", fsPath, err)
 		}
+		defer os.Remove(loopPath)
 
 		fsPath = loopPath
 

--- a/internal/pkg/build/assemblers/assembler_sif_test.go
+++ b/internal/pkg/build/assemblers/assembler_sif_test.go
@@ -46,6 +46,7 @@ func TestSIFAssemblerDocker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make bundle: %v", err)
 	}
+	defer os.RemoveAll(b.Path)
 
 	b.Recipe, err = types.NewDefinitionFromURI(assemblerDockerURI)
 	if err != nil {
@@ -100,6 +101,7 @@ func TestSIFAssemblerShub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make bundle: %v", err)
 	}
+	defer os.RemoveAll(b.Path)
 
 	b.Recipe, err = types.NewDefinitionFromURI(assemblerShubURI)
 	if err != nil {

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -70,7 +70,7 @@ func TestMakeParentDir(t *testing.T) {
 			defer os.RemoveAll(dir)
 
 			// concatenate test path with directory, do not use a join function so that we do not remove a trailing slash
-			path := dir + tt.path
+			path := dir + "/" + tt.path
 			if err := makeParentDir(path, tt.srcNum); err != nil {
 				t.Errorf("")
 			}
@@ -161,10 +161,11 @@ func TestCopyFile(t *testing.T) {
 
 func TestCopyDir(t *testing.T) {
 	// create tmpdir
-	dir, err := ioutil.TempDir("", "copy-test-src")
+	dir, err := ioutil.TempDir("", "copy-test-src-")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(dir)
 
 	// prep src dir to copy
 	srcDir := filepath.Join(dir, "sourceDir")
@@ -231,6 +232,7 @@ func TestCopyFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(dir)
 
 	tests := []struct {
 		name string

--- a/internal/pkg/client/cache/dir_test.go
+++ b/internal/pkg/client/cache/dir_test.go
@@ -139,6 +139,10 @@ func TestRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// drop priv within go routine running this test
+			// in order to clean up cache directories without priv
+			test.DropPrivilege(t)
+			defer test.ResetPrivilege(t)
 			imgCache, err := NewHandle(Config{BaseDir: tt.basedir})
 			if err != nil {
 				t.Fatalf("failed to create new image cache: %s", err)

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -346,7 +346,7 @@ func TestCopyFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
 
 	source := filepath.Join(tmpDir, "source")
 	err = ioutil.WriteFile(source, testData, 0644)

--- a/pkg/image/ext3_test.go
+++ b/pkg/image/ext3_test.go
@@ -121,6 +121,7 @@ func TestCheckExt3Header(t *testing.T) {
 		t.Fatal("impossible to load image for testing")
 	}
 	defer img.Close()
+	defer os.Remove(path)
 
 	n, err := img.Read(b)
 	if err != nil || n != bufferSize {

--- a/pkg/image/squashfs_test.go
+++ b/pkg/image/squashfs_test.go
@@ -104,6 +104,7 @@ func TestSquashfsInitializer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("impossible to create temporary directory: %s\n", err)
 	}
+	defer os.RemoveAll(invalidPath)
 	img.File, err = os.Open(invalidPath)
 	if err != nil {
 		t.Fatalf("open() failed: %s\n", err)

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -549,6 +549,7 @@ func TestGenKeyPair(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temporary directory")
 	}
+	defer os.RemoveAll(dir)
 
 	keyring := NewHandle(dir)
 

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -100,6 +100,8 @@ func checkCryptsetupVersion(cryptsetup string) error {
 // EncryptFilesystem takes the path to a file containing a non-encrypted
 // filesystem, encrypts it using the provided key, and returns a path to
 // a file that can be later used as an encrypted volume with cryptsetup.
+// NOTE: it is the callers responsibility to remove the returned file that
+// contains the crypt header.
 func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) {
 	f, err := os.Stat(path)
 	if err != nil {

--- a/pkg/util/crypt/crypt_dev_test.go
+++ b/pkg/util/crypt/crypt_dev_test.go
@@ -111,6 +111,7 @@ func TestEncrypt(t *testing.T) {
 					t.Fatalf("test %s expected to succeed but failed: %s", tt.name, err)
 				}
 			}
+			defer os.Remove(devPath)
 
 			if !tt.shallPass && err == nil {
 				t.Fatalf("test %s expected to fail but succeeded", tt.name)


### PR DESCRIPTION
These changes are only within the context of unit tests with the
exception of a change to the SIF assembler to clean up a left over file
from building encrypted containers.

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
