### PR TITLE
Set apex log level to correspond with sylog log level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.11
 require (
 	github.com/Netflix/go-expect v0.0.0-20180928190340-9d1f4485533b
 	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f // indirect
-	github.com/apex/log v1.1.1 // indirect
+	github.com/apex/log v1.1.1
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -9,6 +9,7 @@ package sylog
 
 import (
 	"fmt"
+	apexlog "github.com/apex/log"
 	"io"
 	"io/ioutil"
 	"os"
@@ -66,17 +67,15 @@ var colorReset = "\x1b[0m"
 var loggerLevel messageLevel
 
 func init() {
-	_level, ok := os.LookupEnv("SINGULARITY_MESSAGELEVEL")
-	if !ok {
-		loggerLevel = info
-	} else {
-		_levelint, err := strconv.Atoi(_level)
-		if err != nil {
-			loggerLevel = info
-		} else {
-			loggerLevel = messageLevel(_levelint)
+	_levelint := int(messageLevel(info))
+	_levelstr, ok := os.LookupEnv("SINGULARITY_MESSAGELEVEL")
+	if ok {
+		_leveli, err := strconv.Atoi(_levelstr)
+		if err == nil {
+			_levelint = _leveli
 		}
 	}
+	SetLevel(_levelint)
 }
 
 func prefix(level messageLevel) string {
@@ -158,6 +157,14 @@ func Debugf(format string, a ...interface{}) {
 // SetLevel explicitly sets the loggerLevel
 func SetLevel(l int) {
 	loggerLevel = messageLevel(l)
+	// the apex log (for umoci) is too noisy at warn level, avoid that
+	if loggerLevel < verbose {
+		apexlog.SetLevel(apexlog.ErrorLevel)
+	} else if loggerLevel < debug {
+		apexlog.SetLevel(apexlog.InfoLevel)
+	} else {
+		apexlog.SetLevel(apexlog.DebugLevel)
+	}
 }
 
 // DisableColor for the logger

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -9,13 +9,14 @@ package sylog
 
 import (
 	"fmt"
-	apexlog "github.com/apex/log"
 	"io"
 	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
+
+	apexlog "github.com/apex/log"
 )
 
 type messageLevel int
@@ -157,12 +158,15 @@ func Debugf(format string, a ...interface{}) {
 // SetLevel explicitly sets the loggerLevel
 func SetLevel(l int) {
 	loggerLevel = messageLevel(l)
-	// the apex log (for umoci) is too noisy at warn level, avoid that
-	if loggerLevel < verbose {
+	// set the apex log level, for umoci
+	if loggerLevel <= log {
+		// quiet or silent options
 		apexlog.SetLevel(apexlog.ErrorLevel)
-	} else if loggerLevel < debug {
+	} else if loggerLevel <= info {
+		// verbose option or default
 		apexlog.SetLevel(apexlog.InfoLevel)
 	} else {
+		// debug option
 		apexlog.SetLevel(apexlog.DebugLevel)
 	}
 }

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -159,11 +159,14 @@ func Debugf(format string, a ...interface{}) {
 func SetLevel(l int) {
 	loggerLevel = messageLevel(l)
 	// set the apex log level, for umoci
-	if loggerLevel <= log {
-		// quiet or silent options
+	if loggerLevel <= error {
+		// silent option
 		apexlog.SetLevel(apexlog.ErrorLevel)
-	} else if loggerLevel <= info {
-		// verbose option or default
+	} else if loggerLevel <= log {
+		// quiet option
+		apexlog.SetLevel(apexlog.WarnLevel)
+	} else if loggerLevel < debug {
+		// verbose option(s) or default
 		apexlog.SetLevel(apexlog.InfoLevel)
 	} else {
 		// debug option


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make the apex log level, used by umoci, track sylog log levels.  The apex warning level is too verbose, so this only enables that when the sylog level is verbose and by default sets the level to errors only.

This PR is submitted against release-3.4 because sandbox builds on the master branch are broken (at least for docker://centos:7) at the moment, but the PR applies equally to master.

### This fixes or addresses the following GitHub issues:

 - Fixes #4586


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

