### PR TITLE
Return explicit error regarding build with sandbox/update flags

### DIFF
--- a/cmd/internal/cli/build_darwin.go
+++ b/cmd/internal/cli/build_darwin.go
@@ -7,7 +7,6 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/internal/pkg/build/remotebuilder"
@@ -23,8 +22,8 @@ func run(cmd *cobra.Command, args []string) {
 	spec := args[1]
 
 	// check if target collides with existing file
-	if ok := checkBuildTarget(dest, false); !ok {
-		os.Exit(1)
+	if err := checkBuildTarget(dest); err != nil {
+		sylog.Fatalf("%s", err)
 	}
 
 	if !remote {

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -99,8 +99,8 @@ func run(cmd *cobra.Command, args []string) {
 	spec := args[1]
 
 	// check if target collides with existing file
-	if ok := checkBuildTarget(dest, update); !ok {
-		os.Exit(1)
+	if err := checkBuildTarget(dest); err != nil {
+		sylog.Fatalf("%s", err)
 	}
 
 	if remote {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Due to confusion of `-u/--update` flag, this PR fixes error messages and cover error cases where:
- `--update` is used without `--sandbox` flag
- `--update` is used with `--sandbox` and a non-existent "target" sandbox
- `--update` is used with `--sandbox` and a file as "target" sandbox

In a separate commit there few e2e tests covering those cases.

### This fixes or addresses the following GitHub issues:

 - Fixes #4526


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

