### PR TITLE
Generate Go dependencies for CLI/runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,12 @@ x-run:
     name: Build Singularity
     command: |-
       ./mconfig -v -p /usr/local
-      make -j$(nproc) -C ./builddir all
+      make -C ./builddir all
 
   check_singularity: &check_singularity
     name: Check Singularity
     command: |-
-      make -j$(nproc) -C ./builddir check
+      make -C ./builddir check
 
   install_singularity: &install_singularity
     name: Install Singularity
@@ -82,6 +82,20 @@ x-run:
           ;;
       esac
 
+aliases:
+  - &attach_workspace
+    attach_workspace:
+      at: ~/go
+  - &restore_cache
+    restore_cache:
+      keys:
+        - go-vm-mod-{{ checksum "go.sum" }}
+  - &save_cache
+    save_cache:
+      key: go-vm-mod-{{ checksum "go.sum" }}
+      paths:
+        - ~/go/pkg
+
 jobs:
   get_source:
     <<: *defaults
@@ -95,30 +109,25 @@ jobs:
             - singularity
 
   cache_go_mod:
-    <<: *defaults
-    docker:
-      - image: sylabsio/golang:1.13.1-stretch
+    <<: *vm_defaults
     steps:
-      - attach_workspace:
-          at: ~/go
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
+      - *attach_workspace
+      - *restore_cache
+      - run:
+          <<: *setup_environment
+      - run:
+          <<: *update_go
       - run:
           name: Check go.mod
           command: scripts/check-go.mod
-      - save_cache:
-          key: go-mod-{{ checksum "go.sum" }}
-          paths:
-            - ~/go/pkg/mod
+      - *save_cache
 
   go113-stretch:
     <<: *defaults
     docker:
       - image: sylabsio/golang:1.13.1-stretch
     steps:
-      - attach_workspace:
-          at: ~/go
+      - *attach_workspace
       - run:
           <<: *build_singularity
       - run:
@@ -129,8 +138,7 @@ jobs:
     docker:
       - image: sylabsio/golang:1.13.1-alpine
     steps:
-      - attach_workspace:
-          at: ~/go
+      - *attach_workspace
       - run:
           <<: *build_singularity
       - run:
@@ -160,17 +168,17 @@ jobs:
           name: Build Singularity
           command: |-
             ./mconfig -v -p /usr/local
-            make -j$(sysctl -n hw.logicalcpu) -C ./builddir all
+            make -C ./builddir all
       - run:
           name: Check code
           command: |-
-            make -j$(sysctl -n hw.logicalcpu) -C ./builddir check
+            make -C ./builddir check
 
   build_check_and_install:
     <<: *vm_defaults
     steps:
-      - attach_workspace:
-          at: ~/go
+      - *attach_workspace
+      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -189,8 +197,8 @@ jobs:
   unit_tests:
     <<: *vm_defaults
     steps:
-      - attach_workspace:
-          at: ~/go
+      - *attach_workspace
+      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -202,13 +210,13 @@ jobs:
       - run:
           name: Run unit tests
           command: |-
-            make -j$(nproc) -C ./builddir unit-test
+            make -C ./builddir unit-test
 
   integration_tests:
     <<: *vm_defaults
     steps:
-      - attach_workspace:
-          at: ~/go
+      - *attach_workspace
+      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -228,8 +236,8 @@ jobs:
   e2e_tests:
     <<: *vm_defaults
     steps:
-      - attach_workspace:
-          at: ~/go
+      - *attach_workspace
+      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -253,16 +261,16 @@ workflows:
   build_and_test:
     jobs:
       - get_source
+      - go113-stretch:
+          requires:
+            - get_source
+      - go113-alpine:
+          requires:
+            - get_source
+      - go113-macos
       - cache_go_mod:
           requires:
             - get_source
-      - go113-stretch:
-          requires:
-            - cache_go_mod
-      - go113-alpine:
-          requires:
-            - cache_go_mod
-      - go113-macos
       - build_check_and_install:
           requires:
             - cache_go_mod

