### PR TITLE
Cherry pick #4720 to release-3.5

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1453,6 +1453,53 @@ func (c actionTests) actionBinds(t *testing.T) {
 	}
 }
 
+func (c actionTests) exitSignals(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	tests := []struct {
+		name string
+		args []string
+		exit int
+	}{
+		{
+			name: "Exit0",
+			args: []string{c.env.ImagePath, "/bin/sh", "-c", "exit 0"},
+			exit: 0,
+		},
+		{
+			name: "Exit1",
+			args: []string{c.env.ImagePath, "/bin/sh", "-c", "exit 1"},
+			exit: 1,
+		},
+		{
+			name: "Exit134",
+			args: []string{c.env.ImagePath, "/bin/sh", "-c", "exit 134"},
+			exit: 134,
+		},
+		{
+			name: "SignalKill",
+			args: []string{c.env.ImagePath, "/bin/sh", "-c", "kill -KILL $$"},
+			exit: 137,
+		},
+		{
+			name: "SignalAbort",
+			args: []string{c.env.ImagePath, "/bin/sh", "-c", "kill -ABRT $$"},
+			exit: 134,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.exit),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) func(*testing.T) {
 	c := actionTests{
@@ -1473,5 +1520,6 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 		"issue 4768":            c.issue4768,           // https://github.com/sylabs/singularity/issues/4768
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
+		"exit and signals":      c.exitSignals,         // test exit and signals propagation
 	})
 }

--- a/internal/pkg/util/signal/signal_linux.go
+++ b/internal/pkg/util/signal/signal_linux.go
@@ -5,6 +5,16 @@
 
 package signal
 
+/*
+#include <signal.h>
+
+void raiseSignal(int sig) {
+	signal(sig, SIG_DFL);
+	raise(sig);
+}
+*/
+import "C"
+
 import (
 	"fmt"
 	"strconv"
@@ -49,4 +59,16 @@ func Convert(sig string) (unix.Signal, error) {
 	}
 
 	return sigNum, nil
+}
+
+// Raise sends a signal to the current process and ensure the
+// current signal handler is set to its default handler for the
+// corresponding signal. It allows to send signals like SIGABRT
+// without triggering Go core dump handler.
+func Raise(sig unix.Signal) {
+	// signal handlers like the one for SIGABRT can't be reset
+	// easily from Go without using rt_sigaction syscall implying
+	// to defines sigaction structure for various architecture so
+	// let's proceed with C
+	C.raiseSignal(C.int(int(sig)))
 }


### PR DESCRIPTION
Cherry pick #4720  to release-3.5 for 3.5.1

This overrides the Go SIGABRT handler, so that container processes raising SIGABRT return the expected code, and don't dump a Go stack trace.