### PR TITLE
Fix missing STKFLT signal for mips

### DIFF
--- a/internal/pkg/util/signal/signal_linux.go
+++ b/internal/pkg/util/signal/signal_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,65 +9,44 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
-var signalMap = map[string]syscall.Signal{
-	"SIGHUP":    syscall.SIGHUP,
-	"SIGINT":    syscall.SIGINT,
-	"SIGQUIT":   syscall.SIGQUIT,
-	"SIGILL":    syscall.SIGILL,
-	"SIGTRAP":   syscall.SIGTRAP,
-	"SIGABRT":   syscall.SIGABRT,
-	"SIGBUS":    syscall.SIGBUS,
-	"SIGFPE":    syscall.SIGFPE,
-	"SIGKILL":   syscall.SIGKILL,
-	"SIGUSR1":   syscall.SIGUSR1,
-	"SIGSEGV":   syscall.SIGSEGV,
-	"SIGUSR2":   syscall.SIGUSR2,
-	"SIGPIPE":   syscall.SIGPIPE,
-	"SIGALRM":   syscall.SIGALRM,
-	"SIGTERM":   syscall.SIGTERM,
-	"SIGSTKFLT": syscall.SIGSTKFLT,
-	"SIGCHLD":   syscall.SIGCHLD,
-	"SIGCONT":   syscall.SIGCONT,
-	"SIGSTOP":   syscall.SIGSTOP,
-	"SIGTSTP":   syscall.SIGTSTP,
-	"SIGTTIN":   syscall.SIGTTIN,
-	"SIGTTOU":   syscall.SIGTTOU,
-	"SIGURG":    syscall.SIGURG,
-	"SIGXCPU":   syscall.SIGXCPU,
-	"SIGXFSZ":   syscall.SIGXFSZ,
-	"SIGVTALRM": syscall.SIGVTALRM,
-	"SIGPROF":   syscall.SIGPROF,
-	"SIGWINCH":  syscall.SIGWINCH,
-	"SIGIO":     syscall.SIGIO,
-	"SIGPWR":    syscall.SIGPWR,
-	"SIGSYS":    syscall.SIGSYS,
+// similarSignals maps similar signals not handled
+// by unix package.
+var similarSignals = map[string]string{
+	"SIGIOT":  "SIGABRT",
+	"SIGCLD":  "SIGCHLD",
+	"SIGPOLL": "SIGIO",
 }
 
-const signalMax = syscall.SIGSYS
-
 // Convert converts a signal string to corresponding signal number
-func Convert(sig string) (syscall.Signal, error) {
-	var sigNum syscall.Signal
+func Convert(sig string) (unix.Signal, error) {
+	sigStr := strings.ToUpper(sig)
 
-	if strings.HasPrefix(sig, "SIG") {
-		if sigNum, ok := signalMap[sig]; ok {
-			return sigNum, nil
-		}
+	if !strings.HasPrefix(sigStr, "SIG") {
+		sigStr = "SIG" + sigStr
+	}
+	if s, ok := similarSignals[sigStr]; ok {
+		sigStr = s
 	}
 
-	if sigNum, ok := signalMap["SIG"+sig]; ok {
+	sigNum := unix.SignalNum(sigStr)
+	if sigNum != 0 {
 		return sigNum, nil
 	}
 
 	sigConv, err := strconv.ParseInt(sig, 10, 32)
-	if err == nil {
-		if sigConv <= int64(signalMax) && sigConv > 0 {
-			return syscall.Signal(sigConv), nil
-		}
+	if err != nil {
+		return sigNum, fmt.Errorf("%s is not a number", sig)
 	}
 
-	return sigNum, fmt.Errorf("can't convert %s to signal number", sig)
+	sigName := unix.SignalName(unix.Signal(sigConv))
+	sigNum = unix.SignalNum(sigName)
+	if sigNum == 0 {
+		return sigNum, fmt.Errorf("can't convert %s to signal number", sig)
+	}
+
+	return sigNum, nil
 }

--- a/internal/pkg/util/signal/signal_linux_test.go
+++ b/internal/pkg/util/signal/signal_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,50 +6,53 @@
 package signal
 
 import (
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 var signalOK = []struct {
 	tests  []string
-	signal syscall.Signal
+	signal unix.Signal
 }{
-	{[]string{"SIGHUP", "HUP", "1"}, syscall.SIGHUP},
-	{[]string{"SIGINT", "INT", "2"}, syscall.SIGINT},
-	{[]string{"SIGQUIT", "QUIT", "3"}, syscall.SIGQUIT},
-	{[]string{"SIGILL", "ILL", "4"}, syscall.SIGILL},
-	{[]string{"SIGTRAP", "TRAP", "5"}, syscall.SIGTRAP},
-	{[]string{"SIGABRT", "ABRT", "6"}, syscall.SIGABRT},
-	{[]string{"SIGBUS", "BUS", "7"}, syscall.SIGBUS},
-	{[]string{"SIGFPE", "FPE", "8"}, syscall.SIGFPE},
-	{[]string{"SIGKILL", "KILL", "9"}, syscall.SIGKILL},
-	{[]string{"SIGUSR1", "USR1", "10"}, syscall.SIGUSR1},
-	{[]string{"SIGSEGV", "SEGV", "11"}, syscall.SIGSEGV},
-	{[]string{"SIGUSR2", "USR2", "12"}, syscall.SIGUSR2},
-	{[]string{"SIGPIPE", "PIPE", "13"}, syscall.SIGPIPE},
-	{[]string{"SIGALRM", "ALRM", "14"}, syscall.SIGALRM},
-	{[]string{"SIGTERM", "TERM", "15"}, syscall.SIGTERM},
-	{[]string{"SIGSTKFLT", "STKFLT", "16"}, syscall.SIGSTKFLT},
-	{[]string{"SIGCHLD", "CHLD", "17"}, syscall.SIGCHLD},
-	{[]string{"SIGCONT", "CONT", "18"}, syscall.SIGCONT},
-	{[]string{"SIGSTOP", "STOP", "19"}, syscall.SIGSTOP},
-	{[]string{"SIGTSTP", "TSTP", "20"}, syscall.SIGTSTP},
-	{[]string{"SIGTTIN", "TTIN", "21"}, syscall.SIGTTIN},
-	{[]string{"SIGTTOU", "TTOU", "22"}, syscall.SIGTTOU},
-	{[]string{"SIGURG", "URG", "23"}, syscall.SIGURG},
-	{[]string{"SIGXCPU", "XCPU", "24"}, syscall.SIGXCPU},
-	{[]string{"SIGXFSZ", "XFSZ", "25"}, syscall.SIGXFSZ},
-	{[]string{"SIGVTALRM", "VTALRM", "26"}, syscall.SIGVTALRM},
-	{[]string{"SIGPROF", "PROF", "27"}, syscall.SIGPROF},
-	{[]string{"SIGWINCH", "WINCH", "28"}, syscall.SIGWINCH},
-	{[]string{"SIGIO", "IO", "29"}, syscall.SIGIO},
-	{[]string{"SIGPWR", "PWR", "30"}, syscall.SIGPWR},
-	{[]string{"SIGSYS", "SYS", "31"}, syscall.SIGSYS},
+	{[]string{"SIGHUP", "HUP", "1"}, unix.SIGHUP},
+	{[]string{"SIGINT", "INT", "2"}, unix.SIGINT},
+	{[]string{"SIGQUIT", "QUIT", "3"}, unix.SIGQUIT},
+	{[]string{"SIGILL", "ILL", "4"}, unix.SIGILL},
+	{[]string{"SIGTRAP", "TRAP", "5"}, unix.SIGTRAP},
+	{[]string{"SIGABRT", "ABRT", "6"}, unix.SIGABRT},
+	{[]string{"SIGIOT", "IOT", "6"}, unix.SIGIOT},
+	{[]string{"SIGBUS", "BUS", "7"}, unix.SIGBUS},
+	{[]string{"SIGFPE", "FPE", "8"}, unix.SIGFPE},
+	{[]string{"SIGKILL", "KILL", "9"}, unix.SIGKILL},
+	{[]string{"SIGUSR1", "USR1", "10"}, unix.SIGUSR1},
+	{[]string{"SIGSEGV", "SEGV", "11"}, unix.SIGSEGV},
+	{[]string{"SIGUSR2", "USR2", "12"}, unix.SIGUSR2},
+	{[]string{"SIGPIPE", "PIPE", "13"}, unix.SIGPIPE},
+	{[]string{"SIGALRM", "ALRM", "14"}, unix.SIGALRM},
+	{[]string{"SIGTERM", "TERM", "15"}, unix.SIGTERM},
+	{[]string{"SIGCHLD", "CHLD", "17"}, unix.SIGCHLD},
+	{[]string{"SIGCLD", "CLD", "17"}, unix.SIGCLD},
+	{[]string{"SIGCONT", "CONT", "18"}, unix.SIGCONT},
+	{[]string{"SIGSTOP", "STOP", "19"}, unix.SIGSTOP},
+	{[]string{"SIGTSTP", "TSTP", "20"}, unix.SIGTSTP},
+	{[]string{"SIGTTIN", "TTIN", "21"}, unix.SIGTTIN},
+	{[]string{"SIGTTOU", "TTOU", "22"}, unix.SIGTTOU},
+	{[]string{"SIGURG", "URG", "23"}, unix.SIGURG},
+	{[]string{"SIGXCPU", "XCPU", "24"}, unix.SIGXCPU},
+	{[]string{"SIGXFSZ", "XFSZ", "25"}, unix.SIGXFSZ},
+	{[]string{"SIGVTALRM", "VTALRM", "26"}, unix.SIGVTALRM},
+	{[]string{"SIGPROF", "PROF", "27"}, unix.SIGPROF},
+	{[]string{"SIGWINCH", "WINCH", "28"}, unix.SIGWINCH},
+	{[]string{"SIGIO", "IO", "29"}, unix.SIGIO},
+	{[]string{"SIGPOLL", "POLL", "29"}, unix.SIGPOLL},
+	{[]string{"SIGPWR", "PWR", "30"}, unix.SIGPWR},
+	{[]string{"SIGSYS", "SYS", "31"}, unix.SIGSYS},
 }
 
 var signalKO = []struct {
 	tests  []string
-	signal syscall.Signal
+	signal unix.Signal
 }{
 	{[]string{"SIGNULL", "NULL", "0"}, 0},
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

On mips `STKFLT` signal is missing ... This PR reorganizes `internal/pkg/util/signal` to have a signal map for most platform with exception for mips without `STKFLT` signal. This is the opportunity to also address technical debt in #4594

### This fixes or addresses the following GitHub issues:

 - Fixes #4689 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

