### PR TITLE
Keep list of E2E test suites sorted

### DIFF
--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -131,12 +131,13 @@ func Run(t *testing.T) {
 	// is stopped after tests run.
 	defer e2e.KillRegistry(t, testenv)
 
-	// RunE2ETests by functionality
+	// RunE2ETests by functionality.
+	//
+	// Please keep this list sorted.
 	suites := map[string]func(*testing.T){
-		"SECURITY":    security.E2ETests(testenv),
 		"ACTIONS":     actions.E2ETests(testenv),
-		"BUILD":       imgbuild.E2ETests(testenv),
 		"BUILDCFG":    e2ebuildcfg.E2ETests(testenv),
+		"BUILD":       imgbuild.E2ETests(testenv),
 		"CACHE":       cache.E2ETests(testenv),
 		"CMDENVVARS":  cmdenvvars.E2ETests(testenv),
 		"DOCKER":      docker.E2ETests(testenv),
@@ -148,12 +149,13 @@ func Run(t *testing.T) {
 		"OCI":         oci.E2ETests(testenv),
 		"PULL":        pull.E2ETests(testenv),
 		"PUSH":        push.E2ETests(testenv),
+		"REGRESSIONS": regressions.E2ETests(testenv),
 		"REMOTE":      remote.E2ETests(testenv),
 		"RUN":         run.E2ETests(testenv),
+		"SECURITY":    security.E2ETests(testenv),
 		"SIGN":        sign.E2ETests(testenv),
 		"VERIFY":      verify.E2ETests(testenv),
 		"VERSION":     version.E2ETests(testenv),
-		"REGRESSIONS": regressions.E2ETests(testenv),
 	}
 
 	for name, fn := range suites {


### PR DESCRIPTION
Sort the list of E2E test suites alphabetically, again.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
