### PR TITLE
Add run-linter script

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -18,13 +18,10 @@ collect:
 	done
 
 .PHONY: check
-check: $(go_OBJ)
+check: codegen
 	@echo " CHECK golangci-lint"
-	$(V)cd $(SOURCEDIR) && \
-		(PATH=$(SOURCEDIR)/bin:$$PATH; \
-		 (command -v golangci-lint >/dev/null || \
-		  curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.17.1) && \
-		 golangci-lint run --build-tags "$(GO_TAGS)" ./...)
+	$(V) cd $(SOURCEDIR) && \
+		scripts/run-linter run --build-tags "$(GO_TAGS)" ./...
 	@echo "       PASS"
 
 .PHONY: dist
@@ -96,7 +93,7 @@ cscope:
 .PHONY: clean
 clean:
 	@printf " CLEAN\n"
-	$(V)rm -rf $(BUILDDIR)/mergeddeps cscope.* bin/golangci-lint $(CLEANFILES)
+	$(V)rm -rf $(BUILDDIR)/mergeddeps cscope.* $(CLEANFILES)
 
 .PHONY: install
 install: $(INSTALLFILES)

--- a/scripts/run-linter
+++ b/scripts/run-linter
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+set -e
+
+# GO_TAGS='@GO_TAGS@'
+GO_TAGS='containers_image_openpgp sylog imgbuild_engine oci_engine singularity_engine fakeroot_engine apparmor selinux seccomp'
+
+golangci_lint_version=1.20.0
+golangci_lint_install_url=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+
+info() {
+	printf 'I: %s\n' "$*"
+}
+
+warn() {
+	printf 'W: %s\n' "$*"
+}
+
+error() {
+	printf 'E: %s\n' "$*"
+}
+
+cd_to_toplevel() {
+	local toplevel="$(git rev-parse --show-toplevel 2> /dev/null)"
+
+	if test -n "${toplevel}" ; then
+		cd "${toplevel}"
+		return
+	fi
+
+	# failed to get toplevel directory, we are not inside a git
+	# repo?
+
+	if test ! -f "${toplevel}/VERSION" ; then
+		# No VERSION file found, we are not looking at a release
+		# tarball ether? Bail out.
+		error 'Cannot identify toplevel directory. Abort.'
+		exit 1
+	fi
+
+	# already in the top level directory, return
+}
+
+check_golangci_lint() {
+	bindir=$1
+
+	if ! command -v golangci-lint >/dev/null 2>&1 ; then
+		warn 'golangci-lint not found in $PATH. Downloading...'
+		mkdir -p "${bindir}"
+		curl -sfL "${golangci_lint_install_url}" |
+			sh -s -- -b "${bindir}" "v${golangci_lint_version}"
+	fi
+
+	if ! command -v golangci-lint >/dev/null 2>&1 ; then
+		error 'golangci-lint not found in $PATH even after trying to install it. Abort.'
+		info ''
+		info 'Looked in the following directories, in order:'
+		info ''
+		IFS=:
+		for dir in ${PATH} ; do
+			info "    ${dir}"
+		done
+		exit 1
+	elif golangci-lint version 2>&1 | grep -q -F "golangci-lint has version ${golangci_lint_version} " ; then
+		# Found expected golangci-lint version
+		return
+	elif golangci-lint version 2>&1 | grep -q -F 'golangci-lint has version (devel) ' ; then
+		warn 'Using development version of golangci-lint.'
+	else
+		error "Expecting version ${golangci_lint_version} of golangci-lint but found something else. Abort."
+		info ''
+		info 'The output of "golangci-lint version" is:'
+		info ''
+		info "    $(golangci-lint version 2>&1)"
+		info ''
+		info 'It was found in the following location:'
+		info ''
+		info "    $(command -v golangci-lint)"
+		exit 1
+	fi
+}
+
+cd_to_toplevel
+
+bindir=$PWD/builddir/bin
+PATH=${bindir}:$PATH
+
+check_golangci_lint "${bindir}"
+
+exec golangci-lint "$@"


### PR DESCRIPTION
This wraps all the ugly logic around (optionally) downloading and
verifying that the golangci-lint version is the correct one.

This does introduce strict checking for the golangci-lint version
(1.20.0 in this case), as it has been observed that the results change
from version to version. But it also leaves the window open for people
to use a locally built golangci-lint, which reports its version as
"(devel)".

People wanting to control the location of golangci-lint can download and
install it themselves, prior to running this script.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

