### PR TITLE
Set workable permissions on OCI -> sandbox rootless builds

### DIFF
--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -88,3 +88,14 @@ func FileExists(t *testing.T, path string) bool {
 	// todo: we should check if it is a file
 	return PathExists(t, path)
 }
+
+// PathPerms return true if the path (file or directory) has specified permissions, false otherwise.
+func PathPerms(t *testing.T, path string, perms os.FileMode) bool {
+	s, err := os.Stat(path)
+
+	if err != nil {
+		t.Fatalf("While stating file: %v", err)
+	}
+
+	return s.Mode().Perm() == perms
+}

--- a/internal/pkg/build/sources/oci_unpack_linux.go
+++ b/internal/pkg/build/sources/oci_unpack_linux.go
@@ -14,12 +14,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 
 	"github.com/containers/image/types"
 	"github.com/openSUSE/umoci"
 	umocilayer "github.com/openSUSE/umoci/oci/layer"
 	"github.com/openSUSE/umoci/pkg/idtools"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
 	sytypes "github.com/sylabs/singularity/pkg/build/types"
 )
 
@@ -68,5 +71,119 @@ func unpackRootfs(b *sytypes.Bundle, tmpfsRef types.ImageReference, sysCtx *type
 	os.RemoveAll(b.Rootfs())
 
 	// Unpack root filesystem
-	return umocilayer.UnpackRootfs(context.Background(), engineExt, b.Rootfs(), manifest, &mapOptions)
+	err = umocilayer.UnpackRootfs(context.Background(), engineExt, b.Rootfs(), manifest, &mapOptions)
+	if err != nil {
+		return fmt.Errorf("error unpacking rootfs: %s", err)
+	}
+
+	// If this is a rootless extraction we need to mangle permissions to fix #4524. This
+	// returns to the <=3.3 permissions on the rootfs, with the exception that umoci
+	// correctly applies permission changes across layers when extracting.
+	if mapOptions.Rootless {
+		sylog.Debugf("Modifying rootless permissions on temporary rootfs")
+		return fixPermsRootless(b.Rootfs())
+	}
+
+	return nil
+}
+
+// fixPermsRootless forces permissions on the rootfs so that it can be easily
+// moved and deleted by a non-root user owner.
+func fixPermsRootless(rootfs string) (err error) {
+	errors := 0
+	err = permWalk(rootfs, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			sylog.Errorf("Unable to access sandbox path %s: %s", path, err)
+			errors++
+			return nil
+		}
+		// Directories must have the owner 'rx' bits to allow traversal and reading on move, and the 'w' bit
+		// so their content can be deleted by the user when the rootfs/sandbox is deleted
+		switch mode := f.Mode(); {
+		case mode.IsDir():
+			if err := os.Chmod(path, f.Mode().Perm()|0700); err != nil {
+				sylog.Errorf("Error setting rootless permission for %s: %s", path, err)
+				errors++
+			}
+		case mode.IsRegular():
+			// Regular files must have the owner 'r' bit so that everything can be read in order to
+			// copy or move the rootfs/sandbox around. Also, the `w` bit as the build does write into
+			// some files (e.g. resolv.conf) in the container rootfs.
+			if err := os.Chmod(path, f.Mode().Perm()|0600); err != nil {
+				sylog.Errorf("Error setting rootless permission for %s: %s", path, err)
+				errors++
+			}
+		}
+		return nil
+	})
+
+	if errors > 0 {
+		err = fmt.Errorf("%d errors were encountered when setting permissions", errors)
+	}
+
+	return err
+}
+
+// permWalk is similar to os.Walk - but:
+//   1. The skipDir checks are removed (we never want to skip anything here)
+//   2. Our walk will call walkFn on a directory *before* attempting to look
+//      inside that directory.
+func permWalk(root string, walkFn filepath.WalkFunc) error {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return fmt.Errorf("could not access rootfs %s: %s", root, err)
+	}
+	return walk(root, info, walkFn)
+}
+
+func walk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
+	if !info.IsDir() {
+		return walkFn(path, info, nil)
+	}
+
+	// Unlike filepath.walk we call walkFn *before* trying to list the content of
+	// the directory, so that walkFn has a chance to assign perms that allow us into
+	// the directory, if we can't get in there already.
+	if err := walkFn(path, info, nil); err != nil {
+		return err
+	}
+
+	names, err := readDirNames(path)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		filename := filepath.Join(path, name)
+		fileInfo, err := os.Lstat(filename)
+		if err != nil {
+			if err := walkFn(filename, fileInfo, err); err != nil {
+				return err
+			}
+		} else {
+			err = walk(filename, fileInfo, walkFn)
+			if err != nil {
+				if !fileInfo.IsDir() {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// readDirNames reads the directory named by dirname and returns
+// a sorted list of directory entries.
+func readDirNames(dirname string) ([]string, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

We previously used a patched version of `image-tools` to extract OCI layers into a rootfs. This was patched to ensure all files and dirs extracted from a layer had minimum permissions such that when performing a rootless sandbox build:

1. overwrites from subsequent layers succeeded even over files with `000` or similar permissions
2. the rootfs could be moved and deleted by the non-root user/owner

In 3.4.0 we switched to `umoci` for extractions, as it is more faithful to the content of the layers than `image-tools`. `umoci` handles (1) above. However, we need to fix (2) ourself, as `umoci` will faithfully create a rootfs with `000` files in it, which cannot be moved or trivially `rm'd` by the non-root user.

### This fixes or addresses the following GitHub issues:

 - Fixes #4524 (which was split from #4517)


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

