### PR TITLE
Fix PROMPT_COMMAND evaluation issue

### DIFF
--- a/etc/actions/exec
+++ b/etc/actions/exec
@@ -15,7 +15,7 @@ done
 if test -z "${PROMPT_COMMAND:-}"; then
     export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
 else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PS1=\"${PS1}\"; PROMPT_COMMAND=\"${PROMPT_COMMAND:-}\""
+    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
 fi
 
 exec "$@"

--- a/etc/actions/run
+++ b/etc/actions/run
@@ -15,7 +15,7 @@ done
 if test -z "${PROMPT_COMMAND:-}"; then
     export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
 else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PS1=\"${PS1}\"; PROMPT_COMMAND=\"${PROMPT_COMMAND:-}\""
+    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
 fi
 
 if test -n "${SINGULARITY_APPNAME:-}"; then

--- a/etc/actions/shell
+++ b/etc/actions/shell
@@ -15,7 +15,7 @@ done
 if test -z "${PROMPT_COMMAND:-}"; then
     export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
 else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PS1=\"${PS1}\"; PROMPT_COMMAND=\"${PROMPT_COMMAND:-}\""
+    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
 fi
 
 if test -n "$SINGULARITY_SHELL" -a -x "$SINGULARITY_SHELL"; then


### PR DESCRIPTION
## Description of the Pull Request (PR):

During `PS1` injection in `PROMPT_COMMAND`, `PROMPT_COMMAND` is set to the previous value but as it's evaluated by bash it causes issue depending of `PROMPT_COMMAND` content, the fix defer `PROMPT_COMMAND` restore value and use a longest suffix pattern matching to cleanup `PROMPT_COMMAND` in order to restore it as it was before `PS1` injection.

### This fixes or addresses the following GitHub issues:

 - Fixes #4690 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

