### PR TITLE
Run linter fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 3m
+  timeout: 3m
 
 linters:
   disable-all: true

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -21,7 +21,7 @@ collect:
 check: codegen
 	@echo " CHECK golangci-lint"
 	$(V) cd $(SOURCEDIR) && \
-		scripts/run-linter run --build-tags "$(GO_TAGS)" ./...
+		scripts/run-linter run --verbose --build-tags "$(GO_TAGS)" ./...
 	@echo "       PASS"
 
 .PHONY: dist

--- a/scripts/run-linter
+++ b/scripts/run-linter
@@ -2,9 +2,6 @@
 
 set -e
 
-# GO_TAGS='@GO_TAGS@'
-GO_TAGS='containers_image_openpgp sylog imgbuild_engine oci_engine singularity_engine fakeroot_engine apparmor selinux seccomp'
-
 golangci_lint_version=1.20.0
 golangci_lint_install_url=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
 

--- a/scripts/run-linter
+++ b/scripts/run-linter
@@ -26,7 +26,9 @@ cd_to_toplevel() {
 	fi
 
 	# failed to get toplevel directory, we are not inside a git
-	# repo?
+	# repo? Fall back to current directory.
+
+	toplevel=$PWD
 
 	if test ! -f "${toplevel}/VERSION" ; then
 		# No VERSION file found, we are not looking at a release


### PR DESCRIPTION
There are four commits in this PR fixing a couple of defects in the run-linter script:

* Remove leftovers from a previous version

* Fix for toplevel detection outside git working copy

* Rename "deadline" to "timeout" in configuration file for golangci-lint

* Pass --verbose to golangci-lint to gather more timing information