### PR TITLE
Fix fakeroot build issue due to section script location

### DIFF
--- a/internal/pkg/runtime/engine/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engine/imgbuild/create_linux.go
@@ -281,7 +281,12 @@ func createScript(path string, content []byte) error {
 func (e *EngineOperations) runScriptSection(name string, s types.Script, setEnv bool) {
 	sylog.Infof("Running %s scriptlet\n", name)
 
-	script := filepath.Join(e.EngineConfig.RootfsPath, ".build-script-"+name)
+	// all sections except setup are executed inside chroot
+	scriptName := ".build-script-" + name
+	script := filepath.Join("/", scriptName)
+	if name == "setup" {
+		script = filepath.Join(e.EngineConfig.RootfsPath, scriptName)
+	}
 
 	// write the script section in a temporary file to avoid
 	// potential "starvation" issue when passing the script


### PR DESCRIPTION
## Description of the Pull Request (PR):

Due to a wrong generated path, the build section scripts are created in a location which may not exist inside container image, this PR fix that by always generating script at the root of the container filesystem except for `setup` which is executed before chroot.


### This fixes or addresses the following GitHub issues:

 - Fixes #4837 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

