### PR TITLE
Fix image file descriptor leak

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -254,7 +254,6 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		if err != nil {
 			sylog.Fatalf("could not open image %s: %s", engineConfig.GetImage(), err)
 		}
-		defer img.File.Close()
 
 		if !img.HasRootFs() {
 			sylog.Fatalf("no root filesystem found in %s", engineConfig.GetImage())
@@ -276,6 +275,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 			engineConfig.SetEncryptionKey(plaintextKey)
 		}
+
+		// don't defer this call as in all cases it won't be
+		// called before execing starter, so it would leak the
+		// image file descriptor to the container process
+		img.File.Close()
 	}
 
 	engineConfig.SetBindPath(BindPaths)

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -950,5 +950,6 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 		"shell":                 c.actionShell,         // shell interaction
 		"STDPIPE":               c.STDPipe,             // stdin/stdout pipe
 		"action basic profiles": c.actionBasicProfiles, // run basic action under different profiles
+		"issue 4488":            c.issue4488,           // https://github.com/sylabs/singularity/issues/4488
 	})
 }

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+// Check there is no file descriptor leaked in the container
+// process. This test expect 4 file descriptors, 3 for stdin,
+// stdout, stderr and one opened by the ls command.
+func (c actionTests) issue4488(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(c.env.ImagePath, "ls", "-1", "/proc/self/fd"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ExactMatch, "0\n1\n2\n3"),
+		),
+	)
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In actions CLI, the image is closed with a `defer` call which never occured (or too late in case of instances) leaking file descriptor to container process. This PR removes defer call and add a comment for not using `defer`.

### This fixes or addresses the following GitHub issues:

 - Fixes #4488


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

