### PR TITLE
re-download bin/golangci-lint if version changes

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -17,13 +17,18 @@ collect:
 			>> $(BUILDDIR)/mergeddeps)			\
 	done
 
+CI_LINT_VERSION=1.17.1
 .PHONY: check
 check: $(go_OBJ)
 	@echo " CHECK golangci-lint"
 	$(V)cd $(SOURCEDIR) && \
-		(PATH=$(SOURCEDIR)/bin:$$PATH; \
+		(if [ "`bin/golangci-lint --version 2>/dev/null| \
+			sed 's/.* version //;s/ .*//'`" != $(CI_LINT_VERSION) ]; then \
+		    rm -f bin/golangci-lint; \
+		 fi; \
+		 PATH=$(SOURCEDIR)/bin:$$PATH; \
 		 (command -v golangci-lint >/dev/null || \
-		  curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.17.1) && \
+		  curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$(CI_LINT_VERSION)) && \
 		 golangci-lint run --build-tags "$(GO_TAGS)" ./...)
 	@echo "       PASS"
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Change the make check rule to redownload bin/golangci-lint if the version is not the current desired version.


### This fixes or addresses the following GitHub issues:

None, but I had a problem with v1.15.0 complaining about code problems in the master branch that the current version (v.17.1) did not.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

