### PR TITLE
Fakeroot build and missing seccomp support

### DIFF
--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -215,8 +215,12 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 
 	if seccomp.Enabled() {
 		if err := seccomp.LoadSeccompConfig(fakerootSeccompProfile(), false, 0); err != nil {
-			sylog.Warningf("could not apply seccomp filter, some bootstrap may not work correctly")
+			sylog.Warningf("Could not apply seccomp filter, some bootstrap may not work correctly")
 		}
+	} else {
+		sylog.Warningf("Not compiled with seccomp, fakeroot may not work correctly, " +
+			"if you get permission denied error during creation of pseudo devices, " +
+			"you should install seccomp library and recompile Singularity")
 	}
 	return syscall.Exec(args[0], args, env)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

We can't really check this during `./mconfig` due to the complexity of detecting if user namespace is supported or not, and we can't really assume that admins/users will use fakeroot so we simply return a message warning users to compile Singularity with seccomp support if fakeroot build is used without seccomp support.

### This fixes or addresses the following GitHub issues:

 - Fixes #4828 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

