### PR TITLE
Junit publication fixes

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -40,9 +40,10 @@ unit-test:
 
 
 .PHONY: e2e-test
+e2e-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(BUILDDIR_ABSPATH)/e2e-test.xml)
 e2e-test:
 	@echo " TEST sudo go test [e2e]"
-	$(V)cd $(SOURCEDIR) && scripts/e2e-test
+	$(V)cd $(SOURCEDIR) && scripts/e2e-test -v $(EXTRA_FLAGS)
 	@echo "       PASS"
 
 .PHONY: integration-test

--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -20,6 +20,7 @@ gotestsum_runner() {
 }
 
 gotestsum_postprocess() {
+	touch "${junitOutput}.json"
 	gotestsum \
 		--junitfile "${junitOutput}" \
 		--raw-command \
@@ -103,6 +104,9 @@ if ${use_gotestsum} ; then
 	fi
 fi
 
+# capture exit code
+rc=0
+
 "${test_runner}" \
 	-count=1 \
 	-timeout=30m \
@@ -110,6 +114,10 @@ fi
 	-failfast \
 	-cover \
 	-race \
-	"$@"
+	"$@" ||
+rc=$?
 
 "${test_postprocess}"
+
+# return original exit code
+exit ${rc}


### PR DESCRIPTION
This PR contains two commits:

* Make sure that the JUnit report is published even if the test fails

When tests fail, the JUnit report is not published because the script returns too early.

* Publish a JUnit report (on demand) for E2E, too

When the other changes were merged, the unit-test publication went in, but not the e2e publication.