### PR TITLE
Update umoci - minimize xattr warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ replace (
 	// where the patches have been merged. Dependency conflicts currently
 	// prevent this.
 	// For more detail see: https://github.com/sylabs/umoci/blob/singularity/README.md
-	github.com/openSUSE/umoci => github.com/sylabs/umoci v0.4.3-0.20191017185224-21061af9a1e7
+	github.com/openSUSE/umoci => github.com/sylabs/umoci v0.4.3-0.20191023165551-c75d775ed7fd
 	github.com/opencontainers/image-tools => github.com/sylabs/image-tools v0.0.0-20181006203805-2814f4980568
 	golang.org/x/crypto => github.com/sylabs/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9
 )

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/sylabs/scs-library-client v0.4.4 h1:DJpXTEV1TyHe3lGQ9EJ4RzK+0ES+3rDgj
 github.com/sylabs/scs-library-client v0.4.4/go.mod h1:FV1aajXP99oKFFagiomGI6WkWFniKnhIq/z1mITeeb4=
 github.com/sylabs/sif v1.0.8 h1:BK55XU0UhUsbimCr1Sl1tCLDrFsB71EDYDcHRfPpw8k=
 github.com/sylabs/sif v1.0.8/go.mod h1:/W42wtEREMjfQCNz1HhqD2PHW8ZPqjiU7Z2pZQXTRqI=
-github.com/sylabs/umoci v0.4.3-0.20191017185224-21061af9a1e7 h1:xrkM1WVrjk74eTmQSr9CIiV8qklNyykYn+k9zWm6faQ=
-github.com/sylabs/umoci v0.4.3-0.20191017185224-21061af9a1e7/go.mod h1:8rMy7mg/N4lGwWNeoc09op5EoTcFcmmf9D+Kg8HIVKI=
+github.com/sylabs/umoci v0.4.3-0.20191023165551-c75d775ed7fd h1:JZ7kZUI+IHSrK+XdTXaFgZqKJxgfUIif6XMBN8TFQCU=
+github.com/sylabs/umoci v0.4.3-0.20191023165551-c75d775ed7fd/go.mod h1:8rMy7mg/N4lGwWNeoc09op5EoTcFcmmf9D+Kg8HIVKI=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.3.0+incompatible h1:GkY4dP3cEfEASBPPkWd+AmjYxhmDkqO9/zg7R0lSQRs=


### PR DESCRIPTION
## Description of the Pull Request (PR):

This updates our version of umoci to v0.4.2+singularity2 from the sylabs
fork.

This version contains a patch to only show a warning for the first
ENOTSUP error when handling xattrs on a filesystem that does not support
them (e.g. NFS mount). This prevents other warnings/errors being
obscured by huge numbers of unimportant ENOTSUP warnings.

Before:

```
singularity build -s mysandbox docker://centos:7
                      
INFO:    Starting build...
Getting image source signatures
Copying blob d8d02d457314 skipped: already exists
Copying config acab94af64 done
Writing manifest to image destination
Storing signatures
2019/10/23 12:20:43  info unpack layer: sha256:d8d02d45731499028db01b6fa35475f91d230628b4e25fab8e3c015594dc3261
2019/10/23 12:20:49  warn xattr{run/lock/lockdev} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
2019/10/23 12:20:49  warn xattr{run/systemd/netif} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
2019/10/23 12:20:49  warn xattr{run/systemd/netif/leases} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
2019/10/23 12:20:49  warn xattr{run/systemd/netif/links} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
2019/10/23 12:20:50  warn xattr{run/utmp} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
2019/10/23 12:20:57  warn rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/10/23 12:21:02  warn xattr{usr/bin/write} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
...
more warnings...
```

After (with this PR):

```
INFO:    Starting build...
Getting image source signatures
Copying blob d8d02d457314 skipped: already exists
Copying config acab94af64 done
Writing manifest to image destination
Storing signatures
2019/10/23 12:13:42  info unpack layer: sha256:d8d02d45731499028db01b6fa35475f91d230628b4e25fab8e3c015594dc3261
2019/10/23 12:13:47  warn xattr{run/lock/lockdev} ignoring ENOTSUP on setxattr "user.rootlesscontainers"
2019/10/23 12:13:47  warn xattr{rootfs-73ff226d-f5b8-11e9-b105-e0d55e6c2d0d/run/lock/lockdev} destination filesystem does not support xattrs, further warnings will be suppressed
2019/10/23 12:13:55  warn rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/10/23 12:15:18  warn rootless{usr/sbin/arping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/10/23 12:15:18  warn rootless{usr/sbin/clockdiff} ignoring (usually) harmless EPERM on setxattr "security.capability"
INFO:    Creating sandbox directory...
INFO:    Build complete: mysandbox
```


### This fixes or addresses the following GitHub issues:

 - Fixes #4662


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

