### PR TITLE
Rework singularity configuration parser

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -96,6 +96,8 @@ func convertImage(filename string, unsquashfsPath string) (string, error) {
 
 // TODO: Let's stick this in another file so that that CLI is just CLI
 func execStarter(cobraCmd *cobra.Command, image string, args []string, name string) {
+	var err error
+
 	targetUID := 0
 	targetGID := make([]int, 0)
 
@@ -123,8 +125,8 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	engineConfig := singularityConfig.NewConfig()
 
-	configurationFile := buildcfg.SINGULARITY_CONF_FILE
-	if err := config.Parser(configurationFile, engineConfig.File); err != nil {
+	engineConfig.File, err = config.ParseFile(buildcfg.SINGULARITY_CONF_FILE)
+	if err != nil {
 		sylog.Fatalf("Unable to parse singularity.conf file: %s", err)
 	}
 

--- a/etc/conf/gen.go
+++ b/etc/conf/gen.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/sylabs/singularity/pkg/runtime/engine/config"
-	singularityConfig "github.com/sylabs/singularity/pkg/runtime/engine/singularity/config"
 )
 
 func main() {
@@ -38,11 +37,11 @@ func main() {
 func genConf(tmpl, in, out string) {
 	inFile := in
 	// Parse current singularity.conf file into c
-	c := &singularityConfig.FileConfig{}
 	if _, err := os.Stat(in); os.IsNotExist(err) {
 		inFile = ""
 	}
-	if err := config.Parser(inFile, c); err != nil {
+	c, err := config.ParseFile(inFile)
+	if err != nil {
 		fmt.Printf("Unable to parse singularity.conf file: %s\n", err)
 		os.Exit(1)
 	}

--- a/etc/conf/singularity.conf
+++ b/etc/conf/singularity.conf
@@ -158,10 +158,10 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 # allowed to be used. This feature only applies when Singularity is running in
 # SUID mode and the user is non-root.
 #limit container owners = gmk, singularity, nobody
-{{ range $index, $owners := .LimitContainerOwners }}
-limit container owners = 
-{{ if $index }}, {{ end }}{{$owners}}
+{{ range $index, $owner := .LimitContainerOwners }}
+{{- if eq $index 0 }}limit container owners = {{ else }}, {{ end }}{{$owner}}
 {{- end }}
+
 # LIMIT CONTAINER GROUPS: [STRING]
 # DEFAULT: NULL
 # Only allow containers to be used that are owned by a given group. If this
@@ -169,10 +169,10 @@ limit container owners =
 # allowed to be used. This feature only applies when Singularity is running in
 # SUID mode and the user is non-root.
 #limit container groups = group1, singularity, nobody
-{{ range $index, $groups := .LimitContainerGroups }}
-limit container groups = 
-{{ if $index }}, {{ end }}{{$groups}}
+{{ range $index, $group := .LimitContainerGroups }}
+{{- if eq $index 0 }}limit container groups = {{ else }}, {{ end }}{{$group}}
 {{- end }}
+
 # LIMIT CONTAINER PATHS: [STRING]
 # DEFAULT: NULL
 # Only allow containers to be used that are located within an allowed path
@@ -181,10 +181,10 @@ limit container groups =
 # feature only applies when Singularity is running in SUID mode and the user is
 # non-root.
 #limit container paths = /scratch, /tmp, /global
-{{ range $index, $paths := .LimitContainerPaths }}
-limit container paths = 
-{{ if $index }}, {{ end }}{{$paths}}
+{{ range $index, $path := .LimitContainerPaths }}
+{{- if eq $index 0 }}limit container paths = {{ else }}, {{ end }}{{$path}}
 {{- end }}
+
 # ALLOW CONTAINER ${TYPE}: [BOOL]
 # DEFAULT: yes
 # This feature limits what kind of containers that Singularity will allow

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/runtime/engine/config"
-	singularity "github.com/sylabs/singularity/pkg/runtime/engine/singularity/config"
 	"github.com/sylabs/singularity/pkg/util/capabilities"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 )
@@ -70,8 +69,8 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		return fmt.Errorf("%s must be owned by root", configurationFile)
 	}
 
-	fileConfig := &singularity.FileConfig{}
-	if err := config.Parser(configurationFile, fileConfig); err != nil {
+	fileConfig, err := config.ParseFile(configurationFile)
+	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
 

--- a/internal/pkg/runtime/engine/singularity/create_linux.go
+++ b/internal/pkg/runtime/engine/singularity/create_linux.go
@@ -30,6 +30,8 @@ import (
 // of the setup (e.g. mount operations) where privileges may be required is performed
 // by calling RPC server methods (see internal/app/starter/rpc_linux.go for details).
 func (e *EngineOperations) CreateContainer(ctx context.Context, pid int, rpcConn net.Conn) error {
+	var err error
+
 	if e.CommonConfig.EngineName != singularityConfig.Name {
 		return fmt.Errorf("engineName configuration doesn't match runtime name")
 	}
@@ -38,8 +40,8 @@ func (e *EngineOperations) CreateContainer(ctx context.Context, pid int, rpcConn
 		return nil
 	}
 
-	configurationFile := buildcfg.SINGULARITY_CONF_FILE
-	if err := config.Parser(configurationFile, e.EngineConfig.File); err != nil {
+	e.EngineConfig.File, err = config.ParseFile(buildcfg.SINGULARITY_CONF_FILE)
+	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
 

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -55,6 +55,8 @@ var nsProcName = map[specs.LinuxNamespaceType]string{
 // No additional privileges can be gained as any of them are already
 // dropped by the time PrepareConfig is called.
 func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
+	var err error
+
 	if e.CommonConfig.EngineName != singularityConfig.Name {
 		return fmt.Errorf("incorrect engine")
 	}
@@ -64,7 +66,8 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	}
 
 	configurationFile := buildcfg.SINGULARITY_CONF_FILE
-	if err := config.Parser(configurationFile, e.EngineConfig.File); err != nil {
+	e.EngineConfig.File, err = config.ParseFile(configurationFile)
+	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
 

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/runtime/engine/config"
-	singularity "github.com/sylabs/singularity/pkg/runtime/engine/singularity/config"
 )
 
 var (
@@ -55,8 +54,8 @@ func cryptsetup(cfgpath string) (string, error) {
 		return "", errCryptsetupNotFound
 	}
 
-	cfg := singularity.FileConfig{}
-	if err := config.Parser(cfgpath, &cfg); err != nil {
+	cfg, err := config.ParseFile(cfgpath)
+	if err != nil {
 		return "", errors.Wrap(err, "unable to parse singularity configuration file")
 	}
 

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -13,16 +13,15 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/pkg/runtime/engine/config"
-	singularityconfig "github.com/sylabs/singularity/pkg/runtime/engine/singularity/config"
 )
 
 // GetPath figures out where the mksquashfs binary is
 // and return an error is not available or not usable.
 func GetPath() (string, error) {
 	// Parse singularity configuration file
-	c := &singularityconfig.FileConfig{}
 	configFile := buildcfg.SINGULARITY_CONF_FILE
-	if err := config.Parser(configFile, c); err != nil {
+	c, err := config.ParseFile(configFile)
+	if err != nil {
 		return "", fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}
 

--- a/pkg/runtime/engine/config/config.go
+++ b/pkg/runtime/engine/config/config.go
@@ -16,3 +16,41 @@ type Common struct {
 
 // EngineConfig is a generic interface to represent the implementations of an EngineConfig.
 type EngineConfig interface{}
+
+// FileConfig describes the singularity.conf file options
+type FileConfig struct {
+	AllowSetuid             bool     `default:"yes" authorized:"yes,no" directive:"allow setuid"`
+	AllowPidNs              bool     `default:"yes" authorized:"yes,no" directive:"allow pid ns"`
+	ConfigPasswd            bool     `default:"yes" authorized:"yes,no" directive:"config passwd"`
+	ConfigGroup             bool     `default:"yes" authorized:"yes,no" directive:"config group"`
+	ConfigResolvConf        bool     `default:"yes" authorized:"yes,no" directive:"config resolv_conf"`
+	MountProc               bool     `default:"yes" authorized:"yes,no" directive:"mount proc"`
+	MountSys                bool     `default:"yes" authorized:"yes,no" directive:"mount sys"`
+	MountDevPts             bool     `default:"yes" authorized:"yes,no" directive:"mount devpts"`
+	MountHome               bool     `default:"yes" authorized:"yes,no" directive:"mount home"`
+	MountTmp                bool     `default:"yes" authorized:"yes,no" directive:"mount tmp"`
+	MountHostfs             bool     `default:"no" authorized:"yes,no" directive:"mount hostfs"`
+	UserBindControl         bool     `default:"yes" authorized:"yes,no" directive:"user bind control"`
+	EnableFusemount         bool     `default:"yes" authorized:"yes,no" directive:"enable fusemount"`
+	EnableUnderlay          bool     `default:"yes" authorized:"yes,no" directive:"enable underlay"`
+	MountSlave              bool     `default:"yes" authorized:"yes,no" directive:"mount slave"`
+	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
+	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
+	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
+	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
+	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
+	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
+	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
+	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
+	EnableOverlay           string   `default:"try" authorized:"yes,no,try" directive:"enable overlay"`
+	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
+	LimitContainerOwners    []string `directive:"limit container owners"`
+	LimitContainerGroups    []string `directive:"limit container groups"`
+	LimitContainerPaths     []string `directive:"limit container paths"`
+	RootDefaultCapabilities string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
+	MemoryFSType            string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
+	CniConfPath             string   `directive:"cni configuration path"`
+	CniPluginPath           string   `directive:"cni plugin path"`
+	MksquashfsPath          string   `directive:"mksquashfs path"`
+	CryptsetupPath          string   `directive:"cryptsetup path"`
+}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -21,44 +21,6 @@ const (
 	UnderlayLayer = "underlay"
 )
 
-// FileConfig describes the singularity.conf file options
-type FileConfig struct {
-	AllowSetuid             bool     `default:"yes" authorized:"yes,no" directive:"allow setuid"`
-	AllowPidNs              bool     `default:"yes" authorized:"yes,no" directive:"allow pid ns"`
-	ConfigPasswd            bool     `default:"yes" authorized:"yes,no" directive:"config passwd"`
-	ConfigGroup             bool     `default:"yes" authorized:"yes,no" directive:"config group"`
-	ConfigResolvConf        bool     `default:"yes" authorized:"yes,no" directive:"config resolv_conf"`
-	MountProc               bool     `default:"yes" authorized:"yes,no" directive:"mount proc"`
-	MountSys                bool     `default:"yes" authorized:"yes,no" directive:"mount sys"`
-	MountDevPts             bool     `default:"yes" authorized:"yes,no" directive:"mount devpts"`
-	MountHome               bool     `default:"yes" authorized:"yes,no" directive:"mount home"`
-	MountTmp                bool     `default:"yes" authorized:"yes,no" directive:"mount tmp"`
-	MountHostfs             bool     `default:"no" authorized:"yes,no" directive:"mount hostfs"`
-	UserBindControl         bool     `default:"yes" authorized:"yes,no" directive:"user bind control"`
-	EnableFusemount         bool     `default:"yes" authorized:"yes,no" directive:"enable fusemount"`
-	EnableUnderlay          bool     `default:"yes" authorized:"yes,no" directive:"enable underlay"`
-	MountSlave              bool     `default:"yes" authorized:"yes,no" directive:"mount slave"`
-	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
-	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
-	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
-	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
-	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
-	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
-	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
-	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
-	EnableOverlay           string   `default:"try" authorized:"yes,no,try" directive:"enable overlay"`
-	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
-	LimitContainerOwners    []string `directive:"limit container owners"`
-	LimitContainerGroups    []string `directive:"limit container groups"`
-	LimitContainerPaths     []string `directive:"limit container paths"`
-	RootDefaultCapabilities string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
-	MemoryFSType            string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
-	CniConfPath             string   `directive:"cni configuration path"`
-	CniPluginPath           string   `directive:"cni plugin path"`
-	MksquashfsPath          string   `directive:"mksquashfs path"`
-	CryptsetupPath          string   `directive:"cryptsetup path"`
-}
-
 // JSONConfig stores engine specific confguration that is allowed to be set by the user.
 type JSONConfig struct {
 	ScratchDir        []string      `json:"scratchdir,omitempty"`

--- a/pkg/runtime/engine/singularity/config/config_linux.go
+++ b/pkg/runtime/engine/singularity/config/config_linux.go
@@ -17,13 +17,14 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/network"
+	"github.com/sylabs/singularity/pkg/runtime/engine/config"
 )
 
 // EngineConfig stores both the JSONConfig and the FileConfig
 type EngineConfig struct {
 	JSON      *JSONConfig                `json:"jsonConfig"`
 	OciConfig *oci.Config                `json:"ociConfig"`
-	File      *FileConfig                `json:"-"`
+	File      *config.FileConfig         `json:"-"`
 	Network   *network.Setup             `json:"-"`
 	Cgroups   *cgroups.Manager           `json:"-"`
 	CryptDev  string                     `json:"-"`
@@ -42,9 +43,9 @@ type FuseInfo struct {
 // NewConfig returns singularity.EngineConfig with a parsed FileConfig
 func NewConfig() *EngineConfig {
 	ret := &EngineConfig{
-		JSON:      &JSONConfig{},
-		OciConfig: &oci.Config{},
-		File:      &FileConfig{},
+		JSON:      new(JSONConfig),
+		OciConfig: new(oci.Config),
+		File:      new(config.FileConfig),
 		Plugin:    make(map[string]json.RawMessage),
 	}
 

--- a/pkg/runtime/engine/singularity/config/config_unsupported.go
+++ b/pkg/runtime/engine/singularity/config/config_unsupported.go
@@ -9,21 +9,22 @@ package singularity
 
 import (
 	"github.com/sylabs/singularity/internal/pkg/runtime/engine/config/oci"
+	"github.com/sylabs/singularity/pkg/runtime/engine/config"
 )
 
 // EngineConfig stores both the JSONConfig and the FileConfig
 type EngineConfig struct {
-	JSON      *JSONConfig `json:"jsonConfig"`
-	OciConfig *oci.Config `json:"ociConfig"`
-	File      *FileConfig `json:"-"`
+	JSON      *JSONConfig        `json:"jsonConfig"`
+	OciConfig *oci.Config        `json:"ociConfig"`
+	File      *config.FileConfig `json:"-"`
 }
 
 // NewConfig returns singularity.EngineConfig with a parsed FileConfig
 func NewConfig() *EngineConfig {
 	ret := &EngineConfig{
-		JSON:      &JSONConfig{},
-		OciConfig: &oci.Config{},
-		File:      &FileConfig{},
+		JSON:      new(JSONConfig),
+		OciConfig: new(oci.Config),
+		File:      new(config.FileConfig),
 	}
 
 	return ret


### PR DESCRIPTION
## Description of the Pull Request (PR):

To ease development of `singularity config global` see (#3944) the parser code was reworked and cleanup a bit :

- Splitted configuration parser into two functions: `ParseData` and `SetConfig`
- Code cleanup.
- Added unit tests for code coverage.
- Fixed bad template formatting loop for `limit container xxx` directives

### This fixes or addresses the following GitHub issues:

 - Related to #3944 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

