### PR TITLE
Correctly handle group id when signing a group

### DIFF
--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -67,7 +67,7 @@ func (c ctx) singularitySignIDOption(t *testing.T) {
 	}{
 		{
 			name:       "sign deffile",
-			args:       []string{"--sif-id", "0", imgPath},
+			args:       []string{"--sif-id", "1", imgPath},
 			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
 			expectExit: 0,
 		},
@@ -107,7 +107,7 @@ func (c ctx) singularitySignGroupIDOption(t *testing.T) {
 	}{
 		{
 			name:       "groupID 0",
-			args:       []string{"--groupid", "0", imgPath},
+			args:       []string{"--groupid", "1", imgPath},
 			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
 			expectExit: 0,
 		},

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -30,7 +30,7 @@ type verifyOutput struct {
 	dataCheck   bool
 }
 
-const successURL = "library://sylabs/tests/verify_success:1.0.1"
+const successURL = "library://sylabs/tests/verify_success:1.0.2"
 const corruptedURL = "library://sylabs/tests/verify_corrupted:1.0.1"
 
 func getNameJSON(keyNum int) []string {
@@ -295,7 +295,7 @@ func (c ctx) singularityVerifySigner(t *testing.T) {
 }
 
 func (c ctx) checkGroupidOption(t *testing.T) {
-	cmdArgs := []string{"--groupid", "0", c.successImage}
+	cmdArgs := []string{"--groupid", "1", c.successImage}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -309,7 +309,7 @@ func (c ctx) checkGroupidOption(t *testing.T) {
 }
 
 func (c ctx) checkIDOption(t *testing.T) {
-	cmdArgs := []string{"--sif-id", "0", c.successImage}
+	cmdArgs := []string{"--sif-id", "1", c.successImage}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes the issue then signing a group, there should only be one
signature for that group.

This issue seemed to be introduced by https://github.com/sylabs/singularity/pull/4477, and since the e2e test only tries to sign/verify group id 0 (should error out, fixes that here: https://github.com/sylabs/singularity/pull/4601), the e2e tests did not catch the issue.

### This fixes or addresses the following GitHub issues:

 - Fixes #4605

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

