### PR TITLE
Add an e2e test for the buildcfg command

### DIFF
--- a/e2e/buildcfg/buildcfg.go
+++ b/e2e/buildcfg/buildcfg.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package buildcfg
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+type buildcfgTests struct {
+	env e2e.TestEnv
+}
+
+func (c *buildcfgTests) buildcfgTests(t *testing.T) {
+	tests := []struct {
+		name           string
+		cmdArgs        []string
+		expectedOutput string
+	}{
+		{
+			name:           "help",
+			cmdArgs:        []string{"--help"},
+			expectedOutput: "Output the currently set compile-time parameters",
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("buildcfg"),
+			e2e.WithArgs(tt.cmdArgs...),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.RegexMatch, `^`+tt.expectedOutput),
+			),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) func(*testing.T) {
+	c := &buildcfgTests{
+		env: env,
+	}
+
+	return func(t *testing.T) {
+		t.Run("buildcfgHelp", c.buildcfgTests)
+	}
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -17,50 +17,31 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/sylabs/singularity/e2e/security"
-
 	"github.com/sylabs/singularity/e2e/actions"
-
 	"github.com/sylabs/singularity/e2e/cache"
-
 	"github.com/sylabs/singularity/e2e/cmdenvvars"
-
 	"github.com/sylabs/singularity/e2e/docker"
-
 	"github.com/sylabs/singularity/e2e/help"
-
 	"github.com/sylabs/singularity/e2e/imgbuild"
-
 	"github.com/sylabs/singularity/e2e/inspect"
-
 	"github.com/sylabs/singularity/e2e/instance"
-
-	"github.com/sylabs/singularity/e2e/key"
-
-	"github.com/sylabs/singularity/e2e/oci"
-
-	"github.com/sylabs/singularity/e2e/pull"
-
-	"github.com/sylabs/singularity/e2e/push"
-
-	"github.com/sylabs/singularity/e2e/regressions"
-
-	"github.com/sylabs/singularity/e2e/remote"
-
-	"github.com/sylabs/singularity/e2e/run"
-
-	"github.com/sylabs/singularity/e2e/sign"
-
-	"github.com/sylabs/singularity/e2e/verify"
-
-	"github.com/sylabs/singularity/e2e/version"
-
-	singularityenv "github.com/sylabs/singularity/e2e/env"
-
 	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/e2e/key"
+	"github.com/sylabs/singularity/e2e/oci"
+	"github.com/sylabs/singularity/e2e/pull"
+	"github.com/sylabs/singularity/e2e/push"
+	"github.com/sylabs/singularity/e2e/regressions"
+	"github.com/sylabs/singularity/e2e/remote"
+	"github.com/sylabs/singularity/e2e/run"
+	"github.com/sylabs/singularity/e2e/security"
+	"github.com/sylabs/singularity/e2e/sign"
+	"github.com/sylabs/singularity/e2e/verify"
+	"github.com/sylabs/singularity/e2e/version"
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 
+	e2ebuildcfg "github.com/sylabs/singularity/e2e/buildcfg"
+	singularityenv "github.com/sylabs/singularity/e2e/env"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
@@ -155,6 +136,7 @@ func Run(t *testing.T) {
 		"SECURITY":    security.E2ETests(testenv),
 		"ACTIONS":     actions.E2ETests(testenv),
 		"BUILD":       imgbuild.E2ETests(testenv),
+		"BUILDCFG":    e2ebuildcfg.E2ETests(testenv),
 		"CACHE":       cache.E2ETests(testenv),
 		"CMDENVVARS":  cmdenvvars.E2ETests(testenv),
 		"DOCKER":      docker.E2ETests(testenv),


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add an e2e test for the buildcfg command. Only the positive case at the moment in order to improve coverage.

**This fixes or addresses the following GitHub issues:**

- Fixes #4080 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers