### PR TITLE
Document engine operations

### DIFF
--- a/internal/app/starter/master_linux.go
+++ b/internal/app/starter/master_linux.go
@@ -102,6 +102,10 @@ func startContainer(masterSocket int, containerPid int, e *engine.Engine, fatalC
 }
 
 // Master initializes a runtime engine and runs it.
+//
+// Saved uid 0 is preserved when run with suid flow, so that
+// the master is capable to escalate its privileges to setup
+// container environment properly.
 func Master(rpcSocket, masterSocket int, containerPid int, e *engine.Engine) {
 	var status syscall.WaitStatus
 	fatalChan := make(chan error, 1)

--- a/internal/app/starter/rpc_linux.go
+++ b/internal/app/starter/rpc_linux.go
@@ -14,6 +14,13 @@ import (
 )
 
 // RPCServer serves runtime engine requests.
+//
+// The RPC server process is already in correct namespaces
+// required by container, so any operations performed will
+// affect final container environment. When run with suid
+// flow, i.e. no user namespace for container is created
+// and no hybrid workflow is requested, the server is run
+// with escalated privileges (as euid 0).
 func RPCServer(socket int, e *engine.Engine) {
 	comm := os.NewFile(uintptr(socket), "unix")
 	conn, err := net.FileConn(comm)

--- a/internal/pkg/runtime/engine/config/oci/config.go
+++ b/internal/pkg/runtime/engine/config/oci/config.go
@@ -18,14 +18,12 @@ type Config struct {
 	specs.Spec
 }
 
-// MarshalJSON is for json.Marshaler
+// MarshalJSON implements json.Marshaler.
 func (c *Config) MarshalJSON() ([]byte, error) {
-	b, err := json.Marshal(&c.Spec)
-
-	return b, err
+	return json.Marshal(&c.Spec)
 }
 
-// UnmarshalJSON is for json.Unmarshaler
+// UnmarshalJSON implements json.Unmarshaler.
 func (c *Config) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &c.Spec); err != nil {
 		return err

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -158,6 +158,9 @@ func (c *Config) KeepFileDescriptor(fd int) error {
 
 // SetHybridWorkflow sets the flag to tell starter container setup
 // will require an hybrid workflow. Typically used for fakeroot.
+// In hybrid workflow master process lives in host user namespace
+// with the ability to escalate privileges, while container process
+// lives in its own user namespace.
 func (c *Config) SetHybridWorkflow(hybrid bool) {
 	if hybrid {
 		c.config.starter.hybridWorkflow = C.true

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -58,6 +58,7 @@ func (c *Config) GetIsSUID() bool {
 }
 
 // GetContainerPid returns container PID (if any).
+// Container PID is set by master process before stage 2 or rpc.
 func (c *Config) GetContainerPid() int {
 	return int(c.config.container.pid)
 }

--- a/internal/pkg/runtime/engine/imgbuild/config/config.go
+++ b/internal/pkg/runtime/engine/imgbuild/config/config.go
@@ -10,11 +10,11 @@ import (
 	"github.com/sylabs/singularity/pkg/build/types"
 )
 
-// Name of the engine
+// Name of the engine.
 const Name = "imgbuild"
 
-// EngineConfig is the config for the Singularity engine used to run a minimal image
-// during image build process
+// EngineConfig is the config for the Singularity engine used to
+// run a minimal image during image build process.
 type EngineConfig struct {
 	types.Bundle `json:"bundle"`
 	OciConfig    *oci.Config `json:"ociConfig"`

--- a/internal/pkg/runtime/engine/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engine/imgbuild/create_linux.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sylabs/singularity/pkg/util/namespaces"
 )
 
-// CreateContainer creates a container
+// CreateContainer creates a container.
 func (e *EngineOperations) CreateContainer(pid int, rpcConn net.Conn) error {
 	if e.CommonConfig.EngineName != imgbuildConfig.Name {
 		return fmt.Errorf("engineName configuration doesn't match runtime name")


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This is the next step towards #3383.

Additional changes in `starter.c`:
- change `setresuid(uid, uid, 0)` to `priv_drop(false)` before executing master stage
- leverage `bool` in `cleanup_fd` function

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
