### PR TITLE
Split TestSquashfs

### DIFF
--- a/pkg/image/packer/squashfs.go
+++ b/pkg/image/packer/squashfs.go
@@ -24,11 +24,11 @@ func NewSquashfs() *Squashfs {
 }
 
 // HasMksquashfs returns if mksquashfs binary has set or not
-func (s *Squashfs) HasMksquashfs() bool {
+func (s Squashfs) HasMksquashfs() bool {
 	return s.MksquashfsPath != ""
 }
 
-func (s *Squashfs) create(files []string, dest string, opts []string) error {
+func (s Squashfs) create(files []string, dest string, opts []string) error {
 	var stderr bytes.Buffer
 
 	if !s.HasMksquashfs() {
@@ -50,6 +50,6 @@ func (s *Squashfs) create(files []string, dest string, opts []string) error {
 
 // Create makes a squashfs filesystem from a list of source files/directories to a
 // destination file
-func (s *Squashfs) Create(src []string, dest string, opts []string) error {
+func (s Squashfs) Create(src []string, dest string, opts []string) error {
 	return s.create(src, dest, opts)
 }


### PR DESCRIPTION
One test is packing too much things in it. There are three separate
tests here, so there should be three separate tests.

Split TestSquashfs into three separate tests.

Add another one to cover the case where mksquashfs runs but exits with
an error. Given the weird API, there should be a test for the case where
the user sets MksquashfsPath to something other than a valid mksquashfs
program, but that's not really testing the code anymore.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

