### PR TITLE
Information / option to fix restrictive sandbox permissions

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -29,6 +29,7 @@ var buildArgs struct {
 	detached   bool
 	encrypt    bool
 	fakeroot   bool
+	fixPerms   bool
 	isJSON     bool
 	noCleanUp  bool
 	noTest     bool
@@ -183,6 +184,17 @@ var buildEncryptFlag = cmdline.Flag{
 	Usage:        "build an image with an encrypted file system",
 }
 
+// TODO: Deprecate at 3.6, remove at 3.8
+// --fix-perms
+var buildFixPermsFlag = cmdline.Flag{
+	ID:           "fixPermsFlag",
+	Value:        &buildArgs.fixPerms,
+	DefaultValue: false,
+	Name:         "fix-perms",
+	Usage:        "ensure owner has rwX permissions on all container content for oci/docker sources",
+	EnvKeys:      []string{"FIXPERMS"},
+}
+
 func init() {
 	cmdManager.RegisterCmd(buildCmd)
 
@@ -192,6 +204,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&buildDisableCacheFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildEncryptFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildFakerootFlag, buildCmd)
+	cmdManager.RegisterFlagForCmd(&buildFixPermsFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildJSONFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildLibraryFlag, buildCmd)
 	cmdManager.RegisterFlagForCmd(&buildNoCleanupFlag, buildCmd)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -239,8 +239,11 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 	}
 
 	buildFormat := "sif"
+	sandboxTarget := false
 	if buildArgs.sandbox {
 		buildFormat = "sandbox"
+		sandboxTarget = true
+
 	}
 
 	b, err := build.New(
@@ -262,6 +265,8 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 				LibraryAuthToken:  authToken,
 				DockerAuthConfig:  &authConf,
 				EncryptionKeyInfo: keyInfo,
+				FixPerms:          buildArgs.fixPerms,
+				SandboxTarget:     sandboxTarget,
 			},
 		})
 	if err != nil {

--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -82,3 +82,14 @@ func PathExists(t *testing.T, path string) bool {
 
 	return true
 }
+
+// PathPerms return true if the path (file or directory) has specified permissions, false otherwise.
+func PathPerms(t *testing.T, path string, perms os.FileMode) bool {
+	s, err := os.Stat(path)
+
+	if err != nil {
+		t.Fatalf("While stating file: %v", err)
+	}
+
+	return s.Mode().Perm() == perms
+}

--- a/internal/pkg/build/sources/oci_unpack_linux.go
+++ b/internal/pkg/build/sources/oci_unpack_linux.go
@@ -12,6 +12,7 @@ package sources
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -20,6 +21,8 @@ import (
 	umocilayer "github.com/openSUSE/umoci/oci/layer"
 	"github.com/openSUSE/umoci/pkg/idtools"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	sytypes "github.com/sylabs/singularity/pkg/build/types"
 )
 
@@ -68,5 +71,106 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 	os.RemoveAll(b.RootfsPath)
 
 	// Unpack root filesystem
-	return umocilayer.UnpackRootfs(ctx, engineExt, b.RootfsPath, manifest, &mapOptions)
+	err = umocilayer.UnpackRootfs(ctx, engineExt, b.RootfsPath, manifest, &mapOptions)
+	if err != nil {
+		return fmt.Errorf("error unpacking rootfs: %s", err)
+	}
+
+	// If the `--fixperms` flag was used, then modify the permissions so that
+	// content has owner rwX and we're done
+	if b.Opts.FixPerms {
+		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container and will be removed in a future release.")
+		sylog.Warningf("You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671")
+		sylog.Debugf("Modifying permissions for file/directory owners")
+		return fixPerms(b.RootfsPath)
+	}
+
+	// If `--fixperms` was not used and this is a sandbox, scan for restrictive
+	// perms that would stop the user doing an `rm` without a chmod first,
+	// and warn if they exist
+	if b.Opts.SandboxTarget {
+		sylog.Debugf("Scanning for restrictive permissions")
+		return checkPerms(b.RootfsPath)
+	}
+
+	// No `--fixperms` and no sandbox... we are fine
+	return err
+
+}
+
+// fixPerms will work through the rootfs of this bundle, making sure that all
+// files and directories have permissions set such that the owner can read,
+// modify, delete. This brings us to the situation of <=3.4
+func fixPerms(rootfs string) (err error) {
+	errors := 0
+	err = fs.PermWalk(rootfs, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			sylog.Errorf("Unable to access rootfs path %s: %s", path, err)
+			errors++
+			return nil
+		}
+
+		switch mode := f.Mode(); {
+		// Directories must have the owner 'rx' bits to allow traversal and reading on move, and the 'w' bit
+		// so their content can be deleted by the user when the rootfs/sandbox is deleted
+		case mode.IsDir():
+			if err := os.Chmod(path, f.Mode().Perm()|0700); err != nil {
+				sylog.Errorf("Error setting permission for %s: %s", path, err)
+				errors++
+			}
+		case mode.IsRegular():
+			// Regular files must have the owner 'r' bit so that everything can be read in order to
+			// copy or move the rootfs/sandbox around. Also, the `w` bit as the build does write into
+			// some files (e.g. resolv.conf) in the container rootfs.
+			if err := os.Chmod(path, f.Mode().Perm()|0600); err != nil {
+				sylog.Errorf("Error setting permission for %s: %s", path, err)
+				errors++
+			}
+		}
+		return nil
+	})
+
+	if errors > 0 {
+		err = fmt.Errorf("%d errors were encountered when setting permissions", errors)
+	}
+	return err
+}
+
+// checkPerms will work through the rootfs of this bundle, and find if any
+// directory does not have owner rwX - which may cause unexpected issues for a
+// user trying to look through, or delete a sandbox
+func checkPerms(rootfs string) (err error) {
+	// This is a locally defined error we can bubble up to cancel our recursive
+	// structure.
+	var errRestrictivePerm = errors.New("restrictive file permission found")
+
+	err = fs.PermWalkRaiseError(rootfs, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			// If the walk function cannot access a directory at all, that's an
+			// obvious restrictive permission we need to warn on
+			if os.IsPermission(err) {
+				sylog.Debugf("Path %q has restrictive permissions", path)
+				return errRestrictivePerm
+			}
+			return fmt.Errorf("unable to access rootfs path %s: %s", path, err)
+		}
+		// Warn on any directory not `rwX` - technically other combinations may
+		// be traversable / removable... but are confusing to the user vs
+		// the Singularity 3.4 behavior.
+		if f.Mode().IsDir() && f.Mode().Perm()&0700 != 0700 {
+			sylog.Debugf("Path %q has restrictive permissions", path)
+			return errRestrictivePerm
+		}
+		return nil
+	})
+
+	if errors.Is(err, errRestrictivePerm) {
+		sylog.Warningf("Permission handling has changed in Singularity 3.5 for improved OCI compatibility")
+		sylog.Warningf("The sandbox will contain files/dirs that cannot be removed until permissions are modified")
+		sylog.Warningf("Use 'chmod -R u+rwX' to set permissions that allow removal")
+		sylog.Warningf("Use the '--fix-perms' option to 'singularity build' to modify permissions at build time")
+		// It's not an error any further up... the rootfs is still usable
+		return nil
+	}
+	return err
 }

