### PR TITLE
Wrap run-help around singularity exec command

### DIFF
--- a/e2e/runhelp/runhelp.go
+++ b/e2e/runhelp/runhelp.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package runhelp
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/e2e/internal/testhelper"
+)
+
+type ctx struct {
+	env e2e.TestEnv
+}
+
+func (c ctx) testRunHelp(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	tests := []struct {
+		name   string
+		argv   []string
+		output string
+		exit   int
+	}{
+		{
+			name:   "DefaultHelp",
+			argv:   []string{c.env.ImagePath},
+			output: "BAD_GUY=Thanos",
+			exit:   0,
+		},
+		{
+			name:   "AppFooHelp",
+			argv:   []string{"--app", "foo", c.env.ImagePath},
+			output: "This is the help for foo!",
+			exit:   0,
+		},
+		{
+			name:   "AppFakeHelp",
+			argv:   []string{"--app", "fake", c.env.ImagePath},
+			output: "No help sections were defined for this image",
+			exit:   0,
+		},
+		{
+			name: "NoImage",
+			argv: []string{"/fake/image"},
+			exit: 255,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("run-help"),
+			e2e.WithArgs(tt.argv...),
+			e2e.ExpectExit(
+				tt.exit,
+				e2e.ExpectOutput(e2e.ContainMatch, tt.output),
+			),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) func(*testing.T) {
+	c := ctx{
+		env: env,
+	}
+
+	return testhelper.TestRunner(map[string]func(*testing.T){
+		"run-help command": c.testRunHelp,
+	})
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sylabs/singularity/e2e/regressions"
 	"github.com/sylabs/singularity/e2e/remote"
 	"github.com/sylabs/singularity/e2e/run"
+	"github.com/sylabs/singularity/e2e/runhelp"
 	"github.com/sylabs/singularity/e2e/security"
 	"github.com/sylabs/singularity/e2e/sign"
 	"github.com/sylabs/singularity/e2e/verify"
@@ -159,6 +160,7 @@ func Run(t *testing.T) {
 		"REGRESSIONS": regressions.E2ETests(testenv),
 		"REMOTE":      remote.E2ETests(testenv),
 		"RUN":         run.E2ETests(testenv),
+		"RUNHELP":     runhelp.E2ETests(testenv),
 		"SECURITY":    security.E2ETests(testenv),
 		"SIGN":        sign.E2ETests(testenv),
 		"VERIFY":      verify.E2ETests(testenv),


### PR DESCRIPTION
## Description of the Pull Request (PR):

Wrap `run-help` around singularity exec command and make method generic to be used by `inspect`/`run-help` command.

### This fixes or addresses the following GitHub issues:

 - Fixes #4804 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

