### PR TITLE
Skip linting a file almost copied from the standard library

### DIFF
--- a/internal/pkg/util/user/cgo_lookup_unix.go
+++ b/internal/pkg/util/user/cgo_lookup_unix.go
@@ -13,6 +13,11 @@
 // This is a slightly patched version of Go's os/user/cgo_lookup_unix.go file.
 // We need full gecos content so the only way to do so is to call C ourselves.
 // User and Group types are taken from this package rather then from os/user.
+
+// Do not lint this file in order to keep it as close as possible to the
+// original, even if the original has linter issues.
+
+//nolint
 package user
 
 import (


### PR DESCRIPTION
It's not that the standard library cannot make mistakes, but in the
interest of trying to keep things easy to sync, instead of fixing the
linting errors, avoid linting this specific file.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

