### PR TITLE
Cherry pick 4321 and 4375 for 3.4.1

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@
     - Adam Simpson <asimpson@nvidia.com>, <adambsimpson@gmail.com>
     - Afif Elghraoui <afif.elghraoui@nih.gov>
     - Amanda Duffy <aduffy@lenovo.com>
+    - Ana Guerrero Lopez <aguerrero@suse.com>
     - Ángel Bejarano <abejarano@ontropos.com>
     - Bernard Li <bernardli@lbl.gov>
     - Brian Bockelman <bbockelm@cse.unl.edu>

--- a/mlocal/frags/build_scripts.mk
+++ b/mlocal/frags/build_scripts.mk
@@ -11,3 +11,17 @@ $(SOURCEDIR)/scripts/go-test: $(SOURCEDIR)/scripts/go-test.in $(SOURCEDIR)/scrip
 	$(V) chmod +x $@
 
 ALL += $(SOURCEDIR)/scripts/go-test
+
+# go-generate script
+$(SOURCEDIR)/scripts/go-generate: export BUILDDIR := $(BUILDDIR_ABSPATH)
+$(SOURCEDIR)/scripts/go-generate: export GO := $(GO)
+$(SOURCEDIR)/scripts/go-generate: export GO111MODULE := $(GO111MODULE)
+$(SOURCEDIR)/scripts/go-generate: export GOFLAGS := $(GOFLAGS)
+$(SOURCEDIR)/scripts/go-generate: export GO_TAGS := $(GO_TAGS)
+$(SOURCEDIR)/scripts/go-generate: $(SOURCEDIR)/scripts/go-generate.in $(SOURCEDIR)/scripts/expand-env.go
+	@echo ' GEN $@'
+	$(V) $(GO) $(GO_MODFLAGS) run $(SOURCEDIR)/scripts/expand-env.go < $< > $@
+	$(V) chmod +x $@
+
+ALL += $(SOURCEDIR)/scripts/go-generate
+

--- a/mlocal/frags/build_scripts.mk
+++ b/mlocal/frags/build_scripts.mk
@@ -7,7 +7,7 @@ $(SOURCEDIR)/scripts/go-test: export GOFLAGS := $(GOFLAGS)
 $(SOURCEDIR)/scripts/go-test: export GO_TAGS := $(GO_TAGS)
 $(SOURCEDIR)/scripts/go-test: $(SOURCEDIR)/scripts/go-test.in $(SOURCEDIR)/scripts/expand-env.go
 	@echo ' GEN $@'
-	$(V) $(GO) $(GO_MODFLAGS) run $(SOURCEDIR)/scripts/expand-env.go < $< > $@
+	$(V) $(GO) run $(GO_MODFLAGS) $(SOURCEDIR)/scripts/expand-env.go < $< > $@
 	$(V) chmod +x $@
 
 ALL += $(SOURCEDIR)/scripts/go-test
@@ -20,7 +20,7 @@ $(SOURCEDIR)/scripts/go-generate: export GOFLAGS := $(GOFLAGS)
 $(SOURCEDIR)/scripts/go-generate: export GO_TAGS := $(GO_TAGS)
 $(SOURCEDIR)/scripts/go-generate: $(SOURCEDIR)/scripts/go-generate.in $(SOURCEDIR)/scripts/expand-env.go
 	@echo ' GEN $@'
-	$(V) $(GO) $(GO_MODFLAGS) run $(SOURCEDIR)/scripts/expand-env.go < $< > $@
+	$(V) $(GO) run $(GO_MODFLAGS) $(SOURCEDIR)/scripts/expand-env.go < $< > $@
 	$(V) chmod +x $@
 
 ALL += $(SOURCEDIR)/scripts/go-generate

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,2 @@
+go-generate
 go-test

--- a/scripts/go-generate.in
+++ b/scripts/go-generate.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export BUILDDIR='@BUILDDIR@'
+export GO111MODULE='@GO111MODULE@'
+export GO_BUILD_TAGS='@GO_TAGS@'
+export GOFLAGS='@GOFLAGS@'
+
+exec '@GO@' generate \
+	-tags '@GO_TAGS@' \
+	"$@"


### PR DESCRIPTION
Cherry picks #4321 and #4375 

Tested by running `mconfig` and then adding `GO_MODFLAGS := -x` to the `Makefile` before running `make`. Without this fix, the build will fail.