### PR TITLE
Mention bind mount hard fail in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ _The old changelog can be found in the `release-2.6` branch_
 
   - Go 1.13 adopted.
   - Vendored modules removed from the Git tree, will be included in release tarballs.
+  - Singularity will now fail with an error if a requested bind mount cannot be
+      made.
+    - This is beneficial to fail fast in workflows where a task may fail a long
+         way downstream if a bind mount is unavailable.
+    - Any unavailable bind mount sources must be removed from
+        `singularity.conf`.
   - Docker/OCI image extraction now faithfully respects layer
     permissions.
     - This may lead to sandboxes that cannot be removed without


### PR DESCRIPTION
## Description of the Pull Request (PR):

Mention bind mount hard fail in CHANGELOG.md

Singularity now consistently fails early if a requested bind mount
cannot be made (e.g. source on host does not exist).

### This fixes or addresses the following GitHub issues:

 - Fixes: #4712 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

