### PR TITLE
Check all partitions for image type check

### DIFF
--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1200,23 +1200,26 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 		}
 	}
 
-	switch imgObject.Type {
-	case image.SANDBOX:
-		if !e.EngineConfig.File.AllowContainerDir {
-			return nil, fmt.Errorf("configuration disallows users from running sandbox based containers")
-		}
-	case image.EXT3:
-		if !e.EngineConfig.File.AllowContainerExtfs {
-			return nil, fmt.Errorf("configuration disallows users from running extFS based containers")
-		}
-	case image.SQUASHFS:
-		if !e.EngineConfig.File.AllowContainerSquashfs {
-			return nil, fmt.Errorf("configuration disallows users from running squashFS based containers")
-		}
-	case image.ENCRYPTSQUASHFS:
-		if !e.EngineConfig.File.AllowContainerEncrypted {
-			return nil, fmt.Errorf("configuration disallows users from running encrypted containers")
+	for _, p := range imgObject.Partitions {
+		switch p.Type {
+		case image.SANDBOX:
+			if !e.EngineConfig.File.AllowContainerDir {
+				return nil, fmt.Errorf("configuration disallows users from running sandbox based containers")
+			}
+		case image.EXT3:
+			if !e.EngineConfig.File.AllowContainerExtfs {
+				return nil, fmt.Errorf("configuration disallows users from running extFS based containers")
+			}
+		case image.SQUASHFS:
+			if !e.EngineConfig.File.AllowContainerSquashfs {
+				return nil, fmt.Errorf("configuration disallows users from running squashFS based containers")
+			}
+		case image.ENCRYPTSQUASHFS:
+			if !e.EngineConfig.File.AllowContainerEncrypted {
+				return nil, fmt.Errorf("configuration disallows users from running encrypted containers")
+			}
 		}
 	}
+
 	return imgObject, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previously image type was checked based on the primary format, it worked fine for all format except for SIF which is the default format and can embed multiple image format, it was done originally like that because of redundancy with ECL.

There was a recent addition with #4761 to add `allow container encrypted` configuration directive but it's actually not effective without this PR because we need to look at partitions format not file image format with SIF.

### This fixes or addresses the following GitHub issues:

 - Issue spotted during work on #4760 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

