### PR TITLE
Remove old deprecated flags for sign/verify

### DIFF
--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -51,16 +51,6 @@ var signSifDescSifIDFlag = cmdline.Flag{
 	Usage:        "descriptor ID to be signed (default system-partition)",
 }
 
-// --id (deprecated)
-var signSifDescIDFlag = cmdline.Flag{
-	ID:           "signSifDescIDFlag",
-	Value:        &sifDescID,
-	DefaultValue: uint32(0),
-	Name:         "id",
-	Usage:        "descriptor ID to be signed",
-	Deprecated:   "use '--sif-id'",
-}
-
 // -k|--keyidx
 var signKeyIdxFlag = cmdline.Flag{
 	ID:           "signKeyIdxFlag",
@@ -87,7 +77,6 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&signServerURIFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signSifGroupIDFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signSifDescSifIDFlag, SignCmd)
-	cmdManager.RegisterFlagForCmd(&signSifDescIDFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signKeyIdxFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signAllFlag, SignCmd)
 }
@@ -117,9 +106,6 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 
 	// Descriptor id should start at 1.
 	if cmd.Flag(verifySifDescSifIDFlag.Name).Changed && sifDescID == 0 {
-		sylog.Fatalf("invalid descriptor id")
-	}
-	if cmd.Flag(verifySifDescIDFlag.Name).Changed && sifDescID == 0 {
 		sylog.Fatalf("invalid descriptor id")
 	}
 

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -57,16 +57,6 @@ var verifySifDescSifIDFlag = cmdline.Flag{
 	Usage:        "descriptor ID to be verified (default system-partition)",
 }
 
-// --id (deprecated)
-var verifySifDescIDFlag = cmdline.Flag{
-	ID:           "verifySifDescIDFlag",
-	Value:        &sifDescID,
-	DefaultValue: uint32(0),
-	Name:         "id",
-	Usage:        "descriptor ID to be verified",
-	Deprecated:   "use '--sif-id'",
-}
-
 // -l|--local
 var verifyLocalFlag = cmdline.Flag{
 	ID:           "verifyLocalFlag",
@@ -104,7 +94,6 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&verifyServerURIFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifySifGroupIDFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifySifDescSifIDFlag, VerifyCmd)
-	cmdManager.RegisterFlagForCmd(&verifySifDescIDFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifyLocalFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifyJSONFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifyAllFlag, VerifyCmd)
@@ -148,9 +137,6 @@ func doVerifyCmd(ctx context.Context, cmd *cobra.Command, cpath, url string) {
 
 	// Descriptor id should start at 1.
 	if cmd.Flag(verifySifDescSifIDFlag.Name).Changed && sifDescID == 0 {
-		sylog.Fatalf("invalid descriptor id")
-	}
-	if cmd.Flag(verifySifDescIDFlag.Name).Changed && sifDescID == 0 {
 		sylog.Fatalf("invalid descriptor id")
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR removes the old deprecated flags for sign/verify.

Since 3.5 has these flags deprecated, it should be fine to remove them in 3.6. (or whatever the next release is)

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