--- a/makeit/gengodep
+++ b/makeit/gengodep
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$1" != "-v2" ] ; then
+if [ "$1" != "-v3" ] ; then
 	cat 1>&2 <<-EOT
 
 ========================================================================
@@ -18,10 +18,11 @@ fi
 shift
 
 go=$1
-srcdir=$2
+var=$2
 gotags=$3
+depfile=$4
 
-shift 3
+shift 4
 
 # this is needed so that the value we are getting from the makefile does
 # get propagated down to go list.
@@ -33,11 +34,10 @@ else
 	mod_mode=readonly
 fi
 
-"${go}" list -mod=${mod_mode} \
-	-deps \
-	-f '{{ with $d := . }}{{ range $d.GoFiles }}{{ $d.Dir }}/{{ . }} {{ end }}{{ range $d.CgoFiles }}{{ $d.Dir }}/{{ . }} {{ end }}{{ end }}' \
-	-tags "${gotags}" \
-	"$@" |
-tr ' ' '\n' |
-sort -u |
-grep "^${srcdir}"
+template='{{ with $d := . }}{{ if not $d.Standard }}{{ range $d.GoFiles }}{{ printf "%s/%s\n" $d.Dir . }}{{ end }}{{ range $d.CgoFiles }}{{ printf "%s/%s\n" $d.Dir . }}{{ end }}{{ end }}{{ end }}'
+
+godeps=`${go} list -mod=${mod_mode} -deps -f "${template}" -tags "${gotags}" "$@" | sort -u`
+
+for m in ${godeps}; do
+    echo "$var += $m" >> ${depfile}
+done

--- a/mconfig
+++ b/mconfig
@@ -811,6 +811,11 @@ cat $makeit_interdir/all.mk >> $makeit_makefile
 drawline $makeit_fragsdir/build_cli.mk
 cat $makeit_fragsdir/build_cli.mk >> $makeit_makefile
 
+if [ "$with_network" = 1 ]; then
+    drawline $makeit_fragsdir/build_network.mk
+    cat $makeit_fragsdir/build_network.mk >> $makeit_makefile
+fi
+
 if [ "$build_runtime" = 1 ]; then
 	drawline $makeit_fragsdir/build_runtime.mk
 	cat $makeit_fragsdir/build_runtime.mk >> $makeit_makefile
@@ -819,11 +824,6 @@ fi
 if [ "$with_suid" = 1 ]; then
 	drawline $makeit_fragsdir/build_runtime_suid.mk
 	cat $makeit_fragsdir/build_runtime_suid.mk >> $makeit_makefile
-fi
-
-if [ "$with_network" = 1 ]; then
-	drawline $makeit_fragsdir/build_network.mk
-	cat $makeit_fragsdir/build_network.mk >> $makeit_makefile
 fi
 
 drawline $makeit_fragsdir/build_scripts.mk

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -5,9 +5,6 @@
 
 all: $(ALL)
 
-test_sudo := $(SOURCEDIR)/scripts/test-sudo
-e2e_sudo := $(SOURCEDIR)/scripts/e2e-sudo
-
 .PHONY: man
 man: singularity
 	mkdir -p $(DESTDIR)$(MANDIR)/man1

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -5,6 +5,9 @@
 
 all: $(ALL)
 
+test_sudo := $(SOURCEDIR)/scripts/test-sudo
+e2e_sudo := $(SOURCEDIR)/scripts/e2e-sudo
+
 .PHONY: man
 man: singularity
 	mkdir -p $(DESTDIR)$(MANDIR)/man1
