### PR TITLE
Fix regression breaking --net usage

### DIFF
--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1960,6 +1960,12 @@ func (c *container) addFuseMount(system *mount.System) error {
 func (c *container) getBindFlags(source string, defaultFlags uintptr) (uintptr, error) {
 	addFlags := uintptr(0)
 
+	// case where there is a single bind, we doesn't need
+	// to apply mount flags from source directory/file
+	if defaultFlags == syscall.MS_BIND || defaultFlags == syscall.MS_BIND|syscall.MS_REC {
+		return defaultFlags, nil
+	}
+
 	entries, err := proc.GetMountInfoEntry(c.mountInfoPath)
 	if err != nil {
 		return 0, fmt.Errorf("error while reading %s: %s", c.mountInfoPath, err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix another regression introduced by #4411 when using `--net`, using `--net` result in following error :

```
singularity shell -f --net docker://alpine
FATAL:   container creation failed: mount /proc/self/ns/net->/usr/local/var/singularity/mnt/session/netns error: while mounting /proc/self/ns/net: while getting mount flags for /proc/self/ns/net: while searching parent mount point entry for /proc/self/ns/net: while resolving path /proc/self/ns/net: lstat /proc/12772/ns/net:[4026532009]: no such file or directory
```

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

