### PR TITLE
Use Released Version of Key Client

### DIFF
--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
@@ -114,7 +115,7 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if err := sypgp.PushPubkey(key, keyServerURI, authToken); err != nil {
+	if err := sypgp.PushPubkey(http.DefaultClient, key, keyServerURI, authToken); err != nil {
 		fmt.Printf("Failed to push newly created key to keystore: %s\n", err)
 	} else {
 		fmt.Printf("Key successfully pushed to: %s\n", keyServerURI)

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -41,7 +42,7 @@ func doKeyPullCmd(fingerprint string, url string) error {
 	keyring := sypgp.NewHandle("")
 
 	// get matching keyring
-	el, err := sypgp.FetchPubkey(fingerprint, url, authToken, false)
+	el, err := sypgp.FetchPubkey(http.DefaultClient, fingerprint, url, authToken, false)
 	if err != nil {
 		return fmt.Errorf("unable to pull key from server: %v", err)
 	}

--- a/cmd/internal/cli/key_push.go
+++ b/cmd/internal/cli/key_push.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 
@@ -62,7 +63,7 @@ func doKeyPushCmd(fingerprint string, url string) error {
 	}
 	entity := keys[0].Entity
 
-	if err = sypgp.PushPubkey(entity, url, authToken); err != nil {
+	if err = sypgp.PushPubkey(http.DefaultClient, entity, url, authToken); err != nil {
 		return err
 	}
 

--- a/cmd/internal/cli/key_search.go
+++ b/cmd/internal/cli/key_search.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -36,5 +37,5 @@ var KeySearchCmd = &cobra.Command{
 
 func doKeySearchCmd(search string, url string) error {
 	// get keyring with matching search string
-	return sypgp.SearchPubkey(search, url, authToken, keySearchLongList)
+	return sypgp.SearchPubkey(http.DefaultClient, search, url, authToken, keySearchLongList)
 }

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/sylabs/json-resp v0.6.0
 	github.com/sylabs/scs-build-client v0.1.0
-	github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec
+	github.com/sylabs/scs-key-client v0.4.1
 	github.com/sylabs/scs-library-client v0.4.4
 	github.com/sylabs/sif v1.0.8
 	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,14 +278,12 @@ github.com/sylabs/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9 h1:OjtuUh4Z
 github.com/sylabs/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9/go.mod h1:Qf7xZmhvuwq9Hq4LdNLS4xabRQkPJSvEP3Bh4UFG0v4=
 github.com/sylabs/image-tools v0.0.0-20181006203805-2814f4980568 h1:Bv8RD7DVhhvYw31BJbw2vhUie1jqHmRHjcypRtroG6k=
 github.com/sylabs/image-tools v0.0.0-20181006203805-2814f4980568/go.mod h1:1CO+05HLIlepCW8AZHGumlYfh/6mOa6puEIt1Yv0aUM=
-github.com/sylabs/json-resp v0.5.0 h1:AWdKu6aS0WrkkltX1M0ex0lENrIcx5TISox902s2L2M=
-github.com/sylabs/json-resp v0.5.0/go.mod h1:anCzED2SGHHZQDubMuoVtwMuJZdpqQ+7iso8yDFm/nQ=
 github.com/sylabs/json-resp v0.6.0 h1:W/yxwBu6WPMqiU9YBaelUsfWU1ZD+x4f4rxqmTr0LaI=
 github.com/sylabs/json-resp v0.6.0/go.mod h1:QYGGBTYDgiIH+c6zRQuVd4PIYfm//vFD2flnIdF1k7E=
 github.com/sylabs/scs-build-client v0.1.0 h1:PoAsdO8s9QZ4egSLPs9RC3+gn1qNo56MwkmI3QDoGLQ=
 github.com/sylabs/scs-build-client v0.1.0/go.mod h1:l3Nh3ibhEQPH9Y0dZ0DPvAtw6AOh4rL084gahycyk/8=
-github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec h1:PYpPpJokBQc90ErbzDsyRQfff7gUSwtIiWDblx3AM6Y=
-github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec/go.mod h1:nMF8PplFD5ZmDz//GHjaip7+MlQ0z4Qe0RCzaT5Xjes=
+github.com/sylabs/scs-key-client v0.4.1 h1:YM5fZ4ORaAA6ATtwjO1cls47Ggvkoz+gzRKecOBLtFE=
+github.com/sylabs/scs-key-client v0.4.1/go.mod h1:G5WwGCFcwAGLxBzBB/Jw5TiYM+2FZ2T48ItAGzc+t/s=
 github.com/sylabs/scs-library-client v0.4.4 h1:DJpXTEV1TyHe3lGQ9EJ4RzK+0ES+3rDgjBX21LwYKbg=
 github.com/sylabs/scs-library-client v0.4.4/go.mod h1:FV1aajXP99oKFFagiomGI6WkWFniKnhIq/z1mITeeb4=
 github.com/sylabs/sif v1.0.8 h1:BK55XU0UhUsbimCr1Sl1tCLDrFsB71EDYDcHRfPpw8k=

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/fatih/color"
@@ -515,7 +516,7 @@ func getSignerIdentity(keyring *sypgp.Handle, v *sif.Descriptor, block *clearsig
 
 	// download the key
 	sylog.Verbosef("Key not found in local keyring, checking remote keystore: %s\n", fingerprint[32:])
-	netlist, err := sypgp.FetchPubkey(fingerprint, keyServiceURI, authToken, true)
+	netlist, err := sypgp.FetchPubkey(http.DefaultClient, fingerprint, keyServiceURI, authToken, true)
 	if err != nil {
 		return "", false, errNotFound
 	}

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -604,11 +604,12 @@ func formatMROutput(mrString string) (int, []byte, error) {
 }
 
 // SearchPubkey connects to a key server and searches for a specific key
-func SearchPubkey(search, keyserverURI, authToken string, longOutput bool) error {
+func SearchPubkey(httpClient *http.Client, search, keyserverURI, authToken string, longOutput bool) error {
 	// Get a Key Service client.
 	c, err := client.NewClient(&client.Config{
-		BaseURL:   keyserverURI,
-		AuthToken: authToken,
+		BaseURL:    keyserverURI,
+		AuthToken:  authToken,
+		HTTPClient: httpClient,
 	})
 	if err != nil {
 		return err
@@ -796,7 +797,7 @@ func formatMROutputLongList(mrString string) (int, []byte, error) {
 }
 
 // FetchPubkey pulls a public key from the Key Service.
-func FetchPubkey(fingerprint, keyserverURI, authToken string, noPrompt bool) (openpgp.EntityList, error) {
+func FetchPubkey(httpClient *http.Client, fingerprint, keyserverURI, authToken string, noPrompt bool) (openpgp.EntityList, error) {
 
 	// Decode fingerprint and ensure proper length.
 	var fp []byte
@@ -812,8 +813,9 @@ func FetchPubkey(fingerprint, keyserverURI, authToken string, noPrompt bool) (op
 
 	// Get a Key Service client.
 	c, err := client.NewClient(&client.Config{
-		BaseURL:   keyserverURI,
-		AuthToken: authToken,
+		BaseURL:    keyserverURI,
+		AuthToken:  authToken,
+		HTTPClient: httpClient,
 	})
 	if err != nil {
 		return nil, err
@@ -1113,7 +1115,7 @@ func (keyring *Handle) ImportKey(kpath string, setNewPassword bool) error {
 }
 
 // PushPubkey pushes a public key to the Key Service.
-func PushPubkey(e *openpgp.Entity, keyserverURI, authToken string) error {
+func PushPubkey(httpClient *http.Client, e *openpgp.Entity, keyserverURI, authToken string) error {
 	keyText, err := serializeEntity(e, openpgp.PublicKeyType)
 	if err != nil {
 		return err
@@ -1121,8 +1123,9 @@ func PushPubkey(e *openpgp.Entity, keyserverURI, authToken string) error {
 
 	// Get a Key Service client.
 	c, err := client.NewClient(&client.Config{
-		BaseURL:   keyserverURI,
-		AuthToken: authToken,
+		BaseURL:    keyserverURI,
+		AuthToken:  authToken,
+		HTTPClient: httpClient,
 	})
 	if err != nil {
 		return err

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -59,7 +59,7 @@ func (ms *mockPKSLookup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func TestSearchPubkey(t *testing.T) {
 	ms := &mockPKSLookup{}
-	srv := httptest.NewServer(ms)
+	srv := httptest.NewTLSServer(ms)
 	defer srv.Close()
 
 	tests := []struct {
@@ -83,7 +83,7 @@ func TestSearchPubkey(t *testing.T) {
 			ms.code = tt.code
 			ms.el = tt.el
 
-			if err := SearchPubkey(tt.search, tt.uri, tt.authToken, false); (err != nil) != tt.wantErr {
+			if err := SearchPubkey(srv.Client(), tt.search, tt.uri, tt.authToken, false); (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, want error %v", err, tt.wantErr)
 			}
 		})
@@ -92,7 +92,7 @@ func TestSearchPubkey(t *testing.T) {
 
 func TestFetchPubkey(t *testing.T) {
 	ms := &mockPKSLookup{}
-	srv := httptest.NewServer(ms)
+	srv := httptest.NewTLSServer(ms)
 	defer srv.Close()
 
 	fp := hex.EncodeToString(testEntity.PrimaryKey.Fingerprint[:])
@@ -120,7 +120,7 @@ func TestFetchPubkey(t *testing.T) {
 			ms.code = tt.code
 			ms.el = tt.el
 
-			el, err := FetchPubkey(tt.fingerprint, tt.uri, tt.authToken, false)
+			el, err := FetchPubkey(srv.Client(), tt.fingerprint, tt.uri, tt.authToken, false)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("unexpected error: %v", err)
 				return
@@ -174,7 +174,7 @@ func TestPushPubkey(t *testing.T) {
 		t:       t,
 		keyText: keyText,
 	}
-	srv := httptest.NewServer(ms)
+	srv := httptest.NewTLSServer(ms)
 	defer srv.Close()
 
 	tests := []struct {
@@ -195,7 +195,7 @@ func TestPushPubkey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ms.code = tt.code
 
-			if err := PushPubkey(testEntity, tt.uri, tt.authToken); (err != nil) != tt.wantErr {
+			if err := PushPubkey(srv.Client(), testEntity, tt.uri, tt.authToken); (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, want error %v", err, tt.wantErr)
 			}
 		})

--- a/vendor/github.com/sylabs/scs-key-client/client/pks.go
+++ b/vendor/github.com/sylabs/scs-key-client/client/pks.go
@@ -136,8 +136,14 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 	return string(body), nil
 }
 
-// GetKey retrieves an ASCII armored keyring from the Key Service. The context controls the
-// lifetime of the request.
-func (c *Client) GetKey(ctx context.Context, fingerprint []byte) (keyText string, err error) {
-	return c.PKSLookup(ctx, nil, fmt.Sprintf("%#x", fingerprint), OperationGet, false, true, nil)
+// GetKey retrieves an ASCII armored keyring matching search from the Key Service. A 32-bit key ID,
+// 64-bit key ID, 128-bit version 3 fingerprint, or 160-bit version 4 fingerprint can be specified
+// in search. The context controls the lifetime of the request.
+func (c *Client) GetKey(ctx context.Context, search []byte) (keyText string, err error) {
+	switch len(search) {
+	case 4, 8, 16, 20:
+		return c.PKSLookup(ctx, nil, fmt.Sprintf("%#x", search), OperationGet, false, true, nil)
+	default:
+		return "", ErrInvalidSearch
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -326,7 +326,7 @@ github.com/spf13/pflag
 github.com/sylabs/json-resp
 # github.com/sylabs/scs-build-client v0.1.0
 github.com/sylabs/scs-build-client/client
-# github.com/sylabs/scs-key-client v0.3.1-0.20190509220229-bce3b050c4ec
+# github.com/sylabs/scs-key-client v0.4.1
 github.com/sylabs/scs-key-client/client
 # github.com/sylabs/scs-library-client v0.4.4
 github.com/sylabs/scs-library-client/client


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update the `scs-key-client` vendored dep to v0.4.1 which includes changes to the signature of `func GetKey()` which Singularity was relying on prior to this being released in `scs-key-client`.

Starting with v0.4.0, `scs-key-client` requires TLS when an auth token is included in the request. To account for this, `sypgp` unit tests are updated to use a TLS server, and a `*http.Client` parameter has been added to `func sypgp.PushPubkey`, `func sypgp.FetchPubkey`, and `func sypgp.SearchPubkey`.

### This fixes or addresses the following GitHub issues:

 - Fixes #4504

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

