### PR TITLE
Add e2e tests for various configuration directives

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,0 +1,400 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/internal/pkg/util/user"
+)
+
+type configTests struct {
+	env e2e.TestEnv
+}
+
+func (c configTests) configGlobal(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	setDirective := func(t *testing.T, directive, value string) {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("config global"),
+			e2e.WithArgs("--set", directive, value),
+			e2e.ExpectExit(0),
+		)
+	}
+	resetDirective := func(t *testing.T, directive string) {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("config global"),
+			e2e.WithArgs("--reset", directive),
+			e2e.ExpectExit(0),
+		)
+	}
+
+	u := e2e.UserProfile.HostUser(t)
+	g, err := user.GetGrGID(u.GID)
+	if err != nil {
+		t.Fatalf("could not retrieve user group information: %s", err)
+	}
+
+	tests := []struct {
+		name           string
+		argv           []string
+		profile        e2e.Profile
+		cwd            string
+		directive      string
+		directiveValue string
+		exit           int
+		resultOp       e2e.SingularityCmdResultOp
+	}{
+		{
+			name:           "AllowSetuid",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow setuid",
+			directiveValue: "no",
+			exit:           0,
+		},
+		{
+			name:           "MaxLoopDevices",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "max loop devices",
+			directiveValue: "0",
+			exit:           255,
+		},
+		{
+			name:           "AllowPidNsNo",
+			argv:           []string{"--pid", "--no-init", c.env.ImagePath, "/bin/sh", "-c", "echo $$"},
+			profile:        e2e.UserProfile,
+			directive:      "allow pid ns",
+			directiveValue: "no",
+			exit:           0,
+			resultOp:       e2e.ExpectOutput(e2e.UnwantedMatch, "1"),
+		},
+		{
+			name:           "AllowPidNsYes",
+			argv:           []string{"--pid", "--no-init", c.env.ImagePath, "/bin/sh", "-c", "echo $$"},
+			profile:        e2e.UserProfile,
+			directive:      "allow pid ns",
+			directiveValue: "yes",
+			exit:           0,
+			resultOp:       e2e.ExpectOutput(e2e.ExactMatch, "1"),
+		},
+		{
+			name:           "ConfigPasswdNo",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config passwd",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "ConfigPasswdYes",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config passwd",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "ConfigGroupNo",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config group",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "ConfigGroupYes",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config group",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "ConfigResolvConfNo",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config resolv_conf",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "ConfigResolvConfYes",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config resolv_conf",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountProcNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/proc/self"},
+			profile:        e2e.UserProfile,
+			directive:      "mount proc",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountProcYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/proc/self"},
+			profile:        e2e.UserProfile,
+			directive:      "mount proc",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountSysNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/sys/kernel"},
+			profile:        e2e.UserProfile,
+			directive:      "mount sys",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountSysYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/sys/kernel"},
+			profile:        e2e.UserProfile,
+			directive:      "mount sys",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountDevNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/dev/pts"},
+			profile:        e2e.UserProfile,
+			directive:      "mount dev",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountDevMinimal",
+			argv:           []string{c.env.ImagePath, "test", "-b", "/dev/loop0"},
+			profile:        e2e.UserProfile,
+			directive:      "mount dev",
+			directiveValue: "minimal",
+			exit:           1,
+		},
+		{
+			name:           "MountDevYes",
+			argv:           []string{c.env.ImagePath, "test", "-b", "/dev/loop0"},
+			profile:        e2e.UserProfile,
+			directive:      "mount dev",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		// just test 'mount devpts = no' as yes depends of kernel version
+		{
+			name:           "MountDevPtsNo",
+			argv:           []string{"-C", c.env.ImagePath, "test", "-d", "/dev/pts"},
+			profile:        e2e.UserProfile,
+			directive:      "mount devpts",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountHomeNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", u.Dir},
+			profile:        e2e.UserProfile,
+			cwd:            "/",
+			directive:      "mount home",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountHomeYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", u.Dir},
+			profile:        e2e.UserProfile,
+			cwd:            "/",
+			directive:      "mount home",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountTmpNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", c.env.TestDir},
+			profile:        e2e.UserProfile,
+			directive:      "mount tmp",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountTmpYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", c.env.TestDir},
+			profile:        e2e.UserProfile,
+			directive:      "mount tmp",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "BindPathPasswd",
+			argv:           []string{c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserProfile,
+			directive:      "bind path",
+			directiveValue: "/etc/passwd:/passwd",
+			exit:           0,
+		},
+		{
+			name:           "UserBindControlNo",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserProfile,
+			directive:      "user bind control",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "UserBindControlYes",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserProfile,
+			directive:      "user bind control",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		// overlay may or not be available, just test with no
+		{
+			name:           "EnableOverlayNo",
+			argv:           []string{c.env.ImagePath, "grep", "\\- overlay overlay", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "enable overlay",
+			directiveValue: "no",
+			exit:           1,
+		},
+		// use user namespace profile to force underlay use
+		{
+			name:           "EnableUnderlayNo",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "enable underlay",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "EnableUnderlayYes",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "enable underlay",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		// test image is owned by root:root
+		{
+			name:           "LimitContainerOwnersUser",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container owners",
+			directiveValue: u.Name,
+			exit:           255,
+		},
+		{
+			name:           "LimitContainerOwnersUserAndRoot",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container owners",
+			directiveValue: u.Name + ", root",
+			exit:           0,
+		},
+		{
+			name:           "LimitContainerGroupsUser",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container groups",
+			directiveValue: g.Name,
+			exit:           255,
+		},
+		{
+			name:           "LimitContainerGroupsUserAndRoot",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container groups",
+			directiveValue: g.Name + ", root",
+			exit:           0,
+		},
+		{
+			name:           "LimitContainerPathsProc",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container paths",
+			directiveValue: "/proc",
+			exit:           255,
+		},
+		{
+			name:           "LimitContainerPathsTestdir",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container paths",
+			directiveValue: c.env.TestDir,
+			exit:           0,
+		},
+		{
+			name:           "AllowContainerSquashfsNo",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container squashfs",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowContainerSquashfsYes",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container squashfs",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "AllowContainerDirNo",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "allow container dir",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowContainerDirYes",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "allow container dir",
+			directiveValue: "yes",
+			exit:           0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithDir(tt.cwd),
+			e2e.PreRun(func(t *testing.T) {
+				setDirective(t, tt.directive, tt.directiveValue)
+			}),
+			e2e.PostRun(func(t *testing.T) {
+				resetDirective(t, tt.directive)
+			}),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(tt.argv...),
+			e2e.ExpectExit(tt.exit, tt.resultOp),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) func(*testing.T) {
+	c := configTests{
+		env: env,
+	}
+
+	return testhelper.TestRunner(map[string]func(*testing.T){
+		"config global": c.configGlobal, // test various global configuration
+	})
+}

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/pkg/runtime/engine/config"
+	"golang.org/x/sys/unix"
+)
+
+func SetupDefaultConfig(t *testing.T, path string) {
+	c, err := config.ParseFile("")
+	if err != nil {
+		t.Fatalf("while generating singularity configuration: %s", err)
+	}
+
+	Privileged(func(t *testing.T) {
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatalf("while creating singularity configuration: %s", err)
+		}
+
+		if err := config.Generate(f, "", c); err != nil {
+			t.Fatalf("while generating singularity configuration: %s", err)
+		}
+
+		f.Close()
+
+		if err := unix.Mount(path, buildcfg.SINGULARITY_CONF_FILE, "", unix.MS_BIND, ""); err != nil {
+			t.Fatalf("while mounting %s to %s: %s", path, buildcfg.SINGULARITY_CONF_FILE, err)
+		}
+	})(t)
+}

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -45,6 +45,8 @@ const (
 	ContainMatch MatchType = iota
 	// ExactMatch is for exact match
 	ExactMatch
+	// UnwantedMatch is for unwanted match
+	UnwantedMatch
 	// RegexMatch is for regular expression match
 	RegexMatch
 )
@@ -55,6 +57,8 @@ func (m MatchType) String() string {
 		return "ContainMatch"
 	case ExactMatch:
 		return "ExactMatch"
+	case UnwantedMatch:
+		return "UnwantedMatch"
 	case RegexMatch:
 		return "RegexMatch"
 	default:
@@ -98,6 +102,13 @@ func (r *SingularityCmdResult) expectMatch(mt MatchType, stream streamType, patt
 		if strings.TrimSuffix(output, "\n") != pattern {
 			return errors.Errorf(
 				"Command %q:\nExpect %s stream exact match:\n%s\nCommand %s output:\n%s",
+				r.FullCmd, streamName, pattern, streamName, output,
+			)
+		}
+	case UnwantedMatch:
+		if strings.TrimSuffix(output, "\n") == pattern {
+			return errors.Errorf(
+				"Command %q:\nExpect %s stream not matching:\n%s\nCommand %s output:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -22,6 +22,7 @@ import (
 	e2ebuildcfg "github.com/sylabs/singularity/e2e/buildcfg"
 	"github.com/sylabs/singularity/e2e/cache"
 	"github.com/sylabs/singularity/e2e/cmdenvvars"
+	"github.com/sylabs/singularity/e2e/config"
 	"github.com/sylabs/singularity/e2e/delete"
 	"github.com/sylabs/singularity/e2e/docker"
 	singularityenv "github.com/sylabs/singularity/e2e/env"
@@ -73,30 +74,6 @@ func Run(t *testing.T) {
 		return filepath.Join(buildcfg.SYSCONFDIR, "singularity", fn)
 	}
 
-	// e2e tests need to run in a somehow agnostic environment, so we
-	// don't use environment of user executing tests in order to not
-	// wrongly interfering with cache stuff, sylabs library tokens,
-	// PGP keys
-	e2e.SetupHomeDirectories(t)
-
-	// Ensure config files are installed
-	configFiles := []string{
-		sysconfdir("singularity.conf"),
-		sysconfdir("ecl.toml"),
-		sysconfdir("capability.json"),
-		sysconfdir("nvliblist.conf"),
-	}
-
-	for _, cf := range configFiles {
-		if fi, err := os.Stat(cf); err != nil {
-			log.Fatalf("%s is not installed on this system: %v", cf, err)
-		} else if !fi.Mode().IsRegular() {
-			log.Fatalf("%s is not a regular file", cf)
-		} else if fi.Sys().(*syscall.Stat_t).Uid != 0 {
-			log.Fatalf("%s must be owned by root", cf)
-		}
-	}
-
 	// Make temp dir for tests
 	name, err := ioutil.TempDir("", "stest.")
 	if err != nil {
@@ -115,6 +92,33 @@ func Run(t *testing.T) {
 		log.Fatalf("failed to chmod temporary directory: %v", err)
 	}
 	testenv.TestDir = name
+
+	// e2e tests need to run in a somehow agnostic environment, so we
+	// don't use environment of user executing tests in order to not
+	// wrongly interfering with cache stuff, sylabs library tokens,
+	// PGP keys
+	e2e.SetupHomeDirectories(t)
+
+	// generate singularity.conf with default values
+	e2e.SetupDefaultConfig(t, filepath.Join(testenv.TestDir, "singularity.conf"))
+
+	// Ensure config files are installed
+	configFiles := []string{
+		sysconfdir("singularity.conf"),
+		sysconfdir("ecl.toml"),
+		sysconfdir("capability.json"),
+		sysconfdir("nvliblist.conf"),
+	}
+
+	for _, cf := range configFiles {
+		if fi, err := os.Stat(cf); err != nil {
+			log.Fatalf("%s is not installed on this system: %v", cf, err)
+		} else if !fi.Mode().IsRegular() {
+			log.Fatalf("%s is not a regular file", cf)
+		} else if fi.Sys().(*syscall.Stat_t).Uid != 0 {
+			log.Fatalf("%s must be owned by root", cf)
+		}
+	}
 
 	// Build a base image for tests
 	imagePath := path.Join(name, "test.sif")
@@ -146,6 +150,7 @@ func Run(t *testing.T) {
 		"BUILD":       imgbuild.E2ETests(testenv),
 		"CACHE":       cache.E2ETests(testenv),
 		"CMDENVVARS":  cmdenvvars.E2ETests(testenv),
+		"CONFIG":      config.E2ETests(testenv),
 		"DELETE":      delete.E2ETests(testenv),
 		"DOCKER":      docker.E2ETests(testenv),
 		"ENV":         singularityenv.E2ETests(testenv),


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add e2e tests to execute singularity with various configuration directives value

### This fixes or addresses the following GitHub issues:

 - Fixes #4061


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

