### PR TITLE
Fix fakeroot sandbox build chown error

### DIFF
--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sylabs/singularity/pkg/util/fs/proc"
+
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sylabs/singularity/internal/pkg/build/apps"
@@ -76,10 +78,16 @@ func New(defs []types.Definition, conf Config) (*Build, error) {
 }
 
 func newBuild(defs []types.Definition, conf Config) (*Build, error) {
+	sandboxCopy := false
 	oldumask := syscall.Umask(0002)
 	defer syscall.Umask(oldumask)
 
-	conf.Dest = filepath.Clean(conf.Dest)
+	dest, err := filepath.Abs(conf.Dest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine absolute path for %q: %v", conf.Dest, err)
+	}
+	conf.Dest = dest
+
 	// always build a sandbox if updating an existing sandbox
 	if conf.Opts.Update {
 		conf.Format = "sandbox"
@@ -89,8 +97,17 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		Conf: conf,
 	}
 
+	// look if there is mount options set which could conflict
+	// with the build process like nodev and noexec
+	entries, err := proc.GetMountInfoEntry("/proc/self/mountinfo")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve mount information: %v", err)
+	}
+
+	lastStageIndex := len(defs) - 1
+
 	// create stages
-	for _, d := range defs {
+	for i, d := range defs {
 		// verify every definition has a header if there are multiple stages
 		if d.Header == nil {
 			return nil, fmt.Errorf("multiple stages detected, all must have headers")
@@ -115,6 +132,45 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		s.name = d.Header["stage"]
 		s.b.Recipe = d
 
+		if conf.Format == "sandbox" && lastStageIndex == i {
+			// rootfs path changed during bundle creation it means that chown
+			// is not possible within the temporary rootfs, we will switch to
+			// the old behavior which is to create the temporary rootfs inside
+			// $TMPDIR and copy the final root filesystem to the destination
+			// provided
+			if s.b.RootfsPath != rootfs {
+				sandboxCopy = true
+				sylog.Warningf("The underlying filesystem on which resides %q won't allow to set ownership, "+
+					"as a consequence the sandbox could not preserve image's files/directories ownerships", conf.Dest)
+			} else {
+				// check if the final sandbox directory doesn't have noexec set
+				destEntry, err := proc.FindParentMountEntry(rootfsParent, entries)
+				if err != nil {
+					return nil, fmt.Errorf("failed to find mount point for %s: %v", rootfsParent, err)
+				}
+				for _, opt := range destEntry.Options {
+					if opt == "noexec" {
+						return nil, fmt.Errorf("'noexec' mount option set on %s, sandbox %s won't be usable at this location", destEntry.Point, conf.Dest)
+					}
+				}
+			}
+		}
+		if lastStageIndex == i {
+			// check if TMPDIR mount point have nodev and/or noexec set
+			tmpdirEntry, err := proc.FindParentMountEntry(conf.Opts.TmpDir, entries)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find mount point for %s: %v", conf.Opts.TmpDir, err)
+			}
+			for _, opt := range tmpdirEntry.Options {
+				switch opt {
+				case "nodev":
+					sylog.Warningf("'nodev' mount option set on %s, it could be a source of failure during build process", tmpdirEntry.Point)
+				case "noexec":
+					return nil, fmt.Errorf("'noexec' mount option set on %s, temporary root filesystem won't be usable at this location", tmpdirEntry.Point)
+				}
+			}
+		}
+
 		s.b.Opts = conf.Opts
 		// dont need to get cp if we're skipping bootstrap
 		if !conf.Opts.Update || conf.Opts.Force {
@@ -129,10 +185,9 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 	}
 
 	// only need an assembler for last stage
-	lastStageIndex := len(defs) - 1
 	switch conf.Format {
 	case "sandbox":
-		b.stages[lastStageIndex].a = &assemblers.SandboxAssembler{}
+		b.stages[lastStageIndex].a = &assemblers.SandboxAssembler{Copy: sandboxCopy}
 	case "sif":
 		mksquashfsPath, err := squashfs.GetPath()
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fakeroot may fail to set file/directory ownership when building a sandbox on some network filesystems which are not aware of user namespace, to address the issue the build move to a temporary rootfs inside $TMPDIR and copy instead of moving the final rootfs sandbox to the final destination.


### This fixes or addresses the following GitHub issues:

 - Fixes #4829


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

