### PR TITLE
Clean all environment variables that contain PATH

### DIFF
--- a/internal/pkg/util/env/clean.go
+++ b/internal/pkg/util/env/clean.go
@@ -6,48 +6,24 @@
 package env
 
 import (
-	"os"
 	"strings"
 
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 )
 
-const (
-	envPrefix = "SINGULARITYENV_"
-)
-
-var alwaysPassKeys = map[string]bool{
-	"TERM":        true,
-	"http_proxy":  true,
-	"HTTP_PROXY":  true,
-	"https_proxy": true,
-	"HTTPS_PROXY": true,
-	"no_proxy":    true,
-	"NO_PROXY":    true,
-	"all_proxy":   true,
-	"ALL_PROXY":   true,
-	"ftp_proxy":   true,
-	"FTP_PROXY":   true,
+var alwaysPassKeys = map[string]struct{}{
+	"term":        {},
+	"http_proxy":  {},
+	"https_proxy": {},
+	"no_proxy":    {},
+	"all_proxy":   {},
+	"ftp_proxy":   {},
 }
 
-// SetContainerEnv cleans environment variables before running the container
-func SetContainerEnv(g *generate.Generator, env []string, cleanEnv bool, homeDest string) {
-	// first deal with special variables that allow user to control $PATH at
-	// runtime (meh... special cases)
-	if prependPath := os.Getenv("SINGULARITYENV_PREPEND_PATH"); prependPath != "" {
-		g.AddProcessEnv("SING_USER_DEFINED_PREPEND_PATH", prependPath)
-	}
-
-	if appendPath := os.Getenv("SINGULARITYENV_APPEND_PATH"); appendPath != "" {
-		g.AddProcessEnv("SING_USER_DEFINED_APPEND_PATH", appendPath)
-	}
-
-	if userPath := os.Getenv("SINGULARITYENV_PATH"); userPath != "" {
-		g.AddProcessEnv("SING_USER_DEFINED_PATH", userPath)
-	}
-
-	for _, env := range env {
+// SetContainerEnv cleans environment variables before running the container.
+func SetContainerEnv(g *generate.Generator, hostEnvs []string, cleanEnv bool, homeDest string) {
+	for _, env := range hostEnvs {
 		e := strings.SplitN(env, "=", 2)
 		if len(e) != 2 {
 			sylog.Verbosef("Can't process environment variable %s", env)
@@ -58,35 +34,47 @@ func SetContainerEnv(g *generate.Generator, env []string, cleanEnv bool, homeDes
 			continue
 		}
 
-		if e[0] == "SINGULARITYENV_PREPEND_PATH" ||
-			e[0] == "SINGULARITYENV_APPEND_PATH" ||
-			e[0] == "SINGULARITYENV_PATH" {
-			sylog.Verbosef("Not adding special case PATH control variable %s to container environment", e[0])
-			continue
-		}
-
-		// Transpose host env variables into config
-		if addKey, ok := addIfReq(e[0], cleanEnv); ok {
-			g.AddProcessEnv(addKey, e[1])
+		switch e[0] {
+		case "SINGULARITYENV_PREPEND_PATH":
+			g.AddProcessEnv("SING_USER_DEFINED_PREPEND_PATH", e[1])
+		case "SINGULARITYENV_APPEND_PATH":
+			g.AddProcessEnv("SING_USER_DEFINED_APPEND_PATH", e[1])
+		case "SINGULARITYENV_PATH":
+			g.AddProcessEnv("SING_USER_DEFINED_PATH", e[1])
+		default:
+			// transpose host env variables into config
+			if key := keyToAdd(e[0], cleanEnv); key != "" {
+				g.AddProcessEnv(key, e[1])
+			}
 		}
 	}
 
-	sylog.Verbosef("HOME = %s", homeDest)
+	sylog.Verbosef("HOME=%s", homeDest)
 	g.AddProcessEnv("HOME", homeDest)
 	g.AddProcessEnv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin")
 
-	// Set LANG env
 	if cleanEnv {
 		g.AddProcessEnv("LANG", "C")
 	}
 }
 
-func addIfReq(key string, cleanEnv bool) (string, bool) {
+// keyToAdd processes given key and returns a new non-empty key
+// if the environment variable should be added to the container.
+func keyToAdd(key string, cleanEnv bool) string {
+	const envPrefix = "SINGULARITYENV_"
+
 	if strings.HasPrefix(key, envPrefix) {
-		return strings.TrimPrefix(key, envPrefix), true
-	} else if _, ok := alwaysPassKeys[key]; cleanEnv && !ok {
-		return "", false
+		return strings.TrimPrefix(key, envPrefix)
+	}
+	if _, ok := alwaysPassKeys[strings.ToLower(key)]; ok {
+		return key
+	}
+	if cleanEnv {
+		return ""
+	}
+	if strings.Contains(key, "PATH") {
+		return ""
 	}
 
-	return key, true
+	return key
 }

--- a/internal/pkg/util/env/clean_test.go
+++ b/internal/pkg/util/env/clean_test.go
@@ -6,7 +6,6 @@
 package env
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -19,71 +18,193 @@ func TestSetContainerEnv(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	ociConfig := &oci.Config{}
-	generator := generate.Generator{Config: &ociConfig.Spec}
-
-	type args struct {
-		env       []string
+	tt := []struct {
+		name      string
 		cleanEnv  bool
 		homeDest  string
+		env       []string
 		resultEnv []string
-	}
-	tests := []struct {
-		name string
-		args args
 	}{
-		{name: "NO_SINGULARITYENV_",
-			args: args{[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester",
-				"PS1=test", "TERM=xterm-256color", "PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C",
-				"SINGULARITY_NAME=lolcow.sif"}, false, "/home/tester",
-				[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester", "PS1=test",
-					"TERM=xterm-256color", "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
-					"LANG=C", "PWD=/tmp", "LC_ALL=C"},
-			}},
-		{name: "CLEANENV_true",
-			args: args{[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester",
-				"PS1=test", "TERM=xterm-256color", "PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C",
-				"SINGULARITY_NAME=lolcow.sif", "SINGULARITYENV_FOO=VAR", "CLEANENV=TRUE"}, true, "/home/tester",
-				[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester", "PS1=test",
-					"TERM=xterm-256color", "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
-					"LANG=C", "PWD=/tmp", "LC_ALL=C", "FOO=VAR"},
-			}},
-		{name: "alwaysPassKeys",
-			args: args{[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester",
-				"PS1=test", "TERM=xterm-256color", "PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C",
-				"http_proxy=http_proxy", "https_proxy=https_proxy", "no_proxy=no_proxy", "all_proxy=all_proxy", "ftp_proxy=ftp_proxy",
-				"HTTP_PROXY=http_proxy", "HTTPS_PROXY=https_proxy", "NO_PROXY=no_proxy", "ALL_PROXY=all_proxy", "FTP_PROXY=ftp_proxy",
-				"SINGULARITY_NAME=lolcow.sif", "SINGULARITYENV_FOO=VAR", "CLEANENV=TRUE"}, true, "/home/tester",
-				[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester", "PS1=test", "TERM=xterm-256color", "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
-					"LANG=C", "PWD=/tmp", "LC_ALL=C", "FOO=VAR",
-					"http_proxy=http_proxy", "https_proxy=https_proxy", "no_proxy=no_proxy", "all_proxy=all_proxy", "ftp_proxy=ftp_proxy",
-					"HTTP_PROXY=http_proxy", "HTTPS_PROXY=https_proxy", "NO_PROXY=no_proxy", "ALL_PROXY=all_proxy", "FTP_PROXY=ftp_proxy"},
-			}},
+		{
+			name:     "no SINGULARITYENV_",
+			homeDest: "/home/tester",
+			env: []string{
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+				"HOME=/home/john",
+				"SOME_INVALID_VAR:test",
+				"SINGULARITYENV_=invalid",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"LANG=C",
+				"SINGULARITY_CONTAINER=/tmp/lolcow.sif",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"SINGULARITY_NAME=lolcow.sif",
+			},
+			resultEnv: []string{
+				"HOME=/home/tester",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"LANG=C",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+			},
+		},
+		{
+			name:     "exclude PATH",
+			homeDest: "/home/tester",
+			env: []string{
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+				"HOME=/home/john",
+				"PS1=test",
+				"SOCIOPATH=VolanDeMort",
+				"TERM=xterm-256color",
+				"PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"LANG=C",
+				"SINGULARITYENV_LD_LIBRARY_PATH=/my/custom/libs",
+				"SINGULARITY_CONTAINER=/tmp/lolcow.sif",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"SINGULARITY_NAME=lolcow.sif",
+			},
+			resultEnv: []string{
+				"HOME=/home/tester",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"LANG=C",
+				"LD_LIBRARY_PATH=/my/custom/libs",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+			},
+		},
+		{
+			name:     "special PATH envs",
+			homeDest: "/home/tester",
+			env: []string{
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+				"HOME=/home/john",
+				"SINGULARITYENV_APPEND_PATH=/sylabs/container",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"SINGULARITYENV_PATH=/my/path",
+				"PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"LANG=C",
+				"SINGULARITY_CONTAINER=/tmp/lolcow.sif",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"SINGULARITYENV_PREPEND_PATH=/foo/bar",
+				"SINGULARITY_NAME=lolcow.sif",
+			},
+			resultEnv: []string{
+				"HOME=/home/tester",
+				"SING_USER_DEFINED_APPEND_PATH=/sylabs/container",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"SING_USER_DEFINED_PATH=/my/path",
+				"LANG=C",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"SING_USER_DEFINED_PREPEND_PATH=/foo/bar",
+				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+			},
+		},
+		{
+			name:     "clean envs",
+			cleanEnv: true,
+			homeDest: "/home/tester",
+			env: []string{
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+				"HOME=/home/john",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"LANG=C",
+				"SINGULARITY_CONTAINER=/tmp/lolcow.sif",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"SINGULARITY_NAME=lolcow.sif",
+				"SINGULARITYENV_FOO=VAR",
+				"CLEANENV=TRUE",
+			},
+			resultEnv: []string{
+				"TERM=xterm-256color",
+				"FOO=VAR",
+				"HOME=/home/tester",
+				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+				"LANG=C",
+			},
+		},
+		{
+			name:     "always pass keys",
+			cleanEnv: true,
+			homeDest: "/home/tester",
+			env: []string{
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+				"HOME=/home/john",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"LANG=C",
+				"SINGULARITY_CONTAINER=/tmp/lolcow.sif",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"http_proxy=http_proxy",
+				"https_proxy=https_proxy",
+				"no_proxy=no_proxy",
+				"all_proxy=all_proxy",
+				"ftp_proxy=ftp_proxy",
+				"HTTP_PROXY=http_proxy",
+				"HTTPS_PROXY=https_proxy",
+				"NO_PROXY=no_proxy",
+				"ALL_PROXY=all_proxy",
+				"FTP_PROXY=ftp_proxy",
+				"SINGULARITY_NAME=lolcow.sif",
+				"SINGULARITYENV_FOO=VAR",
+				"CLEANENV=TRUE",
+			},
+			resultEnv: []string{
+				"TERM=xterm-256color",
+				"http_proxy=http_proxy",
+				"https_proxy=https_proxy",
+				"no_proxy=no_proxy",
+				"all_proxy=all_proxy",
+				"ftp_proxy=ftp_proxy",
+				"HTTP_PROXY=http_proxy",
+				"HTTPS_PROXY=https_proxy",
+				"NO_PROXY=no_proxy",
+				"ALL_PROXY=all_proxy",
+				"FTP_PROXY=ftp_proxy",
+				"FOO=VAR",
+				"HOME=/home/tester",
+				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+				"LANG=C",
+			},
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			SetContainerEnv(&generator, tt.args.env, tt.args.cleanEnv, tt.args.homeDest)
-			if !equal(ociConfig.Process.Env, tt.args.resultEnv) {
-				fmt.Println(ociConfig.Process.Env)
-				t.Fail()
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ociConfig := &oci.Config{}
+			generator := generate.Generator{Config: &ociConfig.Spec}
+
+			SetContainerEnv(&generator, tc.env, tc.cleanEnv, tc.homeDest)
+			if !equal(t, ociConfig.Process.Env, tc.resultEnv) {
+				t.Fatalf("unexpected envs:\n want: %v\ngot: %v", tc.resultEnv, ociConfig.Process.Env)
 			}
 		})
 	}
 }
 
-// equal tells whether a and b contain the same elements.
-// A nil argument is equivalent to an empty slice.
-func equal(a, b []string) bool {
+// equal tells whether a and b contain the same elements in the
+// same order. A nil argument is equivalent to an empty slice.
+func equal(t *testing.T, a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i, v := range a {
-		fmt.Println(v, b[i])
 		if c := strings.Compare(v, b[i]); c != 0 {
-			fmt.Println(v, b[i])
 			return false
 		}
 	}

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-// SetFromList sets environment variables from environ argument list
+// SetFromList sets environment variables from environ argument list.
 func SetFromList(environ []string) error {
 	for _, env := range environ {
 		splitted := strings.SplitN(env, "=", 2)

--- a/internal/pkg/util/env/env_test.go
+++ b/internal/pkg/util/env/env_test.go
@@ -15,27 +15,52 @@ func TestSetFromList(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	type args struct {
-		environ []string
-	}
-	tests := []struct {
+	tt := []struct {
 		name    string
-		args    args
+		environ []string
 		wantErr bool
 	}{
-		{name: "Good_envs", args: args{[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester",
-			"PS1=test", "TERM=xterm-256color", "PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "PWD=/tmp", "LC_ALL=C",
-			"SINGULARITY_NAME=lolcow.sif"}}, wantErr: false},
-		{name: "Bad_envs", args: args{[]string{"LD_LIBRARY_PATH=/.singularity.d/libs", "HOME=/home/tester",
-			"PS1=test", "TERM=xterm-256color", "PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"LANG=C", "SINGULARITY_CONTAINER=/tmp/lolcow.sif", "TEST", "LC_ALL=C",
-			"SINGULARITY_NAME=lolcow.sif"}}, wantErr: true},
+		{
+			name: "all ok",
+			environ: []string{
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+				"HOME=/home/tester",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"LANG=C",
+				"SINGULARITY_CONTAINER=/tmp/lolcow.sif",
+				"PWD=/tmp",
+				"LC_ALL=C",
+				"SINGULARITY_NAME=lolcow.sif",
+			},
+			wantErr: false,
+		},
+		{
+			name: "bad envs",
+			environ: []string{
+				"LD_LIBRARY_PATH=/.singularity.d/libs",
+				"HOME=/home/tester",
+				"PS1=test",
+				"TERM=xterm-256color",
+				"PATH=/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"LANG=C",
+				"SINGULARITY_CONTAINER=/tmp/lolcow.sif",
+				"TEST",
+				"LC_ALL=C",
+				"SINGULARITY_NAME=lolcow.sif",
+			},
+			wantErr: true,
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := SetFromList(tt.args.environ); (err != nil) != tt.wantErr {
-				t.Errorf("SetFromList() error = %v, wantErr %v", err, tt.wantErr)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SetFromList(tc.environ)
+			if tc.wantErr && err == nil {
+				t.Fatalf("Expected error, but got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Unexpected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- do not propagate any envs that contain PATH
- get special PATH envs from the passed envs, not by calling `Getenv`. Currently `SetContainerEnv` is called from two places: [here](https://github.com/sylabs/singularity/blob/master/cmd/internal/cli/actions_linux.go#L478) where calling `Getenv` doesn't make sense since they are collected right before, and [here](https://github.com/sylabs/singularity/blob/master/internal/pkg/runtime/engine/imgbuild/process_linux.go#L106) where envs are already cleaned by starter.
- fix wrong tests in the package
- use empty struct as a canonical way to represent set

**This fixes or addresses the following GitHub issues:**

- Fixes #3331
- Closes #4366

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
