### PR TITLE
Use image extractor for v2 images

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/image"
-	"github.com/sylabs/singularity/pkg/util/loop"
 )
 
 // LocalConveyor only needs to hold the conveyor to have the needed data to pack
@@ -40,8 +39,6 @@ func GetLocalPacker(src string, b *types.Bundle) (LocalPacker, error) {
 		return nil, err
 	}
 
-	info := new(loop.Info64)
-
 	switch imageObject.Type {
 	case image.SIF:
 		sylog.Debugf("Packing from SIF")
@@ -49,28 +46,23 @@ func GetLocalPacker(src string, b *types.Bundle) (LocalPacker, error) {
 		return &SIFPacker{
 			srcFile: src,
 			b:       b,
+			img:     imageObject,
 		}, nil
 	case image.SQUASHFS:
 		sylog.Debugf("Packing from Squashfs")
 
-		info.Offset = imageObject.Partitions[0].Offset
-		info.SizeLimit = imageObject.Partitions[0].Size
-
 		return &SquashfsPacker{
 			srcfile: src,
 			b:       b,
-			info:    info,
+			img:     imageObject,
 		}, nil
 	case image.EXT3:
 		sylog.Debugf("Packing from Ext3")
 
-		info.Offset = imageObject.Partitions[0].Offset
-		info.SizeLimit = imageObject.Partitions[0].Size
-
 		return &Ext3Packer{
 			srcfile: src,
 			b:       b,
-			info:    info,
+			img:     imageObject,
 		}, nil
 	case image.SANDBOX:
 		sylog.Debugf("Packing from Sandbox")

--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -7,12 +7,12 @@ package sources
 
 import (
 	"github.com/sylabs/singularity/pkg/build/types"
-	"github.com/sylabs/singularity/pkg/util/loop"
+	"github.com/sylabs/singularity/pkg/image"
 )
 
 // Ext3Packer holds the locations of where to back from and to, aswell as image offset info
 type Ext3Packer struct {
 	srcfile string
 	b       *types.Bundle
-	info    *loop.Info64
+	img     *image.Image
 }

--- a/internal/pkg/build/sources/packer_ext3_linux.go
+++ b/internal/pkg/build/sources/packer_ext3_linux.go
@@ -13,19 +13,17 @@ import (
 	"os/exec"
 	"syscall"
 
-	args "github.com/sylabs/singularity/internal/pkg/runtime/engine/singularity/rpc"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
+	"github.com/sylabs/singularity/pkg/image"
 	"github.com/sylabs/singularity/pkg/util/loop"
 )
 
 // Pack puts relevant objects in a Bundle!
 func (p *Ext3Packer) Pack() (*types.Bundle, error) {
-	rootfs := p.srcfile
-
-	err := p.unpackExt3(p.b, p.info, rootfs)
+	err := unpackExt3(p.b, p.img)
 	if err != nil {
-		sylog.Errorf("unpackExt3 Failed: %s", err)
+		sylog.Errorf("while unpacking ext3 image: %v", err)
 		return nil, err
 	}
 
@@ -33,21 +31,26 @@ func (p *Ext3Packer) Pack() (*types.Bundle, error) {
 }
 
 // unpackExt3 mounts the ext3 image using a loop device and then copies its contents to the bundle
-func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs string) error {
-	tmpmnt, err := ioutil.TempDir(p.b.TmpDir, "mnt")
-	if err != nil {
-		return fmt.Errorf("while making tmp mount point: %v", err)
+func unpackExt3(b *types.Bundle, img *image.Image) error {
+	info := &loop.Info64{
+		Offset:    img.Partitions[0].Offset,
+		SizeLimit: img.Partitions[0].Size,
+		Flags:     loop.FlagsAutoClear,
 	}
 
 	var number int
-	info.Flags = loop.FlagsAutoClear
-	arguments := &args.LoopArgs{
-		Image: rootfs,
-		Mode:  os.O_RDONLY,
-		Info:  *info,
+	loopdev := &loop.Device{
+		MaxLoopDevices: 256,
+		Info:           info,
 	}
-	if err := getLoopDevice(arguments); err != nil {
-		return err
+
+	if err := loopdev.AttachFromFile(img.File, os.O_RDONLY, &number); err != nil {
+		return fmt.Errorf("while attaching image to loop device: %v", err)
+	}
+
+	tmpmnt, err := ioutil.TempDir(b.TmpDir, "mnt")
+	if err != nil {
+		return fmt.Errorf("while making tmp mount point: %v", err)
 	}
 
 	path := fmt.Sprintf("/dev/loop%d", number)
@@ -67,16 +70,5 @@ func (p *Ext3Packer) unpackExt3(b *types.Bundle, info *loop.Info64, rootfs strin
 		return fmt.Errorf("while copying files: %v: %v", err, stderr.String())
 	}
 
-	return err
-}
-
-// getLoopDevice attaches a loop device with the specified arguments
-func getLoopDevice(arguments *args.LoopArgs) error {
-	reply := 1
-	loopdev := new(loop.Device)
-	loopdev.MaxLoopDevices = 256
-	loopdev.Info = &arguments.Info
-	loopdev.Shared = arguments.Shared
-
-	return loopdev.AttachFromPath(arguments.Image, arguments.Mode, &reply)
+	return nil
 }

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -7,10 +7,12 @@ package sources
 
 import (
 	"github.com/sylabs/singularity/pkg/build/types"
+	"github.com/sylabs/singularity/pkg/image"
 )
 
 // SIFPacker holds the locations of where to pack from and to.
 type SIFPacker struct {
 	srcFile string
 	b       *types.Bundle
+	img     *image.Image
 }

--- a/internal/pkg/build/sources/packer_squashfs.go
+++ b/internal/pkg/build/sources/packer_squashfs.go
@@ -6,62 +6,34 @@
 package sources
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os/exec"
-	"strconv"
 
-	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/build/types"
-	"github.com/sylabs/singularity/pkg/util/loop"
+	"github.com/sylabs/singularity/pkg/image"
+	"github.com/sylabs/singularity/pkg/image/unpacker"
 )
 
 // SquashfsPacker holds the locations of where to pack from and to, aswell as image offset info
 type SquashfsPacker struct {
 	srcfile string
 	b       *types.Bundle
-	info    *loop.Info64
+	img     *image.Image
 }
 
 // Pack puts relevant objects in a Bundle!
 func (p *SquashfsPacker) Pack() (*types.Bundle, error) {
-	rootfs := p.srcfile
-
-	err := unpackSquashfs(p.b, p.info, rootfs)
+	// create a reader for rootfs partition
+	reader, err := image.NewPartitionReader(p.img, "", 0)
 	if err != nil {
-		sylog.Errorf("unpackSquashfs Failed: %s", err)
-		return nil, err
+		return nil, fmt.Errorf("could not extract root filesystem: %s", err)
+	}
+
+	s := unpacker.NewSquashfs()
+
+	// extract root filesystem
+	if err := s.ExtractAll(reader, p.b.RootfsPath); err != nil {
+		return nil, fmt.Errorf("root filesystem extraction failed: %s", err)
 	}
 
 	return p.b, nil
-}
-
-// unpackSquashfs removes the image header with dd and then unpackes image into bundle directories with unsquashfs
-func unpackSquashfs(b *types.Bundle, info *loop.Info64, rootfs string) (err error) {
-	var stderr bytes.Buffer
-
-	trimfile, err := ioutil.TempFile(b.TmpDir, "trim.squashfs")
-	if err != nil {
-		return fmt.Errorf("while making tmp file: %v", err)
-	}
-
-	// trim header
-	sylog.Debugf("Creating copy of %s without header at %s\n", rootfs, trimfile.Name())
-	cmd := exec.Command("dd", "bs="+strconv.Itoa(int(info.Offset)), "skip=1", "if="+rootfs, "of="+trimfile.Name())
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("trimming header failed: %v: %v", err, stderr.String())
-	}
-
-	// copy filesystem into bundle rootfs
-	sylog.Debugf("Unsquashing %s to %s in Bundle\n", trimfile.Name(), b.RootfsPath)
-	stderr.Reset()
-	cmd = exec.Command("unsquashfs", "-f", "-d", b.RootfsPath, trimfile.Name())
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("unsquashfs Failed: %v: %v", err, stderr.String())
-	}
-
-	return err
 }


### PR DESCRIPTION
Previously this involved using a combination of `dd` and `unsquashfs` to
perform the same task. This also includes some refactoring of the
various packers in the build package.

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>


### This fixes or addresses the following GitHub issues:

 - Fixes #4550 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

