### PR TITLE
Mark some tests as "not short"

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -51,6 +51,9 @@ func TestDebootstrapConveyor(t *testing.T) {
 }
 
 func TestDebootstrapPacker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 
 	if _, err := exec.LookPath("debootstrap"); err != nil {
 		t.Skip("skipping test, debootstrap not installed")

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -48,6 +48,10 @@ func setupCache(t *testing.T) (*cache.Handle, func()) {
 
 // TestOCIConveyorDocker tests if we can pull an alpine image from dockerhub
 func TestOCIConveyorDocker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
@@ -80,6 +84,10 @@ func TestOCIConveyorDocker(t *testing.T) {
 // TestOCIConveyorDockerArchive tests if we can use a docker save archive
 // as a source
 func TestOCIConveyorDockerArchive(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -59,6 +59,10 @@ func TestYumConveyor(t *testing.T) {
 }
 
 func TestYumPacker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	_, dnfErr := exec.LookPath("dnf")
 	_, yumErr := exec.LookPath("yum")
 	if dnfErr != nil && yumErr != nil {

--- a/internal/pkg/build/sources/conveyorPacker_zypper_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper_test.go
@@ -77,6 +77,10 @@ func TestZypperConveyor(t *testing.T) {
 }
 
 func TestZypperPacker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.EnsurePrivilege(t)
 
 	if _, err := exec.LookPath("zypper"); err != nil {

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -107,9 +107,14 @@ func checkSection(reader io.Reader) error {
 }
 
 func TestReader(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	// XXX(mem): This is what makes the test slow
 	filename := downloadImage(t)
 	defer os.Remove(filename)
 
@@ -186,6 +191,10 @@ func TestReader(t *testing.T) {
 }
 
 func TestAuthorizedPath(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
@@ -210,6 +219,7 @@ func TestAuthorizedPath(t *testing.T) {
 			shouldPass: true},
 	}
 
+	// XXX(mem): This is what makes this test slow
 	img, path := createImage(t)
 	defer os.Remove(path)
 
@@ -269,6 +279,10 @@ func runAuthorizedOwnerTest(t *testing.T, testDescr ownerGroupTest, img *Image) 
 }
 
 func TestRootAuthorizedOwner(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// Function focusing only on executing the privileged case
 	test.EnsurePrivilege(t)
 
@@ -290,6 +304,7 @@ func TestRootAuthorizedOwner(t *testing.T) {
 		},
 	}
 
+	// XXX(mem): This is what makes this test slow
 	img, path := createImage(t)
 	defer os.Remove(path)
 
@@ -301,6 +316,10 @@ func TestRootAuthorizedOwner(t *testing.T) {
 }
 
 func TestAuthorizedOwner(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// We will create a runtime test based on the current user that assumes
 	// this not a privileged test
 	test.DropPrivilege(t)
@@ -338,6 +357,7 @@ func TestAuthorizedOwner(t *testing.T) {
 	}
 	tests = append(tests, localUser)
 
+	// XXX(mem): This is what makes this test slow
 	img, path := createImage(t)
 	defer os.Remove(path)
 
@@ -370,6 +390,10 @@ func runAuthorizedGroupTest(t *testing.T, tt groupTest, img *Image) {
 }
 
 func TestPrivilegedAuthorizedGroup(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.EnsurePrivilege(t) // to make sure we create the image under the correct user
 
 	tests := []groupTest{
@@ -389,6 +413,7 @@ func TestPrivilegedAuthorizedGroup(t *testing.T) {
 		*/
 	}
 
+	// XXX(mem): This is what makes this test slow
 	img, path := createImage(t)
 	defer os.Remove(path)
 
@@ -398,6 +423,10 @@ func TestPrivilegedAuthorizedGroup(t *testing.T) {
 }
 
 func TestAuthorizedGroup(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
@@ -432,6 +461,7 @@ func TestAuthorizedGroup(t *testing.T) {
 	}
 	tests = append(tests, validTest)
 
+	// XXX(mem): This is what makes this test slow
 	img, path := createImage(t)
 	defer os.Remove(path)
 

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -22,6 +22,10 @@ import (
 )
 
 func TestFromSif(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.EnsurePrivilege(t)
 
 	// prepare bundle directory and download a SIF image

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -516,6 +516,10 @@ func TestPrintEntities(t *testing.T) {
 }
 
 func TestGenKeyPair(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 


### PR DESCRIPTION
Add `if testing.Short()` to the slower tests (above one second) to try
to keep unit test runtime under control. Some of these tests are
exceedingly long (over a minute).

This is _not_ changing anything in terms of the tests that run or don't
run, as the required flag to `go test` (`-short`) is not passed at the
moment.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
