### PR TITLE
Ask for the version number only once

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -845,8 +845,15 @@ if [ "$host" = "unix" ]; then
 	RPMSPEC=singularity.spec
 	echo "=> generating $RPMSPEC ..."
 	rm -f $sourcedir/$RPMSPEC
-	package_rpm_version="`echo "${short_version}" | tr - .`"
-	sed "s/@PACKAGE_VERSION@/${short_version}/;s/@PACKAGE_RPM_VERSION@/${package_rpm_version}/;s/@PACKAGE_RELEASE@/${release_info}/" \
+
+	# Transform version numbers so that rpm accepts them:
+	#
+	# 3.4.2-rc.1            ->  3.4.2~rc.1
+	# 3.4.2                 ->  3.4.2
+	# 3.4.2+522-gee98ef356  ->  3.4.2+522.gee98ef356
+	package_rpm_version="$(echo "${short_version}" | sed -e 's,\(^[^+]\+\)-,\1~,; s,-,.,g')"
+
+	sed "s/@PACKAGE_VERSION@/${package_version}/;s/@PACKAGE_RPM_VERSION@/${package_rpm_version}/;s/@PACKAGE_RELEASE@/${release_info}/" \
 		$sourcedir/dist/rpm/$RPMSPEC.in >$sourcedir/$RPMSPEC
 fi
 

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -32,7 +32,7 @@ dist:
 		exit 1 ; \
 	fi
 	$(V) cd $(SOURCEDIR) && $(GO) mod vendor
-	$(V) cd $(SOURCEDIR) && $(SOURCEDIR)/scripts/make-dist.sh
+	$(V) cd $(SOURCEDIR) && $(SOURCEDIR)/scripts/make-dist.sh $(VERSION)
 	$(V) rm -rf '$(SOURCEDIR)/vendor'
 
 .PHONY: unit-test

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -
-# Copyright (c) Sylabs Inc. All rights reserved.
+# Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found
 # in the LICENSE file.
 set -e
@@ -11,7 +11,16 @@ if [ ! -f $package_name.spec ]; then
     exit 1
 fi
 
-version=`scripts/get-version`
+version=$1
+
+if test -z "${version}" ; then
+    cat >&2 <-EOT
+	This program requires a version number as argument.
+	
+	        $0 {version}
+	EOT
+    exit 1
+fi
 
 echo " DIST setup VERSION: ${version}"
 echo "${version}" > VERSION
@@ -32,6 +41,10 @@ if test ! -d vendor ; then
     exit 1
 fi
 
+# XXX(mem): In order to accept filenames with colons in it (because of a
+# version number like x.y.z:1.2.3), pass the --force-local flag to tar.
+# This is understood by GNU tar. If other tar programs (also called
+# "tar") don't, this will need to be fixed.
 (echo VERSION; echo $package_name.spec; echo vendor; git ls-files) | \
     sed "s,^,$pathtop/," |
-    tar -C builddir -T - -czf $tarball
+    tar --force-local -C builddir -T - -czf "$tarball"


### PR DESCRIPTION
Currently the script "make-dist" calls "get-version", which is also
called in "mconfig". The problem is that mconfig has additional logic
overriding the output of get-version (to support use cases where the
resulting version number is not singularity's version number).

To avoid making too many changes in (what should be) disconnected
places, have mconfig call get-version, and if the user wants to replace
that with something different by using the -V flag, simply override the
resulting version number and pass that to make-dist as an argument.
make-dist is then called with the correct value when the user runs "make
dist", and writes it to the VERSION file in the release tarball.
get-version will _read_ that file and output whatever the user passed as
argument to -V. This causes the "singularity version" command to report
the actual version number (as recorded in the VERSION file) instead of
some fake x.y.z one, and this helps us to support users.

In this way everything stays consistent.

Follow-up-for: 15bbd6153189a9949a2814c625794d8839021a0d
Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

