### PR TITLE
Override SIGABRT Go handler

### DIFF
--- a/internal/pkg/util/signal/signal_linux.go
+++ b/internal/pkg/util/signal/signal_linux.go
@@ -5,6 +5,16 @@
 
 package signal
 
+/*
+#include <signal.h>
+
+void raiseSignal(int sig) {
+	signal(sig, SIG_DFL);
+	raise(sig);
+}
+*/
+import "C"
+
 import (
 	"fmt"
 	"strconv"
@@ -49,4 +59,16 @@ func Convert(sig string) (unix.Signal, error) {
 	}
 
 	return sigNum, nil
+}
+
+// Raise sends a signal to the current process and ensure the
+// current signal handler is set to its default handler for the
+// corresponding signal. It allows to send signals like SIGABRT
+// without triggering Go core dump handler.
+func Raise(sig unix.Signal) {
+	// signal handlers like the one for SIGABRT can't be reset
+	// easily from Go without using rt_sigaction syscall implying
+	// to defines sigaction structure for various architecture so
+	// let's proceed with C
+	C.raiseSignal(C.int(int(sig)))
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a `Raise` signal method calling a C wrapper responsible of sending signal to the caller after resetting the signal handler for the corresponding signal. It allow us to bypass default signal handler set by Go (eg: SIGABRT).

Also fix issue when exit code returned by container process is > 128, master process wrongly kill itself with signals instead of exiting with the returned exit code. Now master process kill itself only if container process has been interrupted by a signal.

### This fixes or addresses the following GitHub issues:

 - Fixes #4706 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