@@ -45,8 +48,7 @@ unit-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(B
 unit-test:
 	@echo " TEST sudo go test [unit]"
 	$(V)cd $(SOURCEDIR) && \
-		sudo -E \
-		scripts/go-test -v $(EXTRA_FLAGS) \
+		scripts/go-test -sudo -v $(EXTRA_FLAGS) \
 		./...
 	@echo "       PASS"
 
@@ -60,9 +62,8 @@ e2e-test:
 		SINGULARITY_E2E_COVERAGE=$(BUILDDIR_ABSPATH)/e2e-cmd-coverage \
 		scripts/e2e-test -v $(EXTRA_FLAGS)
 	@echo "       PASS"
-	@echo " TEST sudo e2e-coverage"
+	@echo " TEST e2e-coverage"
 	$(V)cd $(SOURCEDIR) && \
-	    sudo -E \
 		$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 			$(SOURCEDIR)/cmd/docs/cmds/cmdtree.go \
 			-coverage $(BUILDDIR_ABSPATH)/e2e-cmd-coverage \
@@ -72,8 +73,7 @@ e2e-test:
 integration-test:
 	@echo " TEST sudo go test [integration]"
 	$(V)cd $(SOURCEDIR) && \
-		sudo -E \
-		scripts/go-test -v -tags 'integration_test' \
+		scripts/go-test -sudo -v -tags 'integration_test' \
 		./cmd/singularity ./pkg/network
 	@echo "       PASS"
 
@@ -83,8 +83,7 @@ test:
 	$(V)M=0; eval 'while [ $$M -le 20 ]; do sleep 60; M=`expr $$M + 1`; echo "Still testing ($$M) ..."; done &' ; \
     	trap "kill $$! || true" 0; \
 		cd $(SOURCEDIR) && \
-		sudo -E \
-		scripts/go-test -v -tags 'integration_test' \
+		scripts/go-test -sudo -v -tags 'integration_test' \
 		./...
 	@echo "       PASS"
 

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -1,3 +1,8 @@
+# as go build already parallelize things, running make in parallel
+# just slow down the whole process and we also requires to respect
+# a specific order
+.NOTPARALLEL:
+
 all: $(ALL)
 
 .PHONY: man

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -11,7 +11,9 @@ CLEANFILES += $(singularity_build_config)
 # contain singularity_SOURCE variable list
 singularity_deps := $(BUILDDIR_ABSPATH)/singularity.d
 
-$(singularity_deps): $(GO_MODFILES) $(singularity_SOURCE)
+-include $(singularity_deps)
+
+$(singularity_deps): $(GO_MODFILES)
 	@echo " GEN GO DEP" $@
 	$(V)$(SOURCEDIR)/makeit/gengodep -v3 "$(GO)" "singularity_SOURCE" "$(GO_TAGS)" "$@" "$(SOURCEDIR)/cmd/singularity"
 
@@ -83,5 +85,3 @@ $(remote_config_INSTALL): $(remote_config)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(remote_config_INSTALL)
-
--include $(singularity_deps)

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -8,11 +8,15 @@ $(singularity_build_config): $(BUILDDIR)/config.h $(SOURCEDIR)/scripts/go-genera
 
 CLEANFILES += $(singularity_build_config)
 
-# singularity
-singularity_SOURCE := $(shell $(SOURCEDIR)/makeit/gengodep -v2 "$(GO)" "$(SOURCEDIR)" "$(GO_TAGS)" "$(SOURCEDIR)/cmd/singularity")
+# contain singularity_SOURCE variable list
+singularity_deps := $(BUILDDIR_ABSPATH)/singularity.d
+
+$(singularity_deps): $(GO_MODFILES) $(singularity_SOURCE)
+	@echo " GEN GO DEP" $@
+	$(V)$(SOURCEDIR)/makeit/gengodep -v3 "$(GO)" "singularity_SOURCE" "$(GO_TAGS)" "$@" "$(SOURCEDIR)/cmd/singularity"
 
 singularity := $(BUILDDIR)/singularity
-$(singularity): $(singularity_build_config) $(singularity_SOURCE)
+$(singularity): $(singularity_build_config) $(singularity_deps) $(singularity_SOURCE)
 	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS)\"
 	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 		-o $(BUILDDIR)/singularity $(SOURCEDIR)/cmd/singularity
@@ -78,3 +82,4 @@ $(remote_config_INSTALL): $(remote_config)
 
 INSTALLFILES += $(remote_config_INSTALL)
 
+-include $(singularity_deps)

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -15,6 +15,8 @@ $(singularity_deps): $(GO_MODFILES) $(singularity_SOURCE)
 	@echo " GEN GO DEP" $@
 	$(V)$(SOURCEDIR)/makeit/gengodep -v3 "$(GO)" "singularity_SOURCE" "$(GO_TAGS)" "$@" "$(SOURCEDIR)/cmd/singularity"
 
