### PR TITLE
Fix x86/arm/mips 32 bits system compilation error

### DIFF
--- a/pkg/util/fs/lock/const.go
+++ b/pkg/util/fs/lock/const.go
@@ -3,6 +3,8 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+// +build linux,!386 linux,!arm linux,!mips linux,!mipsle darwin
+
 package lock
 
 import "golang.org/x/sys/unix"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix regression introduced by #4742 causing compilation issue with x86/arm/mips 32 bits system.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

