### PR TITLE
Fix SCS Key Client Pseudo-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50 // indirect
 	github.com/sylabs/json-resp v0.5.0
 	github.com/sylabs/scs-build-client v0.0.4
-	github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec
+	github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec
 	github.com/sylabs/scs-library-client v0.4.2
 	github.com/sylabs/sif v1.0.8
 	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/sylabs/json-resp v0.5.0 h1:AWdKu6aS0WrkkltX1M0ex0lENrIcx5TISox902s2L2
 github.com/sylabs/json-resp v0.5.0/go.mod h1:anCzED2SGHHZQDubMuoVtwMuJZdpqQ+7iso8yDFm/nQ=
 github.com/sylabs/scs-build-client v0.0.4 h1:y1rer0Mq+GyAFPKn0szpayJfUSTD7SGgRB3Yh0dJo+g=
 github.com/sylabs/scs-build-client v0.0.4/go.mod h1:TxxLkoW6RjzcQXllPAbsA5zmljX/YsHLlQ1gZ5Lkogg=
-github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec h1:dX97dpvwSAF8AFG1f33b1dUueCGc1onK94FUP5pHUsw=
-github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec/go.mod h1:nMF8PplFD5ZmDz//GHjaip7+MlQ0z4Qe0RCzaT5Xjes=
+github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec h1:PYpPpJokBQc90ErbzDsyRQfff7gUSwtIiWDblx3AM6Y=
+github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec/go.mod h1:nMF8PplFD5ZmDz//GHjaip7+MlQ0z4Qe0RCzaT5Xjes=
 github.com/sylabs/scs-library-client v0.4.2 h1:h1w37fbphEkWLVjSoh8YLxjTUJ4VZQlJOw0/WHE3YYc=
 github.com/sylabs/scs-library-client v0.4.2/go.mod h1:89vH+0RQemCEcOnaUUQwnsRVQQmupVh8VQlBbW0ZHss=
 github.com/sylabs/sif v1.0.8 h1:BK55XU0UhUsbimCr1Sl1tCLDrFsB71EDYDcHRfPpw8k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -327,7 +327,7 @@ github.com/spf13/pflag
 github.com/sylabs/json-resp
 # github.com/sylabs/scs-build-client v0.0.4
 github.com/sylabs/scs-build-client/client
-# github.com/sylabs/scs-key-client v0.3.0-0.20190509220229-bce3b050c4ec
+# github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec
 github.com/sylabs/scs-key-client/client
 # github.com/sylabs/scs-library-client v0.4.2
 github.com/sylabs/scs-library-client/client


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Fix invalid pseudo-version in `go.mod` for the `github.com/sylabs/scs-key-client ` package.

**This fixes or addresses the following GitHub issues:**

- Fixes #4378


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
