### PR TITLE
Use the freshly built singularity

### DIFF
--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	testCache "github.com/sylabs/singularity/internal/pkg/test/tool/cache"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
@@ -42,10 +43,11 @@ type groupTest struct {
 }
 
 func downloadImage(t *testing.T) string {
-	sexec, err := exec.LookPath("singularity")
-	if err != nil {
-		t.Log("cannot find singularity path, skipping test")
-		t.SkipNow()
+	// Use singularity located at BUILDDIR, where the singularity
+	// binary should be found after building it.
+	sexec := filepath.Join(buildcfg.BUILDDIR, "singularity")
+	if _, err := exec.LookPath(sexec); err != nil {
+		t.Fatalf("cannot find singularity binary at %s", sexec)
 	}
 	f, err := ioutil.TempFile("", "image-")
 	if err != nil {

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sylabs/singularity/pkg/ocibundle/tools"
 
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	testCache "github.com/sylabs/singularity/internal/pkg/test/tool/cache"
@@ -41,9 +42,11 @@ func TestFromSif(t *testing.T) {
 	f.Close()
 	defer os.Remove(sifFile)
 
-	sing, err := exec.LookPath("singularity")
-	if err != nil {
-		t.Fatal(err)
+	// Use singularity located at BUILDDIR, where the singularity
+	// binary should be found after building it.
+	sing := filepath.Join(buildcfg.BUILDDIR, "singularity")
+	if _, err := exec.LookPath(sing); err != nil {
+		t.Fatalf("cannot find singularity binary at %s", sing)
 	}
 	args := []string{"build", "-F", sifFile, "docker://busybox"}
 


### PR DESCRIPTION
It's questionable where this test should be running singularity in the
first place, but until this is fixed, use the freshly-built singularity
instead of whatever is found in the PATH.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>