### PR TITLE
Add go-generate script

### DIFF
--- a/mlocal/frags/build_scripts.mk
+++ b/mlocal/frags/build_scripts.mk
@@ -11,3 +11,17 @@ $(SOURCEDIR)/scripts/go-test: $(SOURCEDIR)/scripts/go-test.in $(SOURCEDIR)/scrip
 	$(V) chmod +x $@
 
 ALL += $(SOURCEDIR)/scripts/go-test
+
+# go-generate script
+$(SOURCEDIR)/scripts/go-generate: export BUILDDIR := $(BUILDDIR_ABSPATH)
+$(SOURCEDIR)/scripts/go-generate: export GO := $(GO)
+$(SOURCEDIR)/scripts/go-generate: export GO111MODULE := $(GO111MODULE)
+$(SOURCEDIR)/scripts/go-generate: export GOFLAGS := $(GOFLAGS)
+$(SOURCEDIR)/scripts/go-generate: export GO_TAGS := $(GO_TAGS)
+$(SOURCEDIR)/scripts/go-generate: $(SOURCEDIR)/scripts/go-generate.in $(SOURCEDIR)/scripts/expand-env.go
+	@echo ' GEN $@'
+	$(V) $(GO) $(GO_MODFLAGS) run $(SOURCEDIR)/scripts/expand-env.go < $< > $@
+	$(V) chmod +x $@
+
+ALL += $(SOURCEDIR)/scripts/go-generate
+

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,2 @@
+go-generate
 go-test

--- a/scripts/go-generate.in
+++ b/scripts/go-generate.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export BUILDDIR='@BUILDDIR@'
+export GO111MODULE='@GO111MODULE@'
+export GO_BUILD_TAGS='@GO_TAGS@'
+export GOFLAGS='@GOFLAGS@'
+
+exec '@GO@' generate \
+	-tags '@GO_TAGS@' \
+	"$@"


### PR DESCRIPTION
Add a scripts/go-generate script in the same vein as go-test to make
sure that we use the same build flags as when building singularity
itself.

The script can later be used to generate the Go code _before_ building
singularity, which allows us to run the code linter before building
singularity (otherwise the linter fails because of missing files).

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
