### PR TITLE
Add network e2e helper and few basic networking e2e tests

### DIFF
--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -7,40 +7,12 @@ package require
 
 import (
 	"os/exec"
-	"sync"
-	"syscall"
 	"testing"
 
 	"github.com/containerd/cgroups"
 	"github.com/sylabs/singularity/internal/pkg/security/seccomp"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 )
-
-var hasUserNamespace bool
-var hasUserNamespaceOnce sync.Once
-
-// UserNamespace checks that the current test could use
-// user namespace, if user namespaces are not enabled or
-// supported, the current test is skipped with a message.
-func UserNamespace(t *testing.T) {
-	// not performance critical, just save extra execution
-	// to get the same result
-	hasUserNamespaceOnce.Do(func() {
-		// user namespace is a bit special, as there is no simple
-		// way to detect if it's supported or enabled via a call
-		// on /proc/self/ns/user, the easiest and reliable way seems
-		// to directly execute a command by requesting user namespace
-		cmd := exec.Command("/bin/true")
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Cloneflags: syscall.CLONE_NEWUSER,
-		}
-		// no error means user namespaces are enabled
-		hasUserNamespace = cmd.Run() == nil
-	})
-	if !hasUserNamespace {
-		t.Skipf("user namespaces seems not enabled or supported")
-	}
-}
 
 // Filesystem checks that the current test could use the
 // corresponding filesystem, if the filesystem is not

--- a/internal/pkg/test/tool/require/require_linux.go
+++ b/internal/pkg/test/tool/require/require_linux.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package require
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/pkg/network"
+)
+
+var hasUserNamespace bool
+var hasUserNamespaceOnce sync.Once
+
+// UserNamespace checks that the current test could use
+// user namespace, if user namespaces are not enabled or
+// supported, the current test is skipped with a message.
+func UserNamespace(t *testing.T) {
+	// not performance critical, just save extra execution
+	// to get the same result
+	hasUserNamespaceOnce.Do(func() {
+		// user namespace is a bit special, as there is no simple
+		// way to detect if it's supported or enabled via a call
+		// on /proc/self/ns/user, the easiest and reliable way seems
+		// to directly execute a command by requesting user namespace
+		cmd := exec.Command("/bin/true")
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Cloneflags: syscall.CLONE_NEWUSER,
+		}
+		// no error means user namespaces are enabled
+		err := cmd.Run()
+		hasUserNamespace = err == nil
+		if !hasUserNamespace {
+			t.Logf("Could not use user namespaces: %s", err)
+		}
+	})
+	if !hasUserNamespace {
+		t.Skipf("user namespaces seems not enabled or supported")
+	}
+}
+
+var supportNetwork bool
+var supportNetworkOnce sync.Once
+
+// Network check that bridge network is supported by
+// system, if not the current test is skipped with a
+// message.
+func Network(t *testing.T) {
+	supportNetworkOnce.Do(func() {
+		logFn := func(err error) {
+			t.Logf("Could not use network: %s", err)
+		}
+
+		cmd := exec.Command("/bin/cat")
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWNET
+
+		stdinPipe, err := cmd.StdinPipe()
+		if err != nil {
+			logFn(err)
+			return
+		}
+
+		err = cmd.Start()
+		if err != nil {
+			logFn(err)
+			return
+		}
+
+		nsPath := fmt.Sprintf("/proc/%d/ns/net", cmd.Process.Pid)
+
+		cniPath := new(network.CNIPath)
+		cniPath.Conf = filepath.Join(buildcfg.SYSCONFDIR, "singularity", "network")
+		cniPath.Plugin = filepath.Join(buildcfg.LIBEXECDIR, "singularity", "cni")
+
+		setup, err := network.NewSetup([]string{"bridge"}, "_test_", nsPath, cniPath)
+		if err != nil {
+			logFn(err)
+			return
+		}
+		if err := setup.AddNetworks(); err != nil {
+			logFn(err)
+			return
+		}
+		if err := setup.DelNetworks(); err != nil {
+			logFn(err)
+			return
+		}
+
+		stdinPipe.Close()
+
+		if err := cmd.Wait(); err != nil {
+			logFn(err)
+			return
+		}
+
+		supportNetwork = true
+	})
+	if !supportNetwork {
+		t.Skipf("Network (bridge) not supported")
+	}
+}

--- a/internal/pkg/test/tool/require/require_unsupported.go
+++ b/internal/pkg/test/tool/require/require_unsupported.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package require
+
+import "testing"
+
+// UserNamespace checks that the current test could use
+// user namespace, if user namespaces are not enabled or
+// supported, the current test is skipped with a message.
+func UserNamespace(t *testing.T) {
+	t.Skipf("user namespaces not supported on this platform")
+}
+
+// Network check that bridge network is supported by
+// system, if not the current test is skipped with a
+// message.
+func Network(t *testing.T) {
+	t.Skipf("network not supported on this platform")
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds a `require` `Network` helper to proceed with e2e network tests. Also adds few basic networking tests to e2e actions.

### This fixes or addresses the following GitHub issues:

 - Fixes #4496
 - Related to #4487


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

