### PR TITLE
Cherry pick #4761, #4773 to release-3.5

### DIFF
--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1200,23 +1200,26 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 		}
 	}
 
-	switch imgObject.Type {
-	case image.SANDBOX:
-		if !e.EngineConfig.File.AllowContainerDir {
-			return nil, fmt.Errorf("configuration disallows users from running sandbox based containers")
-		}
-	case image.EXT3:
-		if !e.EngineConfig.File.AllowContainerExtfs {
-			return nil, fmt.Errorf("configuration disallows users from running extFS based containers")
-		}
-	case image.SQUASHFS:
-		if !e.EngineConfig.File.AllowContainerSquashfs {
-			return nil, fmt.Errorf("configuration disallows users from running squashFS based containers")
-		}
-	case image.ENCRYPTSQUASHFS:
-		if !e.EngineConfig.File.AllowContainerEncrypted {
-			return nil, fmt.Errorf("configuration disallows users from running encrypted containers")
+	for _, p := range imgObject.Partitions {
+		switch p.Type {
+		case image.SANDBOX:
+			if !e.EngineConfig.File.AllowContainerDir {
+				return nil, fmt.Errorf("configuration disallows users from running sandbox based containers")
+			}
+		case image.EXT3:
+			if !e.EngineConfig.File.AllowContainerExtfs {
+				return nil, fmt.Errorf("configuration disallows users from running extFS based containers")
+			}
+		case image.SQUASHFS:
+			if !e.EngineConfig.File.AllowContainerSquashfs {
+				return nil, fmt.Errorf("configuration disallows users from running squashFS based containers")
+			}
+		case image.ENCRYPTSQUASHFS:
+			if !e.EngineConfig.File.AllowContainerEncrypted {
+				return nil, fmt.Errorf("configuration disallows users from running encrypted containers")
+			}
 		}
 	}
+
 	return imgObject, nil
 }

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1213,6 +1213,10 @@ func (e *EngineOperations) loadImage(path string, writable bool) (*image.Image, 
 		if !e.EngineConfig.File.AllowContainerSquashfs {
 			return nil, fmt.Errorf("configuration disallows users from running squashFS based containers")
 		}
+	case image.ENCRYPTSQUASHFS:
+		if !e.EngineConfig.File.AllowContainerEncrypted {
+			return nil, fmt.Errorf("configuration disallows users from running encrypted containers")
+		}
 	}
 	return imgObject, nil
 }

--- a/pkg/runtime/engine/config/config.go
+++ b/pkg/runtime/engine/config/config.go
@@ -37,6 +37,7 @@ type FileConfig struct {
 	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
 	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
 	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
+	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
 	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
@@ -250,6 +251,7 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 allow container squashfs = {{ if eq .AllowContainerSquashfs true }}yes{{ else }}no{{ end }}
 allow container extfs = {{ if eq .AllowContainerExtfs true }}yes{{ else }}no{{ end }}
 allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }}
+allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else }}no{{ end }}
 
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no


### PR DESCRIPTION
Cherry pick #4761 and #4773 to release-3.5 for the 3.5.1 release.

These cherry picks will enable execution of an encrypted container to be restricted by a config option.