### PR TITLE
Correct sign --id deprecation warning in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.5.0
 
-# v3.5.0 - [2019.10.29]
+# v3.5.0 - [2019.11.13]
 
 ## New features / functionalities
 
@@ -47,7 +47,10 @@ _The old changelog can be found in the `release-2.6` branch_
   - `--fakeroot` supports uid/subgid ranges >65536
   - `singularity version` now reports semver compliant version
       information.
-    
+
+## Deprecated / removed commands
+
+  - Deprecated `--id` flag for `sign` and `verify`; replaced with `--sif-id`.
 
 # v3.4.2 - [2019.10.08]
 
@@ -57,8 +60,6 @@ _The old changelog can be found in the `release-2.6` branch_
     - Correctly handle the starter-suid binary for non-root installs
     - Creates CACHEDIR if it doesn't exist
     - Set apex loglevel for umoci to match singularity loglevel
-
-  - Deprecated `--id` flag for `sign` and `verify`; replaced with `--sif-id`.
 
 # v3.4.1 - [2019.09.17]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):



The deprecation information for the sign --id flag had gotten into the
wrong place in the CHANGELOG.md - it's in 3.5.0, not 3.4.2.

Also bump the 3.5.0 release date while we are at it.

### This fixes or addresses the following GitHub issues:

 - Fixes: #4731

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

