### PR TITLE
Fix exit code for e2e sign tests

### DIFF
--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -75,7 +75,7 @@ func (c ctx) singularitySignIDOption(t *testing.T) {
 			name:       "sign non-exsistent ID",
 			args:       []string{"--sif-id", "5", imgPath},
 			expectOp:   e2e.ExpectError(e2e.ContainMatch, "no descriptor found for id 5"),
-			expectExit: 2,
+			expectExit: 255,
 		},
 	}
 
@@ -115,7 +115,7 @@ func (c ctx) singularitySignGroupIDOption(t *testing.T) {
 			name:       "groupID 5",
 			args:       []string{"--groupid", "5", imgPath},
 			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "no descriptors found for groupid 5"),
-			expectExit: 2,
+			expectExit: 255,
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix exit code (255 instead of 2) for e2e sign tests.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

