### PR TITLE
e2e run: a test with an encrypted container is expected to fail, not pass

### DIFF
--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -147,7 +147,7 @@ func (c *ctx) testRunPassphraseEncrypted(t *testing.T) {
 		e2e.WithCommand("run"),
 		e2e.WithArgs(cmdArgs...),
 		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
-		e2e.ExpectExit(0),
+		e2e.ExpectExit(255),
 	)
 }
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR fixes a problem with the e2e run tests when testing encrypted containers: a test is expected to fail, not pass.

Note that this was not caught by CI because the CI configuration is at the moment not compatible with encryption and therefore tests are skipped.

**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
