### PR TITLE
Fix current working directory mount check

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1032,6 +1032,7 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 		"STDPIPE":               c.STDPipe,             // stdin/stdout pipe
 		"action basic profiles": c.actionBasicProfiles, // run basic action under different profiles
 		"issue 4488":            c.issue4488,           // https://github.com/sylabs/singularity/issues/4488
+		"issue 4587":            c.issue4587,           // https://github.com/sylabs/singularity/issues/4587
 		"network":               c.actionNetwork,       // test basic networking
 	})
 }

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -9,9 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/util/fs"
-
 	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
 // Check there is no file descriptor leaked in the container

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -6,7 +6,10 @@
 package actions
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 )
@@ -26,5 +29,32 @@ func (c actionTests) issue4488(t *testing.T) {
 			0,
 			e2e.ExpectOutput(e2e.ExactMatch, "0\n1\n2\n3"),
 		),
+	)
+}
+
+// Check that current working directory when is the user
+// home directory doesn't override the custom home directory.
+func (c actionTests) issue4587(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	u := e2e.UserProfile.HostUser(t)
+
+	homeDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "homedir-", "")
+	defer cleanup(t)
+
+	canaryFile := filepath.Join(homeDir, "canary_file")
+	if err := fs.Touch(canaryFile); err != nil {
+		t.Fatalf("failed to create canary file: %s", err)
+	}
+
+	homeBind := homeDir + ":" + u.Dir
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithDir(u.Dir),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--home", homeBind, c.env.ImagePath, "test", "-f", filepath.Join(u.Dir, "canary_file")),
+		e2e.ExpectExit(0),
 	)
 }

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -533,6 +533,12 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 			cmd.Dir = s.profile.defaultCwd
 		}
 
+		// when duplicated environment variables are found
+		// only the last one in the slice is taken
+		if cmd.Dir != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
+		}
+
 		cmd.Stdin = s.stdin
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -7,6 +7,7 @@ package rpc
 
 import (
 	"os"
+	"syscall"
 
 	"github.com/sylabs/singularity/pkg/util/loop"
 )
@@ -63,4 +64,15 @@ type SetFsIDArgs struct {
 // ChdirArgs defines the arguments to chdir.
 type ChdirArgs struct {
 	Dir string
+}
+
+// StatReply defines the reply for stat.
+type StatReply struct {
+	Err error
+	St  syscall.Stat_t
+}
+
+// StatArgs defines the arguments to stat.
+type StatArgs struct {
+	Path string
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -124,6 +124,19 @@ func (t *RPC) Chdir(dir string) (int, error) {
 	return reply, err
 }
 
+// Stat calls the stat RPC using the supplied arguments.
+func (t *RPC) Stat(path string) (*syscall.Stat_t, error) {
+	arguments := &args.StatArgs{
+		Path: path,
+	}
+	var reply args.StatReply
+	err := t.Client.Call(t.Name+".Stat", arguments, &reply)
+	if err == nil {
+		err = reply.Err
+	}
+	return &reply.St, err
+}
+
 func init() {
 	var sysErrnoType syscall.Errno
 	// register syscall.Errno as a type we need to get back

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -212,3 +212,10 @@ func (t *Methods) SetFsID(arguments *args.SetFsIDArgs, reply *int) error {
 func (t *Methods) Chdir(arguments *args.ChdirArgs, reply *int) error {
 	return mainthread.Chdir(arguments.Dir)
 }
+
+// Stat gets file status.
+func (t *Methods) Stat(arguments *args.StatArgs, reply *args.StatReply) error {
+	var err error
+	reply.Err = syscall.Stat(arguments.Path, &reply.St)
+	return err
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a new RPC methods to Singularity RPC server to get file status for container mount so dev/ino are checked against the host one to determine if the current working is already mounted.
Also set `PWD` environment variable in `RunSingularity` to match the one set by `WithDir` operations.

### This fixes or addresses the following GitHub issues:

 - Fixes #4587 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

