### PR TITLE
Add get-version script to obtain singularity's version

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -29,12 +29,12 @@
 
 Summary: Application and environment virtualization
 Name: singularity
-Version: @PACKAGE_VERSION@
+Version: @PACKAGE_RPM_VERSION@
 Release: @PACKAGE_RELEASE@%{?dist}
 # https://spdx.org/licenses/BSD-3-Clause-LBNL.html
 License: BSD-3-Clause-LBNL
 URL: https://www.sylabs.io/singularity/
-Source: %{name}-%{version}.tar.gz
+Source: %{name}-@PACKAGE_VERSION@.tar.gz
 ExclusiveOS: linux
 # RPM_BUILD_ROOT wasn't being set ... for some reason
 %if "%{sles_version}" == "11"

--- a/mconfig
+++ b/mconfig
@@ -48,7 +48,12 @@ cflags="$CFLAGS -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector
 ldflags=$LDFLAGS
 
 package_name=singularity
-package_version=`(git describe --match 'v[0-9]*' --dirty --always 2>/dev/null || cat VERSION 2>/dev/null || echo "") | sed -e "s/^v//;s/-/_/g;s/_/-/;s/_/./g"`
+package_version=`scripts/get-version`
+
+if test -z "${package_version}" ; then
+	echo "Failed to get package version. Abort."
+	exit 1
+fi
 
 with_network=1
 with_suid=1
@@ -381,8 +386,16 @@ while [ $# -ne 0 ]; do
   *) break;;
  esac
 done
-short_version="`echo "$package_version"|sed 's/-.*//'`"
-#
+
+# use a colon to provide additional version information such as a
+# release number.
+short_version="`echo "$package_version"|sed 's/:.*//'`"
+release_info="`echo "$package_version"|sed 's/^[^:]*://'`"
+if [ "${short_version}" = "${release_info}" ]; then
+	# $package_version has no colon
+	release_info=1
+fi
+
 # non-option param
 if [ $# != 0 ]; then
 	usage_args
@@ -832,12 +845,8 @@ if [ "$host" = "unix" ]; then
 	RPMSPEC=singularity.spec
 	echo "=> generating $RPMSPEC ..."
 	rm -f $sourcedir/$RPMSPEC
-	release="`echo "$package_version"|sed 's/[^-]*-//'`"
-	if [ "$short_version" = "$release" ]; then
-	    # $package_version has no dash
-	    release=1
-	fi
-	sed "s/@PACKAGE_VERSION@/$short_version/;s/@PACKAGE_RELEASE@/$release/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
+	v="`echo "${package_version}" | tr - .`"
+	sed "s/@PACKAGE_VERSION@/${v}/;s/@PACKAGE_RELEASE@/$release/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
 fi
 
 

--- a/mconfig
+++ b/mconfig
@@ -845,8 +845,9 @@ if [ "$host" = "unix" ]; then
 	RPMSPEC=singularity.spec
 	echo "=> generating $RPMSPEC ..."
 	rm -f $sourcedir/$RPMSPEC
-	v="`echo "${package_version}" | tr - .`"
-	sed "s/@PACKAGE_VERSION@/${v}/;s/@PACKAGE_RELEASE@/$release/" $sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
+	package_rpm_version="`echo "${short_version}" | tr - .`"
+	sed "s/@PACKAGE_VERSION@/${short_version}/;s/@PACKAGE_RPM_VERSION@/${package_rpm_version}/;s/@PACKAGE_RELEASE@/${release_info}/" \
+		$sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
 fi
 
 

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -80,10 +80,10 @@ rpm: dist
 	      --define '_sysconfdir $(RPMPREFIX)/etc' \
 	      --define '_localstatedir $(RPMPREFIX)/var' \
 	      --define '_mandir $(RPMPREFIX)/share/man' \
-	      $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz; \
+	      $(SOURCEDIR)/singularity-$(VERSION).tar.gz; \
 	  else \
 	    rpmbuild $(RPMCLEAN) -ta \
-	      $(SOURCEDIR)/singularity-$(SHORT_VERSION).tar.gz; \
+	      $(SOURCEDIR)/singularity-$(VERSION).tar.gz; \
 	  fi)
 
 .PHONY: cscope

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# optionally take commit-ish as argument for debugging purposes
+head=$1
+
+gitrepo=true
+toplevel="$(git rev-parse --show-toplevel 2> /dev/null)"
+
+if test -z "${toplevel}" ; then
+	# failed to get toplevel directory, we are not inside a git
+	# repo?
+	gitrepo=false
+	toplevel=$PWD
+fi
+
+if test -f "${toplevel}/VERSION" ; then
+	cat "${toplevel}/VERSION"
+	exit 0
+fi
+
+# no VERSION file
+
+if ! ${gitrepo} ; then
+	echo "E: Not inside a git repository and no VERSION file found. Abort." 1>&2
+	exit 1
+fi
+
+# gitdesc extracts the closest version tag, removing the leading "v" and
+# returning the rest
+gitdesc() {
+	git describe --match='v[0-9]*' --always "$@" 2>/dev/null |
+	sed -e 's,^v,,'
+}
+
+closest_tag=$(gitdesc --abbrev=0 ${head})
+current_commit=$(gitdesc ${head})
+if test -n "${head}" ; then
+	# cannot pass --dirty when using commit-ish
+	dirty_info=${current_commit}
+else
+	dirty_info=$(gitdesc --dirty=+dirty)
+fi
+
+# First figure out if the current commit matches a tag:
+#
+# v3.4.1
+# v3.4.1-rc.1
+
+if [ "${closest_tag}" = "${current_commit}" ] ; then
+	# We are on a tag, leave it alone, maybe including the dirty
+	# mark.
+	#
+	# This works even if we ever use a tag like v3.4.1+pl1 (which we
+	# will hopefully never have).
+	echo "${dirty_info}"
+	exit 0
+fi
+
+# We have something which doesn't exactly match a tag:
+#
+# v3.4.1-315-g21e6d6765
+# v3.4.1-rc.1-315-g21e6d6765
+#
+# Use the -315-g21e6d6765 part as metadata, using + to indicate that
+# this is 3.4.1 with 315 additional changes. Keep the g21e6d6765 part to
+# have a record of the corresponding git commit hash.
+#
+# Transform the above into:
+#
+# v3.4.1+315-g21e6d6765
+# v3.4.1-rc.1+315-g21e6d6765
+
+echo "${dirty_info}" | sed -e "s,^\(${closest_tag}\)-,\1+,"

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -11,13 +11,12 @@ if [ ! -f $package_name.spec ]; then
     exit 1
 fi
 
-package_version_short="`sed -n 's/^Version: //p' $package_name.spec`"
-tree_version="$package_version_short-`sed -n 's/^Release: \([^%]*\).*/\1/p' $package_name.spec`"
+version=`scripts/get-version`
 
-echo " DIST setup VERSION: $tree_version"
-echo $tree_version > VERSION
+echo " DIST setup VERSION: ${version}"
+echo "${version}" > VERSION
 rmfiles="VERSION"
-tarball="$package_name-$package_version_short.tar.gz"
+tarball="${package_name}-${version}.tar.gz"
 echo " DIST create tarball: $tarball"
 rm -f $tarball
 pathtop="$package_name"


### PR DESCRIPTION
Instead of trying to pull this off using a one-liner, move the logic to
a separate script that can do error checking, etc.

In the script, change the format of the version from 3.4.1-1 to 3.4.1+1
to address #3653. Consider cases like 3.4.1-rc.1, where the "rc.1" part
does indicate a prerelease.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

