### PR TITLE
Cherry pick #4380 for 3.4.1

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -291,7 +291,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	}
 
 	engineConfig.SetBindPath(BindPaths)
-	if FuseMount != nil {
+	if len(FuseMount) > 0 {
 		/* If --fusemount is given, imply --pid */
 		PidNamespace = true
 		engineConfig.SetFuseMount(FuseMount)


### PR DESCRIPTION
Bring #4380 to fix issue of always using a pid namespace in for 3.4.1

Confirmed host processes visible with `ps aux` in a simple `singularity shell docker://ubuntu:latest`