### PR TITLE
Show explicit error for wrong unprivileged installation

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -1131,7 +1131,11 @@ __attribute__((constructor)) static void init(void) {
          * user namespace not enabled, continue with privileged workflow
          * this will fail if starter is run without suid
          */
-        priv_escalate(true);
+        if ( sconfig->starter.isSuid ) {
+            priv_escalate(true);
+        } else if ( uid != 0 ) {
+            fatalf("No setuid installation found, for unprivileged installation use: ./mconfig --without-suid");
+        }
         break;
     case ENTER_NAMESPACE:
         if ( sconfig->starter.isSuid && !sconfig->starter.hybridWorkflow ) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Typically installation done without root privileges like this :

```
./mconfig --prefix=/tmp/install
make -C builddir
make -C builddir install
/tmp/install/bin/singularity exec docker://alpine true
```

will trigger an explicit message inviting them to install it by specifying `--without-suid` during `mconfig` instead of failing with the message `Failed to set effective UID to 0`.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

