### PR TITLE
Delete ghost instance files

### DIFF
--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -11,7 +11,13 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
+
+	"github.com/sylabs/singularity/pkg/util/fs/proc"
+
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -227,6 +233,77 @@ func (c *ctx) testInstanceFromURI(t *testing.T) {
 	}
 }
 
+// Execute an instance process, kill master process
+// and try to start another instance with same name
+func (c *ctx) testGhostInstance(t *testing.T) {
+	// pick up a random name
+	instanceName := uuid.NewV4().String()
+	pidfile := filepath.Join(c.env.TestDir, instanceName)
+
+	postFn := func(t *testing.T) {
+		defer os.Remove(pidfile)
+
+		if t.Failed() {
+			t.Fatalf("instance %s failed to start correctly", instanceName)
+		}
+
+		d, err := ioutil.ReadFile(pidfile)
+		if err != nil {
+			t.Fatalf("failed to read pid file: %s", err)
+		}
+		trimmed := strings.TrimSuffix(string(d), "\n")
+		pid, err := strconv.ParseInt(trimmed, 10, 32)
+		if err != nil {
+			t.Fatalf("failed to convert PID %s in %s: %s", trimmed, pidfile, err)
+		}
+		ppid, err := proc.Getppid(int(pid))
+		if err != nil {
+			t.Fatalf("failed to get parent process ID for process %d: %s", pid, err)
+		}
+
+		// starting same instance twice must return an error
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(c.profile),
+			e2e.WithCommand("instance start"),
+			e2e.WithArgs(c.env.ImagePath, instanceName),
+			e2e.ExpectExit(
+				255,
+				e2e.ExpectErrorf(e2e.ContainMatch, "instance %s already exists", instanceName),
+			),
+		)
+
+		// kill master process
+		if err := syscall.Kill(int(ppid), syscall.SIGKILL); err != nil {
+			t.Fatalf("failed to send KILL signal to %d: %s", ppid, err)
+		}
+
+		// now check we are deleting ghost instance files correctly
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(c.profile),
+			e2e.WithCommand("instance start"),
+			e2e.WithArgs(c.env.ImagePath, instanceName),
+			e2e.PostRun(func(t *testing.T) {
+				if t.Failed() {
+					return
+				}
+				c.stopInstance(t, instanceName)
+			}),
+			e2e.ExpectExit(0),
+		)
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs("--pid-file", pidfile, c.env.ImagePath, instanceName),
+		e2e.PostRun(postFn),
+		e2e.ExpectExit(0),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
 	c := &ctx{
@@ -250,6 +327,7 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 			{"CreateManyInstances", c.testCreateManyInstances},
 			{"StopAll", c.testStopAll},
 			{"FinalNoInstances", c.testNoInstances},
+			{"GhostInstance", c.testGhostInstance},
 		}
 
 		// run unprivileged

--- a/internal/app/singularity/oci_exec_linux.go
+++ b/internal/app/singularity/oci_exec_linux.go
@@ -11,12 +11,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sylabs/singularity/pkg/ociruntime"
-
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/oci"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/exec"
+	"github.com/sylabs/singularity/pkg/ociruntime"
 )
 
 // OciExec executes a command in a container

--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -209,3 +209,25 @@ func HasNamespace(pid int, nstype string) (bool, error) {
 
 	return has, nil
 }
+
+// Getppid returns the parent process ID for the corresponding
+// process ID passed in parameter.
+func Getppid(pid int) (int, error) {
+	status := fmt.Sprintf("/proc/%d/status", pid)
+	p, err := os.Open(status)
+	if err != nil {
+		return -1, fmt.Errorf("could not open %s: %s", status, err)
+	}
+	defer p.Close()
+
+	scanner := bufio.NewScanner(p)
+	for scanner.Scan() {
+		ppid := -1
+		n, _ := fmt.Sscanf(scanner.Text(), "PPid:\t%d", &ppid)
+		if n == 1 && ppid > 0 {
+			return ppid, nil
+		}
+	}
+
+	return -1, fmt.Errorf("no parent process ID found")
+}

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -281,3 +281,33 @@ func TestHasNamespace(t *testing.T) {
 
 	cmd.Wait()
 }
+
+func TestGetppid(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	pid := os.Getpid()
+	ppid := os.Getppid()
+
+	list := []struct {
+		name          string
+		pid           int
+		ppid          int
+		expectSuccess bool
+	}{
+		{"ProcessZero", 0, -1, false},
+		{"CurrentProcess", pid, ppid, true},
+		{"InitProcess", 1, -1, false},
+	}
+
+	for _, tt := range list {
+		p, err := Getppid(tt.pid)
+		if err != nil && tt.expectSuccess {
+			t.Fatalf("unexpected failure for %q: %s", tt.name, err)
+		} else if err == nil && !tt.expectSuccess {
+			t.Fatalf("unexpected success for %q: got parent process ID %d instead of %d", tt.name, p, tt.ppid)
+		} else if p != tt.ppid {
+			t.Fatalf("unexpected parent process ID returned: got %d instead of %d", p, tt.ppid)
+		}
+	}
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Actually instance files may be left when the instance master process is interrupted by a signal or whatever without any possibility to clean up instance files, this PR fix that by deleting the ghost files in instance API during instance listing and ensure that returned instances have a master process actually running.

**This fixes or addresses the following GitHub issues:**

- Fixes #4332
- Fixes #3852
- Fixes #2759


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
