### PR TITLE
Add allow container encrypted directive

### DIFF
--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1213,6 +1213,10 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 		if !e.EngineConfig.File.AllowContainerSquashfs {
 			return nil, fmt.Errorf("configuration disallows users from running squashFS based containers")
 		}
+	case image.ENCRYPTSQUASHFS:
+		if !e.EngineConfig.File.AllowContainerEncrypted {
+			return nil, fmt.Errorf("configuration disallows users from running encrypted containers")
+		}
 	}
 	return imgObject, nil
 }

--- a/pkg/runtime/engine/config/config.go
+++ b/pkg/runtime/engine/config/config.go
@@ -37,6 +37,7 @@ type FileConfig struct {
 	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
 	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
 	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
+	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
 	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
@@ -250,6 +251,7 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 allow container squashfs = {{ if eq .AllowContainerSquashfs true }}yes{{ else }}no{{ end }}
 allow container extfs = {{ if eq .AllowContainerExtfs true }}yes{{ else }}no{{ end }}
 allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }}
+allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else }}no{{ end }}
 
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds `allow container encrypted` configuration directive in `singularity.conf` to either allow or not running encrypted containers.

### This fixes or addresses the following GitHub issues:

 - Fixes #4758 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

