### PR TITLE
Pass --no-cleanup flag pull command

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -293,7 +293,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While creating Docker credentials: %v", err)
 		}
 
-		err = singularity.OciPull(imgCache, pullTo, pullFrom, tmpDir, ociAuth, noHTTPS)
+		err = singularity.OciPull(imgCache, pullTo, pullFrom, tmpDir, ociAuth, noHTTPS, noCleanUp)
 		if err != nil {
 			sylog.Fatalf("While making image from oci registry: %v", err)
 		}


### PR DESCRIPTION
Fixes issue with pulls always cleaning up the underlying build performed
to convert docker images to SIF

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

