### PR TITLE
Fix compiles on non 64-bit architectures

### DIFF
--- a/internal/pkg/util/fs/overlay/overlay.go
+++ b/internal/pkg/util/fs/overlay/overlay.go
@@ -65,7 +65,7 @@ func check(path string, d dir) error {
 		return fmt.Errorf("could not retrieve underlying filesystem information for %s: %s", path, err)
 	}
 
-	fs, ok := incompatibleFs[stfs.Type]
+	fs, ok := incompatibleFs[int64(stfs.Type)]
 	if !ok || (ok && fs.overlayDir&d == 0) {
 		return nil
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fixes a few Fedora rawhide architecture builds of singularity-3.4.0, on those types that are not 64 bits.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
