### PR TITLE
Add root filesystem escape checks

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -29,12 +29,14 @@
 #include <sys/prctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
 #include <signal.h>
 #include <sched.h>
 #include <setjmp.h>
 #include <sys/syscall.h>
 #include <net/if.h>
 #include <sys/eventfd.h>
+#include <linux/magic.h>
 
 #ifdef SINGULARITY_SECUREBITS
 #  include <linux/securebits.h>
@@ -1318,10 +1320,47 @@ __attribute__((constructor)) static void init(void) {
 
         /* engine requested to propagate mount to container */
         if ( sconfig->starter.masterPropagateMount && userns != ENTER_NAMESPACE ) {
+            struct stat rootfs, newrootfs;
+
+            /* keep stat information for root filesystem comparison */
+            if ( stat("/", &rootfs) < 0 ) {
+                fatalf("Failed to get root directory information: %s", strerror(errno));
+            }
+
             /* join child shared mount namespace with relative path */
             if ( enter_namespace("ns/mnt", CLONE_NEWNS) < 0 ) {
                 fatalf("Failed to enter in shared mount namespace: %s\n", strerror(errno));
             }
+
+            /* take stat information after namespace join */
+            if ( stat("/", &newrootfs) < 0 ) {
+                fatalf("Failed to get root directory information: %s", strerror(errno));
+            }
+
+            /*
+             * we compare st_dev and st_ino to check if we are in the current root
+             * filesystem, on some systems the mount namespace join above could escape the
+             * current root filesystem when an init process (initrd, container or chrooted process)
+             * do a chroot instead of switch_root for the initrd case or didn't use
+             * pivot_root/mount MS_MOVE for the container solution case
+             */
+            if ( rootfs.st_dev != newrootfs.st_dev || rootfs.st_ino != newrootfs.st_ino ) {
+                struct statfs fs;
+
+                debugf("Root filesystem change detected, retrieving new root filesystem information\n");
+                if ( statfs("/", &fs) < 0 ) {
+                    fatalf("Failed to retrieve root filesystem information: %s", strerror(errno));
+                }
+
+                /* check if we are in the ram disk filesystem */
+                if ( newrootfs.st_ino == 2 && (fs.f_type == RAMFS_MAGIC || fs.f_type == TMPFS_MAGIC) ) {
+                    warningf("Initrd uses chroot instead of switch_root to setup the root filesystem\n");
+                } else {
+                    warningf("Running inside a weak chrooted environment, prefer pivot_root instead of chroot\n");
+                }
+                fatalf("Aborting as Singularity cannot run correctly without modifications to your environment\n");
+            }
+
             send_event(master_socket[0]);
         }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Check root filesytem changes when master process is joining the first container mount namespace because we could have escaped to the init ram disk filesystem or escaped a weak chrooted environment. If it's the case we are aborting the execution and notifies users about the weakness of their setup by inviting them to fix the issue.

### This fixes or addresses the following GitHub issues:

 - Fixes #4774


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

