### PR TITLE
Change method receiver to test functions to be a value, not a pointer

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -25,7 +25,7 @@ type actionTests struct {
 }
 
 // run tests min fuctionality for singularity run
-func (c *actionTests) actionRun(t *testing.T) {
+func (c actionTests) actionRun(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tests := []struct {
@@ -73,7 +73,7 @@ func (c *actionTests) actionRun(t *testing.T) {
 }
 
 // exec tests min fuctionality for singularity exec
-func (c *actionTests) actionExec(t *testing.T) {
+func (c actionTests) actionExec(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	user := e2e.CurrentUser(t)
@@ -243,7 +243,7 @@ func (c *actionTests) actionExec(t *testing.T) {
 }
 
 // Shell interaction tests
-func (c *actionTests) actionShell(t *testing.T) {
+func (c actionTests) actionShell(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	hostname, err := os.Hostname()
@@ -309,7 +309,7 @@ func (c *actionTests) actionShell(t *testing.T) {
 }
 
 // STDPipe tests pipe stdin/stdout to singularity actions cmd
-func (c *actionTests) STDPipe(t *testing.T) {
+func (c actionTests) STDPipe(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	stdinTests := []struct {
@@ -450,7 +450,7 @@ func (c *actionTests) STDPipe(t *testing.T) {
 }
 
 // RunFromURI tests min fuctionality for singularity run/exec URI://
-func (c *actionTests) RunFromURI(t *testing.T) {
+func (c actionTests) RunFromURI(t *testing.T) {
 	e2e.PrepRegistry(t, c.env)
 
 	runScript := "testdata/runscript.sh"
@@ -638,7 +638,7 @@ func (c *actionTests) RunFromURI(t *testing.T) {
 }
 
 // PersistentOverlay test the --overlay function
-func (c *actionTests) PersistentOverlay(t *testing.T) {
+func (c actionTests) PersistentOverlay(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	var squashfsImage = filepath.Join(c.env.TestDir, "squashfs.simg")
@@ -839,7 +839,7 @@ func (c *actionTests) PersistentOverlay(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &actionTests{
+	c := actionTests{
 		env: env,
 	}
 

--- a/e2e/buildcfg/buildcfg.go
+++ b/e2e/buildcfg/buildcfg.go
@@ -15,7 +15,7 @@ type buildcfgTests struct {
 	env e2e.TestEnv
 }
 
-func (c *buildcfgTests) buildcfgTests(t *testing.T) {
+func (c buildcfgTests) buildcfgTests(t *testing.T) {
 	tests := []struct {
 		name           string
 		cmdArgs        []string
@@ -45,7 +45,7 @@ func (c *buildcfgTests) buildcfgTests(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &buildcfgTests{
+	c := buildcfgTests{
 		env: env,
 	}
 

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -40,7 +40,7 @@ func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, h *cache.Handl
 	ensureCacheNotEmpty(t, testName, imagePath, h)
 }
 
-func (c *cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
+func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 	tests := []struct {
 		name               string
 		options            []string
@@ -123,7 +123,7 @@ func (c *cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 	}
 }
 
-func (c *cacheTests) testInteractiveCacheCmds(t *testing.T) {
+func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 	tt := []struct {
 		name               string
 		options            []string
@@ -299,7 +299,7 @@ func ensureCacheNotEmpty(t *testing.T, testName string, imagePath string, h *cac
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
 	return func(t *testing.T) {
-		c := &cacheTests{
+		c := cacheTests{
 			env: env,
 		}
 		t.Run("cacheInteractiveCmds", c.testInteractiveCacheCmds)

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -76,7 +76,7 @@ func (c *ctx) cacheIsNotExist(t *testing.T, imgPath string) {
 	}
 }
 
-func (c *ctx) testSingularityCacheDir(t *testing.T) {
+func (c ctx) testSingularityCacheDir(t *testing.T) {
 	// The intent of the test is simple:
 	// - create 2 temporary directories, one where the image will be pulled and one where the
 	//   image cache should be created,
@@ -103,7 +103,7 @@ func (c *ctx) testSingularityCacheDir(t *testing.T) {
 	}
 }
 
-func (c *ctx) testSingularityDisableCache(t *testing.T) {
+func (c ctx) testSingularityDisableCache(t *testing.T) {
 	testDir, cacheDir, cleanup := setupTempDirs(t, false)
 	c.env.TestDir = testDir
 	defer cleanup(t)
@@ -122,7 +122,7 @@ func (c *ctx) testSingularityDisableCache(t *testing.T) {
 // usage of sandboxes shared between users is a common practice. In that
 // context, the home directory ends up being read-only and no caching
 // is required.
-func (c *ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
+func (c ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
 	testDir, cacheDir, cleanup := setupTempDirs(t, true)
 	c.env.TestDir = testDir
 	defer cleanup(t)
@@ -146,7 +146,7 @@ func (c *ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
 	c.cacheIsNotExist(t, imgPath)
 }
 
-func (c *ctx) testSingularitySypgpDir(t *testing.T) {
+func (c ctx) testSingularitySypgpDir(t *testing.T) {
 	// Create a temporary directory to be used for a keyring
 	keyringDir, err := ioutil.TempDir("", "e2e-sypgp-env-")
 	if err != nil {
@@ -184,7 +184,7 @@ func (c *ctx) testSingularitySypgpDir(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/delete/delete.go
+++ b/e2e/delete/delete.go
@@ -16,7 +16,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-func (c *ctx) testDeleteCmd(t *testing.T) {
+func (c ctx) testDeleteCmd(t *testing.T) {
 	tests := []struct {
 		name       string
 		args       []string
@@ -57,7 +57,7 @@ func (c *ctx) testDeleteCmd(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite.
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -22,7 +22,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-func (c *ctx) testDockerPulls(t *testing.T) {
+func (c ctx) testDockerPulls(t *testing.T) {
 	const tmpContainerFile = "test_container.sif"
 
 	tmpPath, err := fs.MakeTmpDir(c.env.TestDir, "docker-", 0755)
@@ -117,7 +117,7 @@ func (c *ctx) testDockerPulls(t *testing.T) {
 }
 
 // AUFS sanity tests
-func (c *ctx) testDockerAUFS(t *testing.T) {
+func (c ctx) testDockerAUFS(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	defer os.Remove(imagePath)
 
@@ -163,7 +163,7 @@ func (c *ctx) testDockerAUFS(t *testing.T) {
 }
 
 // Check force permissions for user builds #977
-func (c *ctx) testDockerPermissions(t *testing.T) {
+func (c ctx) testDockerPermissions(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	defer os.Remove(imagePath)
 
@@ -208,7 +208,7 @@ func (c *ctx) testDockerPermissions(t *testing.T) {
 }
 
 // Check whiteout of symbolic links #1592 #1576
-func (c *ctx) testDockerWhiteoutSymlink(t *testing.T) {
+func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	defer os.Remove(imagePath)
 
@@ -227,7 +227,7 @@ func (c *ctx) testDockerWhiteoutSymlink(t *testing.T) {
 	)
 }
 
-func (c *ctx) testDockerDefFile(t *testing.T) {
+func (c ctx) testDockerDefFile(t *testing.T) {
 	getKernelMajor := func(t *testing.T) (major int) {
 		var buf unix.Utsname
 		if err := unix.Uname(&buf); err != nil {
@@ -306,7 +306,7 @@ func (c *ctx) testDockerDefFile(t *testing.T) {
 	}
 }
 
-func (c *ctx) testDockerRegistry(t *testing.T) {
+func (c ctx) testDockerRegistry(t *testing.T) {
 	e2e.PrepRegistry(t, c.env)
 
 	tests := []struct {
@@ -371,7 +371,7 @@ func (c *ctx) testDockerRegistry(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -18,7 +18,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-func (c *ctx) singularityEnv(t *testing.T) {
+func (c ctx) singularityEnv(t *testing.T) {
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
 	var defaultImage = "docker://alpine:3.8"
 	var defaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -106,7 +106,7 @@ func (c *ctx) singularityEnv(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/help/help.go
+++ b/e2e/help/help.go
@@ -44,7 +44,7 @@ var helpOciContentTests = []struct {
 	{"HelpOciUpdate", []string{"oci", "update"}},
 }
 
-func (c *ctx) testHelpOciContent(t *testing.T) {
+func (c ctx) testHelpOciContent(t *testing.T) {
 	for _, tc := range helpOciContentTests {
 
 		name := fmt.Sprintf("help-%s.txt", strings.Join(tc.cmds, "-"))
@@ -71,7 +71,7 @@ func (c *ctx) testHelpOciContent(t *testing.T) {
 	}
 }
 
-func (c *ctx) testCommands(t *testing.T) {
+func (c ctx) testCommands(t *testing.T) {
 	testCommands := []struct {
 		name string
 		cmd  string
@@ -151,7 +151,7 @@ func (c *ctx) testCommands(t *testing.T) {
 
 }
 
-func (c *ctx) testFailure(t *testing.T) {
+func (c ctx) testFailure(t *testing.T) {
 	if !c.env.RunDisabled {
 		t.Skip("disabled until issue addressed") // TODO
 	}
@@ -189,7 +189,7 @@ const (
 	helpHelpExpectedOutput = "Help about any command"
 )
 
-func (c *ctx) testSingularity(t *testing.T) {
+func (c ctx) testSingularity(t *testing.T) {
 	tests := []struct {
 		name           string
 		argv           []string
@@ -260,7 +260,7 @@ func (c *ctx) testSingularity(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -24,7 +24,7 @@ type imgBuildTests struct {
 	env e2e.TestEnv
 }
 
-func (c *imgBuildTests) buildFrom(t *testing.T) {
+func (c imgBuildTests) buildFrom(t *testing.T) {
 	e2e.PrepRegistry(t, c.env)
 
 	// use a trailing slash in tests for sandbox intentionally to make sure
@@ -127,7 +127,7 @@ func (c *imgBuildTests) buildFrom(t *testing.T) {
 	}
 }
 
-func (c *imgBuildTests) nonRootBuild(t *testing.T) {
+func (c imgBuildTests) nonRootBuild(t *testing.T) {
 	tt := []struct {
 		name      string
 		buildSpec string
@@ -196,7 +196,7 @@ func (c *imgBuildTests) nonRootBuild(t *testing.T) {
 	}
 }
 
-func (c *imgBuildTests) buildLocalImage(t *testing.T) {
+func (c imgBuildTests) buildLocalImage(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	tmpdir, err := ioutil.TempDir(c.env.TestDir, "build-local-image.")
@@ -268,7 +268,7 @@ func (c *imgBuildTests) buildLocalImage(t *testing.T) {
 	}
 }
 
-func (c *imgBuildTests) badPath(t *testing.T) {
+func (c imgBuildTests) badPath(t *testing.T) {
 	imagePath := path.Join(c.env.TestDir, "container")
 	c.env.RunSingularity(
 		t,
@@ -279,7 +279,7 @@ func (c *imgBuildTests) badPath(t *testing.T) {
 	)
 }
 
-func (c *imgBuildTests) buildMultiStageDefinition(t *testing.T) {
+func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {
 		log.Fatal(err)
@@ -494,7 +494,7 @@ func (c *imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 	}
 }
 
-func (c *imgBuildTests) buildDefinition(t *testing.T) {
+func (c imgBuildTests) buildDefinition(t *testing.T) {
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {
 		log.Fatal(err)
@@ -878,7 +878,7 @@ func (c *imgBuildTests) ensureImageIsEncrypted(t *testing.T, imgPath string) {
 	)
 }
 
-func (c *imgBuildTests) buildEncryptPemFile(t *testing.T) {
+func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	// Expected results for a successful command execution
 	expectedExitCode := 0
 	expectedStderr := ""
@@ -944,7 +944,7 @@ func (c *imgBuildTests) buildEncryptPemFile(t *testing.T) {
 // buildEncryptPassphrase is exercising the build command for encrypted containers
 // while using a passphrase. Note that it covers both the normal case and when the
 // version of cryptsetup available is not compliant.
-func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
+func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// Expected results for a successful command execution
 	expectedExitCode := 0
 	expectedStderr := ""
@@ -1046,7 +1046,7 @@ func (c *imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &imgBuildTests{
+	c := imgBuildTests{
 		env: env,
 	}
 

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -18,7 +18,7 @@ type ctx struct {
 
 const containerTesterSIF = "testdata/inspecter_container.sif"
 
-func (c *ctx) singularityInspect(t *testing.T) {
+func (c ctx) singularityInspect(t *testing.T) {
 	tests := []struct {
 		name      string
 		insType   string   // insType the type of 'inspect' flag, eg. '--deffile'
@@ -133,7 +133,7 @@ func (c *ctx) singularityInspect(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -29,13 +29,13 @@ type ctx struct {
 }
 
 // Test that no instances are running.
-func (c *ctx) testNoInstances(t *testing.T) {
+func (c ctx) testNoInstances(t *testing.T) {
 	c.expectedNumberOfInstances(t, 0)
 }
 
 // Test that a basic echo server instance can be started, communicated with,
 // and stopped.
-func (c *ctx) testBasicEchoServer(t *testing.T) {
+func (c ctx) testBasicEchoServer(t *testing.T) {
 	const instanceName = "echo1"
 
 	args := []string{c.env.ImagePath, instanceName, strconv.Itoa(instanceStartPort)}
@@ -59,7 +59,7 @@ func (c *ctx) testBasicEchoServer(t *testing.T) {
 }
 
 // Test creating many instances, but don't stop them.
-func (c *ctx) testCreateManyInstances(t *testing.T) {
+func (c ctx) testCreateManyInstances(t *testing.T) {
 	const n = 10
 
 	// Start n instances.
@@ -84,13 +84,13 @@ func (c *ctx) testCreateManyInstances(t *testing.T) {
 }
 
 // Test stopping all running instances.
-func (c *ctx) testStopAll(t *testing.T) {
+func (c ctx) testStopAll(t *testing.T) {
 	c.stopInstance(t, "", "--all")
 }
 
 // Test basic options like mounting a custom home directory, changing the
 // hostname, etc.
-func (c *ctx) testBasicOptions(t *testing.T) {
+func (c ctx) testBasicOptions(t *testing.T) {
 	const fileName = "hello"
 	const instanceName = "testbasic"
 	const testHostname = "echoserver99"
@@ -149,7 +149,7 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 }
 
 // Test that contain works.
-func (c *ctx) testContain(t *testing.T) {
+func (c ctx) testContain(t *testing.T) {
 	const instanceName = "testcontain"
 	const fileName = "thegreattestfile"
 
@@ -194,7 +194,7 @@ func (c *ctx) testContain(t *testing.T) {
 }
 
 // Test by running directly from URI
-func (c *ctx) testInstanceFromURI(t *testing.T) {
+func (c ctx) testInstanceFromURI(t *testing.T) {
 	instances := []struct {
 		name string
 		uri  string
@@ -235,7 +235,7 @@ func (c *ctx) testInstanceFromURI(t *testing.T) {
 
 // Execute an instance process, kill master process
 // and try to start another instance with same name
-func (c *ctx) testGhostInstance(t *testing.T) {
+func (c ctx) testGhostInstance(t *testing.T) {
 	// pick up a random name
 	instanceName := uuid.NewV4().String()
 	pidfile := filepath.Join(c.env.TestDir, instanceName)
@@ -306,7 +306,7 @@ func (c *ctx) testGhostInstance(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env:     env,
 		profile: e2e.UserProfile,
 	}

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -398,7 +398,7 @@ func (c *ctx) singularityKeyRemove(t *testing.T) {
 	}
 }
 
-func (c *ctx) singularityKeyNewpairWithLen(t *testing.T) {
+func (c ctx) singularityKeyNewpairWithLen(t *testing.T) {
 	// Create a unique keyring shared for all these tests
 	tempKeyring, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "keyring-", "")
 	defer cleanup(t)
@@ -473,7 +473,7 @@ func (c *ctx) checkKeyLength(t *testing.T, expectedKeyLength int) {
 }
 
 // Run the 'key' tests in order
-func (c *ctx) singularityKeyCmd(t *testing.T) {
+func (c ctx) singularityKeyCmd(t *testing.T) {
 	c.singularityKeySearch(t)
 	c.singularityKeyList(t)
 	c.singularityKeyNewpair(t)
@@ -489,7 +489,7 @@ func (c *ctx) singularityKeyCmd(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env:                    env,
 		publicExportPath:       filepath.Join(env.TestDir, "public_key.asc"),
 		publicExportASCIIPath:  filepath.Join(env.TestDir, "public_ascii_key.asc"),

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -96,11 +96,11 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	return bundleDir, cleanup
 }
 
-func (c *ctx) testOciRun(t *testing.T) {
+func (c ctx) testOciRun(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	containerID := uuid.NewV4().String()
-	bundleDir, umountFn := genericOciMount(t, c)
+	bundleDir, umountFn := genericOciMount(t, &c)
 
 	// umount bundle
 	defer umountFn()
@@ -131,11 +131,11 @@ func (c *ctx) testOciRun(t *testing.T) {
 	)
 }
 
-func (c *ctx) testOciAttach(t *testing.T) {
+func (c ctx) testOciAttach(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	containerID := uuid.NewV4().String()
-	bundleDir, umountFn := genericOciMount(t, c)
+	bundleDir, umountFn := genericOciMount(t, &c)
 
 	// umount bundle
 	defer umountFn()
@@ -198,11 +198,11 @@ func (c *ctx) testOciAttach(t *testing.T) {
 	)
 }
 
-func (c *ctx) testOciBasic(t *testing.T) {
+func (c ctx) testOciBasic(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	containerID := uuid.NewV4().String()
-	bundleDir, umountFn := genericOciMount(t, c)
+	bundleDir, umountFn := genericOciMount(t, &c)
 
 	// umount bundle
 	defer umountFn()
@@ -332,7 +332,7 @@ func (c *ctx) testOciBasic(t *testing.T) {
 	)
 }
 
-func (c *ctx) testOciHelp(t *testing.T) {
+func (c ctx) testOciHelp(t *testing.T) {
 	tests := []struct {
 		name          string
 		expectedRegex string
@@ -406,7 +406,7 @@ func (c *ctx) testOciHelp(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -284,7 +284,7 @@ func (c *ctx) setup(t *testing.T) {
 	}
 }
 
-func (c *ctx) testPullCmd(t *testing.T) {
+func (c ctx) testPullCmd(t *testing.T) {
 	// XXX(mem): this should come from the environment
 	sylabsAdminFingerprint := "8883491F4268F173C6E5DC49EDECE4F3F38D871E"
 	argv := []string{"key", "pull", sylabsAdminFingerprint}
@@ -433,7 +433,7 @@ func orasPushNoCheck(file, ref string) error {
 	return nil
 }
 
-func (c *ctx) testPullDisableCacheCmd(t *testing.T) {
+func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 	cacheDir, err := ioutil.TempDir("", "e2e-imgcache-")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
@@ -466,7 +466,7 @@ func (c *ctx) testPullDisableCacheCmd(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -22,7 +22,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-func (c *ctx) testInvalidTransport(t *testing.T) {
+func (c ctx) testInvalidTransport(t *testing.T) {
 	tests := []struct {
 		name       string
 		uri        string
@@ -51,7 +51,7 @@ func (c *ctx) testInvalidTransport(t *testing.T) {
 	}
 }
 
-func (c *ctx) testPushCmd(t *testing.T) {
+func (c ctx) testPushCmd(t *testing.T) {
 	e2e.PrepRegistry(t, c.env)
 
 	// setup file and dir to use as invalid sources
@@ -128,7 +128,7 @@ func (c *ctx) testPushCmd(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/regressions/build.go
+++ b/e2e/regressions/build.go
@@ -26,7 +26,7 @@ type regressionsTests struct {
 // Most if not all NSS services point to the bad NSS library in
 // order to catch all the potential calls which could occur from
 // Go code inside the build engine, singularity engine is also tested.
-func (c *regressionsTests) issue4203(t *testing.T) {
+func (c regressionsTests) issue4203(t *testing.T) {
 	image := filepath.Join(c.env.TestDir, "issue_4203.sif")
 
 	c.env.RunSingularity(
@@ -58,7 +58,7 @@ func (c *regressionsTests) issue4203(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &regressionsTests{
+	c := regressionsTests{
 		env: env,
 	}
 

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -21,7 +21,7 @@ type ctx struct {
 // remoteAdd checks the functionality of "singularity remote add" command.
 // It Verifies that adding valid endpoints results in success and invalid
 // one's results in failure.
-func (c *ctx) remoteAdd(t *testing.T) {
+func (c ctx) remoteAdd(t *testing.T) {
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -75,7 +75,7 @@ func (c *ctx) remoteAdd(t *testing.T) {
 // 1. Adds remote endpoints
 // 2. Deletes the already added entries
 // 3. Verfies that removing an invalid entry results in a failure
-func (c *ctx) remoteRemove(t *testing.T) {
+func (c ctx) remoteRemove(t *testing.T) {
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -148,7 +148,7 @@ func (c *ctx) remoteRemove(t *testing.T) {
 // remoteUse tests the functionality of "singularity remote use" command.
 // 1. Tries to use non-existing remote entry
 // 2. Adds remote entries and tries to use those
-func (c *ctx) remoteUse(t *testing.T) {
+func (c ctx) remoteUse(t *testing.T) {
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -222,7 +222,7 @@ func (c *ctx) remoteUse(t *testing.T) {
 // 1. Adds remote endpoints
 // 2. Verifies that remote status command succeeds on existing endpoints
 // 3. Verifies that remote status command fails on non-existing endpoints
-func (c *ctx) remoteStatus(t *testing.T) {
+func (c ctx) remoteStatus(t *testing.T) {
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -293,7 +293,7 @@ func (c *ctx) remoteStatus(t *testing.T) {
 }
 
 // remoteList tests the functionality of "singularity remote list" command
-func (c *ctx) remoteList(t *testing.T) {
+func (c ctx) remoteList(t *testing.T) {
 	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
@@ -398,7 +398,7 @@ func (c *ctx) remoteList(t *testing.T) {
 	}
 }
 
-func (c *ctx) remoteTestFlag(t *testing.T) {
+func (c ctx) remoteTestFlag(t *testing.T) {
 	tests := []struct {
 		name           string
 		cmdArgs        []string
@@ -454,7 +454,7 @@ func (c *ctx) remoteTestFlag(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -23,7 +23,7 @@ type ctx struct {
 // 0555 for access rights, and we try to run a singularity run command
 // using that directory as cache. This reflects a problem that is important
 // for the grid use case.
-func (c *ctx) testRun555Cache(t *testing.T) {
+func (c ctx) testRun555Cache(t *testing.T) {
 	tempDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 	defer cleanup(t)
 	cacheDir := filepath.Join(tempDir, "image-cache")
@@ -47,7 +47,7 @@ func (c *ctx) testRun555Cache(t *testing.T) {
 	)
 }
 
-func (c *ctx) testRunPEMEncrypted(t *testing.T) {
+func (c ctx) testRunPEMEncrypted(t *testing.T) {
 	// If the version of cryptsetup is not compatible with Singularity encryption,
 	// the build commands are expected to fail
 	err := e2e.CheckCryptsetupVersion()
@@ -99,7 +99,7 @@ func (c *ctx) testRunPEMEncrypted(t *testing.T) {
 	)
 }
 
-func (c *ctx) testRunPassphraseEncrypted(t *testing.T) {
+func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 	// If the version of cryptsetup is not compatible with Singularity encryption,
 	// the build commands are expected to fail
 	err := e2e.CheckCryptsetupVersion()
@@ -153,7 +153,7 @@ func (c *ctx) testRunPassphraseEncrypted(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -21,7 +21,7 @@ type ctx struct {
 }
 
 // testSecurityUnpriv tests the security flag fuctionality for singularity exec without elevated privileges
-func (c *ctx) testSecurityUnpriv(t *testing.T) {
+func (c ctx) testSecurityUnpriv(t *testing.T) {
 	tests := []struct {
 		name       string
 		image      string
@@ -100,7 +100,7 @@ func (c *ctx) testSecurityUnpriv(t *testing.T) {
 }
 
 // testSecurityPriv tests security flag fuctionality for singularity exec with elevated privileges
-func (c *ctx) testSecurityPriv(t *testing.T) {
+func (c ctx) testSecurityPriv(t *testing.T) {
 	tests := []struct {
 		name       string
 		argv       []string
@@ -174,7 +174,7 @@ func (c *ctx) testSecurityPriv(t *testing.T) {
 }
 
 // testSecurityConfOwnership tests checks on config files ownerships
-func (c *ctx) testSecurityConfOwnership(t *testing.T) {
+func (c ctx) testSecurityConfOwnership(t *testing.T) {
 	configFile := buildcfg.SINGULARITY_CONF_FILE
 
 	c.env.RunSingularity(
@@ -207,7 +207,7 @@ func (c *ctx) testSecurityConfOwnership(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env:     env,
 		pingImg: filepath.Join(env.TestDir, "ubuntu-ping.sif"),
 	}

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -24,7 +24,7 @@ type ctx struct {
 const imgURL = "library://sylabs/tests/unsigned:1.0.0"
 const imgName = "testImage.sif"
 
-func (c *ctx) singularitySignHelpOption(t *testing.T) {
+func (c ctx) singularitySignHelpOption(t *testing.T) {
 	c.env.KeyringDir = c.keyringDir
 	c.env.RunSingularity(
 		t,
@@ -55,7 +55,7 @@ func (c *ctx) prepareImage(t *testing.T) (string, func(*testing.T)) {
 	}
 }
 
-func (c *ctx) singularitySignIDOption(t *testing.T) {
+func (c ctx) singularitySignIDOption(t *testing.T) {
 	imgPath, cleanup := c.prepareImage(t)
 	defer cleanup(t)
 
@@ -95,7 +95,7 @@ func (c *ctx) singularitySignIDOption(t *testing.T) {
 	}
 }
 
-func (c *ctx) singularitySignGroupIDOption(t *testing.T) {
+func (c ctx) singularitySignGroupIDOption(t *testing.T) {
 	imgPath, cleanup := c.prepareImage(t)
 	defer cleanup(t)
 
@@ -135,7 +135,7 @@ func (c *ctx) singularitySignGroupIDOption(t *testing.T) {
 	}
 }
 
-func (c *ctx) singularitySignKeyidxOption(t *testing.T) {
+func (c ctx) singularitySignKeyidxOption(t *testing.T) {
 	imgPath, cleanup := c.prepareImage(t)
 	defer cleanup(t)
 
@@ -178,7 +178,7 @@ func (c *ctx) generateKeypair(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -53,7 +53,7 @@ func getDataCheckJSON(keyNum int) []string {
 	return []string{"SignerKeys", fmt.Sprintf("[%d]", keyNum), "Signer", "DataCheck"}
 }
 
-func (c *ctx) singularityVerifyKeyNum(t *testing.T) {
+func (c ctx) singularityVerifyKeyNum(t *testing.T) {
 	keyNumPath := []string{"Signatures"}
 
 	tests := []struct {
@@ -108,7 +108,7 @@ func (c *ctx) singularityVerifyKeyNum(t *testing.T) {
 	}
 }
 
-func (c *ctx) singularityVerifySigner(t *testing.T) {
+func (c ctx) singularityVerifySigner(t *testing.T) {
 	tests := []struct {
 		expectOutput []verifyOutput
 		name         string
@@ -294,7 +294,7 @@ func (c *ctx) singularityVerifySigner(t *testing.T) {
 	}
 }
 
-func (c *ctx) checkGroupidOption(t *testing.T) {
+func (c ctx) checkGroupidOption(t *testing.T) {
 	cmdArgs := []string{"--groupid", "0", c.successImage}
 	c.env.RunSingularity(
 		t,
@@ -308,7 +308,7 @@ func (c *ctx) checkGroupidOption(t *testing.T) {
 	)
 }
 
-func (c *ctx) checkIDOption(t *testing.T) {
+func (c ctx) checkIDOption(t *testing.T) {
 	cmdArgs := []string{"--id", "0", c.successImage}
 	c.env.RunSingularity(
 		t,
@@ -322,7 +322,7 @@ func (c *ctx) checkIDOption(t *testing.T) {
 	)
 }
 
-func (c *ctx) checkURLOption(t *testing.T) {
+func (c ctx) checkURLOption(t *testing.T) {
 	if !fs.IsFile(c.successImage) {
 		t.Fatalf("image file (%s) does not exist", c.successImage)
 	}
@@ -342,7 +342,7 @@ func (c *ctx) checkURLOption(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env:            env,
 		corruptedImage: filepath.Join(env.TestDir, "verify_corrupted.sif"),
 		successImage:   filepath.Join(env.TestDir, "verify_success.sif"),

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -27,7 +27,7 @@ var tests = []struct {
 }
 
 //Test that this version uses the semantic version format
-func (c *ctx) testSemanticVersion(t *testing.T) {
+func (c ctx) testSemanticVersion(t *testing.T) {
 	for _, tt := range tests {
 
 		checkSemanticVersionFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
@@ -55,7 +55,7 @@ func (c *ctx) testSemanticVersion(t *testing.T) {
 
 //Test that both versions when running: singularity --version and
 // singularity version give the same result
-func (c *ctx) testEqualVersion(t *testing.T) {
+func (c ctx) testEqualVersion(t *testing.T) {
 	var tmpVersion = ""
 	for _, tt := range tests {
 
@@ -99,7 +99,7 @@ func (c *ctx) testEqualVersion(t *testing.T) {
 }
 
 // Test the help option
-func (c *ctx) testHelpOption(t *testing.T) {
+func (c ctx) testHelpOption(t *testing.T) {
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -114,7 +114,7 @@ func (c *ctx) testHelpOption(t *testing.T) {
 
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
-	c := &ctx{
+	c := ctx{
 		env: env,
 	}
 


### PR DESCRIPTION
Test functions are being declared like this:

	func (c *ctx) fooTest(t *testing.T)

Change this to:

	func (c ctx) fooTest(t *testing.T)

This prevents the test functions from unadvertedly modifying the context
or the associated test environment.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
