### PR TITLE
Pass -v to go test

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -34,7 +34,9 @@ dist:
 .PHONY: unit-test
 unit-test:
 	@echo " TEST sudo go test [unit]"
-	$(V)cd $(SOURCEDIR) && sudo -E scripts/go-test \
+	$(V)cd $(SOURCEDIR) && \
+		sudo -E \
+		scripts/go-test -v \
 		`$(GO) list ./... | grep -v "cmd/singularity\|pkg/network\|e2e"`
 	@echo "       PASS"
 
@@ -48,7 +50,10 @@ e2e-test:
 .PHONY: integration-test
 integration-test:
 	@echo " TEST sudo go test [integration]"
-	$(V)cd $(SOURCEDIR) && sudo -E scripts/go-test ./cmd/singularity ./pkg/network
+	$(V)cd $(SOURCEDIR) && \
+		sudo -E \
+		scripts/go-test -v \
+		./cmd/singularity ./pkg/network
 	@echo "       PASS"
 
 .PHONY: test
@@ -56,7 +61,10 @@ test:
 	@echo " TEST sudo go test [all]"
 	$(V)M=0; eval 'while [ $$M -le 20 ]; do sleep 60; M=`expr $$M + 1`; echo "Still testing ($$M) ..."; done &' ; \
     	trap "kill $$! || true" 0; \
-		cd $(SOURCEDIR) && sudo -E scripts/go-test ./...
+		cd $(SOURCEDIR) && \
+		sudo -E \
+		scripts/go-test -v \
+		./...
 	@echo "       PASS"
 
 .PHONY: testall


### PR DESCRIPTION
Pass -v flag in all cases where we use go test in order to log the
output of tests (some of them are emitting warnings, others are printing
out debug messages related to anomalous situations, etc).

This should make it a little easier to debug some cases.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
