### PR TITLE
Fix error when using sandbox path with slash at the end

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// RunE2ETests is the main func to trigger the test suite
+// RunE2ETests is the main func to trigger the test suite.
 func RunE2ETests(t *testing.T) {
 	t.Log("Running E2E tests for Singularity")
 	Run(t)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -27,6 +27,9 @@ type imgBuildTests struct {
 func (c *imgBuildTests) buildFrom(t *testing.T) {
 	e2e.PrepRegistry(t, c.env)
 
+	// use a trailing slash in tests for sandbox intentionally to make sure
+	// `singularity build -s /tmp/sand/ docker://alpine` works,
+	// see https://github.com/sylabs/singularity/issues/4407
 	tt := []struct {
 		name       string
 		dest       string

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -17,14 +17,13 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/test/tool/exec"
 )
 
-// ImageVerify checks for an image integrity
+// ImageVerify checks for an image integrity.
 func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
-	type testSpec struct {
+	tt := []struct {
 		name string
 		argv []string
 		exit int
-	}
-	tests := []testSpec{
+	}{
 		{
 			name: "False",
 			argv: []string{imagePath, "false"},
@@ -72,14 +71,14 @@ func (env TestEnv) ImageVerify(t *testing.T, imagePath string) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tc := range tt {
 		env.RunSingularity(
 			t,
-			AsSubtest(tt.name),
+			AsSubtest(tc.name),
 			WithProfile(UserProfile),
 			WithCommand("exec"),
-			WithArgs(tt.argv...),
-			ExpectExit(tt.exit),
+			WithArgs(tc.argv...),
+			ExpectExit(tc.exit),
 		)
 	}
 }

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -79,6 +79,7 @@ func New(defs []types.Definition, conf Config) (*Build, error) {
 func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 	syscall.Umask(0002)
 
+	conf.Dest = filepath.Clean(conf.Dest)
 	// always build a sandbox if updating an existing sandbox
 	if conf.Opts.Update {
 		conf.Format = "sandbox"


### PR DESCRIPTION
**Description of the Pull Request (PR):**

- clean build destination path to avoid bugs (e.g. `singularity build -s /tmp/sand/ docker://alpine` doesn't work now because of slash in the end)
- format tests so they are more readable, run build tests as subtests to avoid skipping of all test cases
- use string concatenation instead of `filepath.Join` in build tests to check the case with slash at the end (`filepath.Join` calls clean under the hood)

**This fixes or addresses the following GitHub issues:**

- Fixes #4407


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
