### PR TITLE
Fix "build_and_test" workflow failure on push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ x-run:
     name: Check changes
     command: |-
       rc=0
-      scripts/should-e2e-run "${CIRCLE_PROJECT_USERNAME}" "${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_PULL_REQUEST}" || rc=$?
+      scripts/should-e2e-run "${CIRCLE_PROJECT_USERNAME}" "${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BRANCH}" "${CIRCLE_PULL_REQUEST}" || rc=$?
       case $rc in
         0)
           echo "Verifying critical changes"

--- a/scripts/should-e2e-run
+++ b/scripts/should-e2e-run
@@ -8,7 +8,12 @@ usage() {
 
 	Usage:
 
-	    $0 {github_username} {github_reponame} {github_pr_url}
+	    $0 {github_username} {github_reponame} {github_branch} [github_pr_url]
+
+	If a {github_pr_url} is provided, it's used to obtain additional
+	information like the target branch and the labels. Otherwise it
+	is assumed that the code is already merged and that only the
+	most recent commit should be examined.
 	EOT
 }
 
@@ -17,7 +22,8 @@ require_e2e=false
 
 GITHUB_USERNAME=$1
 GITHUB_REPONAME=$2
-GITHUB_PR_URL=$3
+GITHUB_BRANCH=$3
+GITHUB_PR_URL=$4
 
 if test -z "${GITHUB_USERNAME}" ; then
 	usage "$0"
@@ -25,32 +31,42 @@ if test -z "${GITHUB_USERNAME}" ; then
 elif test -z "${GITHUB_REPONAME}" ; then
 	usage "$0"
 	exit 2
-elif test -z "${GITHUB_PR_URL}" ; then
+elif test -z "${GITHUB_BRANCH}" ; then
 	usage "$0"
 	exit 2
 fi
 
-PR_NUMBER=$(echo "${GITHUB_PR_URL}" | sed -e 's,.*/,,')
+if test -z "${GITHUB_PR_URL}" ; then
+	echo "Running directly against branch ${GITHUB_BRANCH}"
+	TARGET_BRANCH="${GITHUB_BRANCH}"
+	BASE_COMMIT="HEAD~"
+	# Assume E2E is required for all runs against a branch; below we
+	# constrain this to specific branches.
+	require_e2e=true
+else
+	PR_NUMBER=$(echo "${GITHUB_PR_URL}" | sed -e 's,.*/,,')
 
-pull_info_file=$(mktemp)
-trap "rm -f ${pull_info_file}" EXIT
+	pull_info_file=$(mktemp)
+	trap "rm -f ${pull_info_file}" EXIT
 
-curl -s "https://api.github.com/repos/${GITHUB_USERNAME}/${GITHUB_REPONAME}/pulls/${PR_NUMBER}" > "${pull_info_file}"
+	curl -s "https://api.github.com/repos/${GITHUB_USERNAME}/${GITHUB_REPONAME}/pulls/${PR_NUMBER}" > "${pull_info_file}"
 
-# Keep the matching lines instead of simply looking at the exit
-# code for debugging purposes
-E2E_LABELS=$(jq -r '.labels[].name' < "${pull_info_file}" | grep --line-regexp --fixed-strings ci:e2e || true)
+	# Keep the matching lines instead of simply looking at the exit
+	# code for debugging purposes
+	E2E_LABELS=$(jq -r '.labels[].name' < "${pull_info_file}" | grep --line-regexp --fixed-strings ci:e2e || true)
 
-if test -n "${E2E_LABELS}" ; then
-	echo "Honoring request to run E2E tests from pull request labels"
-	exit 0
+	if test -n "${E2E_LABELS}" ; then
+		echo "Honoring request to run E2E tests from pull request labels"
+		exit 0
+	fi
+
+	TARGET_BRANCH=$(jq -r .base.ref < "${pull_info_file}")
+	BASE_COMMIT="origin/${TARGET_BRANCH}"
 fi
-
-TARGET_BRANCH=$(jq -r .base.ref < "${pull_info_file}")
 
 case "${TARGET_BRANCH}" in
 	master)
-		if git --no-pager diff --name-only HEAD "origin/${TARGET_BRANCH}" |
+		if git --no-pager diff --name-only HEAD "${BASE_COMMIT}" |
 			grep -q -E -f .ci/e2e_triggers
 		then
 			# There are changes in critical components, require e2e


### PR DESCRIPTION
In CircleCI we (unintentionally) configured the build_and_test workflow
to run both on pull requests and pushes, and in the later case the
workflow is failing because no pull request URL is available.

Fix this by handling the case explicitly and assume that pushes MUST run
E2E tests. In that way, even commits that didn't require E2E to run will
get the benefit of testing (after being merged).

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>