### PR TITLE
Detect autofs path automatically and get rid of autofs bug path configuration

### DIFF
--- a/etc/conf/testdata/test_1.out.correct
+++ b/etc/conf/testdata/test_1.out.correct
@@ -189,14 +189,6 @@ allow container extfs = yes
 allow container dir = yes
 
 
-# AUTOFS BUG PATH: [STRING]
-# DEFAULT: Undefined
-# Define list of autofs directories which produces "Too many levels of symbolink links"
-# errors when accessed from container (typically bind mounts)
-#autofs bug path = /nfs
-#autofs bug path = /cifs-share
-
-
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command

--- a/etc/conf/testdata/test_2.in
+++ b/etc/conf/testdata/test_2.in
@@ -189,14 +189,6 @@ allow container extfs = yes
 allow container dir = yes
 
 
-# AUTOFS BUG PATH: [STRING]
-# DEFAULT: Undefined
-# Define list of autofs directories which produces "Too many levels of symbolink links"
-# errors when accessed from container (typically bind mounts)
-#autofs bug path = /nfs
-#autofs bug path = /cifs-share
-
-
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command

--- a/etc/conf/testdata/test_2.out.correct
+++ b/etc/conf/testdata/test_2.out.correct
@@ -189,14 +189,6 @@ allow container extfs = yes
 allow container dir = yes
 
 
-# AUTOFS BUG PATH: [STRING]
-# DEFAULT: Undefined
-# Define list of autofs directories which produces "Too many levels of symbolink links"
-# errors when accessed from container (typically bind mounts)
-#autofs bug path = /nfs
-#autofs bug path = /cifs-share
-
-
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command

--- a/etc/conf/testdata/test_3.in
+++ b/etc/conf/testdata/test_3.in
@@ -180,14 +180,6 @@ allow container extfs = yes
 allow container dir = yes
 
 
-# AUTOFS BUG PATH: [STRING]
-# DEFAULT: Undefined
-# Define list of autofs directories which produces "Too many levels of symbolink links"
-# errors when accessed from container (typically bind mounts)
-#autofs bug path = /nfs
-#autofs bug path = /cifs-share
-
-
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command

--- a/etc/conf/testdata/test_3.out.correct
+++ b/etc/conf/testdata/test_3.out.correct
@@ -189,14 +189,6 @@ allow container extfs = yes
 allow container dir = yes
 
 
-# AUTOFS BUG PATH: [STRING]
-# DEFAULT: Undefined
-# Define list of autofs directories which produces "Too many levels of symbolink links"
-# errors when accessed from container (typically bind mounts)
-#autofs bug path = /nfs
-#autofs bug path = /cifs-share
-
-
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command

--- a/etc/conf/testdata/test_default.tmpl
+++ b/etc/conf/testdata/test_default.tmpl
@@ -200,18 +200,6 @@ allow container extfs = {{ if eq .AllowContainerExtfs true }}yes{{ else }}no{{ e
 allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }}
 
 
-# AUTOFS BUG PATH: [STRING]
-# DEFAULT: Undefined
-# Define list of autofs directories which produces "Too many levels of symbolink links"
-# errors when accessed from container (typically bind mounts)
-#autofs bug path = /nfs
-#autofs bug path = /cifs-share
-{{ range $path := .AutofsBugPath }}
-{{- if ne $path "" -}}
-autofs bug path = {{$path}}
-{{ end -}}
-{{ end }}
-
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -51,7 +51,6 @@ type FileConfig struct {
 	LimitContainerOwners    []string `directive:"limit container owners"`
 	LimitContainerGroups    []string `directive:"limit container groups"`
 	LimitContainerPaths     []string `directive:"limit container paths"`
-	AutofsBugPath           []string `directive:"autofs bug path"`
 	RootDefaultCapabilities string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
 	MemoryFSType            string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
 	CniConfPath             string   `directive:"cni configuration path"`

--- a/pkg/runtime/engines/singularity/config/data/singularity.conf
+++ b/pkg/runtime/engines/singularity/config/data/singularity.conf
@@ -193,17 +193,6 @@ allow container squashfs = {{ if eq .AllowContainerSquashfs true }}yes{{ else }}
 allow container extfs = {{ if eq .AllowContainerExtfs true }}yes{{ else }}no{{ end }}
 allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }}
 
-# AUTOFS BUG PATH: [STRING]
-# DEFAULT: Undefined
-# Define list of autofs directories which produces "Too many levels of symbolink links"
-# errors when accessed from container (typically bind mounts)
-#autofs bug path = /nfs
-#autofs bug path = /cifs-share
-{{ range $path := .AutofsBugPath }}
-{{- if ne $path "" -}}
-autofs bug path = {{$path}}
-{{ end -}}
-{{ end }}
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Look at `/proc/self/mountinfo` to look for potential mount point under autofs control and open them in stage 1 in order to keep a reference in host mount namespace. Those changes make `autofs bug path` configuration directive obsolete.


**This fixes or addresses the following GitHub issues:**

- Fixes #2556


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers
