### PR TITLE
Properly remove bundles with restrictive perms

### DIFF
--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -275,4 +276,117 @@ func FirstExistingParent(path string) (string, error) {
 	}
 
 	return p, nil
+}
+
+// ForceRemoveAll removes a directory like os.RemoveAll, except that it will
+// chmod any directory who's permissions are preventing the removal of contents
+func ForceRemoveAll(path string) error {
+	// First try to remove the directory with os.RemoveAll. This will remove
+	// as much as it can, and return the first error (if any) - so we can avoid
+	// messing with permissions unless we need to.
+	err := os.RemoveAll(path)
+	// Anything other than an permission error is out of scope for us to deal
+	// with here.
+	if err == nil || !os.IsPermission(err) {
+		return err
+	}
+
+	// At this point there is a permissions error. Removal of files is dependent
+	// on the permissions of the containing directory, so walk the (remaining)
+	// tree and set perms that work.
+	sylog.Debugf("Forcing permissions to remove %q completely", path)
+	errors := 0
+	err = permWalk(path, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			sylog.Errorf("Unable to access path %s: %s", path, err)
+			errors++
+			return nil
+		}
+		// Directories must have the owner 'rx' bits to allow traversal, reading content, and the 'w' bit
+		// so their content can be deleted by the user when the bundle is deleted
+		if f.Mode().IsDir() {
+			if err := os.Chmod(path, f.Mode().Perm()|0700); err != nil {
+				sylog.Errorf("Error setting permissions to remove %s: %s", path, err)
+				errors++
+			}
+		}
+		return nil
+	})
+
+	// Catastrophic error during the permission walk
+	if err != nil {
+		sylog.Errorf("Unable to set permissions to remove %q: %s", path, err)
+	}
+	// Individual errors accumulated while setting permissions in the walk
+	if errors > 0 {
+		sylog.Errorf("%d errors were encountered when setting permissions to remove bundle", errors)
+	}
+
+	// Call RemoveAll again to get rid of things... even if we had errors when
+	// trying to set permissions, so we remove as much as possible.
+	return os.RemoveAll(path)
+}
+
+// permWalk is similar to filepath.Walk - but:
+//   1. The skipDir checks are removed (we never want to skip anything here)
+//   2. Our walk will call walkFn on a directory *before* attempting to look
+//      inside that directory.
+func permWalk(root string, walkFn filepath.WalkFunc) error {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return fmt.Errorf("could not access rootfs %s: %s", root, err)
+	}
+	return walk(root, info, walkFn)
+}
+
+func walk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
+	if !info.IsDir() {
+		return walkFn(path, info, nil)
+	}
+
+	// Unlike filepath.walk we call walkFn *before* trying to list the content of
+	// the directory, so that walkFn has a chance to assign perms that allow us into
+	// the directory, if we can't get in there already.
+	if err := walkFn(path, info, nil); err != nil {
+		return err
+	}
+
+	names, err := readDirNames(path)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		filename := filepath.Join(path, name)
+		fileInfo, err := os.Lstat(filename)
+		if err != nil {
+			if err := walkFn(filename, fileInfo, err); err != nil {
+				return err
+			}
+		} else {
+			err = walk(filename, fileInfo, walkFn)
+			if err != nil {
+				if !fileInfo.IsDir() {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// readDirNames reads the directory named by dirname and returns
+// a sorted list of directory entries.
+func readDirNames(dirname string) ([]string, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
 }

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -14,6 +14,7 @@ import (
 	ocitypes "github.com/containers/image/types"
 	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/util/crypt"
 )
 
@@ -91,7 +92,7 @@ func (b *Bundle) RunSection(s string) bool {
 func (b *Bundle) Remove() error {
 	var errors []string
 	for _, dir := range []string{b.TmpDir, b.RootfsPath} {
-		if err := os.RemoveAll(dir); err != nil {
+		if err := fs.ForceRemoveAll(dir); err != nil {
 			errors = append(errors, fmt.Sprintf("could not remove %q: %v", dir, err))
 		}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

When a bundle is created from an OCI image that has files with
restrictive permissions, removal of the temporary bundle directory can
fail. Use a stronger approach to remove these, modifying permissions to
allow removal of all directory content.

Signed-off-by: David Trudgian <dave@trudgian.net>

### This fixes or addresses the following GitHub issues:

 - Fixes #4632


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

