### PR TITLE
Merge from 3.5.1-rc.2 tag into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.5.1
 
-# v3.5.1 - [2019.12.03]
+# v3.5.1 - [2019.12.05]
 
 ## New features / functionalities
 
@@ -37,6 +37,8 @@ This point release addresses the following issues:
   - Fixes build / check failures for MIPS & PPC64.
   - Ensures file ownership maintained when building image from sandbox.
   - Fixes a squashfs mount error on kernel 5.4.0 and above.
+  - Fixes an underlay fallback problem, which prevented use of sandboxes on
+    lustre filesystems.
 
 # v3.5.0 - [2019.11.13]
 

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -226,7 +226,7 @@ static int apply_container_privileges(struct privileges *privileges) {
      * and to set ambient capabilities. We can't use capset before changing uid/gid
      * because CAP_SETUID/CAP_SETGID could be already dropped
      */
-    if ( prctl(PR_SET_SECUREBITS, SECBIT_NO_SETUID_FIXUP|SECBIT_NO_SETUID_FIXUP_LOCKED) < 0 ) {
+    if ( prctl(PR_SET_SECUREBITS, SECBIT_KEEP_CAPS) < 0 ) {
         fatalf("Failed to set securebits: %s\n", strerror(errno));
     }
 

--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -122,7 +122,8 @@ func parseMountInfoLine(line string) MountInfoEntry {
 		fi, err := os.Stat(entry.Point)
 		if err == nil {
 			st := fi.Sys().(*syscall.Stat_t)
-			entry.Dev = fmt.Sprintf("%d:%d", unix.Major(st.Dev), unix.Minor(st.Dev))
+			// cast to uint64 as st.Dev is uint32 on MIPS
+			entry.Dev = fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev)))
 		}
 	}
 
@@ -161,7 +162,8 @@ func FindParentMountEntry(path string, entries []MountInfoEntry) (*MountInfoEntr
 		return nil, fmt.Errorf("while getting stat for %s: %s", path, err)
 	}
 	st := fi.Sys().(*syscall.Stat_t)
-	dev := fmt.Sprintf("%d:%d", unix.Major(st.Dev), unix.Minor(st.Dev))
+	// cast to uint64 as st.Dev is uint32 on MIPS
+	dev := fmt.Sprintf("%d:%d", unix.Major(uint64(st.Dev)), unix.Minor(uint64(st.Dev)))
 
 	var entry *MountInfoEntry
 	matchLen := 0

--- a/pkg/util/loop/loop_linux.go
+++ b/pkg/util/loop/loop_linux.go
@@ -31,7 +31,8 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 	}
 	st := fi.Sys().(*syscall.Stat_t)
 	imageIno := st.Ino
-	imageDev := st.Dev
+	// cast to uint64 as st.Dev is uint32 on MIPS
+	imageDev := uint64(st.Dev)
 
 	fd, err := lock.Exclusive("/dev")
 	if err != nil {

--- a/pkg/util/loop/loop_linux_test.go
+++ b/pkg/util/loop/loop_linux_test.go
@@ -73,7 +73,8 @@ func TestLoop(t *testing.T) {
 	}
 
 	st := fi.Sys().(*syscall.Stat_t)
-	if st.Dev != i1.Device || st.Ino != i1.Inode {
+	// cast to uint64 as st.Dev is uint32 on MIPS
+	if uint64(st.Dev) != i1.Device || st.Ino != i1.Inode {
 		t.Errorf("bad file association for %s", path)
 	}
 


### PR DESCRIPTION
Fold in the #4810 KEEP_CAPS, #4817 lustre/underlay fix and #4816 MIPS build fixes that were against release-3.5 into master.