### PR TITLE
Add `integration_test` build tag to integration tests

### DIFF
--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/build_test.go
+++ b/cmd/singularity/build_test.go
@@ -6,6 +6,8 @@
 // This file is been deprecated and will disappear on with version 3.3
 // of singularity. The functionality has been moved to e2e/imgbuild/imgbuild.go
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/cli_test.go
+++ b/cmd/singularity/cli_test.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/deffile_test.go
+++ b/cmd/singularity/deffile_test.go
@@ -5,6 +5,9 @@
 
 // This file is been deprecated and will disappear on with version 3.3
 // of singularity. The functionality has been moved to e2e/imgbuild/imgbuild.go
+
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/docker_test.go
+++ b/cmd/singularity/docker_test.go
@@ -6,6 +6,8 @@
 // This file is been deprecated and will disappear on with version 3.3
 // of singularity. The functionality has been moved to e2e/docker/docker.go
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/env_test.go
+++ b/cmd/singularity/env_test.go
@@ -6,6 +6,8 @@
 // This file has been deprecated and will disappear with version 3.3
 // of singularity. The functionality has been moved to e2e/env/env.go
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/help_test.go
+++ b/cmd/singularity/help_test.go
@@ -6,6 +6,8 @@
 // This file has been deprecated and will disappear with version 3.3
 // of singularity. The functionality has been moved to e2e/help/help.go
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -6,6 +6,8 @@
 // This file has been deprecated and will be removed in version 3.3 of
 // Singularity. The functionality has been moved to e2e/instance/instance*.go.
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/pull_test.go
+++ b/cmd/singularity/pull_test.go
@@ -6,6 +6,8 @@
 // This file is been deprecated and will disappear on with version 3.3
 // of singularity. The functionality has been moved to e2e/pull/pull.go
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/remote_test.go
+++ b/cmd/singularity/remote_test.go
@@ -6,6 +6,8 @@
 // This file has been deprecated and will disappear with version 3.3
 // of singularity. The functionality has been moved to e2e/remote/remote.go
 
+// +build integration_test
+
 package main
 
 import (

--- a/cmd/singularity/security_test.go
+++ b/cmd/singularity/security_test.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build integration_test
 // +build seccomp
 
 package main

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -52,7 +52,7 @@ integration-test:
 	@echo " TEST sudo go test [integration]"
 	$(V)cd $(SOURCEDIR) && \
 		sudo -E \
-		scripts/go-test -v \
+		scripts/go-test -v -tags 'integration_test' \
 		./cmd/singularity ./pkg/network
 	@echo "       PASS"
 
@@ -63,7 +63,7 @@ test:
     	trap "kill $$! || true" 0; \
 		cd $(SOURCEDIR) && \
 		sudo -E \
-		scripts/go-test -v \
+		scripts/go-test -v -tags 'integration_test' \
 		./...
 	@echo "       PASS"
 

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build integration_test
+
 package network
 
 import (


### PR DESCRIPTION
Instead of keeping an implicit record of which tests are integration
tests are which are something else, make it explicit using the existing
Go mechanisms.

Specifically add an `integration_test` build tag to the integration
tests and pass `-tags integration_tests` to the test runs that wish to
include these tests in their runs.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
