### PR TITLE
Remove the 'pull' overridden image at the last moment

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -8,10 +8,8 @@ package cli
 import (
 	"context"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"runtime"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/scs-library-client/client"
@@ -201,21 +199,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 		if !forceOverwrite {
 			sylog.Fatalf("Image file already exists: %q - will not overwrite", pullTo)
 		}
-		sylog.Debugf("Removing overridden file: %s", pullTo)
-		if err := os.Remove(pullTo); err != nil {
-			sylog.Fatalf("Unable to remove %q: %s", pullTo, err)
-		}
 	}
-
-	// monitor for OS signals and remove invalid file
-	c := make(chan os.Signal)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	go func(fileName string) {
-		<-c
-		sylog.Debugf("Removing incomplete file because of receiving Termination signal")
-		os.Remove(fileName)
-		os.Exit(1)
-	}(pullTo)
 
 	switch transport {
 	case LibraryProtocol, "":


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR changes the `pull` to only remove the overridden image at the
last moment. So if the `pull` fails, the overridden image will not be
deleted/lost.

### This fixes or addresses the following GitHub issues:

 - Fixes #4561


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

