### PR TITLE
Use errors=remount-ro mount option with ext3 filesystems only

### DIFF
--- a/internal/pkg/runtime/engine/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engine/imgbuild/create_linux.go
@@ -96,7 +96,7 @@ func (e *EngineOperations) CreateContainer(ctx context.Context, pid int, rpcConn
 	}
 
 	sylog.Debugf("Mounting image directory %s\n", rootfs)
-	if err := rpcOps.Mount(rootfs, sessionRootFs, "", syscall.MS_BIND, "errors=remount-ro"); err != nil {
+	if err := rpcOps.Mount(rootfs, sessionRootFs, "", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("failed to mount directory filesystem %s: %s", rootfs, err)
 	}
 

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -610,7 +610,10 @@ func (p *Points) AddImage(tag AuthorizedTag, source string, dest string, fstype 
 		return fmt.Errorf("invalid image size, zero length")
 	}
 	keyB64 := base64.StdEncoding.EncodeToString(key)
-	options = fmt.Sprintf("loop,offset=%d,sizelimit=%d,key=%s,errors=remount-ro", offset, sizelimit, keyB64)
+	options = fmt.Sprintf("loop,offset=%d,sizelimit=%d,key=%s", offset, sizelimit, keyB64)
+	if fstype == "ext3" {
+		options += ",errors=remount-ro"
+	}
 	return p.add(tag, source, dest, fstype, flags, options)
 }
 

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -125,7 +125,7 @@ func (s *sifBundle) Create(ociConfig *specs.Spec) error {
 	}
 
 	rootFs := tools.RootFs(s.bundlePath).Path()
-	if err := syscall.Mount(loop, rootFs, "squashfs", syscall.MS_RDONLY, "errors=remount-ro"); err != nil {
+	if err := syscall.Mount(loop, rootFs, "squashfs", syscall.MS_RDONLY, ""); err != nil {
 		tools.DeleteBundle(s.bundlePath)
 		return fmt.Errorf("failed to mount SIF partition: %s", err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Since 5.4.0 kernel passing `errors=remount-ro` with `squashfs` mount options returns an error, fix that by conditionally set this option for `ext3` filesystems only.

### This fixes or addresses the following GitHub issues:

 - Fixes #4801 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

