### PR TITLE
Move e2e test image from centos to alpine

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -244,7 +244,7 @@ func (c actionTests) actionExec(t *testing.T) {
 		{
 			name: "NoHome",
 			argv: []string{"--no-home", c.env.ImagePath, "ls", "-ld", user.Dir},
-			exit: 2,
+			exit: 1,
 		},
 	}
 

--- a/e2e/testdata/Singularity
+++ b/e2e/testdata/Singularity
@@ -1,8 +1,8 @@
 bootstrap: library
-from: centos:7
+from: alpine:3.7
 
 %labels
-    maintainer "Eduardo Arango<eduardo@sylabs.io>"
+    maintainer "Sylabs Team <support@sylabs.io>"
 
 %help
     export BAD_GUY=Thanos
@@ -65,7 +65,8 @@ export HELLOTHISIS
 %post
     echo "POST"
     # Needed for startscript
-    yum install -y nmap-ncat hostname
+    apk update
+    apk add nmap-ncat
 
 %test
     exec "$@"

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -72,7 +72,7 @@ func (c ctx) singularityVerifyKeyNum(t *testing.T) {
 		},
 		{
 			name:         "verify number signers success",
-			expectNumOut: 1,
+			expectNumOut: 2,
 			imageURL:     successURL,
 			imagePath:    c.successImage,
 			expectExit:   0,


### PR DESCRIPTION
## Description of the Pull Request (PR):

Move e2e test image from centos to alpine to speed up test bootstrap

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

