### PR TITLE
Use an essential Ubuntu GPG key for external test

### DIFF
--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -95,12 +95,12 @@ func (c *ctx) singularityKeySearch(t *testing.T) {
 		},
 		{
 			name:   "key search --url <open key server> <name>",
-			args:   []string{"search", "--url", "https://keyserver.2ndquadrant.com", "WestleyK"},
+			args:   []string{"search", "--url", "https://keyserver.ubuntu.com", "ftpmaster@ubuntu.com"},
 			stdout: "^Showing",
 		},
 		{
 			name:   "key search --url <open key server> <key id>",
-			args:   []string{"search", "--url", "https://keyserver.2ndquadrant.com", "0x0E92D0AC"},
+			args:   []string{"search", "--url", "https://keyserver.ubuntu.com", "0x991BC93C"},
 			stdout: "^Showing 1 results",
 		},
 		// TODO: add tests for --long-list after #4156 is solved


### PR DESCRIPTION
This should mostly prevent issues with tests being blocked due to an
unreliable keyserver. The existing hardcoded server has failed with 500 issues
and the hkps pool sometimes presents bad certificates. The Ubuntu
keyserver and the 2018 signing key should be a fairly safe bet.
