### PR TITLE
Rework overlay image loading code

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -496,6 +496,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	Env := []string{sylog.GetEnvVar()}
 
+	// starter will force the loading of kernel overlay module
+	if !UserNamespace && buildcfg.SINGULARITY_SUID_INSTALL == 1 {
+		Env = append(Env, "LOAD_OVERLAY_MODULE=1")
+	}
+
 	generator.AddProcessEnv("SINGULARITY_APPNAME", AppName)
 
 	// convert image file to sandbox if we are using user

--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -447,7 +447,7 @@ func testPersistentOverlay(t *testing.T) {
 	}))
 	// look for the file squashFs
 	t.Run("overlay_squashFS_find", test.WithPrivilege(func(t *testing.T) {
-		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{squashfsImage}}, imagePath, []string{"test", "-f", fmt.Sprintf("/%s", tmpfile.Name())})
+		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{squashfsImage + ":ro"}}, imagePath, []string{"test", "-f", fmt.Sprintf("/%s", tmpfile.Name())})
 		if exitCode != 0 {
 			t.Log(stderr, err)
 			t.Fatalf("unexpected failure running '%v'", strings.Join([]string{"test", "-f", fmt.Sprintf("/%s", tmpfile.Name())}, " "))
@@ -455,7 +455,7 @@ func testPersistentOverlay(t *testing.T) {
 	}))
 	// create a file multiple overlays
 	t.Run("overlay_multiple_create", test.WithPrivilege(func(t *testing.T) {
-		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{"ext3_fs.img", squashfsImage}}, imagePath, []string{"touch", "/multiple_overlay_fs"})
+		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{"ext3_fs.img", squashfsImage + ":ro"}}, imagePath, []string{"touch", "/multiple_overlay_fs"})
 		if exitCode != 0 {
 			t.Log(stderr, err)
 			t.Fatalf("unexpected failure running '%v'", strings.Join([]string{"touch", "/multiple_overlay_fs"}, " "))
@@ -463,14 +463,14 @@ func testPersistentOverlay(t *testing.T) {
 	}))
 	// look for the file with multiple overlays
 	t.Run("overlay_multiple_find_ext3", test.WithPrivilege(func(t *testing.T) {
-		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{"ext3_fs.img", squashfsImage}}, imagePath, []string{"test", "-f", "/multiple_overlay_fs"})
+		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{"ext3_fs.img", squashfsImage + ":ro"}}, imagePath, []string{"test", "-f", "/multiple_overlay_fs"})
 		if exitCode != 0 {
 			t.Log(stderr, err)
 			t.Fatalf("unexpected failure running '%v'", strings.Join([]string{"test", "-f", "multiple_overlay_fs"}, " "))
 		}
 	}))
 	t.Run("overlay_multiple_find_squashfs", test.WithPrivilege(func(t *testing.T) {
-		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{"ext3_fs.img", squashfsImage}}, imagePath, []string{"test", "-f", fmt.Sprintf("/%s", tmpfile.Name())})
+		_, stderr, exitCode, err := imageExec(t, "exec", opts{overlay: []string{"ext3_fs.img", squashfsImage + ":ro"}}, imagePath, []string{"test", "-f", fmt.Sprintf("/%s", tmpfile.Name())})
 		if exitCode != 0 {
 			t.Log(stderr, err)
 			t.Fatalf("unexpected failure running '%v'", strings.Join([]string{"test", "-f", fmt.Sprintf("/%s", tmpfile.Name())}, " "))

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -63,7 +63,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 		// start script in e2e/testdata/Docker_registry.def will listen
 		// on port 5111 once docker registry is up and initialized, so
 		// we are trying to connect to this port until we got a response,
-		// without any response after 10 seconds we abort tests execution
+		// without any response after 30 seconds we abort tests execution
 		// because the start script probably failed
 		retry := 0
 		for {
@@ -75,8 +75,8 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 			}
 			time.Sleep(100 * time.Millisecond)
 			retry++
-			if retry == 100 {
-				t.Fatalf("docker registry unreachable after 10 seconds: %+v", err)
+			if retry == 300 {
+				t.Fatalf("docker registry unreachable after 30 seconds: %+v", err)
 			}
 		}
 

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -14,17 +14,23 @@ from: registry:2.7.1
     if ! brctl show docker0; then
         DELETE_BRIDGE=1
     fi
+
     dockerd --iptables=false --ip-forward=false --ip-masq=false --storage-driver=vfs &
     /.singularity.d/runscript &
+
     # wait until docker registry is up
-    while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.2; done
+    while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.5; done
+
+    # delete bridge if docker0 was not previously present
     if [ ! -z "${DELETE_BRIDGE}" ]; then
-        ip link set docker0 down || kill -TERM 1
-        brctl delbr docker0
+        ip link set docker0 down || true
+        brctl delbr docker0 || true
     fi
+
     docker pull busybox || kill -TERM 1
     docker tag busybox localhost:5000/my-busybox || kill -TERM 1
     docker push localhost:5000/my-busybox || kill -TERM 1
+
     # e2e PrepRegistry will repeatedly trying to connect to this port
     # giving indication that it can start
     nc -l -p 5111

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -155,8 +155,7 @@ func (f *squashfsFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	}
 
 	if img.Writable {
-		sylog.Warningf("squashfs is not a writable filesystem")
-		img.Writable = false
+		return fmt.Errorf("could not set image writable: squashfs is a read-only filesystem")
 	}
 
 	return nil

--- a/pkg/image/squashfs_test.go
+++ b/pkg/image/squashfs_test.go
@@ -92,10 +92,18 @@ func TestSquashfsInitializer(t *testing.T) {
 		t.Fatalf("cannot stat the image file: %s\n", err)
 	}
 
+	// initializer must fail if writable is true
+	err = squashfsfmt.initializer(img, fileinfo)
+	if err == nil {
+		t.Fatalf("unexpected success for squashfs initializer\n")
+	}
+	// reset cursor for header parsing
+	img.File.Seek(0, os.SEEK_SET)
+	// initialized must succeed if writable is false
+	img.Writable = false
 	err = squashfsfmt.initializer(img, fileinfo)
 	if err != nil {
-		img.File.Close()
-		t.Fatalf("initializer failed: %s\n", err)
+		t.Fatalf("unexpected error for squashfs initializer: %s\n", err)
 	}
 	img.File.Close()
 

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -12,7 +12,16 @@ import (
 // Name is the name of the runtime.
 const Name = "singularity"
 
-// FileConfig describes the singularity.conf file options.
+const (
+	// DefaultLayer is the string representation for the default layer.
+	DefaultLayer string = "none"
+	// OverlayLayer is the string representation for the overlay layer.
+	OverlayLayer = "overlay"
+	// UnderlayLayer is the string representation for the underlay layer.
+	UnderlayLayer = "underlay"
+)
+
+// FileConfig describes the singularity.conf file options
 type FileConfig struct {
 	AllowSetuid             bool     `default:"yes" authorized:"yes,no" directive:"allow setuid"`
 	AllowPidNs              bool     `default:"yes" authorized:"yes,no" directive:"allow pid ns"`
@@ -76,6 +85,7 @@ type JSONConfig struct {
 	Network           string        `json:"network,omitempty"`
 	DNS               string        `json:"dns,omitempty"`
 	Cwd               string        `json:"cwd,omitempty"`
+	SessionLayer      string        `json:"sessionLayer,omitempty"`
 	EncryptionKey     []byte        `json:"encryptionKey,omitempty"`
 	TargetUID         int           `json:"targetUID,omitempty"`
 	WritableImage     bool          `json:"writableImage,omitempty"`
@@ -511,4 +521,16 @@ func (e *EngineConfig) SetSignalPropagation(propagation bool) {
 // processes (see SetSignalPropagation).
 func (e *EngineConfig) GetSignalPropagation() bool {
 	return e.JSON.SignalPropagation
+}
+
+// GetSessionLayer returns the session layer used to setup the
+// container mount points.
+func (e *EngineConfig) GetSessionLayer() string {
+	return e.JSON.SessionLayer
+}
+
+// SetSessionLayer sets the session layer to use to setup the
+// container mount points.
+func (e *EngineConfig) SetSessionLayer(sessionLayer string) {
+	e.JSON.SessionLayer = sessionLayer
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This PR reorganize overlay image loading code in order to prepare overlay image loading in `PrepareConfig` engine method to fail faster and take appropriate decision regarding layer to use.
Also fixes issues below.

**This fixes or addresses the following GitHub issues:**

- Fixes #4329
- Fixes #4270

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
