### PR TITLE
Make sure we use the same go binary in go-generate

### DIFF
--- a/internal/pkg/buildcfg/config_gen.go
+++ b/internal/pkg/buildcfg/config_gen.go
@@ -5,4 +5,4 @@
 
 package buildcfg
 
-//go:generate go run confgen/gen.go "${BUILDDIR}/config.h"
+//go:generate "${GO_TOOL}" run confgen/gen.go "${BUILDDIR}/config.h"

--- a/scripts/go-generate.in
+++ b/scripts/go-generate.in
@@ -4,6 +4,7 @@ export BUILDDIR='@BUILDDIR@'
 export GO111MODULE='@GO111MODULE@'
 export GO_BUILD_TAGS='@GO_TAGS@'
 export GOFLAGS='@GOFLAGS@'
+export GO_TOOL='@GO@'
 
 exec '@GO@' generate \
 	-tags '@GO_TAGS@' \


### PR DESCRIPTION
This is hopefully the last case of a naked "go" invocation. The rest of
the go calls are happening using the path that mconfig determined, and
this change is fixing that for the _program_ that go-generate ends up
running.

When you run "go generate" (what "go-generate" does) it looks for
'//go:generate' comments and runs whatever command is specified there in
order to generate something. This goes thru the shell, so it's OK to use
environment variables on that command line.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

