### PR TITLE
Reformat imgBuildTests.buildFrom

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -33,74 +33,61 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 	// see https://github.com/sylabs/singularity/issues/4407
 	tt := []struct {
 		name       string
-		dest       string
 		dependency string
 		buildSpec  string
-		sandbox    bool
 	}{
 		{
 			name:      "BusyBox",
-			dest:      c.env.TestDir + "/container",
 			buildSpec: "../examples/busybox/Singularity",
 		},
 		{
 			name:       "Debootstrap",
-			dest:       c.env.TestDir + "/container/",
 			dependency: "debootstrap",
 			buildSpec:  "../examples/debian/Singularity",
-			sandbox:    true,
 		},
 		{
 			name:      "DockerURI",
-			dest:      c.env.TestDir + "/container/",
 			buildSpec: "docker://busybox",
-			sandbox:   true,
 		},
 		{
 			name:      "DockerDefFile",
-			dest:      c.env.TestDir + "/container/",
 			buildSpec: "../examples/docker/Singularity",
-			sandbox:   true,
 		},
 		// TODO(mem): reenable this; disabled while shub is down
-		// {"ShubURI", "", "shub://GodloveD/busybox", true},
+		// {
+		// 	name:       "ShubURI",
+		// 	buildSpec:  "shub://GodloveD/busybox",
+		// },
 		// TODO(mem): reenable this; disabled while shub is down
-		// {"ShubDefFile", "", "../examples/shub/Singularity", true},
+		// {
+		// 	name:       "ShubDefFile",
+		// 	buildSpec:  "../examples/shub/Singularity",
+		// },
 		{
 			name:      "LibraryDefFile",
-			dest:      c.env.TestDir + "/container/",
 			buildSpec: "../examples/library/Singularity",
-			sandbox:   true,
 		},
 		{
 			name:      "OrasURI",
-			dest:      c.env.TestDir + "/container/",
 			buildSpec: c.env.OrasTestImage,
-			sandbox:   true,
 		},
 		{
 			name:       "Yum",
-			dest:       c.env.TestDir + "/container/",
 			dependency: "yum",
 			buildSpec:  "../examples/centos/Singularity",
-			sandbox:    true,
 		},
 		{
 			name:       "Zypper",
-			dest:       c.env.TestDir + "/container/",
 			dependency: "zypper",
 			buildSpec:  "../examples/opensuse/Singularity",
-			sandbox:    true,
 		},
 	}
 
 	for _, tc := range tt {
-		// conditionally build a sandbox
-		var args []string
-		if tc.sandbox {
-			args = []string{"--sandbox"}
-		}
-		args = append(args, tc.dest, tc.buildSpec)
+		imagePath := path.Join(c.env.TestDir, "container")
+
+		// sandboxes take less time to build
+		args := []string{"--sandbox", imagePath, tc.buildSpec}
 
 		c.env.RunSingularity(
 			t,
@@ -109,10 +96,12 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
 			e2e.PreRun(func(t *testing.T) {
-				if tc.dependency != "" {
-					if _, err := exec.LookPath(tc.dependency); err != nil {
-						t.Skipf("%v not found in path", tc.dependency)
-					}
+				if tc.dependency == "" {
+					return
+				}
+
+				if _, err := exec.LookPath(tc.dependency); err != nil {
+					t.Skipf("%v not found in path", tc.dependency)
 				}
 			}),
 			e2e.PostRun(func(t *testing.T) {
@@ -120,8 +109,8 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 					return
 				}
 
-				defer os.RemoveAll(tc.dest)
-				c.env.ImageVerify(t, tc.dest)
+				defer os.RemoveAll(imagePath)
+				c.env.ImageVerify(t, imagePath)
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -132,55 +121,45 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 	tt := []struct {
 		name      string
 		buildSpec string
-		sandbox   bool
+		args      []string
 	}{
 		{
 			name:      "local sif",
 			buildSpec: "testdata/busybox.sif",
-			sandbox:   false,
 		},
 		{
 			name:      "local sif to sandbox",
 			buildSpec: "testdata/busybox.sif",
-			sandbox:   true,
+			args:      []string{"--sandbox"},
 		},
 		{
 			name:      "library sif",
 			buildSpec: "library://sylabs/tests/busybox:1.0.0",
-			sandbox:   false,
 		},
 		{
 			name:      "library sif sandbox",
 			buildSpec: "library://sylabs/tests/busybox:1.0.0",
-			sandbox:   true,
+			args:      []string{"--sandbox"},
 		},
 		{
 			name:      "library sif sha",
 			buildSpec: "library://sylabs/tests/busybox:sha256.8b5478b0f2962eba3982be245986eb0ea54f5164d90a65c078af5b83147009ba",
-			sandbox:   false,
 		},
 		// TODO: uncomment when shub is working
 		//{
 		//		name:      "shub busybox",
 		//		buildSpec: "shub://GodloveD/busybox",
-		//		sandbox:   false,
 		//},
 		{
 			name:      "docker busybox",
 			buildSpec: "docker://busybox:latest",
-			sandbox:   false,
 		},
 	}
 
 	for _, tc := range tt {
 		imagePath := path.Join(c.env.TestDir, "container")
 
-		// conditionally build a sandbox
-		var args []string
-		if tc.sandbox {
-			args = []string{"--sandbox"}
-		}
-		args = append(args, imagePath, tc.buildSpec)
+		args := append(tc.args, imagePath, tc.buildSpec)
 
 		c.env.RunSingularity(
 			t,
@@ -289,15 +268,12 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		force   bool
-		sandbox bool
 		dfd     []e2e.DefFileDetails
 		correct e2e.DefFileDetails // a bit hacky, but this allows us to check final image for correct artifacts
 	}{
 		// Simple copy from stage one to final stage
 		{
-			name:    "FileCopySimple",
-			sandbox: true,
+			name: "FileCopySimple",
 			dfd: []e2e.DefFileDetails{
 				{
 					Bootstrap: "docker",
@@ -349,8 +325,7 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 		},
 		// Complex copy of files from stage one and two to stage three, then final copy from three to final stage
 		{
-			name:    "FileCopyComplex",
-			sandbox: true,
+			name: "FileCopyComplex",
 			dfd: []e2e.DefFileDetails{
 				{
 					Bootstrap: "docker",
@@ -470,14 +445,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 		imagePath := path.Join(c.env.TestDir, "container")
 		defFile := e2e.PrepareMultiStageDefFile(tt.dfd)
 
-		args := []string{}
-		if tt.force {
-			args = append([]string{"--force"}, args...)
-		}
-		if tt.sandbox {
-			args = append([]string{"--sandbox"}, args...)
-		}
-		args = append(args, imagePath, defFile)
+		// sandboxes take less time to build
+		args := []string{"--sandbox", imagePath, defFile}
 
 		c.env.RunSingularity(
 			t,
@@ -502,362 +471,277 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 	}
 	defer os.Remove(tmpfile) // clean up
 
-	tt := []struct {
-		name    string
-		force   bool
-		sandbox bool
-		dfd     e2e.DefFileDetails
-	}{
-		{
-			name:    "Empty",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
+	tt := map[string]e2e.DefFileDetails{
+		"Empty": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+		},
+		"Help": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Help: []string{
+				"help info line 1",
+				"help info line 2",
+				"help info line 3",
 			},
 		},
-		{
-			name:    "Help",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Help: []string{
-					"help info line 1",
-					"help info line 2",
-					"help info line 3",
+		"Files": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Files: []e2e.FilePair{
+				{
+					Src: tmpfile,
+					Dst: "NewName2.txt",
+				},
+				{
+					Src: tmpfile,
+					Dst: "NewName.txt",
 				},
 			},
 		},
-		{
-			name:    "Files",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Files: []e2e.FilePair{
-					{
-						Src: tmpfile,
-						Dst: "NewName2.txt",
+		"Test": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Test: []string{
+				"echo testscript line 1",
+				"echo testscript line 2",
+				"echo testscript line 3",
+			},
+		},
+		"Startscript": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			StartScript: []string{
+				"echo startscript line 1",
+				"echo startscript line 2",
+				"echo startscript line 3",
+			},
+		},
+		"Runscript": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			RunScript: []string{
+				"echo runscript line 1",
+				"echo runscript line 2",
+				"echo runscript line 3",
+			},
+		},
+		"Env": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Env: []string{
+				"testvar1=one",
+				"testvar2=two",
+				"testvar3=three",
+			},
+		},
+		"Labels": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Labels: map[string]string{
+				"customLabel1": "one",
+				"customLabel2": "two",
+				"customLabel3": "three",
+			},
+		},
+		"Pre": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Pre: []string{
+				filepath.Join(c.env.TestDir, "PreFile1"),
+			},
+		},
+		"Setup": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Setup: []string{
+				filepath.Join(c.env.TestDir, "SetupFile1"),
+			},
+		},
+		"Post": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Post: []string{
+				"PostFile1",
+			},
+		},
+		"AppHelp": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Apps: []e2e.AppDetail{
+				{
+					Name: "foo",
+					Help: []string{
+						"foo help info line 1",
+						"foo help info line 2",
+						"foo help info line 3",
 					},
-					{
-						Src: tmpfile,
-						Dst: "NewName.txt",
+				},
+				{
+					Name: "bar",
+					Help: []string{
+						"bar help info line 1",
+						"bar help info line 2",
+						"bar help info line 3",
 					},
 				},
 			},
 		},
-		{
-			name:    "Test",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Test: []string{
-					"echo testscript line 1",
-					"echo testscript line 2",
-					"echo testscript line 3",
+		"AppEnv": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Apps: []e2e.AppDetail{
+				{
+					Name: "foo",
+					Env: []string{
+						"testvar1=fooOne",
+						"testvar2=fooTwo",
+						"testvar3=fooThree",
+					},
+				},
+				{
+					Name: "bar",
+					Env: []string{
+						"testvar1=barOne",
+						"testvar2=barTwo",
+						"testvar3=barThree",
+					},
 				},
 			},
 		},
-		{
-			name:    "Startscript",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				StartScript: []string{
-					"echo startscript line 1",
-					"echo startscript line 2",
-					"echo startscript line 3",
+		"AppLabels": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Apps: []e2e.AppDetail{
+				{
+					Name: "foo",
+					Labels: map[string]string{
+						"customLabel1": "fooOne",
+						"customLabel2": "fooTwo",
+						"customLabel3": "fooThree",
+					},
+				},
+				{
+					Name: "bar",
+					Labels: map[string]string{
+						"customLabel1": "barOne",
+						"customLabel2": "barTwo",
+						"customLabel3": "barThree",
+					},
 				},
 			},
 		},
-		{
-			name:    "Runscript",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				RunScript: []string{
-					"echo runscript line 1",
-					"echo runscript line 2",
-					"echo runscript line 3",
-				},
-			},
-		},
-		{
-			name:    "Env",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Env: []string{
-					"testvar1=one",
-					"testvar2=two",
-					"testvar3=three",
-				},
-			},
-		},
-		{
-			name:    "Labels",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Labels: map[string]string{
-					"customLabel1": "one",
-					"customLabel2": "two",
-					"customLabel3": "three",
-				},
-			},
-		},
-		{
-			name:    "Pre",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Pre: []string{
-					filepath.Join(c.env.TestDir, "PreFile1"),
-				},
-			},
-		},
-		{
-			name:    "Setup",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Setup: []string{
-					filepath.Join(c.env.TestDir, "SetupFile1"),
-				},
-			},
-		},
-		{
-			name:    "Post",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Post: []string{
-					"PostFile1",
-				},
-			},
-		},
-		{
-			name:    "AppHelp",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Apps: []e2e.AppDetail{
-					{
-						Name: "foo",
-						Help: []string{
-							"foo help info line 1",
-							"foo help info line 2",
-							"foo help info line 3",
+		"AppFiles": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Apps: []e2e.AppDetail{
+				{
+					Name: "foo",
+					Files: []e2e.FilePair{
+						{
+							Src: tmpfile,
+							Dst: "FooFile2.txt",
+						},
+						{
+							Src: tmpfile,
+							Dst: "FooFile.txt",
 						},
 					},
-					{
-						Name: "bar",
-						Help: []string{
-							"bar help info line 1",
-							"bar help info line 2",
-							"bar help info line 3",
-						},
-					},
 				},
-			},
-		},
-		{
-			name:    "AppEnv",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Apps: []e2e.AppDetail{
-					{
-						Name: "foo",
-						Env: []string{
-							"testvar1=fooOne",
-							"testvar2=fooTwo",
-							"testvar3=fooThree",
+				{
+					Name: "bar",
+					Files: []e2e.FilePair{
+						{
+							Src: tmpfile,
+							Dst: "BarFile2.txt",
 						},
-					},
-					{
-						Name: "bar",
-						Env: []string{
-							"testvar1=barOne",
-							"testvar2=barTwo",
-							"testvar3=barThree",
+						{
+							Src: tmpfile,
+							Dst: "BarFile.txt",
 						},
 					},
 				},
 			},
 		},
-		{
-			name:    "AppLabels",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Apps: []e2e.AppDetail{
-					{
-						Name: "foo",
-						Labels: map[string]string{
-							"customLabel1": "fooOne",
-							"customLabel2": "fooTwo",
-							"customLabel3": "fooThree",
-						},
+		"AppInstall": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Apps: []e2e.AppDetail{
+				{
+					Name: "foo",
+					Install: []string{
+						"FooInstallFile1",
 					},
-					{
-						Name: "bar",
-						Labels: map[string]string{
-							"customLabel1": "barOne",
-							"customLabel2": "barTwo",
-							"customLabel3": "barThree",
-						},
+				},
+				{
+					Name: "bar",
+					Install: []string{
+						"BarInstallFile1",
 					},
 				},
 			},
 		},
-		{
-			name:    "AppFiles",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Apps: []e2e.AppDetail{
-					{
-						Name: "foo",
-						Files: []e2e.FilePair{
-							{
-								Src: tmpfile,
-								Dst: "FooFile2.txt",
-							},
-							{
-								Src: tmpfile,
-								Dst: "FooFile.txt",
-							},
-						},
+		"AppRun": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Apps: []e2e.AppDetail{
+				{
+					Name: "foo",
+					Run: []string{
+						"echo foo runscript line 1",
+						"echo foo runscript line 2",
+						"echo foo runscript line 3",
 					},
-					{
-						Name: "bar",
-						Files: []e2e.FilePair{
-							{
-								Src: tmpfile,
-								Dst: "BarFile2.txt",
-							},
-							{
-								Src: tmpfile,
-								Dst: "BarFile.txt",
-							},
-						},
+				},
+				{
+					Name: "bar",
+					Run: []string{
+						"echo bar runscript line 1",
+						"echo bar runscript line 2",
+						"echo bar runscript line 3",
 					},
 				},
 			},
 		},
-		{
-			name:    "AppInstall",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Apps: []e2e.AppDetail{
-					{
-						Name: "foo",
-						Install: []string{
-							"FooInstallFile1",
-						},
-					},
-					{
-						Name: "bar",
-						Install: []string{
-							"BarInstallFile1",
-						},
+		"AppTest": {
+			Bootstrap: "docker",
+			From:      "alpine:latest",
+			Apps: []e2e.AppDetail{
+				{
+					Name: "foo",
+					Test: []string{
+						"echo foo testscript line 1",
+						"echo foo testscript line 2",
+						"echo foo testscript line 3",
 					},
 				},
-			},
-		},
-		{
-			name:    "AppRun",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Apps: []e2e.AppDetail{
-					{
-						Name: "foo",
-						Run: []string{
-							"echo foo runscript line 1",
-							"echo foo runscript line 2",
-							"echo foo runscript line 3",
-						},
-					},
-					{
-						Name: "bar",
-						Run: []string{
-							"echo bar runscript line 1",
-							"echo bar runscript line 2",
-							"echo bar runscript line 3",
-						},
-					},
-				},
-			},
-		},
-		{
-			name:    "AppTest",
-			sandbox: true,
-			dfd: e2e.DefFileDetails{
-				Bootstrap: "docker",
-				From:      "alpine:latest",
-				Apps: []e2e.AppDetail{
-					{
-						Name: "foo",
-						Test: []string{
-							"echo foo testscript line 1",
-							"echo foo testscript line 2",
-							"echo foo testscript line 3",
-						},
-					},
-					{
-						Name: "bar",
-						Test: []string{
-							"echo bar testscript line 1",
-							"echo bar testscript line 2",
-							"echo bar testscript line 3",
-						},
+				{
+					Name: "bar",
+					Test: []string{
+						"echo bar testscript line 1",
+						"echo bar testscript line 2",
+						"echo bar testscript line 3",
 					},
 				},
 			},
 		},
 	}
 
-	for _, tc := range tt {
+	for name, dfd := range tt {
 		imagePath := path.Join(c.env.TestDir, "container")
-		defFile := e2e.PrepareDefFile(tc.dfd)
-
-		args := []string{}
-		if tc.force {
-			args = append([]string{"--force"}, args...)
-		}
-		if tc.sandbox {
-			args = append([]string{"--sandbox"}, args...)
-		}
-		args = append(args, imagePath, defFile)
+		defFile := e2e.PrepareDefFile(dfd)
 
 		c.env.RunSingularity(
 			t,
+			e2e.AsSubtest(name),
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs(args...),
+			e2e.WithArgs("--sandbox", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
 				defer os.Remove(defFile)
 				defer os.RemoveAll(imagePath)
 
-				e2e.DefinitionImageVerify(t, c.env.CmdPath, imagePath, tc.dfd)
+				e2e.DefinitionImageVerify(t, c.env.CmdPath, imagePath, dfd)
 			}),
 			e2e.ExpectExit(0),
 		)


### PR DESCRIPTION
It took some heavy editing to notice that the individual tests weren't
being run as subtests, which has a weird interaction with the e2e.PreRun
where tests are skipped based on the availability of a particular
program in the host.

It also took some heavy editing to notice that the BusyBox test was
missing the --sandbox option, which is required to get the ImageVerify
helper to do its thing.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

**Description of the Pull Request (PR):**

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


**This fixes or addresses the following GitHub issues:**

- Fixes #


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
