### PR TITLE
Clean up e2e

### DIFF
--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -95,6 +95,8 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 
 	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "library", shasum, imgName)
 	if _, err := os.Stat(cacheEntryPath); os.IsNotExist(err) {
+		ls(t, c.env.TestDir)
+		ls(t, c.env.ImgCacheDir)
 		t.Fatalf("Cache entry %s for image %s with name %s does not exists: %s",
 			cacheEntryPath, imgPath, imgName, err)
 	}
@@ -128,6 +130,24 @@ func (c ctx) testSingularityCacheDir(t *testing.T) {
 
 	// there should be an entry for this image in the library cache
 	c.assertLibraryCacheEntryExists(t, imgPath, "alpine_latest.sif")
+}
+
+func ls(t *testing.T, dir string) {
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Logf("W: skipping path %q due to error: %v\n", path, err)
+			return err
+		}
+
+		t.Logf("%-20d  %s  %s\n", info.Size(), info.Mode(), path)
+
+		return nil
+	})
+
+	if err != nil {
+		t.Logf("E: error walking the path %q: %v\n", dir, err)
+		return
+	}
 }
 
 func (c ctx) testSingularityDisableCache(t *testing.T) {

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -20,42 +20,61 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-func setupTempDirs(t *testing.T, readOnly bool) (string, string, func(t *testing.T)) {
-	cacheDir, err := ioutil.TempDir("", "e2e-imgcache-")
+func setupTemporaryDir(t *testing.T, testdir, label string) (string, func(*testing.T)) {
+	tmpdir, err := ioutil.TempDir(testdir, label+".")
 	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
+		t.Fatalf("failed to create '%s' directory for test %s: %s (%#[3]v)",
+			label, t.Name(), err)
 	}
 
-	testDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		os.RemoveAll(cacheDir) // Something went wrong before we can setup a cleanup function so we do our best to manually cleanup
-		t.Fatalf("failed to create temporary directory: %s", err)
-	}
+	t.Logf("Set up temporary %s directory to %s", label, tmpdir)
 
-	return testDir, cacheDir, func(t *testing.T) {
-		err := os.RemoveAll(cacheDir)
+	return tmpdir, func(t *testing.T) {
+		err := os.RemoveAll(tmpdir)
 		if err != nil {
-			t.Fatalf("failed to delete temporary directory %s: %s", cacheDir, err)
-		}
-
-		err = os.RemoveAll(testDir)
-		if err != nil {
-			t.Fatalf("failed to delete temporary directory %s: %s", testDir, err)
+			t.Fatalf("failed to delete temporary %s directory %s: %s", label, tmpdir, err)
 		}
 	}
 }
 
-func (c *ctx) testSingularityImgCache(t *testing.T, disableCache bool) string {
-	if disableCache {
-		c.env.DisableCache = true
+// setupTemporaryCache creates a temporary cache directory and modifies
+// the test environment to use it. The code calling this function is
+// responsible for calling the returned function when its done using the
+// temporary directory.
+func (c *ctx) setupTemporaryCache(t *testing.T) func(*testing.T) {
+	cacheDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "cache-dir")
+
+	c.env.ImgCacheDir = cacheDir
+
+	return cleanup
+}
+
+// setupTemporaryKeyringDir creates a temporary keyring directory and modifies
+// the test environment to use it. The code calling this function is
+// responsible for calling the returned function when its done using the
+// temporary directory.
+func (c *ctx) setupTemporaryKeyringDir(t *testing.T) func(*testing.T) {
+	keyringDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "sypgp-dir")
+
+	c.env.KeyringDir = keyringDir
+
+	return cleanup
+}
+
+// pullTestImage will pull a known image from the network in order to
+// exercise the image cache. It returns the full path to the image.
+func (c ctx) pullTestImage(t *testing.T) string {
+	// create a temporary directory for the destination image
+	tmpdir, err := ioutil.TempDir(c.env.TestDir, "image-cache.")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory for test %s: %s (%#v)", t.Name(), err, err)
 	}
 
-	imgName := "testImg.sif"
-	imgPath := filepath.Join(c.env.TestDir, imgName)
+	imgPath := filepath.Join(tmpdir, "testImg.sif")
+
 	cmdArgs := []string{imgPath, "library://alpine:latest"}
 
-	// Build the image. We make sure to use RunSingularity since the goal here is to check
-	// whether it does the correct thing or not.
+	// Pull the specified image to the temporary location
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -67,9 +86,23 @@ func (c *ctx) testSingularityImgCache(t *testing.T, disableCache bool) string {
 	return imgPath
 }
 
-// cacheExists checks that the image cache that is associated to the test exists
-// and is valid (i.e., include the correct entry)
-func (c *ctx) cacheIsNotExist(t *testing.T, imgPath string) {
+func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string) {
+	// The cache should exist and have the correct entry
+	shasum, err := client.ImageHash(imgPath)
+	if err != nil {
+		t.Fatalf("Cannot get the shasum for image %s: %s", imgPath, err)
+	}
+
+	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "library", shasum, imgName)
+	if _, err := os.Stat(cacheEntryPath); os.IsNotExist(err) {
+		t.Fatalf("Cache entry %s for image %s with name %s does not exists: %s",
+			cacheEntryPath, imgPath, imgName, err)
+	}
+}
+
+// assertCacheDoesNotExist checks that the image cache that is associated to the
+// test DOES NOT exists.
+func (c ctx) assertCacheDoesNotExist(t *testing.T) {
 	cacheRoot := filepath.Join(c.env.ImgCacheDir, "cache")
 	if _, err := os.Stat(cacheRoot); !os.IsNotExist(err) {
 		// The root of the cache does exists
@@ -78,109 +111,133 @@ func (c *ctx) cacheIsNotExist(t *testing.T, imgPath string) {
 }
 
 func (c ctx) testSingularityCacheDir(t *testing.T) {
-	// The intent of the test is simple:
-	// - create 2 temporary directories, one where the image will be pulled and one where the
-	//   image cache should be created,
-	// - pull an image,
-	// - check whether we have the correct entry in the cache, within the directory we created.
-	// If the file is in our cache, it means the e2e framework correctly set the SINGULARITY_CACHE_DIR
-	// while executing the pull command.
+	// Test plan:
+	//
+	// - create a temporary directory for the cache
+	// - pull a known image from the network
+	// - assert that there's an entry for this image in the cache
+	//
+	// If the file is in the temporary cache, it means singularity
+	// followed the SINGULARITY_CACHEDIR environment variable (set
+	// up deep in the e2e framework) to store the cached image.
 
-	testDir, cacheDir, cleanup := setupTempDirs(t, false)
-	c.env.TestDir = testDir
+	cleanup := c.setupTemporaryCache(t)
 	defer cleanup(t)
 
-	c.env.ImgCacheDir = cacheDir
-	imgPath := c.testSingularityImgCache(t, false)
+	imgPath := c.pullTestImage(t)
 
-	// The cache should exist and have the correct entry
-	shasum, err := client.ImageHash(imgPath)
-	if err != nil {
-		t.Fatalf("Cannot get the shasum for image %s: %s", imgPath, err)
-	}
-	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "library", shasum, "alpine_latest.sif")
-	if _, err := os.Stat(cacheEntryPath); os.IsNotExist(err) {
-		t.Fatalf("Cache entry %s does not exists: %s", cacheEntryPath, err)
-	}
+	// there should be an entry for this image in the library cache
+	c.assertLibraryCacheEntryExists(t, imgPath, "alpine_latest.sif")
 }
 
 func (c ctx) testSingularityDisableCache(t *testing.T) {
-	testDir, cacheDir, cleanup := setupTempDirs(t, false)
-	c.env.TestDir = testDir
+	// Test plan:
+	//
+	// - create a temporary directory for the cache
+	// - disable the cache in the test environment
+	// - pull a known image from the network
+	// - assert that there is no entry for this image in the cache
+	//
+	// If the file is not in the temporary cache, it means
+	// singularity followed the SINGULARITY_DISABLE_CACHE environment
+	// variable (set up deep in the e2e framework) and avoided
+	// creating an entry in the library cache. If it fails to do so,
+	// we expect the entry to be found in the directory specified by
+	// SINGULARITY_CACHEDIR (see testSingularityCacheDir).
+
+	cleanup := c.setupTemporaryCache(t)
 	defer cleanup(t)
 
-	c.env.ImgCacheDir = cacheDir
-	imgPath := c.testSingularityImgCache(t, true)
+	// disable the cache; it's safe to do this here because we have
+	// a value receiver, not a pointer receiver, so this setting
+	// won't propagate to the rest of the tests.
+	c.env.DisableCache = true
+
+	c.pullTestImage(t)
 
 	// the cache should not exist
-	c.cacheIsNotExist(t, imgPath)
+	c.assertCacheDoesNotExist(t)
 }
 
-// This test checks if the cache is correctly and implicitly disabled
-// when its target location is read-only.
-//
-// This use case is common in the context of Grid computing where the
-// usage of sandboxes shared between users is a common practice. In that
-// context, the home directory ends up being read-only and no caching
-// is required.
 func (c ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
-	testDir, cacheDir, cleanup := setupTempDirs(t, true)
-	c.env.TestDir = testDir
+	// Test plan:
+	//
+	// - create a temporary directory for the cache
+	// - make the temporary directory readonly (but accessible,
+	//   otherwise we are testing something else)
+	// - pull a known image from the network
+	// - assert that there is no entry for this image in the cache
+	//
+	// If the file is not in the temporary cache, it means
+	// singularity followed the SINGULARITY_DISABLE_CACHE environment
+	// variable (set up deep in the e2e framework) and disabled
+	// caching (because the directory is readonly). If it fails to
+	// do so (e.g. by "fixing" the access permissions on the
+	// directory), we expect the entry to be found in the directory
+	// specified by SINGULARITY_CACHEDIR (see
+	// testSingularityCacheDir).
+	//
+	// This use case is common in the context of grid computing
+	// where the usage of sandboxes shared between users is a common
+	// practice. In that context, the home directory ends up being
+	// read-only and no caching is required.
+	cleanup := c.setupTemporaryCache(t)
 	defer cleanup(t)
 
 	// Change the mode of the image cache to read-only
-	err := os.Chmod(cacheDir, 0444)
+	err := os.Chmod(c.env.ImgCacheDir, 0555)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}
 
-	c.env.ImgCacheDir = cacheDir
-	imgPath := c.testSingularityImgCache(t, false)
+	c.pullTestImage(t)
 
-	// Change the mode of the image cache back so we can actually check everything
-	err = os.Chmod(cacheDir, 0755)
+	// Change the mode of the image cache to read-write so that we
+	// can delete the cache if it was created. Do this _before_
+	// calling c.assertCacheDoesNotExist because that function will
+	// fail if it find a cache.
+	err = os.Chmod(c.env.ImgCacheDir, 0755)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}
 
 	// the cache should not exist
-	c.cacheIsNotExist(t, imgPath)
+	c.assertCacheDoesNotExist(t)
 }
 
 func (c ctx) testSingularitySypgpDir(t *testing.T) {
-	// Create a temporary directory to be used for a keyring
-	keyringDir, err := ioutil.TempDir("", "e2e-sypgp-env-")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
-	}
-	defer func() {
-		err := os.RemoveAll(keyringDir)
-		if err != nil {
-			t.Fatalf("failed to delete temporary directory %s: %s", keyringDir, err)
-		}
-	}()
+	// Test plan:
+	//
+	// - create a temporary directory for the keyrings
+	// - run 'singularity key list' to create the keyrings
+	// - assert that both files were created
+	//
+	// If the files are in the temporary directory, it means
+	// singularity followed the SINGULARITY_SYPGPDIR environment
+	// variable (set up deep in the e2e framework) to store the
+	// keyrings.
 
