### PR TITLE
Fix mconfig seccomp detection on Opensuse

### DIFF
--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -344,8 +344,9 @@ fi
 # libseccomp dev
 ########################
 printf " checking: libseccomp+headers... "
+seccomp_iflags=`pkg-config --cflags-only-I libseccomp 2>/dev/null || true`
 if ! printf "#include <seccomp.h>\nint main() { seccomp_syscall_resolve_name(\"read\"); }" | \
-   $tgtcc $user_cflags $ldflags -x c -o /dev/null - -lseccomp >/dev/null 2>&1; then
+   $tgtcc $user_cflags $ldflags $seccomp_iflags -x c -o /dev/null - -lseccomp >/dev/null 2>&1; then
     tgtstatic=0
     echo "no"
 else


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Opensuse put `seccomp.h` in `/usr/include/libseccomp` and `mconfig` checks always say no for libseccomp check even after package installation, this PR fixes that by using `pkg-config` to use the correct include path for libseccomp.

**This fixes or addresses the following GitHub issues:**

- Fixes #4340


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
