### PR TITLE
Fix fakeroot build with pacstrap and debootstrap

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
+	"github.com/sylabs/singularity/pkg/util/namespaces"
 )
 
 const (
@@ -83,6 +84,17 @@ func (cp *ArchConveyorPacker) Get(b *types.Bundle) (err error) {
 	pacConf, err := cp.getPacConf(pacmanConfURL)
 	if err != nil {
 		return fmt.Errorf("while getting pacman config: %v", err)
+	}
+
+	insideUserNs, setgroupsAllowed := namespaces.IsInsideUserNamespace(os.Getpid())
+	if insideUserNs && setgroupsAllowed {
+		umountFn, err := cp.prepareFakerootEnv()
+		if umountFn != nil {
+			defer umountFn()
+		}
+		if err != nil {
+			return fmt.Errorf("while preparing fakeroot build environment: %s", err)
+		}
 	}
 
 	args := []string{"-C", pacConf, "-c", "-d", "-G", "-M", cp.b.RootfsPath, "haveged"}

--- a/internal/pkg/build/sources/conveyorPacker_arch_linux.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_linux.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sources
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
+)
+
+// prepareFakerootEnv prepares a build environment to
+// make fakeroot working with pacstrap.
+func (cp *ArchConveyorPacker) prepareFakerootEnv() (func(), error) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		return nil, fmt.Errorf("while searching true command: %s", err)
+	}
+	mountPath, err := exec.LookPath("mount")
+	if err != nil {
+		return nil, fmt.Errorf("while searching mount command: %s", err)
+	}
+	umountPath, err := exec.LookPath("umount")
+	if err != nil {
+		return nil, fmt.Errorf("while searching umount command: %s", err)
+	}
+
+	devs := []string{
+		"/dev/null",
+		"/dev/random",
+		"/dev/urandom",
+		"/dev/zero",
+	}
+
+	devPath := filepath.Join(cp.b.RootfsPath, "dev")
+	if err := os.Mkdir(devPath, 0755); err != nil {
+		return nil, fmt.Errorf("while creating %s: %s", devPath, err)
+	}
+	procPath := filepath.Join(cp.b.RootfsPath, "proc")
+	if err := os.Mkdir(procPath, 0755); err != nil {
+		return nil, fmt.Errorf("while creating %s: %s", procPath, err)
+	}
+
+	umountFn := func() {
+		syscall.Unmount(mountPath, syscall.MNT_DETACH)
+		syscall.Unmount(umountPath, syscall.MNT_DETACH)
+		syscall.Unmount(procPath, syscall.MNT_DETACH)
+		for _, d := range devs {
+			path := filepath.Join(cp.b.RootfsPath, d)
+			syscall.Unmount(path, syscall.MNT_DETACH)
+		}
+	}
+
+	// bind /bin/true on top of mount/umount command so
+	// pacstrap wouldn't fail while preparing chroot
+	// environment
+	if err := syscall.Mount(truePath, mountPath, "", syscall.MS_BIND, ""); err != nil {
+		return umountFn, fmt.Errorf("while mounting %s to %s: %s", truePath, mountPath, err)
+	}
+	if err := syscall.Mount(truePath, umountPath, "", syscall.MS_BIND, ""); err != nil {
+		return umountFn, fmt.Errorf("while mounting %s to %s: %s", truePath, umountPath, err)
+	}
+	if err := syscall.Mount("/proc", procPath, "", syscall.MS_BIND, ""); err != nil {
+		return umountFn, fmt.Errorf("while mounting /proc to %s: %s", procPath, err)
+	}
+
+	// mount required block devices
+	for _, p := range devs {
+		rootfsPath := filepath.Join(cp.b.RootfsPath, p)
+		if err := fs.Touch(rootfsPath); err != nil {
+			return umountFn, fmt.Errorf("while creating %s: %s", rootfsPath, err)
+		}
+		if err := syscall.Mount(p, rootfsPath, "", syscall.MS_BIND, ""); err != nil {
+			return umountFn, fmt.Errorf("while mounting %s to %s: %s", p, rootfsPath, err)
+		}
+	}
+
+	return umountFn, nil
+}

