### PR TITLE
Remove gpgme as a dependency for building singularity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
             # https://discuss.circleci.com/t/could-not-get-lock-var-lib-apt-lists-lock/28337/4
             sudo killall -9 apt-get || true && \
             sudo apt-get update -y && \
-            sudo apt-get install -f -y build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev
+            sudo apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev
       - run:
           name: Build and Install Singularity
           command: |-
@@ -182,7 +182,7 @@ jobs:
             # https://discuss.circleci.com/t/could-not-get-lock-var-lib-apt-lists-lock/28337/4
             sudo killall -9 apt-get || true && \
             sudo apt-get update -y && \
-            sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev cryptsetup
+            sudo apt-get install -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup
       - run:
           name: Build and Install singularity
           command: |-

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
       - libssl-dev
       - libssl1.0.0
       - libarchive-dev
-      - libgpgme11-dev
       - libseccomp-dev
       - cryptsetup
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ On Debian-based systems:
 ```
 $ sudo apt-get update && \
   sudo apt-get install -y build-essential \
-  libssl-dev uuid-dev libgpgme11-dev libseccomp-dev \
+  libssl-dev uuid-dev libseccomp-dev \
   pkg-config squashfs-tools cryptsetup
 ```
 


### PR DESCRIPTION
github.com/containers/image can switch between using gpgme and openpgp
for processing PGP signatures. It does this using a build tag.

We are _always_ passing the build tag to have it use openpgp.

Remove gpgme as a dependency for building singularity as it is not
required.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
