### PR TITLE
Remove deprecation/removal warning for --fix-perms

### DIFF
--- a/internal/pkg/build/sources/oci_unpack_linux.go
+++ b/internal/pkg/build/sources/oci_unpack_linux.go
@@ -79,8 +79,7 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 	// If the `--fix-perms` flag was used, then modify the permissions so that
 	// content has owner rwX and we're done
 	if b.Opts.FixPerms {
-		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container and will be removed in a future release.")
-		sylog.Warningf("You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671")
+		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container.")
 		sylog.Debugf("Modifying permissions for file/directory owners")
 		return fixPerms(b.RootfsPath)
 	}
@@ -169,6 +168,7 @@ func checkPerms(rootfs string) (err error) {
 		sylog.Warningf("The sandbox will contain files/dirs that cannot be removed until permissions are modified")
 		sylog.Warningf("Use 'chmod -R u+rwX' to set permissions that allow removal")
 		sylog.Warningf("Use the '--fix-perms' option to 'singularity build' to modify permissions at build time")
+		sylog.Warningf("You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671")
 		// It's not an error any further up... the rootfs is still usable
 		return nil
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Per discussion in #4672 the --fix-perms option will remain in future
versions of Singularity.

Move the link to the discussion issue, as remaining discussion is
relevant to the need for `--fix-perms` to generate removable sandboxes,
rather than its deprecation/removal in future.

Example:

```
dave@piran~> singularity build -s centos1 docker://centos:7
INFO:    Starting build...
Getting image source signatures
Copying blob d8d02d457314 done
Copying config acab94af64 done
Writing manifest to image destination
Storing signatures
2019/11/04 09:12:06  info unpack layer: sha256:d8d02d45731499028db01b6fa35475f91d230628b4e25fab8e3c015594dc3261
2019/11/04 09:12:06  warn rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/11/04 09:12:07  warn rootless{usr/sbin/arping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/11/04 09:12:07  warn rootless{usr/sbin/clockdiff} ignoring (usually) harmless EPERM on setxattr "security.capability"
WARNING: Permission handling has changed in Singularity 3.5 for improved OCI compatibility
WARNING: The sandbox will contain files/dirs that cannot be removed until permissions are modified
WARNING: Use 'chmod -R u+rwX' to set permissions that allow removal
WARNING: Use the '--fix-perms' option to 'singularity build' to modify permissions at build time
WARNING: You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671
INFO:    Creating sandbox directory...
INFO:    Build complete: centos1


dave@piran~> singularity build --fix-perms -s centos2 docker://centos:7
INFO:    Starting build...
Getting image source signatures
Copying blob d8d02d457314 skipped: already exists
Copying config acab94af64 done
Writing manifest to image destination
Storing signatures
2019/11/04 09:12:55  info unpack layer: sha256:d8d02d45731499028db01b6fa35475f91d230628b4e25fab8e3c015594dc3261
2019/11/04 09:12:55  warn rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/11/04 09:12:56  warn rootless{usr/sbin/arping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2019/11/04 09:12:56  warn rootless{usr/sbin/clockdiff} ignoring (usually) harmless EPERM on setxattr "security.capability"
WARNING: The --fix-perms option modifies the filesystem permissions on the resulting container.
INFO:    Creating sandbox directory...
INFO:    Build complete: centos2
```

### This fixes or addresses the following GitHub issues:

 - Fixes #4694 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

