### PR TITLE
Fix container mount destination containing symlink

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1198,6 +1198,42 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 255,
 		},
 		{
+			name: "SymlinkOneLevelFileBind",
+			args: []string{
+				"--bind", hostCanaryFile + ":/var/etc/symlink1",
+				sandbox,
+				"test", "-f", "/etc/symlink1",
+			},
+			exit: 0,
+		},
+		{
+			name: "SymlinkTwoLevelFileBind",
+			args: []string{
+				"--bind", hostCanaryFile + ":/var/etc/madness/symlink2",
+				sandbox,
+				"test", "-f", "/madness/symlink2",
+			},
+			exit: 0,
+		},
+		{
+			name: "SymlinkOneLevelDirBind",
+			args: []string{
+				"--bind", hostCanaryDir + ":/var/etc",
+				sandbox,
+				"test", "-f", "/etc/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "SymlinkTwoLevelDirBind",
+			args: []string{
+				"--bind", hostCanaryDir + ":/var/etc/madness",
+				sandbox,
+				"test", "-f", "/madness/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "NestedBindFile",
 			args: []string{
 				"--bind", canaryDirBind,

--- a/e2e/testdata/Singularity
+++ b/e2e/testdata/Singularity
@@ -68,5 +68,11 @@ export HELLOTHISIS
     apk update
     apk add nmap-ncat
 
+    # for symlink tests, ensure runtime will bind
+    # in the image and not on /etc on host filesystem
+    ln -s /etc /var/etc
+    mkdir /madness
+    ln -s /madness /var/etc/madness
+
 %test
     exec "$@"

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -134,34 +134,117 @@ func RootDir(path string) string {
 	return p
 }
 
-// EvalRelative evaluates symlinks in path relative to root path. This
-// function doesn't return error but always returns an evaluated path.
-func EvalRelative(path string, root string) string {
-	splitted := strings.Split(filepath.Clean(path), string(os.PathSeparator))
-	dest := string(os.PathSeparator)
+// walkSymRelative follows and resolves all symlinks found in a path
+// located in root, it ensures symlinks resolution never go past the
+// provided root path.
+func walkSymRelative(path string, root string, maxLinks uint) string {
+	// symlinks counter
+	symlinks := uint(0)
 
-	for i := 1; i < len(splitted); i++ {
-		s := splitted[i : i+1][0]
-		dest = filepath.Join(dest, s)
+	// generate clean absolute path
+	absRoot := filepath.Join("/", root)
+	absPath := filepath.Join("/", path)
 
-		if s != "" {
-			rootDestPath := filepath.Join(root, dest)
-			for {
-				target, err := filepath.EvalSymlinks(rootDestPath)
-				if err != nil {
-					break
-				}
-				if !strings.HasPrefix(target, root) {
-					rootDestPath = filepath.Join(root, target)
-					continue
-				}
-				dest = strings.Replace(target, root, "", 1)
-				break
-			}
+	sep := string(os.PathSeparator)
+
+	// get path components by skipping the first
+	// character as it will be always "/" to avoid
+	// to add an empty first element in the array
+	comp := strings.Split(absPath[1:], sep)
+
+	// start from absolute root path
+	dest := absRoot
+
+	for i := 0; i < len(comp); i++ {
+		dest = filepath.Join(dest, comp[i])
+
+		// this call can return various errors that we don't need
+		// or want to deal with like a lack of permission for a
+		// directory traversal, not a symlink, non-existent path.
+		// As this function doesn't return any error we ignore them
+		// and generate the path assuming there is no hidden symlink
+		// in the next components
+		d, err := os.Readlink(dest)
+		if err != nil {
+			continue
 		}
+		symlinks++
+
+		newDest := absRoot
+
+		if !filepath.IsAbs(d) {
+			// this is a relative target, we are taking the current
+			// parent path of dest concatenated with the target
+			parentDest := filepath.Dir(dest)
+			dest = filepath.Join(parentDest, d)
+
+			// if we are outside of root, we join the relative target
+			// with "/" to obtain an absolute path as we were at root
+			// of "/" thanks to filepath.Clean implicitly called by
+			// filepath.Join
+			if !strings.HasPrefix(dest, absRoot) {
+				d = filepath.Join("/", d)
+				dest = filepath.Join(absRoot, d)
+			} else {
+				if strings.HasPrefix(dest, parentDest) {
+					// trivial case where the resulting path is
+					// within the current path
+					d = strings.TrimPrefix(dest, parentDest)
+					newDest = parentDest
+				} else {
+					// we go back in the hierarchy and take a
+					// naive approach by trimming root prefix
+					// from path instead of finding the exact
+					// path chunk involving too much complexity
+					d = strings.TrimPrefix(dest, absRoot)
+				}
+			}
+		} else {
+			// it's an absolute path, simply concatenate root
+			// and symlink target
+			dest = filepath.Join(absRoot, d)
+		}
+
+		// too many symbolic links, stop and return the
+		// resolved path as is, should not happen with
+		// sane images
+		if symlinks == maxLinks {
+			break
+		}
+		// symlink target point to the current destination,
+		// nothing to do
+		if len(d) == 0 {
+			continue
+		}
+
+		dest = newDest
+		// either replace current path components or merge
+		// the components of the symlink target with the next
+		// components
+		if i+1 < len(comp) {
+			comp = append(strings.Split(d[1:], sep), comp[i+1:]...)
+		} else {
+			comp = strings.Split(d[1:], sep)
+		}
+		i = -1
 	}
 
-	return dest
+	// ensure the final path is absolute
+	return filepath.Join("/", strings.TrimPrefix(dest, absRoot))
+}
+
+// EvalRelative evaluates symlinks in path relative to root path, it returns
+// a path as if it was evaluated from chroot. This function always returns
+// an absolute path and is intended to be used to resolve mount points
+// destinations, it helps the runtime to not bind mount directories/files
+// outside of the container image provided by the root argument.
+func EvalRelative(path string, root string) string {
+	// return "/ if path is empty
+	if path == "" {
+		return "/"
+	}
+	// resolve path and allow up to 40 symlinks
+	return walkSymRelative(path, root, 40)
 }
 
 // Touch behaves like touch command.

--- a/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
@@ -123,8 +123,16 @@ func (o *Overlay) createLayer(rootFsPath string, system *mount.System) error {
 			if strings.HasPrefix(point.Destination, sessionDir) {
 				continue
 			}
-			p := rootFsPath + point.Destination
-			if syscall.Stat(p, st) == nil {
+
+			// get rid of symlinks and resolve the path within the
+			// rootfs path to not have false positive while creating
+			// the layer with calls below
+			dest := fs.EvalRelative(point.Destination, rootFsPath)
+
+			// now we are (almost) sure that we will get path information
+			// for a path in the rootfs path and we would create the right
+			// destination in the layer
+			if syscall.Stat(filepath.Join(rootFsPath, dest), st) == nil {
 				continue
 			}
 			if point.Type == "" {
@@ -133,8 +141,6 @@ func (o *Overlay) createLayer(rootFsPath string, system *mount.System) error {
 					continue
 				}
 			}
-
-			dest := fs.EvalRelative(point.Destination, rootFsPath)
 
 			dest = filepath.Join(lowerDir, dest)
 			if _, err := o.session.GetPath(dest); err == nil {

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/internal/pkg/util/fs/layout"
 	"github.com/sylabs/singularity/internal/pkg/util/fs/mount"
 )
@@ -75,14 +75,23 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 			if strings.HasPrefix(point.Destination, sessionDir) {
 				continue
 			}
-			if err := syscall.Stat(rootFsPath+point.Destination, st); err == nil {
+
+			// get rid of symlinks and resolve the path within the
+			// rootfs path to not have false positive while creating
+			// the layer with calls below
+			dst := fs.EvalRelative(point.Destination, rootFsPath)
+
+			// now we are (almost) sure that we will get path information
+			// for a path in the rootfs path and we would create the right
+			// destination in the layer
+			if err := syscall.Stat(filepath.Join(rootFsPath, dst), st); err == nil {
 				continue
 			}
 			if err := syscall.Stat(point.Source, st); err != nil {
 				sylog.Warningf("skipping mount of %s: %s", point.Source, err)
 				continue
 			}
-			dst := underlayDir + point.Destination
+			dst = filepath.Join(underlayDir, dst)
 			if _, err := u.session.GetPath(dst); err == nil {
 				continue
 			}
@@ -96,11 +105,19 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 					return err
 				}
 			}
-			createdPath = append(createdPath, pathLen{path: point.Destination, len: uint16(strings.Count(point.Destination, "/"))})
+			createdPath = append(
+				createdPath,
+				pathLen{
+					path: point.Destination,
+					len:  uint16(strings.Count(point.Destination, "/")),
+				},
+			)
 		}
 	}
 
-	sort.SliceStable(createdPath, func(i, j int) bool { return createdPath[i].len < createdPath[j].len })
+	sort.SliceStable(createdPath, func(i, j int) bool {
+		return createdPath[i].len < createdPath[j].len
+	})
 
 	for _, pl := range createdPath {
 		splitted := strings.Split(filepath.Dir(pl.path), string(os.PathSeparator))
@@ -115,7 +132,8 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 						return err
 					}
 				}
-				if err := u.duplicateDir(p, system, pl.path); err != nil {
+				dir := fs.EvalRelative(p, rootFsPath)
+				if err := u.duplicateDir(dir, system, pl.path); err != nil {
 					return err
 				}
 			}
@@ -143,14 +161,14 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 
 func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath string) error {
 	binds := 0
-	path := filepath.Clean(u.session.RootFsPath() + dir)
+	path := filepath.Join(u.session.RootFsPath(), dir)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		// directory doesn't exists, nothing to duplicate
 		return nil
 	}
 	for _, file := range files {
-		dst := filepath.Join(underlayDir+dir, file.Name())
+		dst := filepath.Join(underlayDir, dir, file.Name())
 		src := filepath.Join(path, file.Name())
 
 		// no error means entry is already created


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix overlay/underlay layers to resolve destination relative to the container root filesystem, `fs.EvalRelative` was reworked by replacing `filepath.EvalSymlinks` with `os.Readlink` in order to minimize false positive and follow links relatively to the root destination.

### This fixes or addresses the following GitHub issues:

 - Fixes #4702 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

