### PR TITLE
Set default umask during stages build

### DIFF
--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -257,6 +257,8 @@ func (b *Build) Full(ctx context.Context) error {
 	// clean up build normally
 	defer b.cleanUp()
 
+	oldumask := syscall.Umask(0002)
+
 	// build each stage one after the other
 	for i, stage := range b.stages {
 		if err := stage.runPreScript(); err != nil {
@@ -318,6 +320,8 @@ func (b *Build) Full(ctx context.Context) error {
 			return fmt.Errorf("while inserting metadata to bundle: %v", err)
 		}
 	}
+
+	syscall.Umask(oldumask)
 
 	sylog.Debugf("Calling assembler")
 	if err := b.stages[len(b.stages)-1].Assemble(b.Conf.Dest); err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix regression introduced by #4542  where the umask is reset to its old value a bit too early. We restore it just before `Assemble` step to also fix the original addressed by #4542 

### This fixes or addresses the following GitHub issues:

 - Fixes #4749 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

