### PR TITLE
Start flag descriptions with lowercase

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -251,7 +251,7 @@ var actionVMRAMFlag = cmdline.Flag{
 	Value:        &VMRAM,
 	DefaultValue: "1024",
 	Name:         "vm-ram",
-	Usage:        "Amount of RAM in MiB to allocate to Virtual Machine (implies --vm)",
+	Usage:        "amount of RAM in MiB to allocate to Virtual Machine (implies --vm)",
 	Tag:          "<size>",
 	EnvKeys:      []string{"VM_RAM"},
 }
@@ -262,7 +262,7 @@ var actionVMCPUFlag = cmdline.Flag{
 	Value:        &VMCPU,
 	DefaultValue: "1",
 	Name:         "vm-cpu",
-	Usage:        "Number of CPU cores to allocate to Virtual Machine (implies --vm)",
+	Usage:        "number of CPU cores to allocate to Virtual Machine (implies --vm)",
 	Tag:          "<CPU #>",
 	EnvKeys:      []string{"VM_CPU"},
 }
@@ -284,7 +284,7 @@ var actionNONETFlag = cmdline.Flag{
 	Value:        &NoNet,
 	DefaultValue: false,
 	Name:         "nonet",
-	Usage:        "Disable VM network handling",
+	Usage:        "disable VM network handling",
 	EnvKeys:      []string{"VM_NONET"},
 }
 
@@ -305,7 +305,7 @@ var actionPassphraseFlag = cmdline.Flag{
 	Value:        &enterPassphrase,
 	DefaultValue: false,
 	Name:         "passphrase",
-	Usage:        "Enter a passphrase for an encrypted contaner",
+	Usage:        "enter a passphrase for an encrypted contaner",
 }
 
 // --pem-path
@@ -314,7 +314,7 @@ var actionPEMPathFlag = cmdline.Flag{
 	Value:        &encryptionPEMPath,
 	DefaultValue: "",
 	Name:         "pem-path",
-	Usage:        "Enter an path to a PEM formated RSA key for an encrypted container",
+	Usage:        "enter an path to a PEM formated RSA key for an encrypted container",
 }
 
 // --fusemount, hidden for now while experimental

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -126,7 +126,7 @@ var buildArchFlag = cmdline.Flag{
 	Value:        &buildArch,
 	DefaultValue: runtime.GOARCH,
 	Name:         "arch",
-	Usage:        "Architecture for remote build",
+	Usage:        "architecture for remote build",
 	EnvKeys:      []string{"BUILD_ARCH"},
 }
 

--- a/cmd/internal/cli/instance_list_linux.go
+++ b/cmd/internal/cli/instance_list_linux.go
@@ -28,7 +28,7 @@ var instanceListUserFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "user",
 	ShortHand:    "u",
-	Usage:        `If running as root, list instances from "<username>"`,
+	Usage:        `if running as root, list instances from "<username>"`,
 	Tag:          "<username>",
 	EnvKeys:      []string{"USER"},
 }
@@ -41,7 +41,7 @@ var instanceListJSONFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "json",
 	ShortHand:    "j",
-	Usage:        "Print structured json instead of list",
+	Usage:        "print structured json instead of list",
 	EnvKeys:      []string{"JSON"},
 }
 

--- a/cmd/internal/cli/instance_start_linux.go
+++ b/cmd/internal/cli/instance_start_linux.go
@@ -24,7 +24,7 @@ var instanceStartPidFileFlag = cmdline.Flag{
 	Value:        &instanceStartPidFile,
 	DefaultValue: "",
 	Name:         "pid-file",
-	Usage:        "Write instance PID to the file with the given name",
+	Usage:        "write instance PID to the file with the given name",
 	EnvKeys:      []string{"PID_FILE"},
 }
 

--- a/cmd/internal/cli/instance_stop_linux.go
+++ b/cmd/internal/cli/instance_stop_linux.go
@@ -35,7 +35,7 @@ var instanceStopUserFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "user",
 	ShortHand:    "u",
-	Usage:        "If running as root, stop instances belonging to user",
+	Usage:        "if running as root, stop instances belonging to user",
 	Tag:          "<username>",
 	EnvKeys:      []string{"USER"},
 }

--- a/cmd/internal/cli/plugin_install_linux.go
+++ b/cmd/internal/cli/plugin_install_linux.go
@@ -25,7 +25,7 @@ var pluginInstallNameFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "name",
 	ShortHand:    "n",
-	Usage:        "Name to install the plugin as, defaults to the value in the manifest",
+	Usage:        "name to install the plugin as, defaults to the value in the manifest",
 }
 
 func init() {

--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -35,7 +35,7 @@ var runHelpAppNameFlag = cmdline.Flag{
 	Value:        &AppName,
 	DefaultValue: "",
 	Name:         "app",
-	Usage:        "Show the help for an app",
+	Usage:        "show the help for an app",
 	EnvKeys:      []string{"APP"},
 }
 


### PR DESCRIPTION
It's this:

	--flag    this is the description

versus this:

	--flag    This is the description

_most_ of the existing flags use the former (~ 130 vs ~ 10).

Fixes #2925.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
