### PR TITLE
Add e2e_test to end-to-end tests

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -6,16 +6,11 @@
 package e2e
 
 import (
-	"os"
 	"testing"
 )
 
 // RunE2ETests is the main func to trigger the test suite
 func RunE2ETests(t *testing.T) {
-	if os.Getenv("SINGULARITY_E2E") == "" {
-		t.Skip("Skipping e2e tests, SINGULARITY_E2E not set")
-	} else {
-		t.Log("Running E2E tests for Singularity")
-		Run(t)
-	}
+	t.Log("Running E2E tests for Singularity")
+	Run(t)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,6 +3,8 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build e2e_test
+
 package e2e
 
 import (

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -16,6 +16,5 @@ sudo \
 	env -i \
 		PATH=$PATH \
 		HOME=$HOME \
-		SINGULARITY_E2E=1 \
 		SINGULARITY_E2E_COVERAGE=$SINGULARITY_E2E_COVERAGE \
-	scripts/go-test "$@" ./e2e
+	scripts/go-test -tags "e2e_test" "$@" ./e2e


### PR DESCRIPTION
Same as with integration tests, the E2E tests need to have a build tag
to explicitly mark them as such. This replaces the more obscure
mechanism that uses the SINGULARITY_E2E environment variable for the
same purpose.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
