### PR TITLE
Cherry pick #4370 into 3.4.1

### DIFF
--- a/internal/pkg/util/fs/overlay/overlay.go
+++ b/internal/pkg/util/fs/overlay/overlay.go
@@ -65,7 +65,7 @@ func check(path string, d dir) error {
 		return fmt.Errorf("could not retrieve underlying filesystem information for %s: %s", path, err)
 	}
 
-	fs, ok := incompatibleFs[stfs.Type]
+	fs, ok := incompatibleFs[int64(stfs.Type)]
 	if !ok || (ok && fs.overlayDir&d == 0) {
 		return nil
 	}


### PR DESCRIPTION
Apply #4370 to branch for 3.4.1 - Fix build on 32-bit machines.

Tested by myself on a Pi4 with 32-bit OS install.
