### PR TITLE
Removed useless '--url' flag for sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _The old changelog can be found in the `release-2.6` branch_
 # Changes Since v3.5.0
 
  - Deprecated `--groupid` flag for `sign` and `verify`; replaced with `--group-id`.
+ - Removed useless flag `--url` for `sign`.
 
 # v3.5.0 - [2019.11.13]
 

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -20,17 +20,6 @@ var (
 	signAll bool
 )
 
-// -u|--url
-var signServerURIFlag = cmdline.Flag{
-	ID:           "signServerURIFlag",
-	Value:        &keyServerURI,
-	DefaultValue: defaultKeyServer,
-	Name:         "url",
-	ShortHand:    "u",
-	Usage:        "key server URL",
-	EnvKeys:      []string{"URL"},
-}
-
 // -g|--group-id
 var signSifGroupIDFlag = cmdline.Flag{
 	ID:           "signSifGroupIDFlag",
@@ -94,7 +83,6 @@ var signAllFlag = cmdline.Flag{
 func init() {
 	cmdManager.RegisterCmd(SignCmd)
 
-	cmdManager.RegisterFlagForCmd(&signServerURIFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signSifGroupIDFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signOldSifGroupIDFlag, SignCmd)
 	cmdManager.RegisterFlagForCmd(&signSifDescSifIDFlag, SignCmd)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `--url` flag does nothing for `sign`, so it should be removed.

### This fixes or addresses the following GitHub issues:

 - Fixes #3225


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

