### PR TITLE
Check go version at buildtime

### DIFF
--- a/internal/pkg/util/goversion/goversion.go
+++ b/internal/pkg/util/goversion/goversion.go
@@ -3,11 +3,11 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// +build go1.11
+// +build go1.13
 
 package goversion
 
-// __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__ provides a human-readable
+// __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__ provides a human-readable
 // error message when building this package with an unsupported version
 // of the Go compiler.
 //
@@ -15,4 +15,4 @@ package goversion
 // version specified in the build tag above.
 //
 // nolint:golint
-const __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__ = uint8(0)
+const __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__ = uint8(0)

--- a/internal/pkg/util/goversion/version_check.go
+++ b/internal/pkg/util/goversion/version_check.go
@@ -10,7 +10,7 @@
 // sufficient to trigger a build failure like:
 //
 //     ...
-//     ../internal/pkg/util/goversion/version_check.go:19:9: undefined: __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__
+//     ../internal/pkg/util/goversion/version_check.go:19:9: undefined: __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__
 //
 //
 // This is based on the technique presented at
@@ -19,4 +19,4 @@ package goversion
 
 // keep the variable here in sync with the mininum required version
 // specified in goversion.go
-var _ = __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__
+var _ = __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__

--- a/mconfig
+++ b/mconfig
@@ -20,7 +20,7 @@ hstld=
 hstranlib=
 hstobjcopy=
 hstgo=
-hstgo_version="go1.11"
+hstgo_version="go1.13"
 hstgo_opts="go"
 
 tgtcc=

--- a/mconfig
+++ b/mconfig
@@ -20,7 +20,7 @@ hstld=
 hstranlib=
 hstobjcopy=
 hstgo=
-hstgo_version="go1.13"
+hstgo_version="1.13"
 hstgo_opts="go"
 
 tgtcc=

--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -58,7 +58,7 @@ fi
 if [ "$hstgo" = "" ]; then
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
 	for go in $hstgo_opts; do
-		if env GO111MODULE=off $go run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
+		if env GO111MODULE=off $go run $makeit_checksdir/version.go go$hstgo_version >/dev/null 2>&1; then
 			hstgo=`command -v $go`
 			break
 		fi
@@ -72,7 +72,7 @@ if [ "$hstgo" = "" ]; then
 	fi
 else
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
-	if env GO111MODULE=off $hstgo run $makeit_checksdir/version.go $hstgo_version >/dev/null 2>&1; then
+	if env GO111MODULE=off $hstgo run $makeit_checksdir/version.go go$hstgo_version >/dev/null 2>&1; then
 		hstgo=`command -v $go`
 		echo $hstgo
 	else

--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -73,7 +73,7 @@ if [ "$hstgo" = "" ]; then
 else
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
 	if env GO111MODULE=off $hstgo run $makeit_checksdir/version.go go$hstgo_version >/dev/null 2>&1; then
-		hstgo=`command -v $go`
+		hstgo=`command -v $hstgo`
 		echo $hstgo
 	else
 		echo "$hstgo cannot compile test code!"


### PR DESCRIPTION
This PR contains three commits:

* Update goversion to require Go 1.13

Checks for the correct go version at build time and errors out if Go 1.13 or later is not in use.

* Improve messaging around Go version check

Change the format of the messaging around the version check to make it more clear.

* Use correct Go path is the user provided one

Fix typo (?) in expansion of go's path.