### PR TITLE
Switch back to build with golang-1.11

### DIFF
--- a/internal/app/singularity/plugin_uninstall_linux.go
+++ b/internal/app/singularity/plugin_uninstall_linux.go
@@ -18,7 +18,7 @@ var ErrPluginNotFound = errors.New("plugin not found")
 // UninstallPlugin removes the named plugin from the system.
 func UninstallPlugin(name, libexecdir string) error {
 	err := plugin.Uninstall(name, libexecdir)
-	if errors.Is(err, os.ErrNotExist) {
+	if err == os.ErrNotExist {
 		return ErrPluginNotFound
 	}
 	if err != nil {

--- a/internal/pkg/build/sources/oci_unpack_linux.go
+++ b/internal/pkg/build/sources/oci_unpack_linux.go
@@ -163,7 +163,7 @@ func checkPerms(rootfs string) (err error) {
 		return nil
 	})
 
-	if errors.Is(err, errRestrictivePerm) {
+	if err == errRestrictivePerm {
 		sylog.Warningf("Permission handling has changed in Singularity 3.5 for improved OCI compatibility")
 		sylog.Warningf("The sandbox will contain files/dirs that cannot be removed until permissions are modified")
 		sylog.Warningf("Use 'chmod -R u+rwX' to set permissions that allow removal")

--- a/internal/pkg/util/goversion/goversion.go
+++ b/internal/pkg/util/goversion/goversion.go
@@ -3,11 +3,11 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// +build go1.13
+// +build go1.11
 
 package goversion
 
-// __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__ provides a human-readable
+// __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__ provides a human-readable
 // error message when building this package with an unsupported version
 // of the Go compiler.
 //
@@ -15,4 +15,4 @@ package goversion
 // version specified in the build tag above.
 //
 // nolint:golint
-const __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__ = uint8(0)
+const __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__ = uint8(0)

--- a/internal/pkg/util/goversion/version_check.go
+++ b/internal/pkg/util/goversion/version_check.go
@@ -10,7 +10,7 @@
 // sufficient to trigger a build failure like:
 //
 //     ...
-//     ../internal/pkg/util/goversion/version_check.go:19:9: undefined: __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__
+//     ../internal/pkg/util/goversion/version_check.go:19:9: undefined: __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__
 //
 //
 // This is based on the technique presented at
@@ -19,4 +19,4 @@ package goversion
 
 // keep the variable here in sync with the mininum required version
 // specified in goversion.go
-var _ = __BUILD_REQUIRES_GO_VERSION_1_13_OR_LATER__
+var _ = __BUILD_REQUIRES_GO_VERSION_1_11_OR_LATER__

--- a/mconfig
+++ b/mconfig
@@ -20,7 +20,7 @@ hstld=
 hstranlib=
 hstobjcopy=
 hstgo=
-hstgo_version="1.13"
+hstgo_version="1.11"
 hstgo_opts="go"
 
 tgtcc=

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -7,7 +7,7 @@ GO_BUILDMODE := -buildmode=default
 GO_GCFLAGS :=
 GO_ASMFLAGS :=
 GO_MODFLAGS := $(if $(wildcard $(SOURCEDIR)/vendor/modules.txt),-mod=vendor,-mod=readonly)
-GOFLAGS := $(GO_MODFLAGS) -trimpath
+GOFLAGS := $(GO_MODFLAGS)
 GOPROXY := https://proxy.golang.org
 
 export GOFLAGS GO111MODULE GOPROXY


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR switches singularity-3.5 back to building with golang-1.11.  This is needed for building for epel8 because golang-1.13 is not currently available there.  I do not intend for this to be merged, but it is for making the source code publicly available as a reference for the epel8 build, and for ease of carrying forward to other releases until golang-1.13 becomes available on rhel8.


### This fixes or addresses the following GitHub issues:

 - Fixes #4756


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

