### PR TITLE
Cherry pick #4850 to release-3.5 for 3.5.2

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1519,6 +1519,7 @@ func E2ETests(env e2e.TestEnv) func(*testing.T) {
 		"issue 4755":            c.issue4755,           // https://github.com/sylabs/singularity/issues/4755
 		"issue 4768":            c.issue4768,           // https://github.com/sylabs/singularity/issues/4768
 		"issue 4797":            c.issue4797,           // https://github.com/sylabs/singularity/issues/4797
+		"issue 4823":            c.issue4823,           // https://github.com/sylabs/singularity/issues/4823
 		"issue 4836":            c.issue4836,           // https://github.com/sylabs/singularity/issues/4836
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds


### PR DESCRIPTION
Cherry pick #4850 to release-3.5 for 3.5.2

Use a sensible hash for http(s) source caching

Fixes: #4823

We will cache using a sha256 over the URL and the date of the file that is to be
fetched, as returned by an HTTP HEAD call. If no date is available, use the current
date-time, which will effectively result in no caching.


