### PR TITLE
Fix rocmliblist for OpenCL apps and blender example

### DIFF
--- a/etc/rocmliblist.conf
+++ b/etc/rocmliblist.conf
@@ -7,14 +7,14 @@
 # put binaries here
 # In shared environments you should ensure that permissions on these files 
 # exclude writing by non-privileged users.  
-#rocm-smi
+rocm-smi
 rocminfo
 
 # put libs here (must end in .so)
 libamd_comgr.so
 libcomgr.so
 libCXLActivityLogger.so
-# libelf.so
+libelf.so
 libhc_am.so
 libhipblas.so
 libhip_hcc.so
@@ -26,12 +26,17 @@ libmcwamp_cpu.so
 libmcwamp_hsa.so
 libmiopengemm.so
 libMIOpen.so
-# libnuma.so
-# libpci.so
+libnuma.so
+libpci.so
 librccl.so
 librocblas.so
 librocfft-device.so
 librocfft.so
 librocrand.so
 librocr_debug_agent64.so
+
+libamdcomgr64.so
+libamdocl64.so
+libcltrace.so
+libOpenCL.so
  


### PR DESCRIPTION
## Description of the Pull Request (PR):

In order for a blender OpenCL example container to work we need to bind
in things from /opt/rocm/opencl/lib via `--rocm`

We also need to uncomment the libpci, libelf, libnuma binds as though
all the ROCm GPU computer containers I've tried work, the blender OpenCL
example trips up with these not available in the container.

Now blender works for OpenCL rendering with `--rocm --bind /etc/OpenCL`
(the bind is needed for the vendor icd) which is not needed for general
ROCm workloads.

### This fixes or addresses the following GitHub issues:

 - Fixes #4705 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

