### PR TITLE
Add direct-io/block size for loop devices

### DIFF
--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -513,7 +513,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 	}
 
 	attachFlag := os.O_RDWR
-	loopFlags := uint32(loop.FlagsAutoClear)
+	loopFlags := uint32(loop.FlagsAutoClear | loop.FlagsDirectIO)
 
 	if flags&syscall.MS_RDONLY == 1 {
 		loopFlags |= loop.FlagsReadOnly

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -37,15 +37,16 @@ const (
 
 // Loop device IOCTL commands
 const (
-	CmdSetFd       = 0x4C00
-	CmdClrFd       = 0x4C01
-	CmdSetStatus   = 0x4C02
-	CmdGetStatus   = 0x4C03
-	CmdSetStatus64 = 0x4C04
-	CmdGetStatus64 = 0x4C05
-	CmdChangeFd    = 0x4C06
-	CmdSetCapacity = 0x4C07
-	CmdSetDirectIO = 0x4C08
+	CmdSetFd        = 0x4C00
+	CmdClrFd        = 0x4C01
+	CmdSetStatus    = 0x4C02
+	CmdGetStatus    = 0x4C03
+	CmdSetStatus64  = 0x4C04
+	CmdGetStatus64  = 0x4C05
+	CmdChangeFd     = 0x4C06
+	CmdSetCapacity  = 0x4C07
+	CmdSetDirectIO  = 0x4C08
+	CmdSetBlockSize = 0x4C09
 )
 
 // Info64 contains information about a loop device.


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds direct-io/block size support for loop devices if systems support it and image offset meet requirements.

### This fixes or addresses the following GitHub issues:

 - Fixes #4383


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

