### PR TITLE
Fix F_SETLK64 bad value on ppc64 arch with fcntl syscall

### DIFF
--- a/pkg/util/fs/lock/const.go
+++ b/pkg/util/fs/lock/const.go
@@ -3,8 +3,6 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// +build !linux
-
 package lock
 
 import "golang.org/x/sys/unix"

--- a/pkg/util/fs/lock/const_linux_32bit.go
+++ b/pkg/util/fs/lock/const_linux_32bit.go
@@ -3,6 +3,8 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build linux,386 linux,arm linux,mips linux,mipsle
+
 package lock
 
 import "golang.org/x/sys/unix"


### PR DESCRIPTION
## Description of the Pull Request (PR):

ppc64(le) are the only systems where `F_SETLK` and `F_SETLK64` values are different leading to an invalid argument error during `fcntl` call as we use `F_SETLK64` as default for linux, this PR fixes that by using `F_SETLK64` only for 32 bit systems.

### This fixes or addresses the following GitHub issues:

 - Fixes #4741 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

