### PR TITLE
Cherry pick #4796 into release-3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This point release addresses the following issues:
   - Corrects the behaviour of underlay with non-empty / symlinked CWD.
   - Fixes execution of containers when binding BTRFS filesystems.
   - Fixes build / check failures for MIPS & PPC64.
+  - Ensures file ownership maintained when building image from sandbox.
 
 # v3.5.0 - [2019.11.13]
 

--- a/internal/pkg/build/sources/packer_ext3_linux.go
+++ b/internal/pkg/build/sources/packer_ext3_linux.go
@@ -65,7 +65,7 @@ func unpackExt3(b *types.Bundle, img *image.Image) error {
 	// copy filesystem into bundle rootfs
 	sylog.Debugf("Copying filesystem from %s to %s in Bundle\n", tmpmnt, b.RootfsPath)
 	var stderr bytes.Buffer
-	cmd := exec.Command("cp", "-r", tmpmnt+`/.`, b.RootfsPath)
+	cmd := exec.Command("cp", "-a", tmpmnt+`/.`, b.RootfsPath)
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("while copying files: %v: %v", err, stderr.String())

--- a/internal/pkg/build/sources/packer_sandbox.go
+++ b/internal/pkg/build/sources/packer_sandbox.go
@@ -29,7 +29,7 @@ func (p *SandboxPacker) Pack(context.Context) (*types.Bundle, error) {
 	// copy filesystem into bundle rootfs
 	sylog.Debugf("Copying file system from %s to %s in Bundle\n", rootfs, p.b.RootfsPath)
 	var stderr bytes.Buffer
-	cmd := exec.Command("cp", "-r", rootfs+`/.`, p.b.RootfsPath)
+	cmd := exec.Command("cp", "-a", rootfs+`/.`, p.b.RootfsPath)
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("cp Failed: %v: %v", err, stderr.String())


### PR DESCRIPTION
Cherry picks #4796, which stops ownership being reset to root when building from a sandbox into a SIF.

Cedric confirms this was tested okay with fakeroot, which was the only real concern for the change.