### PR TITLE
Increase the timeout for the execution of e2e tests 

### DIFF
--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -5,7 +5,7 @@ export GO111MODULE='@GO111MODULE@'
 
 exec '@GO@' test \
 	-count=1 \
-	-timeout=20m \
+	-timeout=30m \
 	-tags '@GO_TAGS@' \
 	-failfast \
 	-cover \


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Increase the timeout for the execution of e2e tests since i am reaching that timeout on most of the testbeds.

**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers