### PR TITLE
Preserve parent OCI config

### DIFF
--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sylabs/singularity/pkg/util/crypt"
 )
 
-// SIFAssembler doesnt store anything
+// SIFAssembler doesn't store anything.
 type SIFAssembler struct {
 	GzipFlag       bool
 	MksquashfsPath string
@@ -151,7 +151,7 @@ func createSIF(path string, definition, ociConf []byte, squashfile string, encOp
 	return nil
 }
 
-// Assemble creates a SIF image from a Bundle
+// Assemble creates a SIF image from a Bundle.
 func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 	sylog.Infof("Creating SIF file...")
 
@@ -211,7 +211,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 
 	}
 
-	err = createSIF(path, b.Recipe.Raw, b.JSONObjects["oci-config"], fsPath, encOpts)
+	err = createSIF(path, b.Recipe.Raw, b.JSONObjects[types.OCIConfigJSON], fsPath, encOpts)
 	if err != nil {
 		return fmt.Errorf("while creating SIF: %v", err)
 	}
@@ -220,7 +220,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 }
 
 // changeOwner check the command being called with sudo with the environment
-// variable SUDO_COMMAND. Pattern match that for the singularity bin
+// variable SUDO_COMMAND. Pattern match that for the singularity bin.
 func changeOwner() (int, int, bool) {
 	r := regexp.MustCompile("(singularity)")
 	sudoCmd := os.Getenv("SUDO_COMMAND")

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -42,20 +42,20 @@ import (
 type Build struct {
 	// stages of the build
 	stages []stage
-	// Conf contains cross stage build configuration
+	// Conf contains cross stage build configuration.
 	Conf Config
 }
 
 // Config defines how build is executed, including things like where final image is written.
 type Config struct {
-	// Dest is the location for container after build is complete
+	// Dest is the location for container after build is complete.
 	Dest string
-	// Format is the format of built container, e.g., SIF, sandbox
+	// Format is the format of built container, e.g. SIF, sandbox.
 	Format string
-	// NoCleanUp allows a user to prevent a bundle from being cleaned up after a failed build
-	// useful for debugging
+	// NoCleanUp allows a user to prevent a bundle from being cleaned
+	// up after a failed build, useful for debugging.
 	NoCleanUp bool
-	// Opts for bundles
+	// Opts for bundles.
 	Opts types.Options
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -25,7 +25,7 @@ type LibraryConveyorPacker struct {
 	LocalPacker
 }
 
-// Get downloads container from Singularityhub
+// Get downloads container from Sylabs Cloud Library.
 func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 	sylog.Debugf("Getting container from Library")
 
@@ -116,7 +116,7 @@ func (cp *LibraryConveyorPacker) Get(b *types.Bundle) (err error) {
 	return err
 }
 
-// CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem
+// CleanUp removes any files owned by the conveyorPacker on the filesystem.
 func (cp *LibraryConveyorPacker) CleanUp() {
 	cp.b.Remove()
 }

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -47,7 +47,7 @@ func GetLocalPacker(src string, b *types.Bundle) (LocalPacker, error) {
 		sylog.Debugf("Packing from SIF")
 
 		return &SIFPacker{
-			srcfile: src,
+			srcFile: src,
 			b:       b,
 		}, nil
 	case image.SQUASHFS:
@@ -84,7 +84,7 @@ func GetLocalPacker(src string, b *types.Bundle) (LocalPacker, error) {
 	}
 }
 
-// Get just stores the source
+// Get just stores the source.
 func (cp *LocalConveyorPacker) Get(b *types.Bundle) (err error) {
 	// insert base metadata before unpacking fs
 	if err = makeBaseEnv(b.RootfsPath); err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -31,6 +31,7 @@ import (
 	ociclient "github.com/sylabs/singularity/internal/pkg/client/oci"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/shell"
+	buildTypes "github.com/sylabs/singularity/pkg/build/types"
 	sytypes "github.com/sylabs/singularity/pkg/build/types"
 )
 
@@ -144,7 +145,7 @@ func (cp *OCIConveyorPacker) Get(b *sytypes.Bundle) (err error) {
 	return nil
 }
 
-// Pack puts relevant objects in a Bundle!
+// Pack puts relevant objects in a Bundle.
 func (cp *OCIConveyorPacker) Pack() (*sytypes.Bundle, error) {
 	err := cp.unpackTmpfs()
 	if err != nil {
@@ -208,7 +209,7 @@ func (cp *OCIConveyorPacker) insertOCIConfig() error {
 		return err
 	}
 
-	cp.b.JSONObjects["oci-config"] = conf
+	cp.b.JSONObjects[buildTypes.OCIConfigJSON] = conf
 	return nil
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -15,7 +15,7 @@ import (
 )
 
 // OrasConveyorPacker only needs to hold a packer to pack the image it pulls
-// as well as extra information about the library it's pulling from
+// as well as extra information about the library it's pulling from.
 type OrasConveyorPacker struct {
 	LocalPacker
 }

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -14,7 +14,7 @@ import (
 	shub "github.com/sylabs/singularity/pkg/client/shub"
 )
 
-// ShubConveyorPacker only needs to hold the conveyor to have the needed data to pack
+// ShubConveyorPacker only needs to hold the conveyor to have the needed data to pack.
 type ShubConveyorPacker struct {
 	recipe types.Definition
 	b      *types.Bundle

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sylabs/singularity/pkg/build/types"
 )
 
-// SIFPacker holds the locations of where to pack from and to
+// SIFPacker holds the locations of where to pack from and to.
 type SIFPacker struct {
-	srcfile string
+	srcFile string
 	b       *types.Bundle
 }

--- a/internal/pkg/build/sources/packer_sif_linux.go
+++ b/internal/pkg/build/sources/packer_sif_linux.go
@@ -77,13 +77,14 @@ func unpackSIF(b *types.Bundle, srcFile string) (err error) {
 	}
 
 	ociReader, err := image.NewSectionReader(img, "oci-config.json", -1)
-	if err != nil && err != image.ErrNoSection {
-		sylog.Errorf("Could not read image OCI config: %v", err)
-	}
-	if ociReader != nil {
+	if err == image.ErrNoSection {
+		sylog.Debugf("No oci-config.json section found")
+	} else if err != nil {
+		return fmt.Errorf("could not get OCI config section reader: %v", err)
+	} else {
 		ociConfig, err := ioutil.ReadAll(ociReader)
 		if err != nil {
-			sylog.Errorf("Could not read OCI config: %v", err)
+			return fmt.Errorf("could not read OCI config: %v", err)
 		}
 		b.JSONObjects[types.OCIConfigJSON] = ociConfig
 	}

--- a/internal/pkg/build/sources/packer_sif_unsupported.go
+++ b/internal/pkg/build/sources/packer_sif_unsupported.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sylabs/singularity/pkg/build/types"
 )
 
-// Pack puts relevant objects in a Bundle!
+// Pack puts relevant objects in a Bundle.
 func (p *SIFPacker) Pack() (*types.Bundle, error) {
 	return nil, fmt.Errorf("unsupported on this platform")
 }

--- a/internal/pkg/build/sources/packer_squashfs.go
+++ b/internal/pkg/build/sources/packer_squashfs.go
@@ -28,7 +28,7 @@ type SquashfsPacker struct {
 func (p *SquashfsPacker) Pack() (*types.Bundle, error) {
 	rootfs := p.srcfile
 
-	err := p.unpackSquashfs(p.b, p.info, rootfs)
+	err := unpackSquashfs(p.b, p.info, rootfs)
 	if err != nil {
 		sylog.Errorf("unpackSquashfs Failed: %s", err)
 		return nil, err
@@ -38,10 +38,10 @@ func (p *SquashfsPacker) Pack() (*types.Bundle, error) {
 }
 
 // unpackSquashfs removes the image header with dd and then unpackes image into bundle directories with unsquashfs
-func (p *SquashfsPacker) unpackSquashfs(b *types.Bundle, info *loop.Info64, rootfs string) (err error) {
+func unpackSquashfs(b *types.Bundle, info *loop.Info64, rootfs string) (err error) {
 	var stderr bytes.Buffer
 
-	trimfile, err := ioutil.TempFile(p.b.TmpDir, "trim.squashfs")
+	trimfile, err := ioutil.TempFile(b.TmpDir, "trim.squashfs")
 	if err != nil {
 		return fmt.Errorf("while making tmp file: %v", err)
 	}

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -17,7 +17,7 @@ import (
 
 // stage represents the process of constructing a root filesystem.
 type stage struct {
-	// name of the stage
+	// name of the stage.
 	name string
 	// c Gets and Packs data needed to build a container into a Bundle from various sources.
 	c ConveyorPacker

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -17,6 +17,8 @@ import (
 	"github.com/sylabs/singularity/pkg/util/crypt"
 )
 
+const OCIConfigJSON = "oci-config"
+
 // Bundle is the temporary environment used during the image building process.
 type Bundle struct {
 	JSONObjects map[string][]byte `json:"jsonObjects"`

--- a/pkg/image/reader.go
+++ b/pkg/image/reader.go
@@ -16,9 +16,9 @@ type readerError string
 func (e readerError) Error() string { return string(e) }
 
 const (
-	// ErrNoSection corresponds to an image section not found
+	// ErrNoSection corresponds to an image section not found.
 	ErrNoSection = readerError("no section found")
-	// ErrNoPartition corresponds to an image partition not found
+	// ErrNoPartition corresponds to an image partition not found.
 	ErrNoPartition = readerError("no partition found")
 )
 
@@ -83,7 +83,7 @@ func NewPartitionReader(image *Image, name string, index int) (io.Reader, error)
 // NewSectionReader searches and returns a reader for an image
 // section identified by name or by index, if index is less than 0
 // only section with provided name will be returned if a matching
-// entry is found
+// entry is found.
 func NewSectionReader(image *Image, name string, index int) (io.Reader, error) {
 	return commonSectionReader(false, image, name, index)
 }

--- a/pkg/image/sandbox.go
+++ b/pkg/image/sandbox.go
@@ -11,8 +11,8 @@ import (
 
 type sandboxFormat struct{}
 
-func (f *sandboxFormat) initializer(img *Image, fileinfo os.FileInfo) error {
-	if fileinfo.IsDir() {
+func (f *sandboxFormat) initializer(img *Image, fi os.FileInfo) error {
+	if fi.IsDir() {
 		img.Type = SANDBOX
 	} else {
 		return debugError("not a directory image")

--- a/pkg/image/unpacker/squashfs.go
+++ b/pkg/image/unpacker/squashfs.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 )
 
-// Squashfs represents a squashfs unpacker
+// Squashfs represents a squashfs unpacker.
 type Squashfs struct {
 	UnsquashfsPath string
 }
@@ -76,13 +76,13 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) error 
 }
 
 // ExtractAll extracts a squashfs filesystem read from reader to a
-// destination directory
+// destination directory.
 func (s *Squashfs) ExtractAll(reader io.Reader, dest string) error {
-	return s.extract([]string{}, reader, dest)
+	return s.extract(nil, reader, dest)
 }
 
 // ExtractFiles extracts provided files from a squashfs filesystem
-// read from reader to a destination directory
+// read from reader to a destination directory.
 func (s *Squashfs) ExtractFiles(files []string, reader io.Reader, dest string) error {
 	if len(files) == 0 {
 		return fmt.Errorf("no files to extract")


### PR DESCRIPTION
**Description of the Pull Request (PR):**

In order to preserve parent's OCI config SIF packer now stores it (if any) into a bundle's JSON objects map.

Also minor changes:
- add a constant for oci config JSON object 
- change methods to functions where receiver is not used
- use sif magic as defined in sif package
- use nil slice instead of `[]string{}` in squashfs extractor
- remove redundant uint64 conversion
- do not check rootfs descriptor datatype b/c it is already checked in the next called function
- use camelCase/common names where possible
- add periods in godoc comments

**This fixes or addresses the following GitHub issues:**

- Fixes #4415 

**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
