### PR TITLE
Fix ioctl errno handling for LOOP_SET_STATUS64

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@
     - Divya Cote <divya.cote@gmail.com>
     - Eduardo Arango <eduardo@sylabs.io>, <arangogutierrez@gmail.com>
     - Egbert Eich <eich@suse.com>
+    - Eric Müller <mueller@kip.uni-heidelberg.de>
     - Felix Abecassis <fabecassis@nvidia.com>
     - Geoffroy Vallee <geoffroy@sylabs.io>, <geoffroy.vallee@gmail.com>
     - George Hartzell <hartzell@alerce.com>


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Based on work from @muffgaga in #4373 with minor addition and loop device cleanup in case of failure.

Fix ioctl errno handling for LOOP_SET_STATUS64 Linux kernel commit 5db470e229e22b7eda6e23b5566e532c96fb5bc3 ("loop:
drop caches if offset or block_size are changed") introduced a transient
fail (with -EAGAIN) possibility into the LOOP_SET_STATUS64 ioctl.
This also affects longterm kernel versions 4.14 and 4.19.

**This fixes or addresses the following GitHub issues:**

- Fixes #3764
- Related to #4373 


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
