### PR TITLE
Fix a problem with the e2e sign test

### DIFF
--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -175,7 +175,7 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 
 		t.Run("singularitySignHelpOption", c.singularitySignHelpOption)
 		t.Run("singularitySignIDOption", c.singularitySignIDOption)
-		t.Run("singularitySignGroupIDOption", c.singularitySignIDOption)
+		t.Run("singularitySignGroupIDOption", c.singularitySignGroupIDOption)
 		t.Run("singularitySignKeyidxOption", c.singularitySignKeyidxOption)
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR ensures that the e2e test for `sign --groupid` is actually executed.

**This fixes or addresses the following GitHub issues:**

- Addresses #4099 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
