### PR TITLE
Add singularity config fakeroot command to manage fakeroot user mappings

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -40,16 +40,9 @@ import (
 )
 
 // EnsureRootPriv ensures that a command is executed with root privileges.
-// To customize the output, arguments can be used to specify the context (e.g., "oci", "plugin"),
-// where the first argument (string) will be displayed before the command itself.
 func EnsureRootPriv(cmd *cobra.Command, args []string) {
 	if os.Geteuid() != 0 {
-		if len(args) >= 1 && len(args[0]) > 0 {
-			// The first argument is the context
-			sylog.Fatalf("command '%s %s' requires root privileges", args[0], cmd.Name())
-		} else {
-			sylog.Fatalf("command '%s' requires root privileges", cmd.CommandPath())
-		}
+		sylog.Fatalf("%q command requires root privileges", cmd.CommandPath())
 	}
 }
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -48,7 +48,7 @@ func EnsureRootPriv(cmd *cobra.Command, args []string) {
 			// The first argument is the context
 			sylog.Fatalf("command '%s %s' requires root privileges", args[0], cmd.Name())
 		} else {
-			sylog.Fatalf("command %s requires root privileges", cmd.Name())
+			sylog.Fatalf("command '%s' requires root privileges", cmd.CommandPath())
 		}
 	}
 }

--- a/cmd/internal/cli/config_fakeroot_linux.go
+++ b/cmd/internal/cli/config_fakeroot_linux.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/pkg/cmdline"
+)
+
+// -a|--add
+var fakerootConfigAdd bool
+var fakerootConfigAddFlag = cmdline.Flag{
+	ID:           "fakerootConfigAddFlag",
+	Value:        &fakerootConfigAdd,
+	DefaultValue: false,
+	Name:         "add",
+	ShortHand:    "a",
+	Usage:        "add a fakeroot mapping entry for a user allowing him to use the fakeroot feature",
+}
+
+// -r|--remove
+var fakerootConfigRemove bool
+var fakerootConfigRemoveFlag = cmdline.Flag{
+	ID:           "fakerootConfigRemoveFlag",
+	Value:        &fakerootConfigRemove,
+	DefaultValue: false,
+	Name:         "remove",
+	ShortHand:    "r",
+	Usage:        "remove the user fakeroot mapping entry preventing him to use the fakeroot feature",
+}
+
+// -e|--enable
+var fakerootConfigEnable bool
+var fakerootConfigEnableFlag = cmdline.Flag{
+	ID:           "fakerootConfigEnableFlag",
+	Value:        &fakerootConfigEnable,
+	DefaultValue: false,
+	Name:         "enable",
+	ShortHand:    "e",
+	Usage:        "enable a user fakeroot mapping entry allowing him to use the fakeroot feature",
+}
+
+// -d|--disable
+var fakerootConfigDisable bool
+var fakerootConfigDisableFlag = cmdline.Flag{
+	ID:           "fakerootConfigDisableFlag",
+	Value:        &fakerootConfigDisable,
+	DefaultValue: false,
+	Name:         "disable",
+	ShortHand:    "d",
+	Usage:        "disable a user fakeroot mapping entry preventing him to use the fakeroot feature",
+}
+
+// configFakerootCmd singularity config fakeroot
+var configFakerootCmd = &cobra.Command{
+	Args:                  cobra.ExactArgs(1),
+	DisableFlagsInUseLine: true,
+	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, nil) },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		username := args[0]
+		var op singularity.FakerootConfigOp
+
+		if fakerootConfigAdd {
+			op = singularity.FakerootAddUser
+		} else if fakerootConfigRemove {
+			op = singularity.FakerootRemoveUser
+		} else if fakerootConfigEnable {
+			op = singularity.FakerootEnableUser
+		} else if fakerootConfigDisable {
+			op = singularity.FakerootDisableUser
+		} else {
+			return fmt.Errorf("you must specify an option (eg: --add/--remove)")
+		}
+
+		if err := singularity.FakerootConfig(username, op); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+
+		return nil
+	},
+
+	Use:     docs.ConfigFakerootUse,
+	Short:   docs.ConfigFakerootShort,
+	Long:    docs.ConfigFakerootLong,
+	Example: docs.ConfigFakerootExample,
+}
+
+func init() {
+	cmdManager.RegisterFlagForCmd(&fakerootConfigAddFlag, configFakerootCmd)
+	cmdManager.RegisterFlagForCmd(&fakerootConfigRemoveFlag, configFakerootCmd)
+	cmdManager.RegisterFlagForCmd(&fakerootConfigEnableFlag, configFakerootCmd)
+	cmdManager.RegisterFlagForCmd(&fakerootConfigDisableFlag, configFakerootCmd)
+}

--- a/cmd/internal/cli/config_fakeroot_linux.go
+++ b/cmd/internal/cli/config_fakeroot_linux.go
@@ -45,7 +45,7 @@ var fakerootConfigEnableFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "enable",
 	ShortHand:    "e",
-	Usage:        "enable a user fakeroot mapping entry allowing him to use the fakeroot feature",
+	Usage:        "enable a user fakeroot mapping entry allowing him to use the fakeroot feature (the user mapping must be present)",
 }
 
 // -d|--disable
@@ -56,14 +56,14 @@ var fakerootConfigDisableFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "disable",
 	ShortHand:    "d",
-	Usage:        "disable a user fakeroot mapping entry preventing him to use the fakeroot feature",
+	Usage:        "disable a user fakeroot mapping entry preventing him to use the fakeroot feature (the user mapping must be present)",
 }
 
 // configFakerootCmd singularity config fakeroot
 var configFakerootCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, nil) },
+	PreRun:                EnsureRootPriv,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		username := args[0]
 		var op singularity.FakerootConfigOp

--- a/cmd/internal/cli/config_linux.go
+++ b/cmd/internal/cli/config_linux.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+)
+
+// configCmd is the config command
+var configCmd = &cobra.Command{
+	DisableFlagsInUseLine: true,
+	Use:                   docs.ConfigUse,
+	Short:                 docs.ConfigShort,
+	Long:                  docs.ConfigLong,
+	Example:               docs.ConfigExample,
+	SilenceErrors:         true,
+}
+
+func init() {
+	cmdManager.RegisterCmd(configCmd)
+
+	cmdManager.RegisterSubCmd(configCmd, configFakerootCmd)
+}

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -128,11 +128,6 @@ var ociUpdateFromFileFlag = cmdline.Flag{
 	EnvKeys:      []string{"FROM_FILE"},
 }
 
