### PR TITLE
Don't prune integration and E2E tests by hand anymore

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -37,7 +37,7 @@ unit-test:
 	$(V)cd $(SOURCEDIR) && \
 		sudo -E \
 		scripts/go-test -v \
-		`$(GO) list ./... | grep -v "cmd/singularity\|pkg/network\|e2e"`
+		./...
 	@echo "       PASS"
 
 


### PR DESCRIPTION
The purpose of this:

    `$(GO) list ./... | grep -v "cmd/singularity\|pkg/network\|e2e"`

is to manually prune the directories that contain integration and E2E
tests from the unit test run. While this works in the current state of
the repository, note that this is a brittle mechanism, as it uses loose
regular expressions to catch the undesired directories.

Now that the integration and E2E are properly tagged using the
`integration_test` and `e2e_test` build tags, it's possible to remove
this pruning and simply request everything to be tested. By not passing
the corresponding flags, the undesired tests will be automatically
pruned \o/

This has the extra benefit that it will become obvious which code is
lacking tests.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
