### PR TITLE
Rename cli.run to cli.runBuild

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -259,7 +259,7 @@ var buildCmd = &cobra.Command{
 	Long:             docs.BuildLong,
 	Example:          docs.BuildExample,
 	PreRun:           preRun,
-	Run:              run,
+	Run:              runBuild,
 	TraverseChildren: true,
 }
 

--- a/cmd/internal/cli/build_darwin.go
+++ b/cmd/internal/cli/build_darwin.go
@@ -17,7 +17,7 @@ func fakerootExec(cmdArgs []string) {
 	sylog.Fatalf("fakeroot is not supported on this platform")
 }
 
-func run(cmd *cobra.Command, args []string) {
+func runBuild(cmd *cobra.Command, args []string) {
 	dest := args[0]
 	spec := args[1]
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -85,7 +85,7 @@ func fakerootExec(cmdArgs []string) {
 	sylog.Fatalf("%s", err)
 }
 
-func run(cmd *cobra.Command, args []string) {
+func runBuild(cmd *cobra.Command, args []string) {
 	buildFormat := "sif"
 	if sandbox {
 		buildFormat = "sandbox"


### PR DESCRIPTION
Try to make things more readable by giving buildCmd's Run function a
more specific name.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

