### PR TITLE
Integrate e2e command coverage report with CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,8 @@ jobs:
           no_output_timeout: 35m
           command: |-
             make -C ./builddir e2e-test
+      - store_artifacts:
+          path: builddir/e2e-cmd-report.txt
 
 workflows:
   version: 2

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -55,10 +55,13 @@ e2e-test:
 		SINGULARITY_E2E_COVERAGE=$(BUILDDIR_ABSPATH)/e2e-cmd-coverage \
 		scripts/e2e-test -v $(EXTRA_FLAGS)
 	@echo "       PASS"
-	@echo " TEST e2e-coverage"
-	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
-		$(SOURCEDIR)/cmd/docs/cmds/cmdtree.go \
-		-coverage $(BUILDDIR_ABSPATH)/e2e-cmd-coverage -report $(BUILDDIR_ABSPATH)/e2e-cmd-report.txt
+	@echo " TEST sudo e2e-coverage"
+	$(V)cd $(SOURCEDIR) && \
+	    sudo -E \
+		$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
+			$(SOURCEDIR)/cmd/docs/cmds/cmdtree.go \
+			-coverage $(BUILDDIR_ABSPATH)/e2e-cmd-coverage \
+			-report $(BUILDDIR_ABSPATH)/e2e-cmd-report.txt
 
 .PHONY: integration-test
 integration-test:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -50,8 +50,15 @@ unit-test:
 e2e-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(BUILDDIR_ABSPATH)/e2e-test.xml)
 e2e-test:
 	@echo " TEST sudo go test [e2e]"
-	$(V)cd $(SOURCEDIR) && scripts/e2e-test -v $(EXTRA_FLAGS)
+	$(V)rm -f $(BUILDDIR_ABSPATH)/e2e-cmd-coverage
+	$(V)cd $(SOURCEDIR) && \
+		SINGULARITY_E2E_COVERAGE=$(BUILDDIR_ABSPATH)/e2e-cmd-coverage \
+		scripts/e2e-test -v $(EXTRA_FLAGS)
 	@echo "       PASS"
+	@echo " TEST e2e-coverage"
+	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
+		$(SOURCEDIR)/cmd/docs/cmds/cmdtree.go \
+		-coverage $(BUILDDIR_ABSPATH)/e2e-cmd-coverage -report $(BUILDDIR_ABSPATH)/e2e-cmd-report.txt
 
 .PHONY: integration-test
 integration-test:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow the e2e command coverage report to integrate nicely with the CI
by:

 - Don't directly run the e2e-test script from the command coverage tool as
   this isn't flexible for CI / local development
 - Make the command coverage tool accept a coverage input file specified
   on the `--coverage` option instead.
 - Allow the report to be written to a file specified by the `--report`
   option.
 - Minimize stdout prints unless running verbose
 - Create the coverage file and call the script from `make e2e-test`
   target.
 - Store the coverage report as a CircleCI artifact.

### This fixes or addresses the following GitHub issues:

 - Fixes #4697

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

