### PR TITLE
Cast Stat_t.Dev to uint64 for MIPS oddities

### DIFF
--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -122,7 +122,8 @@ func parseMountInfoLine(line string) MountInfoEntry {
 		fi, err := os.Stat(entry.Point)
 		if err == nil {
 			st := fi.Sys().(*syscall.Stat_t)
-			entry.Dev = fmt.Sprintf("%d:%d", unix.Major(st.Dev), unix.Minor(st.Dev))
+			// cast to uint64 as st.Dev is uint32 on MIPS
+			entry.Dev = fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev)))
 		}
 	}
 
@@ -161,7 +162,8 @@ func FindParentMountEntry(path string, entries []MountInfoEntry) (*MountInfoEntr
 		return nil, fmt.Errorf("while getting stat for %s: %s", path, err)
 	}
 	st := fi.Sys().(*syscall.Stat_t)
-	dev := fmt.Sprintf("%d:%d", unix.Major(st.Dev), unix.Minor(st.Dev))
+	// cast to uint64 as st.Dev is uint32 on MIPS
+	dev := fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev)))
 
 	var entry *MountInfoEntry
 	matchLen := 0

--- a/pkg/util/loop/loop_linux.go
+++ b/pkg/util/loop/loop_linux.go
@@ -31,7 +31,8 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 	}
 	st := fi.Sys().(*syscall.Stat_t)
 	imageIno := st.Ino
-	imageDev := st.Dev
+	// cast to uint64 as st.Dev is uint32 on MIPS
+	imageDev := uint64(st.Dev)
 
 	fd, err := lock.Exclusive("/dev")
 	if err != nil {

--- a/pkg/util/loop/loop_linux_test.go
+++ b/pkg/util/loop/loop_linux_test.go
@@ -73,7 +73,8 @@ func TestLoop(t *testing.T) {
 	}
 
 	st := fi.Sys().(*syscall.Stat_t)
-	if st.Dev != i1.Device || st.Ino != i1.Inode {
+	// cast to uint64 as st.Dev is uint32 on MIPS
+	if uint64(st.Dev) != i1.Device || st.Ino != i1.Inode {
 		t.Errorf("bad file association for %s", path)
 	}
 


### PR DESCRIPTION
### This fixes or addresses the following GitHub issues:

 - Fixes #4814 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

