### PR TITLE
Only try to connect to the keystore if we are pushing the key

### DIFF
--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -93,7 +93,6 @@ type keyNewPairOptions struct {
 
 func runNewPairCmd(cmd *cobra.Command, args []string) {
 	keyring := sypgp.NewHandle("")
-	handleKeyNewPairEndpoint()
 
 	opts, err := collectInput(cmd)
 	if err != nil {
@@ -115,6 +114,8 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Only connect to the endpoint if we are pushing the key.
+	handleKeyNewPairEndpoint()
 	if err := sypgp.PushPubkey(http.DefaultClient, key, keyServerURI, authToken); err != nil {
 		fmt.Printf("Failed to push newly created key to keystore: %s\n", err)
 	} else {


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR changes the `key newpair` to only try to connect to the keystore
**if** the user requested to push it.

### This fixes or addresses the following GitHub issues:

 - Fixes: #4530

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

