### PR TITLE
Fix CHANGELOG on master for post 3.5.1 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.5.1
 
+ - Deprecated `--groupid` flag for `sign` and `verify`; replaced with `--group-id`.
+ - Removed useless flag `--url` for `sign`.
+
 # v3.5.1 - [2019.12.03]
 
 ## New features / functionalities
@@ -37,9 +40,6 @@ This point release addresses the following issues:
   - Fixes build / check failures for MIPS & PPC64.
   - Ensures file ownership maintained when building image from sandbox.
   - Fixes a squashfs mount error on kernel 5.4.0 and above.
-
- - Deprecated `--groupid` flag for `sign` and `verify`; replaced with `--group-id`.
- - Removed useless flag `--url` for `sign`.
 
 # v3.5.0 - [2019.11.13]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Apologies - I messed up the CHANGELOG in the merge from release-3.5

This puts the master specific stuff back in the correct place at the top of the changelog.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

