### PR TITLE
Fix useless error when an element of the current working directory is a symlink

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1519,6 +1519,7 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 		"issue 4755":            c.issue4755,           // https://github.com/sylabs/singularity/issues/4755
 		"issue 4768":            c.issue4768,           // https://github.com/sylabs/singularity/issues/4768
 		"issue 4797":            c.issue4797,           // https://github.com/sylabs/singularity/issues/4797
+		"issue 4836":            c.issue4836,           // https://github.com/sylabs/singularity/issues/4836
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -342,12 +342,12 @@ func (m *Manager) sync() error {
 				if !os.IsExist(err) {
 					return fmt.Errorf("failed to create symlink %s: %s", path, err)
 				}
-				// check that current symlink point to the right target
+				// check that current symlink point to the right target if it's a symlink
+				// otherwise we consider the entry as already created no matter if it's a
+				// file, a directory or something else
 				target, err := os.Readlink(path)
 				if err == nil && target != entry.target {
 					return fmt.Errorf("symlink %s point to %s instead of %s", path, target, entry.target)
-				} else if err != nil {
-					return fmt.Errorf("failed to read symlink %s: %s", path, err)
 				}
 				// skip symlink owner change, not created by us
 				entry.created = true


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix useless error when an element of the current working directory is a symlink


### This fixes or addresses the following GitHub issues:

 - Fixes #4836 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

