### PR TITLE
Restore vendor/ for release tarballs

### DIFF
--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -93,6 +93,18 @@ func buildPlugin(sourceDir, buildTags string) (string, error) {
 		return "", errors.New("singularity source directory not found")
 	}
 
+	modFlag := "-mod=readonly"
+
+	hasVendor := func() bool {
+		vendorDir := filepath.Join(workpath, "vendor")
+		_, err := os.Stat(vendorDir)
+		return !os.IsNotExist(err)
+	}()
+
+	if hasVendor {
+		modFlag = "-mod=vendor"
+	}
+
 	// assuming that sourceDir is within trimpath for now
 	out := pluginObjPath(sourceDir)
 
@@ -104,6 +116,7 @@ func buildPlugin(sourceDir, buildTags string) (string, error) {
 	args := []string{
 		"build",
 		"-o", out,
+		modFlag,
 		"-trimpath",
 		"-buildmode=plugin",
 		"-tags", buildTags,

--- a/makeit/gengodep
+++ b/makeit/gengodep
@@ -27,7 +27,13 @@ shift 3
 # get propagated down to go list.
 export GOPROXY
 
-"${go}" list -mod=readonly \
+if test -e "${srcdir}/vendor/modules.txt" ; then
+	mod_mode=vendor
+else
+	mod_mode=readonly
+fi
+
+"${go}" list -mod=${mod_mode} \
 	-deps \
 	-f '{{ with $d := . }}{{ range $d.GoFiles }}{{ $d.Dir }}/{{ . }} {{ end }}{{ range $d.CgoFiles }}{{ $d.Dir }}/{{ . }} {{ end }}{{ end }}' \
 	-tags "${gotags}" \

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -26,7 +26,14 @@ check: codegen
 
 .PHONY: dist
 dist:
-	$(V)(cd $(SOURCEDIR) && $(SOURCEDIR)/scripts/make-dist.sh)
+	$(V) if test -e '$(SOURCEDIR)/vendor' ; then \
+		echo 'E: There is a vendor directory in $(SOURCEDIR).' ; \
+		echo 'E: This is unexpected. Abort.' ; \
+		exit 1 ; \
+	fi
+	$(V) cd $(SOURCEDIR) && $(GO) mod vendor
+	$(V) cd $(SOURCEDIR) && $(SOURCEDIR)/scripts/make-dist.sh
+	$(V) rm -rf '$(SOURCEDIR)/vendor'
 
 .PHONY: unit-test
 unit-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(BUILDDIR_ABSPATH)/unit-test.xml)

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -6,8 +6,8 @@ GO_LDFLAGS :=
 GO_BUILDMODE := -buildmode=default
 GO_GCFLAGS :=
 GO_ASMFLAGS :=
-GO_MODFLAGS :=
-GOFLAGS := -mod=readonly -trimpath
+GO_MODFLAGS := $(if $(wildcard $(SOURCEDIR)/vendor/modules.txt),-mod=vendor,-mod=readonly)
+GOFLAGS := $(GO_MODFLAGS) -trimpath
 GOPROXY := https://proxy.golang.org
 
 export GOFLAGS GO111MODULE GOPROXY

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -23,5 +23,15 @@ pathtop="$package_name"
 ln -sf .. builddir/$pathtop
 rmfiles="$rmfiles builddir/$pathtop"
 trap "rm -f $rmfiles" 0
-(echo VERSION; echo $package_name.spec; git ls-files) | \
-    sed "s,^,$pathtop/," | tar -C builddir -T - -czf $tarball
+
+# modules should have been vendored using the correct version of the Go
+# tool, so we expect to find a vendor directory. Bail out if there isn't
+# one.
+if test ! -d vendor ; then
+    echo 'E: vendor directory not found. Abort.'
+    exit 1
+fi
+
+(echo VERSION; echo $package_name.spec; echo vendor; git ls-files) | \
+    sed "s,^,$pathtop/," |
+    tar -C builddir -T - -czf $tarball


### PR DESCRIPTION
In order to be more friendly to people wanting to build singularity in
air-gapped or air-gapped-like situations (like Linux distributions),
restore the vendor directory in release tarballs (and only in that
case).

There's a simple assumption here: if there's a vendor directory, we must
pass -mod=vendor, and if there isn't, we pass -mod=readonly to make sure
that we are not unintentionally adding modules.

Since this affects the resulting binary interface, plugins need to be
aware of this. Make the corresponding adjustments there.

The vendor directory is created when running "make dist". To avoid
making larger changes, make it a requirement to use the make-dist script
from the makefile. It's still possible to use it directly if the user
runs "go mod vendor" manually _before_ calling scripts/make-dist.sh. In
the future all the scripts requiring access to the Go tool path, build
flags, etc, can move to sourcing a shell file with those settings.

Fixes: #4664
Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

