### PR TITLE
Use a sensible hash for http(s) source caching

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1519,6 +1519,7 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 		"issue 4755":            c.issue4755,           // https://github.com/sylabs/singularity/issues/4755
 		"issue 4768":            c.issue4768,           // https://github.com/sylabs/singularity/issues/4768
 		"issue 4797":            c.issue4797,           // https://github.com/sylabs/singularity/issues/4797
+		"issue 4823":            c.issue4823,           // https://github.com/sylabs/singularity/issues/4823
 		"issue 4836":            c.issue4836,           // https://github.com/sylabs/singularity/issues/4836
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds


### PR DESCRIPTION
## Description of the Pull Request (PR):

The existing caching for `http` and `https` sources uses the final part of the URL as the key for the image within the cache. This means that `http://example.com/container1/v1.sif` and `http://example.com/container2/v1.sif` result in the same cache key, and unexpected behaviour as in #4823.

We will cache using a sha256 over the URL and the date of the file that is to be
fetched, as returned by an HTTP HEAD call. If no date is available, use the current
date-time, which will effectively result in no caching.

### This fixes or addresses the following GitHub issues:

 - Fixes: #4823

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