--- a/internal/pkg/build/sources/oci_unpack_linux.go
+++ b/internal/pkg/build/sources/oci_unpack_linux.go
@@ -76,7 +76,7 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 		return fmt.Errorf("error unpacking rootfs: %s", err)
 	}
 
-	// If the `--fixperms` flag was used, then modify the permissions so that
+	// If the `--fix-perms` flag was used, then modify the permissions so that
 	// content has owner rwX and we're done
 	if b.Opts.FixPerms {
 		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container and will be removed in a future release.")
@@ -85,7 +85,7 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 		return fixPerms(b.RootfsPath)
 	}
 
-	// If `--fixperms` was not used and this is a sandbox, scan for restrictive
+	// If `--fix-perms` was not used and this is a sandbox, scan for restrictive
 	// perms that would stop the user doing an `rm` without a chmod first,
 	// and warn if they exist
 	if b.Opts.SandboxTarget {
@@ -93,7 +93,7 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 		return checkPerms(b.RootfsPath)
 	}
 
-	// No `--fixperms` and no sandbox... we are fine
+	// No `--fix-perms` and no sandbox... we are fine
 	return err
 
 }

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -46,6 +46,8 @@ type Options struct {
 	// encryption if applicable.
 	// A nil value indicates encryption should not occur.
 	EncryptionKeyInfo *crypt.KeyInfo
+	// ImgCache stores a pointer to the image cache to use.
+	ImgCache *cache.Handle
 	// NoTest indicates if build should skip running the test script.
 	NoTest bool `json:"noTest"`
 	// Force automatically deletes an existing container at build destination while performing build.
@@ -59,8 +61,13 @@ type Options struct {
 	NoCleanUp bool `json:"noCleanUp"`
 	// NoCache when true, will not use any cache, or make cache.
 	NoCache bool
-	// ImgCache stores a pointer to the image cache to use.
-	ImgCache *cache.Handle
+	// FixPerms controls if we will ensure owner rwX on container content
+	// to preserve <=3.4 behavior.
+	// TODO: Deprecate in 3.6, remove in 3.8
+	FixPerms bool
+	// To warn when the above is needed, we need to know if the target of this
+	// bundle will be a sandbox
+	SandboxTarget bool
 }
 
 // NewEncryptedBundle creates an Encrypted Bundle environment.


### PR DESCRIPTION
For discussion of the changes introduced here, please go to: #4671 

-----
## Description of the Pull Request (PR):

With umoci unpacking, 3.5 will honor the permissions in OCI/docker
layers when extracting them. This can result in a sandbox build
containing files/dirs that cannot be 'rm'd without modifying the
permissions. To make things easier for users, and provide a way to use
the 3.4 behavior in a transition period:

- Add a `--fix-perms` option that will modify the permissions on
oci/docker layer extraction like 3.4 and earlier did.
- Warn the user about future removal of the `--fix-perms` option, and
provide a link to the discussion issue.
- When `--fix-perms` is not used, scan the result of OCI/docker extraction
to warn the user if any files in there will not be easily removable,
directing them to `chmod -R u+rwX` and the `--fixperms` option.

#### How this looks...

*Built an ubuntu sandbox (no permission issues)*

```
dave@piran~/permcheck> singularity  build -s mysandbox docker://ubuntu
INFO:    Starting build...
Getting image source signatures
Copying blob 22e816666fd6 skipped: already exists
Copying blob 079b6d2a1e53 skipped: already exists
Copying blob 11048ebae908 skipped: already exists
Copying blob c58094023a2e skipped: already exists
Copying config 6cd71496ca done
Writing manifest to image destination
Storing signatures
2019/10/25 10:41:31  info unpack layer: sha256:22e816666fd6516bccd19765947232debc14a5baf2418b2202fd67b3807b6b91
2019/10/25 10:41:32  info unpack layer: sha256:079b6d2a1e53c648abc48222c63809de745146c2ee8322a1b9e93703318290d6
2019/10/25 10:41:32  info unpack layer: sha256:11048ebae90883c19c9b20f003d5dd2f5bbf5b48556dabf06c8ea5c871c8debe
2019/10/25 10:41:32  info unpack layer: sha256:c58094023a2e61ef9388e283026c5d6a4b6ff6d10d4f626e866d38f061e79bb9
INFO:    Creating sandbox directory...
INFO:    Build complete: mysandbox

```

*Build a centos:7 sandbox*
```
dave@piran~/permcheck> singularity  build -s mysandbox docker://centos:7
Build target already exists. Do you want to overwrite? [N/y] y
INFO:    Starting build...
Getting image source signatures
Copying blob d8d02d457314 skipped: already exists
Copying config acab94af64 done
Writing manifest to image destination
Storing signatures
2019/10/25 10:31:54  info unpack layer: sha256:d8d02d45731499028db01b6fa35475f91d230628b4e25fab8e3c015594dc3261
2019/10/25 10:31:55  warn rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/10/25 10:31:56  warn rootless{usr/sbin/arping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/10/25 10:31:56  warn rootless{usr/sbin/clockdiff} ignoring (usually) harmless EPERM on setxattr "security.capability"
WARNING: Permission handling has changed in Singularity 3.5 for improved OCI compatibility
WARNING: The sandbox will contain files/dirs that cannot be removed until permissions are modified
WARNING: Use 'chmod -R u+rwX' to set permissions that allow removal
WARNING: Use the '--fix-perms' option to 'singularity build' to modify permissions at build time
INFO:    Creating sandbox directory...
INFO:    Build complete: mysandbox
```

*Build a centos:7 sandbox with `--fix-perms`*
```
dave@piran~/permcheck> singularity  build --fix-perms -s mysandbox docker://centos:7
INFO:    Starting build...
Getting image source signatures
Copying blob d8d02d457314 skipped: already exists
Copying config acab94af64 done
Writing manifest to image destination
Storing signatures
2019/10/25 10:40:39  info unpack layer: sha256:d8d02d45731499028db01b6fa35475f91d230628b4e25fab8e3c015594dc3261
2019/10/25 10:40:39  warn rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/10/25 10:40:40  warn rootless{usr/sbin/arping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/10/25 10:40:41  warn rootless{usr/sbin/clockdiff} ignoring (usually) harmless EPERM on setxattr "security.capability"
WARNING: The --fix-perms option modifies the filesystem permissions on the resulting container and will be removed in a future release.
WARNING: You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671
INFO:    Creating sandbox directory...
INFO:    Build complete: mysandbox
```

### This fixes or addresses the following GitHub issues:

 - Fixes #4628


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