-	// Run 'key list' to initialize the keyring.
-	cmdArgs := []string{"list"}
-	c.env.KeyringDir = keyringDir
+	cleanup := c.setupTemporaryKeyringDir(t)
+	defer cleanup(t)
+
+	// run 'key list' to initialize the keyring directory.
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("key"),
-		e2e.WithArgs(cmdArgs...),
+		e2e.WithArgs("list"),
 		e2e.ExpectExit(0),
 	)
 
-	pubKeyringPath := filepath.Join(keyringDir, "pgp-public")
+	pubKeyringPath := filepath.Join(c.env.KeyringDir, "pgp-public")
 	if _, err := os.Stat(pubKeyringPath); os.IsNotExist(err) {
 		t.Fatalf("failed to find keyring (expected: %s)", pubKeyringPath)
 	}
 
-	privKeyringPath := filepath.Join(keyringDir, "pgp-secret")
+	privKeyringPath := filepath.Join(c.env.KeyringDir, "pgp-secret")
 	if _, err := os.Stat(privKeyringPath); os.IsNotExist(err) {
 		t.Fatalf("failed to find keyring (expected: %s)", privKeyringPath)
 	}
-
 }
 
 // E2ETests is the main func to trigger the test suite
@@ -191,7 +248,7 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 
 	return testhelper.TestRunner(map[string]func(*testing.T){
 		"read-only cache directory": c.testSingularityReadOnlyCacheDir,
-		"SINGULARITY_CACHE_DIR":     c.testSingularityCacheDir,
+		"SINGULARITY_CACHEDIR":      c.testSingularityCacheDir,
 		"singularity disable cache": c.testSingularityDisableCache,
 		"SINGULARITY_SYPGPDIR":      c.testSingularitySypgpDir,
 	})

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -103,6 +103,11 @@ func Run(t *testing.T) {
 		log.Fatalf("failed to create temporary directory: %v", err)
 	}
 	defer e2e.Privileged(func(t *testing.T) {
+		if t.Failed() {
+			t.Logf("Test failed, not removing %s", name)
+			return
+		}
+
 		os.RemoveAll(name)
 	})(t)
 
@@ -113,7 +118,7 @@ func Run(t *testing.T) {
 
 	// Build a base image for tests
 	imagePath := path.Join(name, "test.sif")
-	t.Log(imagePath)
+	t.Log("Path to test image:", imagePath)
 	testenv.ImagePath = imagePath
 	defer os.Remove(imagePath)
 


### PR DESCRIPTION
    Keep test artifacts in separate directories

    Clean up cmdenvvars E2E tests

    - Move some code around so that it's more clear what's going on.
    - Rename some functions so that it's more clear what they are trying to
      do.
    - Add some documentation in the form of test plans as to what the tests
      are doing.

    Dump directory contents on failure

    Do not remove test directory in case of failure
