### PR TITLE
Fix ioctl errno handling for LOOP_SET_STATUS64

### DIFF
--- a/pkg/util/loop/loop_linux.go
+++ b/pkg/util/loop/loop_linux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/sylabs/singularity/pkg/util/fs/lock"
@@ -101,8 +102,18 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 		return fmt.Errorf("failed to set close-on-exec on loop device %s: %s", path, err.Error())
 	}
 
-	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdSetStatus64, uintptr(unsafe.Pointer(loop.Info))); err != 0 {
-		return fmt.Errorf("failed to set loop flags on loop device: %s", syscall.Errno(err))
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(loopFd), CmdSetStatus64, uintptr(unsafe.Pointer(loop.Info))); err != 0 {
+			if err == syscall.EAGAIN && i < maxRetries-1 {
+				// loop_set_status() can temporarily fail with EAGAIN -> sleep and try again
+				// (cf. https://github.com/karelzak/util-linux/blob/dab1303287b7ebe30b57ccc78591070dad0a85ea/lib/loopdev.c#L1355)
+				time.Sleep(250*time.Millisecond)
+				continue
+			}
+			return fmt.Errorf("failed to set loop flags on loop device: %s", syscall.Errno(err))
+		}
+		break
 	}
 
 	return nil


### PR DESCRIPTION
Linux kernel commit [5db470e229e22b7eda6e23b5566e532c96fb5bc3](https://github.com/torvalds/linux/commit/5db470e229e22b7eda6e23b5566e532c96fb5bc3) ("_loop:
drop caches if offset or block_size are changed_") introduced a transient
fail (with `-EAGAIN`) possibility into the `LOOP_SET_STATUS64` `ioctl`.
This also affects longterm kernel versions 4.14 and 4.19.


**Description of the Pull Request (PR):**

Since we switched to a newer kernel version 4.19.37 (Debian Buster), we sporadically encountered errors such as:
```
container creation failed: mount error: can't mount image /proc/self/fd/29: failed to find loop device: could not attach image file to loop device: Failed to set loop flags on loop device: resource temporarily unavailable
```
As mentioned above, in recent kernel versions the syscall might fail with `errno == EAGAIN`; similar to what the [`losetup` tool](https://github.com/karelzak/util-linux/blob/dab1303287b7ebe30b57ccc78591070dad0a85ea/lib/loopdev.c#L1355) does, we have to retry when encountering EAGAIN.

**This fixes or addresses the following GitHub issues:**

- might be related to #3764


Attn: @singularity-maintainers