### PR TITLE
Do not export SingularityCmd

### DIFF
--- a/cmd/bash_completion/bash_completion.go
+++ b/cmd/bash_completion/bash_completion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,7 +13,15 @@ import (
 )
 
 func main() {
-	if err := cli.SingularityCmd.GenBashCompletionFile(os.Args[1]); err != nil {
+	fh, err := os.Create(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer fh.Close()
+
+	if err := cli.GenBashCompletion(fh); err != nil {
 		fmt.Println(err)
 		return
 	}

--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -215,10 +215,10 @@ func createCmdsFiles() (string, string, error) {
 		return "", "", fmt.Errorf("failed to create command text file: %s", err)
 	}
 	defer textFile.Close()
-	cli.SingularityCmd.InitDefaultHelpCmd()
-	cli.SingularityCmd.InitDefaultVersionFlag()
+	cli.RootCmd().InitDefaultHelpCmd()
+	cli.RootCmd().InitDefaultVersionFlag()
 
-	tree := buildTree(cli.SingularityCmd, textFile)
+	tree := buildTree(cli.RootCmd(), textFile)
 
 	json, err := json.MarshalIndent(tree, "", "  ")
 	if err != nil {

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -21,15 +21,15 @@ func assertAccess(dir string) {
 	}
 }
 
-func markdownDocs(outDir string) {
+func markdownDocs(rootCmd *cobra.Command, outDir string) {
 	assertAccess(outDir)
 	sylog.Infof("Creating Singularity markdown docs at %s\n", outDir)
-	if err := doc.GenMarkdownTree(cli.SingularityCmd, outDir); err != nil {
+	if err := doc.GenMarkdownTree(rootCmd, outDir); err != nil {
 		sylog.Fatalf("Failed to create markdown docs for singularity\n")
 	}
 }
 
-func manDocs(outDir string) {
+func manDocs(rootCmd *cobra.Command, outDir string) {
 	assertAccess(outDir)
 	sylog.Infof("Creating Singularity man pages at %s\n", outDir)
 	header := &doc.GenManHeader{
@@ -38,15 +38,15 @@ func manDocs(outDir string) {
 	}
 
 	// works recursively on all sub-commands (thanks bauerm97)
-	if err := doc.GenManTree(cli.SingularityCmd, header, outDir); err != nil {
+	if err := doc.GenManTree(rootCmd, header, outDir); err != nil {
 		sylog.Fatalf("Failed to create man pages for singularity\n")
 	}
 }
 
-func rstDocs(outDir string) {
+func rstDocs(rootCmd *cobra.Command, outDir string) {
 	assertAccess(outDir)
 	sylog.Infof("Creating Singularity RST docs at %s\n", outDir)
-	if err := doc.GenReSTTreeCustom(cli.SingularityCmd, outDir, func(a string) string {
+	if err := doc.GenReSTTreeCustom(rootCmd, outDir, func(a string) string {
 		return ""
 	}, func(name, ref string) string {
 		return fmt.Sprintf(":ref:`%s <%s>`", name, ref)
@@ -63,13 +63,14 @@ func main() {
 		Use:       "makeDocs {markdown | man | rst}",
 		Short:     "Generates Singularity documentation",
 		Run: func(cmd *cobra.Command, args []string) {
+			rootCmd := cli.RootCmd()
 			switch args[0] {
 			case "markdown":
-				markdownDocs(dir)
+				markdownDocs(rootCmd, dir)
 			case "man":
-				manDocs(dir)
+				manDocs(rootCmd, dir)
 			case "rst":
-				rstDocs(dir)
+				rstDocs(rootCmd, dir)
 			default:
 				sylog.Fatalf("Invalid output type %s\n", args[0])
 			}

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"path"
@@ -24,7 +25,7 @@ import (
 	"github.com/sylabs/singularity/pkg/syfs"
 )
 
-var cmdManager = cmdline.NewCommandManager(SingularityCmd)
+var cmdManager = cmdline.NewCommandManager(singularityCmd)
 
 // CurrentUser holds the current user account information
 var CurrentUser = getCurrentUser()
@@ -138,31 +139,31 @@ func initializePlugins() {
 }
 
 func init() {
-	SingularityCmd.Flags().SetInterspersed(false)
-	SingularityCmd.PersistentFlags().SetInterspersed(false)
+	singularityCmd.Flags().SetInterspersed(false)
+	singularityCmd.PersistentFlags().SetInterspersed(false)
 
 	templateFuncs := template.FuncMap{
 		"TraverseParentsUses": TraverseParentsUses,
 	}
 	cobra.AddTemplateFuncs(templateFuncs)
 
-	SingularityCmd.SetHelpTemplate(docs.HelpTemplate)
-	SingularityCmd.SetUsageTemplate(docs.UseTemplate)
+	singularityCmd.SetHelpTemplate(docs.HelpTemplate)
+	singularityCmd.SetUsageTemplate(docs.UseTemplate)
 
 	vt := fmt.Sprintf("%s version {{printf \"%%s\" .Version}}\n", buildcfg.PACKAGE_NAME)
-	SingularityCmd.SetVersionTemplate(vt)
+	singularityCmd.SetVersionTemplate(vt)
 
-	cmdManager.RegisterFlagForCmd(&singDebugFlag, SingularityCmd)
-	cmdManager.RegisterFlagForCmd(&singNoColorFlag, SingularityCmd)
-	cmdManager.RegisterFlagForCmd(&singSilentFlag, SingularityCmd)
-	cmdManager.RegisterFlagForCmd(&singQuietFlag, SingularityCmd)
-	cmdManager.RegisterFlagForCmd(&singVerboseFlag, SingularityCmd)
-	cmdManager.RegisterFlagForCmd(&singTokenFileFlag, SingularityCmd)
+	cmdManager.RegisterFlagForCmd(&singDebugFlag, singularityCmd)
+	cmdManager.RegisterFlagForCmd(&singNoColorFlag, singularityCmd)
+	cmdManager.RegisterFlagForCmd(&singSilentFlag, singularityCmd)
+	cmdManager.RegisterFlagForCmd(&singQuietFlag, singularityCmd)
+	cmdManager.RegisterFlagForCmd(&singVerboseFlag, singularityCmd)
+	cmdManager.RegisterFlagForCmd(&singTokenFileFlag, singularityCmd)
 
 	cmdManager.RegisterCmd(VersionCmd)
 
 	initializePlugins()
-	SingularityCmd.AddCommand(plugin.AllCommands()...)
+	singularityCmd.AddCommand(plugin.AllCommands()...)
 }
 
 func setSylogMessageLevel() {
@@ -203,8 +204,8 @@ func createConfDir(d string) {
 	}
 }
 
-// SingularityCmd is the base command when called without any subcommands
-var SingularityCmd = &cobra.Command{
+// singularityCmd is the base command when called without any subcommands
+var singularityCmd = &cobra.Command{
 	TraverseChildren:      true,
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -227,12 +228,17 @@ func persistentPreRunE(cmd *cobra.Command, _ []string) error {
 	return cmdManager.UpdateCmdFlagFromEnv(cmd, envPrefix)
 }
 
+// RootCmd returns the root singularity cobra command.
+func RootCmd() *cobra.Command {
+	return singularityCmd
+}
+
 // ExecuteSingularity adds all child commands to the root command and sets
 // flags appropriately. This is called by main.main(). It only needs to happen
 // once to the root command (singularity).
 func ExecuteSingularity() {
 	// set persistent pre run function here to avoid initialization loop error
-	SingularityCmd.PersistentPreRunE = persistentPreRunE
+	singularityCmd.PersistentPreRunE = persistentPreRunE
 
 	for _, e := range cmdManager.GetError() {
 		sylog.Errorf("%s", e)
@@ -243,23 +249,28 @@ func ExecuteSingularity() {
 		sylog.Fatalf("CLI command manager reported %d error(s)", cliErrors)
 	}
 
-	if cmd, err := SingularityCmd.ExecuteC(); err != nil {
+	if cmd, err := singularityCmd.ExecuteC(); err != nil {
 		name := cmd.Name()
 		switch err.(type) {
 		case cmdline.FlagError:
 			usage := cmd.Flags().FlagUsagesWrapped(getColumns())
-			SingularityCmd.Printf("Error for command %q: %s\n\n", name, err)
-			SingularityCmd.Printf("Options for %s command:\n\n%s\n", name, usage)
+			singularityCmd.Printf("Error for command %q: %s\n\n", name, err)
+			singularityCmd.Printf("Options for %s command:\n\n%s\n", name, usage)
 		case cmdline.CommandError:
-			SingularityCmd.Println(cmd.UsageString())
+			singularityCmd.Println(cmd.UsageString())
 		default:
-			SingularityCmd.Printf("Error for command %q: %s\n\n", name, err)
-			SingularityCmd.Println(cmd.UsageString())
+			singularityCmd.Printf("Error for command %q: %s\n\n", name, err)
+			singularityCmd.Println(cmd.UsageString())
 		}
-		SingularityCmd.Printf("Run '%s --help' for more detailed usage information.\n",
+		singularityCmd.Printf("Run '%s --help' for more detailed usage information.\n",
 			cmd.CommandPath())
 		os.Exit(1)
 	}
+}
+
+// GenBashCompletionFile
+func GenBashCompletion(w io.Writer) error {
+	return singularityCmd.GenBashCompletion(fn)
 }
 
 // TraverseParentsUses walks the parent commands and outputs a properly formatted use string

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -270,7 +270,7 @@ func ExecuteSingularity() {
 
 // GenBashCompletionFile
 func GenBashCompletion(w io.Writer) error {
-	return singularityCmd.GenBashCompletion(fn)
+	return singularityCmd.GenBashCompletion(w)
 }
 
 // TraverseParentsUses walks the parent commands and outputs a properly formatted use string

--- a/internal/pkg/plugin/command.go
+++ b/internal/pkg/plugin/command.go
@@ -22,9 +22,9 @@ func (r *commandRegistry) RegisterCommand(hook pluginapi.CommandHook) error {
 	return nil
 }
 
-// AllCommands returns a slice of commands registered by plugins which need to be
-// added to the main SingularityCmd. By simply returning the slice of objects, it's
-// trivial to handle this from the CLI.
+// AllCommands returns a slice of commands registered by plugins which
+// need to be added to the root singularity command. By simply returning
+// the slice of objects, it's trivial to handle this from the CLI.
 func AllCommands() []*cobra.Command {
 	return reg.commandRegistry.Commands
 }


### PR DESCRIPTION
This is a minimal change to avoid exporting SingularityCmd so that we
don't have to chase its uses all over the place. In order to avoid
touching the few instances outside
github.com/sylabs/singularity/cmd/internal/cli where SingularityCmd is
being used, introduce a couple of functions in that package to provide
access to this command.

There's one used to generate bash completions, where it doesn't really
need access to the command, it just needs a way to request the cobra
bash completions to be generated.

There are a couple of other ones where they need to traverse the command
tree to access every command, and SingularityCmd is just the starting
poont. While the change is still leaving the door open for arbitrary
modifications, it makes it easier to track down these accesses.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