+# Look at dependencies file changes via singularity_deps
+# because it means that a module was updated.
 singularity := $(BUILDDIR)/singularity
 $(singularity): $(singularity_build_config) $(singularity_deps) $(singularity_SOURCE)
 	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS)\"

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -18,6 +18,8 @@ $(BUILDDIR)/.clean-starter: $(starter_CSOURCE)
 
 
 # starter
+# Look at dependencies file changes via starter_deps
+# because it means that a module was updated.
 starter := $(BUILDDIR)/cmd/starter/c/starter
 $(starter): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starter_deps) $(starter_SOURCE)
 	@echo " GO" $@

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -1,11 +1,15 @@
 # This file contains all of the rules for building the singularity runtime
 #   and installing the necessary config files.
 
-starter_SOURCE := $(shell $(SOURCEDIR)/makeit/gengodep -v2 "$(GO)" "$(SOURCEDIR)" "$(GO_TAGS)" "$(SOURCEDIR)/cmd/starter")
-starter_CSOURCE := $(SOURCEDIR)/cmd/starter/c/starter.c \
-                  $(SOURCEDIR)/cmd/starter/c/capability.c \
-                  $(SOURCEDIR)/cmd/starter/c/message.c \
-                  $(SOURCEDIR)/cmd/starter/c/setns.c
+# contain starter_SOURCE variable list
+starter_deps := $(BUILDDIR_ABSPATH)/starter.d
+
+$(starter_deps): $(GO_MODFILES) $(starter_SOURCE)
+	@echo " GEN GO DEP" $@
+	$(V)$(SOURCEDIR)/makeit/gengodep -v3 "$(GO)" "starter_SOURCE" "$(GO_TAGS)" "$@" "$(SOURCEDIR)/cmd/starter"
+
+starter_CSOURCE := $(wildcard $(SOURCEDIR)/cmd/starter/c/*.c)
+starter_CSOURCE += $(wildcard $(SOURCEDIR)/cmd/starter/c/include/*.h)
 
 $(BUILDDIR)/.clean-starter: $(starter_CSOURCE)
 	@echo " GO clean -cache"
@@ -15,7 +19,7 @@ $(BUILDDIR)/.clean-starter: $(starter_CSOURCE)
 
 # starter
 starter := $(BUILDDIR)/cmd/starter/c/starter
-$(starter): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starter_SOURCE)
+$(starter): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starter_deps) $(starter_SOURCE)
 	@echo " GO" $@
 	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go
@@ -134,4 +138,4 @@ $(cgroups_config_INSTALL): $(cgroups_config)
 
 INSTALLFILES += $(cgroups_config_INSTALL)
 
-
+-include $(starter_deps)

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -4,7 +4,9 @@
 # contain starter_SOURCE variable list
 starter_deps := $(BUILDDIR_ABSPATH)/starter.d
 
-$(starter_deps): $(GO_MODFILES) $(starter_SOURCE)
+-include $(starter_deps)
+
+$(starter_deps): $(GO_MODFILES)
 	@echo " GEN GO DEP" $@
 	$(V)$(SOURCEDIR)/makeit/gengodep -v3 "$(GO)" "starter_SOURCE" "$(GO_TAGS)" "$@" "$(SOURCEDIR)/cmd/starter"
 
@@ -139,5 +141,3 @@ $(cgroups_config_INSTALL): $(cgroups_config)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(cgroups_config_INSTALL)
-
--include $(starter_deps)

--- a/mlocal/frags/build_runtime_suid.mk
+++ b/mlocal/frags/build_runtime_suid.mk
@@ -5,7 +5,7 @@
 starter_suid := $(BUILDDIR)/cmd/starter/c/starter-suid
 starter_suid_INSTALL := $(DESTDIR)$(LIBEXECDIR)/singularity/bin/starter-suid
 
-$(starter_suid): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starter_SOURCE)
+$(starter_suid): $(starter)
 	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS_SUID)\"
 	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS_SUID)" $(GO_LDFLAGS) $(GO_GCFLAGS) $(GO_ASMFLAGS) \
 		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go

--- a/mlocal/frags/build_scripts.mk
+++ b/mlocal/frags/build_scripts.mk
@@ -5,6 +5,7 @@ $(SOURCEDIR)/scripts/go-test: export GO := $(GO)
 $(SOURCEDIR)/scripts/go-test: export GO111MODULE := $(GO111MODULE)
 $(SOURCEDIR)/scripts/go-test: export GOFLAGS := $(GOFLAGS)
 $(SOURCEDIR)/scripts/go-test: export GO_TAGS := $(GO_TAGS)
+$(SOURCEDIR)/scripts/go-test: export SUDO_SCRIPT := $(SOURCEDIR)/scripts/test-sudo
 $(SOURCEDIR)/scripts/go-test: $(SOURCEDIR)/scripts/go-test.in $(SOURCEDIR)/scripts/expand-env.go
 	@echo ' GEN $@'
 	$(V) $(GO) run $(GO_MODFLAGS) $(SOURCEDIR)/scripts/expand-env.go < $< > $@

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -7,6 +7,7 @@ GO_BUILDMODE := -buildmode=default
 GO_GCFLAGS :=
 GO_ASMFLAGS :=
 GO_MODFLAGS := $(if $(wildcard $(SOURCEDIR)/vendor/modules.txt),-mod=vendor,-mod=readonly)
+GO_MODFILES := $(SOURCEDIR)/go.mod $(SOURCEDIR)/go.sum
 GOFLAGS := $(GO_MODFLAGS) -trimpath
 GOPROXY := https://proxy.golang.org
 

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -21,11 +21,5 @@ else
     procs=`getconf _NPROCESSORS_ONLN`
 fi
 
-sudo -v
-
-sudo \
-	env -i \
-		PATH=$PATH \
-		HOME=$HOME \
-		SINGULARITY_E2E_COVERAGE=$SINGULARITY_E2E_COVERAGE \
-	scripts/go-test -parallel $procs -tags "e2e_test" "$@" ./e2e
+export sudo_args="env -i PATH=$PATH HOME=$HOME SINGULARITY_E2E_COVERAGE=$SINGULARITY_E2E_COVERAGE"
+exec scripts/go-test -sudo -parallel $procs -tags "e2e_test" "$@" ./e2e

--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -61,6 +61,23 @@ for arg in "$@" ; do
 	fi
 
 	case "${arg}" in
+		-sudo)
+			# prepare sudo execution
+			sudo_exec='-exec @SUDO_SCRIPT@'
+			if [ `id -u` = 0 ]; then
+				error "Run $0 as user when specifying -sudo. Abort."
+				exit 1
+			fi
+			if ! command -v sudo > /dev/null 2>&1; then
+				error "sudo command not found in PATH. Abort."
+				exit 1
+			fi
+			# ask for password or reset the session timeout
+			if ! sudo -v; then
+				exit 1
+			fi
+			;;
+
 		-tags)
 			GO_TAGS="${GO_TAGS} ${1}"
 			skip=true
@@ -114,6 +131,7 @@ rc=0
 	-failfast \
 	-cover \
 	-race \
+	${sudo_exec} \
 	"$@" ||
 rc=$?
 

--- a/scripts/test-sudo
+++ b/scripts/test-sudo
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+sudocmd="sudo -E ${sudo_args}"
+unset sudo_args
+
+# reset timeout for each invocation or exit
+# if a password is required
+if ! sudo -vn ; then
+    exit 1
+fi
+
+exec ${sudocmd} "$@"


### PR DESCRIPTION
## Description of the Pull Request (PR):

- mconfig: move network chunk before runtime to install setuid binary at the end of make install step (see #4494).
- gengodep: get all Go dependencies outside of the source tree and exlude Go standard packages.
- makefile: cli/runtime dependencies are generated and stored in dedicated variable list. Dependency files are updated if go.mod/go.sum changed or if any source file is updated.

### This fixes or addresses the following GitHub issues:

 - Fixes #4789 
 - Fixes #4494 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

