### PR TITLE
Update scs-build-client to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/sylabs/json-resp v0.6.0
-	github.com/sylabs/scs-build-client v0.0.4
+	github.com/sylabs/scs-build-client v0.1.0
 	github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec
 	github.com/sylabs/scs-library-client v0.4.4
 	github.com/sylabs/sif v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,6 @@ github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZs
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
@@ -284,8 +282,8 @@ github.com/sylabs/json-resp v0.5.0 h1:AWdKu6aS0WrkkltX1M0ex0lENrIcx5TISox902s2L2
 github.com/sylabs/json-resp v0.5.0/go.mod h1:anCzED2SGHHZQDubMuoVtwMuJZdpqQ+7iso8yDFm/nQ=
 github.com/sylabs/json-resp v0.6.0 h1:W/yxwBu6WPMqiU9YBaelUsfWU1ZD+x4f4rxqmTr0LaI=
 github.com/sylabs/json-resp v0.6.0/go.mod h1:QYGGBTYDgiIH+c6zRQuVd4PIYfm//vFD2flnIdF1k7E=
-github.com/sylabs/scs-build-client v0.0.4 h1:y1rer0Mq+GyAFPKn0szpayJfUSTD7SGgRB3Yh0dJo+g=
-github.com/sylabs/scs-build-client v0.0.4/go.mod h1:TxxLkoW6RjzcQXllPAbsA5zmljX/YsHLlQ1gZ5Lkogg=
+github.com/sylabs/scs-build-client v0.1.0 h1:PoAsdO8s9QZ4egSLPs9RC3+gn1qNo56MwkmI3QDoGLQ=
+github.com/sylabs/scs-build-client v0.1.0/go.mod h1:l3Nh3ibhEQPH9Y0dZ0DPvAtw6AOh4rL084gahycyk/8=
 github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec h1:PYpPpJokBQc90ErbzDsyRQfff7gUSwtIiWDblx3AM6Y=
 github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec/go.mod h1:nMF8PplFD5ZmDz//GHjaip7+MlQ0z4Qe0RCzaT5Xjes=
 github.com/sylabs/scs-library-client v0.4.4 h1:DJpXTEV1TyHe3lGQ9EJ4RzK+0ES+3rDgjBX21LwYKbg=

--- a/vendor/github.com/sylabs/scs-build-client/client/client.go
+++ b/vendor/github.com/sylabs/scs-build-client/client/client.go
@@ -88,10 +88,9 @@ func New(cfg *Config) (c *Client, err error) {
 }
 
 // newRequest returns a new Request given a method, path, query, and optional body.
-func (c *Client) newRequest(method, path, rawQuery string, body io.Reader) (r *http.Request, err error) {
+func (c *Client) newRequest(method, path string, body io.Reader) (r *http.Request, err error) {
 	u := c.BaseURL.ResolveReference(&url.URL{
-		Path:     path,
-		RawQuery: rawQuery,
+		Path: path,
 	})
 
 	r, err = http.NewRequest(method, u.String(), body)

--- a/vendor/github.com/sylabs/scs-build-client/client/status.go
+++ b/vendor/github.com/sylabs/scs-build-client/client/status.go
@@ -14,7 +14,7 @@ import (
 
 // GetStatus gets the status of a build from the Build Service by build ID
 func (c *Client) GetStatus(ctx context.Context, buildID string) (bi BuildInfo, err error) {
-	req, err := c.newRequest(http.MethodGet, "/v1/build/"+buildID, "", nil)
+	req, err := c.newRequest(http.MethodGet, "/v1/build/"+buildID, nil)
 	if err != nil {
 		return
 	}

--- a/vendor/github.com/sylabs/scs-build-client/client/version.go
+++ b/vendor/github.com/sylabs/scs-build-client/client/version.go
@@ -22,7 +22,7 @@ type VersionInfo struct {
 // GetVersion gets version information from the build service. The context
 // controls the lifetime of the request.
 func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
-	req, err := c.newRequest(http.MethodGet, pathVersion, "", nil)
+	req, err := c.newRequest(http.MethodGet, pathVersion, nil)
 	if err != nil {
 		return VersionInfo{}, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -324,7 +324,7 @@ github.com/spf13/cobra/doc
 github.com/spf13/pflag
 # github.com/sylabs/json-resp v0.6.0
 github.com/sylabs/json-resp
-# github.com/sylabs/scs-build-client v0.0.4
+# github.com/sylabs/scs-build-client v0.1.0
 github.com/sylabs/scs-build-client/client
 # github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec
 github.com/sylabs/scs-key-client/client


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update the `scs-library-client` vendored dep to `v0.1.0` which includes functionality to send a build cancellation request to the remote build server when a `Ctrl-C` exit happens during an attached remote build.

This reflects user expectation in an attached build... that Ctrl-C should stop a build, and not leave it running and consuming their build minutes

### This fixes or addresses the following GitHub issues:

 - Fixes #4500 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

