### PR TITLE
Fix cli to use pem path envvar

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -375,13 +375,13 @@ func getEncryptionMaterial(cmd *cobra.Command) (crypt.KeyInfo, error) {
 	}
 
 	if pemPathEnvOK {
-		exists, err := fs.FileExists(encryptionPEMPath)
+		exists, err := fs.FileExists(pemPathEnv)
 		if err != nil {
-			sylog.Fatalf("Unable to verify existence of %s: %v", encryptionPEMPath, err)
+			sylog.Fatalf("Unable to verify existence of %s: %v", pemPathEnv, err)
 		}
 
 		if !exists {
-			sylog.Fatalf("Specified PEM file %s: does not exist.", encryptionPEMPath)
+			sylog.Fatalf("Specified PEM file %s: does not exist.", pemPathEnv)
 		}
 
 		sylog.Verbosef("Using pem path environment variable for encrypted container")


### PR DESCRIPTION
Fixes issue where CLI will only use --pem-path flag variable instead of
envvar variable

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>


**This fixes or addresses the following issue:**

```
$ sudo SINGULARITY_ENCRYPTION_PEM_PATH=ssh.pub singularity build -e test.sif library://alpine
FATAL:   Specified PEM file : does not exist.
```
to be 

```
sudo SINGULARITY_ENCRYPTION_PEM_PATH=ssh.pub singularity build -e test.sif library://alpine
INFO:    Starting build...
INFO:    Creating SIF file...
INFO:    Build complete: test.sif
```

Cc: @GodloveD 