### PR TITLE
Replace NO_SETUID_FIXUP with KEEP_CAPS

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -226,7 +226,7 @@ static int apply_container_privileges(struct privileges *privileges) {
      * and to set ambient capabilities. We can't use capset before changing uid/gid
      * because CAP_SETUID/CAP_SETGID could be already dropped
      */
-    if ( prctl(PR_SET_SECUREBITS, SECBIT_NO_SETUID_FIXUP|SECBIT_NO_SETUID_FIXUP_LOCKED) < 0 ) {
+    if ( prctl(PR_SET_SECUREBITS, SECBIT_KEEP_CAPS) < 0 ) {
         fatalf("Failed to set securebits: %s\n", strerror(errno));
     }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

`NO_SETUID_FIXUP` is propagated to container processes leading them to retain their capabilities when they switch to a non-zero UID/GID, it causes issues with some services like openssh server (see #4319)

### This fixes or addresses the following GitHub issues:

 - Fixes #4319 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

