### PR TITLE
Use hkps pool for test hitting external keyserver

### DIFF
--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -95,12 +95,12 @@ func (c *ctx) singularityKeySearch(t *testing.T) {
 		},
 		{
 			name:   "key search --url <open key server> <name>",
-			args:   []string{"search", "--url", "https://keyserver.2ndquadrant.com", "WestleyK"},
+			args:   []string{"search", "--url", "https://hkps.pool.sks-keyservers.net", "WestleyK"},
 			stdout: "^Showing",
 		},
 		{
 			name:   "key search --url <open key server> <key id>",
-			args:   []string{"search", "--url", "https://keyserver.2ndquadrant.com", "0x0E92D0AC"},
+			args:   []string{"search", "--url", "https://hkps.pool.sks-keyservers.net", "0x0E92D0AC"},
 			stdout: "^Showing 1 results",
 		},
 		// TODO: add tests for --long-list after #4156 is solved


### PR DESCRIPTION
Replace a single-server hardcoded hkps URI with the address of the hkps pool.

This should help stop PR merge being blocked by consistently failing tests where the one keyserver we depend on has an issue.

https://sks-keyservers.net/overview-of-pools.php


>hkps.pool.sks-keyservers.net
>
>This is a pool containing only servers available using hkps. Regular A and AAAA and SRV records are included for port 443 servers, and a lookup is performed for _pgpkey-https._tcp on the individual servers to determine if a hkps enabled service is listening on another port. At this point, however, servers not running on port 443 are not included.
>
>This pool only include servers that have been certified by the sks-keyservers.net CA, of which the certificate can be found at https://sks-keyservers.net/sks-keyservers.netCA.pem [OpenPGP signature] [CRL].