--- a/internal/pkg/build/sources/conveyorPacker_arch_unsupported.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_unsupported.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package sources
+
+import "fmt"
+
+func (cp *ArchConveyorPacker) prepareFakerootEnv() (func(), error) {
+	return nil, fmt.Errorf("fakeroot not supported on this platform")
+}

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_linux.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_linux.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sources
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
+)
+
+// prepareFakerootEnv prepares a build environment to
+// make fakeroot working with debootstrap.
+func (cp *DebootstrapConveyorPacker) prepareFakerootEnv() (func(), error) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		return nil, fmt.Errorf("while searching true command: %s", err)
+	}
+	mountPath, err := exec.LookPath("mount")
+	if err != nil {
+		return nil, fmt.Errorf("while searching mount command: %s", err)
+	}
+	mknodPath, err := exec.LookPath("mknod")
+	if err != nil {
+		return nil, fmt.Errorf("while searching mknod command: %s", err)
+	}
+
+	procFsPath := "/proc/filesystems"
+
+	devs := []string{
+		"/dev/null",
+		"/dev/random",
+		"/dev/urandom",
+		"/dev/zero",
+	}
+
+	devPath := filepath.Join(cp.b.RootfsPath, "dev")
+	if err := os.Mkdir(devPath, 0755); err != nil {
+		return nil, fmt.Errorf("while creating %s: %s", devPath, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	umountFn := func() {
+		cancel()
+
+		syscall.Unmount(mountPath, syscall.MNT_DETACH)
+		syscall.Unmount(mknodPath, syscall.MNT_DETACH)
+		for _, d := range devs {
+			path := filepath.Join(cp.b.RootfsPath, d)
+			syscall.Unmount(path, syscall.MNT_DETACH)
+		}
+	}
+
+	// bind /bin/true on top of mount/mknod command
+	// so debootstrap wouldn't fail while preparing
+	// chroot environment
+	if err := syscall.Mount(truePath, mountPath, "", syscall.MS_BIND, ""); err != nil {
+		return umountFn, fmt.Errorf("while mounting %s to %s: %s", truePath, mountPath, err)
+	}
+	if err := syscall.Mount(truePath, mknodPath, "", syscall.MS_BIND, ""); err != nil {
+		return umountFn, fmt.Errorf("while mounting %s to %s: %s", truePath, mknodPath, err)
+	}
+
+	// very dirty workaround to address issue with makedev
+	// package installation during ubuntu bootstrap, we watch
+	// for the creation of $ROOTFS/sbin/MAKEDEV and truncate
+	// the file to obtain an equivalent of /bin/true, for makedev
+	// post-configuration package we also need to create at least
+	// one /dev/ttyX file
+	go func() {
+		makedevPath := filepath.Join(cp.b.RootfsPath, "/sbin/MAKEDEV")
+		for {
+			select {
+			case <-ctx.Done():
+				break
+			case <-time.After(100 * time.Millisecond):
+				if _, err := os.Stat(makedevPath); err == nil {
+					os.Truncate(makedevPath, 0)
+					os.Create(filepath.Join(cp.b.RootfsPath, "/dev/tty1"))
+					break
+				}
+			}
+		}
+	}()
+
+	// debootstrap look at /proc/filesystems to check
+	// if sysfs is present, we bind /dev/null on top
+	// of /proc/filesystems to trick debootstrap to not
+	// mount /sys
+	if err := syscall.Mount("/dev/null", procFsPath, "", syscall.MS_BIND, ""); err != nil {
+		return umountFn, fmt.Errorf("while mounting /dev/null to %s: %s", procFsPath, err)
+	}
+
+	// mount required block devices
+	for _, p := range devs {
+		rootfsPath := filepath.Join(cp.b.RootfsPath, p)
+		if err := fs.Touch(rootfsPath); err != nil {
+			return umountFn, fmt.Errorf("while creating %s: %s", rootfsPath, err)
+		}
+		if err := syscall.Mount(p, rootfsPath, "", syscall.MS_BIND, ""); err != nil {
+			return umountFn, fmt.Errorf("while mounting %s to %s: %s", p, rootfsPath, err)
+		}
+	}
+
+	return umountFn, nil
+}

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_unsupported.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_unsupported.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package sources
+
+import "fmt"
+
+func (cp *DebootstrapConveyorPacker) prepareFakerootEnv() (func(), error) {
+	return nil, fmt.Errorf("fakeroot not supported on this platform")
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes fakeroot build bootstrap:
- pacstrap works and was tested with `examples/arch/Singularity`)
- debootstrap debian works and was tested with `examples/debian/Singularity`
- debootstrap ubuntu works and was tested with `examples/ubuntu/Singularity`

**This fixes or addresses the following GitHub issues:**

- Fixes #4331


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
