### PR TITLE
Use 755 when downloading from library (for consistency)

### DIFF
--- a/internal/pkg/library/library.go
+++ b/internal/pkg/library/library.go
@@ -41,7 +41,7 @@ func DownloadImage(ctx context.Context, c *client.Client, imagePath, arch, libra
 	}
 
 	// open destination file for writing
-	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0777)
+	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
 	if err != nil {
 		return fmt.Errorf("error opening file %s for writing: %v", imagePath, err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR changes the perm for the output image for `DownloadImage` from
777 to 755, to be consistent.

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

