### PR TITLE
Cherry pick #4449 to 3.4.1

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@
     - Divya Cote <divya.cote@gmail.com>
     - Eduardo Arango <eduardo@sylabs.io>, <arangogutierrez@gmail.com>
     - Egbert Eich <eich@suse.com>
+    - Eric Müller <mueller@kip.uni-heidelberg.de>
     - Felix Abecassis <fabecassis@nvidia.com>
     - Geoffroy Vallee <geoffroy@sylabs.io>, <geoffroy.vallee@gmail.com>
     - George Hartzell <hartzell@alerce.com>


### PR DESCRIPTION
Cherry pick #4449 to fix ioctl errno handling on loop operations in 3.4.1

Tested with a tight loop of `singularity exec` which failed often on my Pi4 (kernel 4.19.57-v7l+) prior to this fix - and now does not fail with this fix.