### PR TITLE
Change '--groupid' to '--group-id' to match '--sif-id'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.5.0
 
+ - Deprecated `--groupid` flag for `sign` and `verify`; replaced with `--group-id`.
+
 # v3.5.0 - [2019.10.29]
 
 ## New features / functionalities

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -31,14 +31,24 @@ var signServerURIFlag = cmdline.Flag{
 	EnvKeys:      []string{"URL"},
 }
 
-// -g|--groupid
+// -g|--group-id
 var signSifGroupIDFlag = cmdline.Flag{
 	ID:           "signSifGroupIDFlag",
 	Value:        &sifGroupID,
 	DefaultValue: uint32(0),
-	Name:         "groupid",
+	Name:         "group-id",
 	ShortHand:    "g",
 	Usage:        "group ID to be signed",
+}
+
+// --groupid (deprecated)
+var signOldSifGroupIDFlag = cmdline.Flag{
+	ID:           "signOldSifGroupIDFlag",
+	Value:        &sifGroupID,
+	DefaultValue: uint32(0),
+	Name:         "groupid",
+	Usage:        "group ID to be signed",
+	Deprecated:   "use '--group-id'",
 }
 
 // -i| --sif-id
@@ -86,6 +96,7 @@ func init() {
 
 	cmdManager.RegisterFlagForCmd(&signServerURIFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signSifGroupIDFlag, SignCmd)
+	cmdManager.RegisterFlagForCmd(&signOldSifGroupIDFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signSifDescSifIDFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signSifDescIDFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signKeyIdxFlag, SignCmd)
@@ -137,7 +148,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	}
 
 	if (id != 0 || isGroup) && signAll {
-		sylog.Fatalf("'--all' not compatible with '--sif-id' or '--groupid'")
+		sylog.Fatalf("'--all' not compatible with '--sif-id' or '--group-id'")
 	}
 
 	if err := signing.Sign(cpath, id, isGroup, signAll, privKey); err != nil {

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -37,14 +37,24 @@ var verifyServerURIFlag = cmdline.Flag{
 	EnvKeys:      []string{"URL"},
 }
 
-// -g|--groupid
+// -g|--group-id
 var verifySifGroupIDFlag = cmdline.Flag{
 	ID:           "verifySifGroupIDFlag",
 	Value:        &sifGroupID,
 	DefaultValue: uint32(0),
-	Name:         "groupid",
+	Name:         "group-id",
 	ShortHand:    "g",
 	Usage:        "group ID to be verified",
+}
+
+// --groupid (deprecated)
+var verifyOldSifGroupIDFlag = cmdline.Flag{
+	ID:           "verifyOldSifGroupIDFlag",
+	Value:        &sifGroupID,
+	DefaultValue: uint32(0),
+	Name:         "groupid",
+	Usage:        "group ID to be verified",
+	Deprecated:   "use '--group-id'",
 }
 
 // -i|--sif-id
@@ -103,6 +113,7 @@ func init() {
 
 	cmdManager.RegisterFlagForCmd(&verifyServerURIFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifySifGroupIDFlag, VerifyCmd)
+	cmdManager.RegisterFlagForCmd(&verifyOldSifGroupIDFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifySifDescSifIDFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifySifDescIDFlag, VerifyCmd)
 	cmdManager.RegisterFlagForCmd(&verifyLocalFlag, VerifyCmd)
@@ -168,7 +179,7 @@ func doVerifyCmd(ctx context.Context, cmd *cobra.Command, cpath, url string) {
 	}
 
 	if (id != 0 || isGroup) && verifyAll {
-		sylog.Fatalf("'--all' not compatible with '--sif-id' or '--groupid'")
+		sylog.Fatalf("'--all' not compatible with '--sif-id' or '--group-id'")
 	}
 
 	author, _, err := signing.Verify(ctx, cpath, url, id, isGroup, verifyAll, authToken, localVerify, jsonVerify)

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -147,13 +147,13 @@ func (c ctx) singularitySignGroupIDOption(t *testing.T) {
 	}{
 		{
 			name:       "groupID 0",
-			args:       []string{"--groupid", "1", imgPath},
+			args:       []string{"--group-id", "1", imgPath},
 			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Signature created and applied to "+imgPath),
 			expectExit: 0,
 		},
 		{
 			name:       "groupID 5",
-			args:       []string{"--groupid", "5", imgPath},
+			args:       []string{"--group-id", "5", imgPath},
 			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "no descriptors found for groupid 5"),
 			expectExit: 255,
 		},

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -295,7 +295,7 @@ func (c ctx) singularityVerifySigner(t *testing.T) {
 }
 
 func (c ctx) checkGroupidOption(t *testing.T) {
-	cmdArgs := []string{"--groupid", "1", c.successImage}
+	cmdArgs := []string{"--group-id", "1", c.successImage}
 	c.env.RunSingularity(
 		t,
 		e2e.WithProfile(e2e.UserProfile),


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds a new flag (`--group-id`), and mark the old `--groupid` as
deprecated.

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

