### PR TITLE
Do some minor CLI cleanup

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -14,26 +14,25 @@ import (
 
 // actionflags.go contains flag variables for action-like commands to draw from
 var (
-	AppName           string
-	BindPaths         []string
-	HomePath          string
-	OverlayPath       []string
-	ScratchPath       []string
-	WorkdirPath       string
-	PwdPath           string
-	ShellPath         string
-	Hostname          string
-	Network           string
-	NetworkArgs       []string
-	DNS               string
-	Security          []string
-	CgroupsPath       string
-	VMRAM             string
-	VMCPU             string
-	VMIP              string
-	ContainLibsPath   []string
-	encryptionPEMPath string
-	FuseMount         []string
+	AppName         string
+	BindPaths       []string
+	HomePath        string
+	OverlayPath     []string
+	ScratchPath     []string
+	WorkdirPath     string
+	PwdPath         string
+	ShellPath       string
+	Hostname        string
+	Network         string
+	NetworkArgs     []string
+	DNS             string
+	Security        []string
+	CgroupsPath     string
+	VMRAM           string
+	VMCPU           string
+	VMIP            string
+	ContainLibsPath []string
+	FuseMount       []string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -51,7 +50,6 @@ var (
 	NoNet           bool
 	IsSyOS          bool
 	disableCache    bool
-	enterPassphrase bool
 
 	NetNamespace  bool
 	UtsNamespace  bool
@@ -299,24 +297,6 @@ var actionContainLibsFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
-// --passphrase
-var actionPassphraseFlag = cmdline.Flag{
-	ID:           "actionEncryptionPassphrase",
-	Value:        &enterPassphrase,
-	DefaultValue: false,
-	Name:         "passphrase",
-	Usage:        "enter a passphrase for an encrypted contaner",
-}
-
-// --pem-path
-var actionPEMPathFlag = cmdline.Flag{
-	ID:           "actionEncryptionPEMPath",
-	Value:        &encryptionPEMPath,
-	DefaultValue: "",
-	Name:         "pem-path",
-	Usage:        "enter an path to a PEM formated RSA key for an encrypted container",
-}
-
 // --fusemount, hidden for now while experimental
 var actionFuseMountFlag = cmdline.Flag{
 	ID:           "actionFuseMountFlag",
@@ -327,28 +307,6 @@ var actionFuseMountFlag = cmdline.Flag{
 	EnvKeys:      []string{"FUSESPEC"},
 	ExcludedOS:   []string{cmdline.Darwin},
 	Hidden:       true,
-}
-
-// hidden flags to handle docker credentials
-var actionDockerUsernameFlag = cmdline.Flag{
-	ID:           "actionDockerUsernameFlag",
-	Value:        &dockerUsername,
-	DefaultValue: "",
-	Name:         "docker-username",
-	Usage:        "specify a username for docker authentication",
-	Hidden:       true,
-	EnvKeys:      []string{"DOCKER_USERNAME"},
-}
-
-// --docker-password
-var actionDockerPasswordFlag = cmdline.Flag{
-	ID:           "actionDockerPasswordFlag",
-	Value:        &dockerPassword,
-	DefaultValue: "",
-	Name:         "docker-password",
-	Usage:        "specify a password for docker authentication",
-	Hidden:       true,
-	EnvKeys:      []string{"DOCKER_PASSWORD"},
 }
 
 // hidden flag to handle SINGULARITY_TMPDIR environment variable
@@ -475,26 +433,6 @@ var actionNoInitFlag = cmdline.Flag{
 	Usage:        "do NOT start shim process with --pid",
 	EnvKeys:      []string{"NOSHIMINIT"},
 	ExcludedOS:   []string{cmdline.Darwin},
-}
-
-// --nohttps
-var actionNoHTTPSFlag = cmdline.Flag{
-	ID:           "actionNoHTTPSFlag",
-	Value:        &noHTTPS,
-	DefaultValue: false,
-	Name:         "nohttps",
-	Usage:        "do NOT use HTTPS, for communicating with local docker registry",
-	EnvKeys:      []string{"NOHTTPS"},
-}
-
-// --docker-login
-var actionDockerLoginFlag = cmdline.Flag{
-	ID:           "actionDockerLoginFlag",
-	Value:        &dockerLogin,
-	DefaultValue: false,
-	Name:         "docker-login",
-	Usage:        "login to a Docker Repository interactively",
-	EnvKeys:      []string{"DOCKER_LOGIN"},
 }
 
 // hidden flag to disable nvidia bindings when 'always use nv = yes'
@@ -673,57 +611,57 @@ func init() {
 
 	initPlatformDefaults()
 
+	cmdManager.RegisterFlagForCmd(&actionAddCapsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionAllowSetuidFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionAppFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionBindFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionHomeFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionOverlayFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionScratchFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionWorkdirFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionShellFlag, ShellCmd)
-	cmdManager.RegisterFlagForCmd(&actionHostnameFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionNetworkFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionNetworkArgsFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionDNSFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionSecurityFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionApplyCgroupsFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionVMRAMFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionVMCPUFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionVMIPFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionNONETFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionContainLibsFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionFuseMountFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionDockerUsernameFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionDockerPasswordFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionFakerootFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionDisableCacheFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionTmpDirFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionBindFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionCleanEnvFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionContainFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionContainAllFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionNvidiaFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionWritableFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionWritableTmpfsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionContainFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionContainLibsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionDisableCacheFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionDNSFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionDropCapsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionFakerootFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionFuseMountFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionHomeFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionHostnameFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionIpcNamespaceFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionKeepPrivsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionNetNamespaceFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionNetworkArgsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionNetworkFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionNoHomeFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionNoInitFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionNoHTTPSFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionDockerLoginFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionNONETFlag, actionsCmd...)
 	cmdManager.RegisterFlagForCmd(&actionNoNvidiaFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionVMFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionVMErrFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionSyOSFlag, ShellCmd)
-	cmdManager.RegisterFlagForCmd(&actionPidNamespaceFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionIpcNamespaceFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionNetNamespaceFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionUtsNamespaceFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionUserNamespaceFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionKeepPrivsFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionNoPrivsFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionAddCapsFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionDropCapsFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionAllowSetuidFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionNvidiaFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionOverlayFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&commonPromptForPassphraseFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&commonPEMFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionPidNamespaceFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionPwdFlag, actionsCmd...)
-	cmdManager.RegisterFlagForCmd(&actionPassphraseFlag, actionsInstanceCmd...)
-	cmdManager.RegisterFlagForCmd(&actionPEMPathFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionScratchFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionSecurityFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionShellFlag, ShellCmd)
+	cmdManager.RegisterFlagForCmd(&actionSyOSFlag, ShellCmd)
+	cmdManager.RegisterFlagForCmd(&actionTmpDirFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionUserNamespaceFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionUtsNamespaceFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionVMCPUFlag, actionsCmd...)
+	cmdManager.RegisterFlagForCmd(&actionVMErrFlag, actionsCmd...)
+	cmdManager.RegisterFlagForCmd(&actionVMFlag, actionsCmd...)
+	cmdManager.RegisterFlagForCmd(&actionVMIPFlag, actionsCmd...)
+	cmdManager.RegisterFlagForCmd(&actionVMRAMFlag, actionsCmd...)
+	cmdManager.RegisterFlagForCmd(&actionWorkdirFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionWritableFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionWritableTmpfsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&dockerLoginFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&dockerPasswordFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&dockerUsernameFlag, actionsInstanceCmd...)
 
 	for _, cmd := range actionsCmd {
 		plugin.AddFlagHooks(cmd.Flags())

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -72,7 +72,7 @@ func handleOCI(imgCache *cache.Handle, cmd *cobra.Command, u string) (string, er
 	sysCtx := &ocitypes.SystemContext{
 		OCIInsecureSkipTLSVerify:    noHTTPS,
 		DockerInsecureSkipTLSVerify: noHTTPS,
-		DockerAuthConfig:            authConf,
+		DockerAuthConfig:            &authConf,
 	}
 
 	imgabs := ""
@@ -97,7 +97,7 @@ func handleOCI(imgCache *cache.Handle, cmd *cobra.Command, u string) (string, er
 					NoCache:          true,
 					NoTest:           true,
 					NoHTTPS:          noHTTPS,
-					DockerAuthConfig: authConf,
+					DockerAuthConfig: &authConf,
 				},
 			})
 
@@ -131,7 +131,7 @@ func handleOCI(imgCache *cache.Handle, cmd *cobra.Command, u string) (string, er
 						TmpDir:           tmpDir,
 						NoTest:           true,
 						NoHTTPS:          noHTTPS,
-						DockerAuthConfig: authConf,
+						DockerAuthConfig: &authConf,
 						ImgCache:         imgCache,
 					},
 				})
@@ -157,7 +157,7 @@ func handleOras(imgCache *cache.Handle, cmd *cobra.Command, u string) (string, e
 	}
 
 	_, ref := uri.Split(u)
-	sum, err := oras.ImageSHA(ref, ociAuth)
+	sum, err := oras.ImageSHA(ref, &ociAuth)
 	if err != nil {
 		return "", fmt.Errorf("failed to get SHA of %v: %v", u, err)
 	}
@@ -169,7 +169,7 @@ func handleOras(imgCache *cache.Handle, cmd *cobra.Command, u string) (string, e
 	} else if !exists {
 		sylog.Infof("Downloading image with ORAS")
 
-		if err := oras.DownloadImage(cacheImagePath, ref, ociAuth); err != nil {
+		if err := oras.DownloadImage(cacheImagePath, ref, &ociAuth); err != nil {
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -21,32 +21,26 @@ import (
 	"github.com/sylabs/singularity/pkg/cmdline"
 )
 
-var (
-	remote         bool
-	buildArch      string
-	builderURL     string
-	detached       bool
-	libraryURL     string
-	isJSON         bool
-	sandbox        bool
-	force          bool
-	update         bool
-	noTest         bool
-	sections       []string
-	noHTTPS        bool
-	tmpDir         string
-	dockerUsername string
-	dockerPassword string
-	dockerLogin    bool
-	noCleanUp      bool
-	fakeroot       bool
-	encrypt        bool
-)
+var buildArgs struct {
+	sections   []string
+	arch       string
+	builderURL string
+	libraryURL string
+	detached   bool
+	encrypt    bool
+	fakeroot   bool
+	isJSON     bool
+	noCleanUp  bool
+	noTest     bool
+	remote     bool
+	sandbox    bool
+	update     bool
+}
 
 // -s|--sandbox
 var buildSandboxFlag = cmdline.Flag{
 	ID:           "buildSandboxFlag",
-	Value:        &sandbox,
+	Value:        &buildArgs.sandbox,
 	DefaultValue: false,
 	Name:         "sandbox",
 	ShortHand:    "s",
@@ -57,7 +51,7 @@ var buildSandboxFlag = cmdline.Flag{
 // --section
 var buildSectionFlag = cmdline.Flag{
 	ID:           "buildSectionFlag",
-	Value:        &sections,
+	Value:        &buildArgs.sections,
 	DefaultValue: []string{"all"},
 	Name:         "section",
 	Usage:        "only run specific section(s) of deffile (setup, post, files, environment, test, labels, none)",
@@ -67,28 +61,17 @@ var buildSectionFlag = cmdline.Flag{
 // --json
 var buildJSONFlag = cmdline.Flag{
 	ID:           "buildJSONFlag",
-	Value:        &isJSON,
+	Value:        &buildArgs.isJSON,
 	DefaultValue: false,
 	Name:         "json",
 	Usage:        "interpret build definition as JSON",
 	EnvKeys:      []string{"JSON"},
 }
 
-// -F|--force
-var buildForceFlag = cmdline.Flag{
-	ID:           "buildForceFlag",
-	Value:        &force,
-	DefaultValue: false,
-	Name:         "force",
-	ShortHand:    "F",
-	Usage:        "delete and overwrite an image if it currently exists",
-	EnvKeys:      []string{"FORCE"},
-}
-
 // -u|--update
 var buildUpdateFlag = cmdline.Flag{
 	ID:           "buildUpdateFlag",
-	Value:        &update,
+	Value:        &buildArgs.update,
 	DefaultValue: false,
 	Name:         "update",
 	ShortHand:    "u",
@@ -99,7 +82,7 @@ var buildUpdateFlag = cmdline.Flag{
 // -T|--notest
 var buildNoTestFlag = cmdline.Flag{
 	ID:           "buildNoTestFlag",
-	Value:        &noTest,
+	Value:        &buildArgs.noTest,
 	DefaultValue: false,
 	Name:         "notest",
 	ShortHand:    "T",
@@ -110,7 +93,7 @@ var buildNoTestFlag = cmdline.Flag{
 // -r|--remote
 var buildRemoteFlag = cmdline.Flag{
 	ID:           "buildRemoteFlag",
-	Value:        &remote,
+	Value:        &buildArgs.remote,
 	DefaultValue: false,
 	Name:         "remote",
 	ShortHand:    "r",
@@ -121,7 +104,7 @@ var buildRemoteFlag = cmdline.Flag{
 // --arch
 var buildArchFlag = cmdline.Flag{
 	ID:           "buildArchFlag",
-	Value:        &buildArch,
+	Value:        &buildArgs.arch,
 	DefaultValue: runtime.GOARCH,
 	Name:         "arch",
 	Usage:        "architecture for remote build",
@@ -131,7 +114,7 @@ var buildArchFlag = cmdline.Flag{
 // -d|--detached
 var buildDetachedFlag = cmdline.Flag{
 	ID:           "buildDetachedFlag",
-	Value:        &detached,
+	Value:        &buildArgs.detached,
 	DefaultValue: false,
 	Name:         "detached",
 	ShortHand:    "d",
@@ -142,7 +125,7 @@ var buildDetachedFlag = cmdline.Flag{
 // --builder
 var buildBuilderFlag = cmdline.Flag{
 	ID:           "buildBuilderFlag",
-	Value:        &builderURL,
+	Value:        &buildArgs.builderURL,
 	DefaultValue: "https://build.sylabs.io",
 	Name:         "builder",
 	Usage:        "remote Build Service URL, setting this implies --remote",
@@ -152,21 +135,11 @@ var buildBuilderFlag = cmdline.Flag{
 // --library
 var buildLibraryFlag = cmdline.Flag{
 	ID:           "buildLibraryFlag",
-	Value:        &libraryURL,
+	Value:        &buildArgs.libraryURL,
 	DefaultValue: "https://library.sylabs.io",
 	Name:         "library",
 	Usage:        "container Library URL",
 	EnvKeys:      []string{"LIBRARY"},
-}
-
-// --tmpdir
-var buildTmpdirFlag = cmdline.Flag{
-	ID:           "buildTmpdirFlag",
-	Value:        &tmpDir,
-	DefaultValue: os.TempDir(),
-	Name:         "tmpdir",
-	Usage:        "specify a temporary directory to use for build",
-	EnvKeys:      []string{"TMPDIR"},
 }
 
 // --disable-cache
@@ -179,20 +152,10 @@ var buildDisableCacheFlag = cmdline.Flag{
 	EnvKeys:      []string{"DISABLE_CACHE"},
 }
 
-// --nohttps
-var buildNoHTTPSFlag = cmdline.Flag{
-	ID:           "buildNoHTTPSFlag",
-	Value:        &noHTTPS,
-	DefaultValue: false,
-	Name:         "nohttps",
-	Usage:        "do NOT use HTTPS, for communicating with local docker registry",
-	EnvKeys:      []string{"NOHTTPS"},
-}
-
 // --no-cleanup
 var buildNoCleanupFlag = cmdline.Flag{
 	ID:           "buildNoCleanupFlag",
-	Value:        &noCleanUp,
+	Value:        &buildArgs.noCleanUp,
 	DefaultValue: false,
 	Name:         "no-cleanup",
 	Usage:        "do NOT clean up bundle after failed build, can be helpul for debugging",
@@ -202,7 +165,7 @@ var buildNoCleanupFlag = cmdline.Flag{
 // --fakeroot
 var buildFakerootFlag = cmdline.Flag{
 	ID:           "buildFakerootFlag",
-	Value:        &fakeroot,
+	Value:        &buildArgs.fakeroot,
 	DefaultValue: false,
 	Name:         "fakeroot",
 	ShortHand:    "f",
@@ -213,7 +176,7 @@ var buildFakerootFlag = cmdline.Flag{
 // -e|--encrypt
 var buildEncryptFlag = cmdline.Flag{
 	ID:           "buildEncryptFlag",
-	Value:        &encrypt,
+	Value:        &buildArgs.encrypt,
 	DefaultValue: false,
 	Name:         "encrypt",
 	ShortHand:    "e",
@@ -223,30 +186,30 @@ var buildEncryptFlag = cmdline.Flag{
 func init() {
 	cmdManager.RegisterCmd(buildCmd)
 
+	cmdManager.RegisterFlagForCmd(&buildArchFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildBuilderFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildDetachedFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&buildForceFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&buildDisableCacheFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&buildEncryptFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&buildFakerootFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildJSONFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildLibraryFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildNoCleanupFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&buildNoHTTPSFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildNoTestFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildRemoteFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&buildArchFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSandboxFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildSectionFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&buildTmpdirFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&buildDisableCacheFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildUpdateFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&buildFakerootFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&buildEncryptFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&commonForceFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&commonTmpDirFlag, buildCmd)
 
-	cmdManager.RegisterFlagForCmd(&actionDockerUsernameFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&actionDockerPasswordFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&actionDockerLoginFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&dockerUsernameFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&dockerPasswordFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&dockerLoginFlag, buildCmd)
 
-	cmdManager.RegisterFlagForCmd(&actionPassphraseFlag, buildCmd)
-	cmdManager.RegisterFlagForCmd(&actionPEMPathFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&commonPromptForPassphraseFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&commonPEMFlag, buildCmd)
 }
 
 // buildCmd represents the build command.
@@ -264,7 +227,7 @@ var buildCmd = &cobra.Command{
 }
 
 func preRun(cmd *cobra.Command, args []string) {
-	if fakeroot && !remote {
+	if buildArgs.fakeroot && !buildArgs.remote {
 		fakerootExec(args)
 	}
 
@@ -279,14 +242,14 @@ func preRun(cmd *cobra.Command, args []string) {
 // checkBuildTarget makes sure output target doesn't exist, or is ok to overwrite.
 // And checks that update flag will update an existing directory.
 func checkBuildTarget(path string) error {
-	if !sandbox && update {
+	if !buildArgs.sandbox && buildArgs.update {
 		return fmt.Errorf("only sandbox update is supported: --sandbox flag is missing")
 	}
 	if f, err := os.Stat(path); err == nil {
-		if update && !f.IsDir() {
+		if buildArgs.update && !f.IsDir() {
 			return fmt.Errorf("only sandbox update is supported: %s is not a directory", path)
 		}
-		if !update && !force {
+		if !buildArgs.update && !forceOverwrite {
 			question := "Build target already exists. Do you want to overwrite? [N/y] "
 			input, err := interactive.AskYNQuestion("n", question)
 			if err != nil {
@@ -295,9 +258,9 @@ func checkBuildTarget(path string) error {
 			if input != "y" {
 				return fmt.Errorf("stopping build")
 			}
-			force = true
+			forceOverwrite = true
 		}
-	} else if os.IsNotExist(err) && update && sandbox {
+	} else if os.IsNotExist(err) && buildArgs.update && buildArgs.sandbox {
 		return fmt.Errorf("could not update sandbox %s: doesn't exist", path)
 	}
 	return nil
@@ -345,36 +308,33 @@ func definitionFromSpec(spec string) (types.Definition, error) {
 	return def, nil
 }
 
-func makeDockerCredentials(cmd *cobra.Command) (authConf *ocitypes.DockerAuthConfig, err error) {
+func makeDockerCredentials(cmd *cobra.Command) (authConf ocitypes.DockerAuthConfig, err error) {
 	usernameFlag := cmd.Flags().Lookup("docker-username")
 	passwordFlag := cmd.Flags().Lookup("docker-password")
 
 	if dockerLogin {
 		if !usernameFlag.Changed {
-			dockerUsername, err = interactive.AskQuestion("Enter Docker Username: ")
+			dockerAuthConfig.Username, err = interactive.AskQuestion("Enter Docker Username: ")
 			if err != nil {
-				return
+				return authConf, err
 			}
-			usernameFlag.Value.Set(dockerUsername)
+			usernameFlag.Value.Set(dockerAuthConfig.Username)
 			usernameFlag.Changed = true
 		}
 
-		dockerPassword, err = interactive.AskQuestionNoEcho("Enter Docker Password: ")
+		dockerAuthConfig.Password, err = interactive.AskQuestionNoEcho("Enter Docker Password: ")
 		if err != nil {
-			return
+			return authConf, err
 		}
-		passwordFlag.Value.Set(dockerPassword)
+		passwordFlag.Value.Set(dockerAuthConfig.Password)
 		passwordFlag.Changed = true
 	}
 
-	if usernameFlag.Changed && passwordFlag.Changed {
-		authConf = &ocitypes.DockerAuthConfig{
-			Username: dockerUsername,
-			Password: dockerPassword,
-		}
+	if usernameFlag.Changed || passwordFlag.Changed {
+		authConf = dockerAuthConfig
 	}
 
-	return
+	return authConf, nil
 }
 
 // remote builds need to fail if we cannot resolve remote URLS
@@ -395,13 +355,13 @@ func handleRemoteBuildFlags(cmd *cobra.Command) {
 		if err != nil {
 			sylog.Fatalf("Unable to get build service URI: %v", err)
 		}
-		builderURL = uri
+		buildArgs.builderURL = uri
 	}
 	if !cmd.Flags().Lookup("library").Changed {
 		uri, err := endpoint.GetServiceURI("library")
 		if err != nil {
 			sylog.Fatalf("Unable to get library service URI: %v", err)
 		}
-		libraryURL = uri
+		buildArgs.libraryURL = uri
 	}
 }

--- a/cmd/internal/cli/build_darwin.go
+++ b/cmd/internal/cli/build_darwin.go
@@ -26,7 +26,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("%s", err)
 	}
 
-	if !remote {
+	if !buildArgs.remote {
 		sylog.Fatalf("Only remote builds are supported on this platform")
 	}
 
@@ -42,7 +42,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Unable to build from %s: %v", spec, err)
 	}
 
-	b, err := remotebuilder.New(dest, libraryURL, def, detached, force, builderURL, authToken, buildArch)
+	b, err := remotebuilder.New(dest, buildArgs.libraryURL, def, buildArgs.detached, forceOverwrite, buildArgs.builderURL, authToken, buildArgs.arch)
 	if err != nil {
 		sylog.Fatalf("Failed to create builder: %v", err)
 	}

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -54,8 +54,8 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&pushLibraryURIFlag, PushCmd)
 	cmdManager.RegisterFlagForCmd(&pushAllowUnsignedFlag, PushCmd)
 
-	cmdManager.RegisterFlagForCmd(&actionDockerUsernameFlag, PushCmd)
-	cmdManager.RegisterFlagForCmd(&actionDockerPasswordFlag, PushCmd)
+	cmdManager.RegisterFlagForCmd(&dockerUsernameFlag, PushCmd)
+	cmdManager.RegisterFlagForCmd(&dockerPasswordFlag, PushCmd)
 }
 
 // PushCmd singularity push
@@ -90,7 +90,7 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}
 
-			if err := oras.UploadImage(file, ref, ociAuth); err != nil {
+			if err := oras.UploadImage(file, ref, &ociAuth); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"text/template"
 
+	ocitypes "github.com/containers/image/types"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
@@ -43,6 +44,15 @@ var (
 		Token:  "",
 		System: true,
 	}
+
+	dockerAuthConfig ocitypes.DockerAuthConfig
+	dockerLogin      bool
+
+	encryptionPEMPath   string
+	promptForPassphrase bool
+	forceOverwrite      bool
+	noHTTPS             bool
+	tmpDir              string
 )
 
 const (
@@ -115,6 +125,88 @@ var singTokenFileFlag = cmdline.Flag{
 	ShortHand:    "t",
 	Usage:        "path to the file holding your sylabs authentication token",
 	Deprecated:   "Use 'singularity remote' to manage remote endpoints and tokens.",
+}
+
+// --docker-username
+var dockerUsernameFlag = cmdline.Flag{
+	ID:           "dockerUsernameFlag",
+	Value:        &dockerAuthConfig.Username,
+	DefaultValue: "",
+	Name:         "docker-username",
+	Usage:        "specify a username for docker authentication",
+	Hidden:       true,
+	EnvKeys:      []string{"DOCKER_USERNAME"},
+}
+
+// --docker-password
+var dockerPasswordFlag = cmdline.Flag{
+	ID:           "dockerPasswordFlag",
+	Value:        &dockerAuthConfig.Password,
+	DefaultValue: "",
+	Name:         "docker-password",
+	Usage:        "specify a password for docker authentication",
+	Hidden:       true,
+	EnvKeys:      []string{"DOCKER_PASSWORD"},
+}
+
+// --docker-login
+var dockerLoginFlag = cmdline.Flag{
+	ID:           "dockerLoginFlag",
+	Value:        &dockerLogin,
+	DefaultValue: false,
+	Name:         "docker-login",
+	Usage:        "login to a Docker Repository interactively",
+	EnvKeys:      []string{"DOCKER_LOGIN"},
+}
+
+// --passphrase
+var commonPromptForPassphraseFlag = cmdline.Flag{
+	ID:           "commonPromptForPassphraseFlag",
+	Value:        &promptForPassphrase,
+	DefaultValue: false,
+	Name:         "passphrase",
+	Usage:        "prompt for an encryption passphrase",
+}
+
+// --pem-path
+var commonPEMFlag = cmdline.Flag{
+	ID:           "actionEncryptionPEMPath",
+	Value:        &encryptionPEMPath,
+	DefaultValue: "",
+	Name:         "pem-path",
+	Usage:        "enter an path to a PEM formated RSA key for an encrypted container",
+}
+
+// -F|--force
+var commonForceFlag = cmdline.Flag{
+	ID:           "commonForceFlag",
+	Value:        &forceOverwrite,
+	DefaultValue: false,
+	Name:         "force",
+	ShortHand:    "F",
+	Usage:        "overwrite an image file if it exists",
+	EnvKeys:      []string{"FORCE"},
+}
+
+// --nohttps
+var commonNoHTTPSFlag = cmdline.Flag{
+	ID:           "commonNoHTTPSFlag",
+	Value:        &noHTTPS,
+	DefaultValue: false,
+	Name:         "nohttps",
+	Usage:        "do NOT use HTTPS with the docker:// transport (useful for local docker registries without a certificate)",
+	EnvKeys:      []string{"NOHTTPS"},
+}
+
+// --tmpdir
+var commonTmpDirFlag = cmdline.Flag{
+	ID:           "commonTmpDirFlag",
+	Value:        &tmpDir,
+	DefaultValue: os.TempDir(),
+	Hidden:       true,
+	Name:         "tmpdir",
+	Usage:        "specify a temporary directory to use for build",
+	EnvKeys:      []string{"TMPDIR"},
 }
 
 func getCurrentUser() *user.User {


### PR DESCRIPTION
Even if a lot of lines are changing, there are not significant changes
here. It's mostly about removing duplicated flag definitions (multiple
flags are touching the same package-level variable) and moving them to a
more neutral location (e.g. force is defined in build.go but it's used
in all the actions).

Split runBuild into runBuildLocal and runBuildRemote.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

