### PR TITLE
Merge release-3.5 fixes to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
-# Changes Since v3.4.2
+# Changes Since v3.5.0
+
+# v3.5.0 - [2019.10.29]
 
 ## New features / functionalities
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove `/u
 reinstalling it._
 
 ```
-$ export VERSION=1.13.1 OS=linux ARCH=amd64  # change this as you need
+$ export VERSION=1.13.3 OS=linux ARCH=amd64  # change this as you need
 
 $ wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz && \
   sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
@@ -89,7 +89,7 @@ $ mkdir -p ${GOPATH}/src/github.com/sylabs && \
 To build a stable version of Singularity, check out a [release tag](https://github.com/sylabs/singularity/tags) before compiling:
 
 ```
-$ git checkout v3.4.2
+$ git checkout v3.5.0
 ```
 
 ## Compiling Singularity

--- a/etc/actions/exec
+++ b/etc/actions/exec
@@ -15,7 +15,7 @@ done
 if test -z "${PROMPT_COMMAND:-}"; then
     export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
 else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PS1=\"${PS1}\"; PROMPT_COMMAND=\"${PROMPT_COMMAND:-}\""
+    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
 fi
 
 exec "$@"

--- a/etc/actions/run
+++ b/etc/actions/run
@@ -15,7 +15,7 @@ done
 if test -z "${PROMPT_COMMAND:-}"; then
     export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
 else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PS1=\"${PS1}\"; PROMPT_COMMAND=\"${PROMPT_COMMAND:-}\""
+    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
 fi
 
 if test -n "${SINGULARITY_APPNAME:-}"; then

--- a/etc/actions/shell
+++ b/etc/actions/shell
@@ -15,7 +15,7 @@ done
 if test -z "${PROMPT_COMMAND:-}"; then
     export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
 else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PS1=\"${PS1}\"; PROMPT_COMMAND=\"${PROMPT_COMMAND:-}\""
+    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
 fi
 
 if test -n "$SINGULARITY_SHELL" -a -x "$SINGULARITY_SHELL"; then

--- a/etc/rocmliblist.conf
+++ b/etc/rocmliblist.conf
@@ -7,14 +7,14 @@
 # put binaries here
 # In shared environments you should ensure that permissions on these files 
 # exclude writing by non-privileged users.  
-#rocm-smi
+rocm-smi
 rocminfo
 
 # put libs here (must end in .so)
 libamd_comgr.so
 libcomgr.so
 libCXLActivityLogger.so
-# libelf.so
+libelf.so
 libhc_am.so
 libhipblas.so
 libhip_hcc.so
@@ -26,12 +26,17 @@ libmcwamp_cpu.so
 libmcwamp_hsa.so
 libmiopengemm.so
 libMIOpen.so
-# libnuma.so
-# libpci.so
+libnuma.so
+libpci.so
 librccl.so
 librocblas.so
 librocfft-device.so
 librocfft.so
 librocrand.so
 librocr_debug_agent64.so
+
+libamdcomgr64.so
+libamdocl64.so
+libcltrace.so
+libOpenCL.so
  

--- a/internal/pkg/build/sources/oci_unpack_linux.go
+++ b/internal/pkg/build/sources/oci_unpack_linux.go
@@ -79,8 +79,7 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 	// If the `--fix-perms` flag was used, then modify the permissions so that
 	// content has owner rwX and we're done
 	if b.Opts.FixPerms {
-		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container and will be removed in a future release.")
-		sylog.Warningf("You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671")
+		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container.")
 		sylog.Debugf("Modifying permissions for file/directory owners")
 		return fixPerms(b.RootfsPath)
 	}
@@ -169,6 +168,7 @@ func checkPerms(rootfs string) (err error) {
 		sylog.Warningf("The sandbox will contain files/dirs that cannot be removed until permissions are modified")
 		sylog.Warningf("Use 'chmod -R u+rwX' to set permissions that allow removal")
 		sylog.Warningf("Use the '--fix-perms' option to 'singularity build' to modify permissions at build time")
+		sylog.Warningf("You can provide feedback about this change at https://github.com/sylabs/singularity/issues/4671")
 		// It's not an error any further up... the rootfs is still usable
 		return nil
 	}


### PR DESCRIPTION
I'd like to merge the release-3.5 fixes into master at this point, if possible, so that the ROCm OpenCL functionality is operational - but especially so the deprecation message on `--fix-perms` is removed and doesn't cause any confusion to people using `master`