-// ociContext is a variable used to describe the context of a OCI command.
-// This variable is for example passed in to the EnsureRootPriv() function to
-// customize the output.
-var ociContext = []string{"oci"}
-
 func init() {
 	cmdManager.RegisterCmd(OciCmd)
 	cmdManager.RegisterSubCmd(OciCmd, OciStartCmd)
@@ -169,7 +164,7 @@ func init() {
 var OciCreateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciCreate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
@@ -185,7 +180,7 @@ var OciCreateCmd = &cobra.Command{
 var OciRunCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciRun(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
@@ -201,7 +196,7 @@ var OciRunCmd = &cobra.Command{
 var OciStartCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciStart(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -217,7 +212,7 @@ var OciStartCmd = &cobra.Command{
 var OciDeleteCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciDelete(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -233,7 +228,7 @@ var OciDeleteCmd = &cobra.Command{
 var OciKillCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		timeout := int(ociArgs.KillTimeout)
 		killSignal := ""
@@ -259,7 +254,7 @@ var OciKillCmd = &cobra.Command{
 var OciStateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciState(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
@@ -275,7 +270,7 @@ var OciStateCmd = &cobra.Command{
 var OciAttachCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciAttach(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -291,7 +286,7 @@ var OciAttachCmd = &cobra.Command{
 var OciExecCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciExec(args[0], args[1:]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -307,7 +302,7 @@ var OciExecCmd = &cobra.Command{
 var OciUpdateCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciUpdate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
@@ -323,7 +318,7 @@ var OciUpdateCmd = &cobra.Command{
 var OciPauseCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciPauseResume(args[0], true); err != nil {
 			sylog.Fatalf("%s", err)
@@ -339,7 +334,7 @@ var OciPauseCmd = &cobra.Command{
 var OciResumeCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciPauseResume(args[0], false); err != nil {
 			sylog.Fatalf("%s", err)
@@ -355,7 +350,7 @@ var OciResumeCmd = &cobra.Command{
 var OciMountCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(2),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciMount(args[0], args[1]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -371,7 +366,7 @@ var OciMountCmd = &cobra.Command{
 var OciUmountCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, ociContext) },
+	PreRun:                EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciUmount(args[0]); err != nil {
 			sylog.Fatalf("%s", err)

--- a/cmd/internal/cli/plugin_disable_linux.go
+++ b/cmd/internal/cli/plugin_disable_linux.go
@@ -14,7 +14,7 @@ import (
 //
 // singularity plugin disable <name>
 var PluginDisableCmd = &cobra.Command{
-	PreRun: func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, pluginContext) },
+	PreRun: EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := singularity.DisablePlugin(args[0], buildcfg.LIBEXECDIR)
 		if err != nil {

--- a/cmd/internal/cli/plugin_enable_linux.go
+++ b/cmd/internal/cli/plugin_enable_linux.go
@@ -14,7 +14,7 @@ import (
 //
 // singularity plugin enable <name>
 var PluginEnableCmd = &cobra.Command{
-	PreRun: func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, pluginContext) },
+	PreRun: EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := singularity.EnablePlugin(args[0], buildcfg.LIBEXECDIR)
 		if err != nil {

--- a/cmd/internal/cli/plugin_install_linux.go
+++ b/cmd/internal/cli/plugin_install_linux.go
@@ -37,7 +37,7 @@ func init() {
 //
 // singularity plugin install <path> [-n name]
 var PluginInstallCmd = &cobra.Command{
-	PreRun: func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, pluginContext) },
+	PreRun: EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := singularity.InstallPlugin(args[0], buildcfg.LIBEXECDIR)
 		if err != nil {

--- a/cmd/internal/cli/plugin_linux.go
+++ b/cmd/internal/cli/plugin_linux.go
@@ -12,11 +12,6 @@ import (
 	"github.com/sylabs/singularity/docs"
 )
 
-// pluginContext is a variable used to describe the context of a plugin command.
-// This variable is for example passed in to the EnsureRootPriv() function to
-// customize the output.
-var pluginContext = []string{"plugin"}
-
 func init() {
 	cmdManager.RegisterCmd(PluginCmd)
 	cmdManager.RegisterSubCmd(PluginCmd, PluginListCmd)

--- a/cmd/internal/cli/plugin_uninstall_linux.go
+++ b/cmd/internal/cli/plugin_uninstall_linux.go
@@ -18,7 +18,7 @@ import (
 //
 // singularity plugin uninstall <name>
 var PluginUninstallCmd = &cobra.Command{
-	PreRun: func(cmd *cobra.Command, args []string) { EnsureRootPriv(cmd, pluginContext) },
+	PreRun: EnsureRootPriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := singularity.UninstallPlugin(args[0], buildcfg.LIBEXECDIR)
 		if err != nil {

--- a/docs/content.go
+++ b/docs/content.go
@@ -970,7 +970,7 @@ Enterprise Performance Computing (EPC)`
 	ConfigUse   string = `config`
 	ConfigShort string = `Manage various singularity configuration (root user only)`
 	ConfigLong  string = `
-  The config command allow root user to manage various configuration like fakeroot
+  The config command allows root user to manage various configuration like fakeroot
   user mapping entries.`
 	ConfigExample string = `
   All config commands have their own help output:

--- a/docs/content.go
+++ b/docs/content.go
@@ -966,4 +966,33 @@ Enterprise Performance Computing (EPC)`
   mount.`
 	OciUmountExample string = `
   $ singularity oci umount /var/lib/singularity/bundles/example`
+
+	ConfigUse   string = `config`
+	ConfigShort string = `Manage various singularity configuration (root user only)`
+	ConfigLong  string = `
+  The config command allow root user to manage various configuration like fakeroot
+  user mapping entries.`
+	ConfigExample string = `
+  All config commands have their own help output:
+
+  $ singularity help config fakeroot
+  $ singularity config fakeroot --help`
+
+	ConfigFakerootUse   string = `fakeroot <option> <user>`
+	ConfigFakerootShort string = `Manage fakeroot user mappings entries (root user only)`
+	ConfigFakerootLong  string = `
+  The config fakeroot command allow a root user to add/remove/enable/disable fakeroot
+  user mappings.`
+	ConfigFakerootExample string = `
+  To add a fakeroot user mapping for vagrant user:
+  $ singularity config fakeroot --add vagrant
+
+  To remove a fakeroot user mapping for vagrant user:
+  $ singularity config fakeroot --remove vagrant
+
+  To disable a fakeroot user mapping for vagrant user:
+  $ singularity config fakeroot --disable vagrant
+
+  To enable a fakeroot user mapping for vagrant user:
+  $ singularity config fakeroot --enable vagrant`
 )

--- a/internal/app/singularity/config_fakeroot_linux.go
+++ b/internal/app/singularity/config_fakeroot_linux.go
@@ -16,13 +16,13 @@ import (
 type FakerootConfigOp uint8
 
 const (
-	// FakerootAddUser is the operation to add a user fakeroot mapping
+	// FakerootAddUser is the operation to add a user fakeroot mapping.
 	FakerootAddUser FakerootConfigOp = iota
-	// FakerootRemoveUser is the operation to remove a user fakeroot mapping
+	// FakerootRemoveUser is the operation to remove a user fakeroot mapping.
 	FakerootRemoveUser
-	// FakerootEnableUser is the operation to enable a user fakeroot mapping
+	// FakerootEnableUser is the operation to enable a user fakeroot mapping.
 	FakerootEnableUser
-	// FakerootDisableUser is the operation to disable a user fakeroot mapping
+	// FakerootDisableUser is the operation to disable a user fakeroot mapping.
 	FakerootDisableUser
 )
 

--- a/internal/app/singularity/config_fakeroot_linux.go
+++ b/internal/app/singularity/config_fakeroot_linux.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularity
+
+import (
+	"fmt"
+
+	"github.com/sylabs/singularity/internal/pkg/fakeroot"
+)
+
+// FakerootConfigOp defines a type for a fakeroot
+// configuration operation.
+type FakerootConfigOp uint8
+
+const (
+	// FakerootAddUser is the operation to add a user fakeroot mapping
+	FakerootAddUser FakerootConfigOp = iota
+	// FakerootRemoveUser is the operation to remove a user fakeroot mapping
+	FakerootRemoveUser
+	// FakerootEnableUser is the operation to enable a user fakeroot mapping
+	FakerootEnableUser
+	// FakerootDisableUser is the operation to disable a user fakeroot mapping
+	FakerootDisableUser
+)
+
+// FakerootConfig allows to add/remove/enable/disable a user fakeroot
+// mapping entry in /etc/subuid and /etc/subgid files.
+func FakerootConfig(username string, op FakerootConfigOp) error {
+	subUIDConfig, err := fakeroot.GetConfig(fakeroot.SubUIDFile, true, nil)
+	if err != nil {
+		return fmt.Errorf("while opening %s: %s", fakeroot.SubUIDFile, err)
+	}
+	subGIDConfig, err := fakeroot.GetConfig(fakeroot.SubGIDFile, true, nil)
+	if err != nil {
+		return fmt.Errorf("while opening %s: %s", fakeroot.SubGIDFile, err)
+	}
+
+	switch op {
+	case FakerootAddUser:
+		if err := subUIDConfig.AddUser(username); err != nil {
+			return fmt.Errorf("while adding %s: %s", username, err)
+		}
+		if err := subGIDConfig.AddUser(username); err != nil {
+			return fmt.Errorf("while adding %s: %s", username, err)
+		}
+	case FakerootRemoveUser:
+		if err := subUIDConfig.RemoveUser(username); err != nil {
+			return fmt.Errorf("while removing %s: %s", username, err)
+		}
+		if err := subGIDConfig.RemoveUser(username); err != nil {
+			return fmt.Errorf("while removing %s: %s", username, err)
+		}
+	case FakerootEnableUser:
+		if err := subUIDConfig.EnableUser(username); err != nil {
+			return fmt.Errorf("while enabling %s: %s", username, err)
+		}
+		if err := subGIDConfig.EnableUser(username); err != nil {
+			return fmt.Errorf("while enabling %s: %s", username, err)
+		}
+	case FakerootDisableUser:
+		if err := subUIDConfig.DisableUser(username); err != nil {
+			return fmt.Errorf("while disabling %s: %s", username, err)
+		}
+		if err := subGIDConfig.DisableUser(username); err != nil {
+			return fmt.Errorf("while disabling %s: %s", username, err)
+		}
+	default:
+		return fmt.Errorf("unknown configuration operation")
+	}
+
+	if err := subUIDConfig.Close(); err != nil {
+		return fmt.Errorf("while writing configuration: %s", err)
+	}
+	if err := subGIDConfig.Close(); err != nil {
+		return fmt.Errorf("while writing configuration: %s", err)
+	}
+
+	return nil
+}

--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -27,7 +27,7 @@ const (
 	// validRangeCount is the valid fakeroot range count.
 	validRangeCount = uint32(65536)
 	// StartMax is the maximum possible range start.
-	startMax = uint32(4294967296 - 65536)
+	startMax = uint32(4294967296 - 131072)
 	// StartMin is the minimum possible range start.
 	startMin = uint32(65536)
 	// disabledPrefix is the character prefix marking an entry as disabled.
@@ -311,11 +311,11 @@ func (c *Config) GetUserEntry(username string, reportBadEntry bool) (*Entry, err
 	}
 	if reportBadEntry && entryCount > 0 {
 		return nil, fmt.Errorf(
-			"entries for user %s found in %s but all with a range count different from %d",
+			"mapping entries for user %s found in %s but all with a range count different from %d",
 			username, c.file.Name(), validRangeCount,
 		)
 	}
-	return nil, fmt.Errorf("no user entry found for %s", username)
+	return nil, fmt.Errorf("no mapping entry found in %s for %s", c.file.Name(), username)
 }
 
 // GetIDRange determines UID/GID mappings based on configuration
@@ -334,6 +334,9 @@ func GetIDRange(path string, uid uint32) (*specs.LinuxIDMapping, error) {
 	e, err := config.GetUserEntry(userinfo.Name, true)
 	if err != nil {
 		return nil, err
+	}
+	if e.disabled {
+		return nil, fmt.Errorf("your fakeroot mapping has been disabled by the administrator")
 	}
 	return &specs.LinuxIDMapping{
 		ContainerID: 1,


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR adds a new `singularity config fakeroot` command to easy fakeroot user mappings management.

**This fixes or addresses the following GitHub issues:**

- Fixes #4345 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
