### PR TITLE
Add a travis branch safelist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+branches:
+  only:
+    - master
+    - /^release-\d+\..+$/
+    - /^v\d+\..+$/
+
 language: go
 
 sudo: required


### PR DESCRIPTION
Since travis-ci is configured to build both on pushes and pull requests,
pull requests created using branches on the repository (as done by
dependabot) will trigger two travis-ci runs: one for the pull request
itself and one for the push to the branch.

With this change that should be fixed and only one run will start (for
the pull requests). After merging the pull request to the target branch
this triggers another run.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>