### PR TITLE
Add test for the help flag for e2e remote tests

### DIFF
--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -398,6 +398,60 @@ func (c *ctx) remoteList(t *testing.T) {
 	}
 }
 
+func (c *ctx) remoteTestFlag(t *testing.T) {
+	tests := []struct {
+		name           string
+		cmdArgs        []string
+		expectedOutput string
+	}{
+		{
+			name:           "add help",
+			cmdArgs:        []string{"add", "--help"},
+			expectedOutput: "Create a new singularity remote endpoint",
+		},
+		{
+			name:           "list help",
+			cmdArgs:        []string{"list", "--help"},
+			expectedOutput: "List all singularity remote endpoints that are configured",
+		},
+		{
+			name:           "login help",
+			cmdArgs:        []string{"login", "--help"},
+			expectedOutput: "Log into a singularity remote endpoint using an authentication token",
+		},
+		{
+			name:           "remove help",
+			cmdArgs:        []string{"remove", "--help"},
+			expectedOutput: "Remove an existing singularity remote endpoint",
+		},
+		{
+			name:           "status help",
+			cmdArgs:        []string{"status", "--help"},
+			expectedOutput: "Check the status of the singularity services at an endpoint",
+		},
+		{
+			name:           "use help",
+			cmdArgs:        []string{"use", "--help"},
+			expectedOutput: "Set a singularity remote endpoint to be actively used",
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("remote"),
+			e2e.WithArgs(tt.cmdArgs...),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.RegexMatch, `^`+tt.expectedOutput),
+			),
+		)
+
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
 	c := &ctx{
@@ -410,5 +464,6 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 		t.Run("use", c.remoteUse)
 		t.Run("status", c.remoteStatus)
 		t.Run("list", c.remoteList)
+		t.Run("test flag", c.remoteTestFlag)
 	}
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Add test for the help flag for e2e remote tests. This PR is only focusing on positive cases in order to increase coverage.

**This fixes or addresses the following GitHub issues:**

- Addresses #4093 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers