### PR TITLE
Fallback correctly to user namespace for non setuid installation

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -202,7 +202,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	starter := filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter-suid")
 	// singularity was compiled with '--without-suid' option
 	if buildcfg.SINGULARITY_SUID_INSTALL == 0 {
-		starter = filepath.Join(buildcfg.LIBEXECDIR, "singularity/bin/starter")
+		UserNamespace = true
 	}
 
 	// use non privileged starter binary:


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes regression in 3.4 (also present in 3.3 releases) where CLI doesn't fallback correctly to user namespace with non setuid installation resulting in issue 4537.

Note: master branch is not impacted and was fixed by #4387, that's why this PR is against release-3.4

### This fixes or addresses the following GitHub issues:

 - Fixes #4537 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

