### PR TITLE
Use nil pointer for noop DockerAuthConfig

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -78,7 +78,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 	sysCtx := &ocitypes.SystemContext{
 		OCIInsecureSkipTLSVerify:    noHTTPS,
 		DockerInsecureSkipTLSVerify: ocitypes.NewOptionalBool(noHTTPS),
-		DockerAuthConfig:            &authConf,
+		DockerAuthConfig:            authConf,
 	}
 
 	imgabs := ""
@@ -103,7 +103,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 					NoCache:          true,
 					NoTest:           true,
 					NoHTTPS:          noHTTPS,
-					DockerAuthConfig: &authConf,
+					DockerAuthConfig: authConf,
 				},
 			})
 
@@ -137,7 +137,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 						TmpDir:           tmpDir,
 						NoTest:           true,
 						NoHTTPS:          noHTTPS,
-						DockerAuthConfig: &authConf,
+						DockerAuthConfig: authConf,
 						ImgCache:         imgCache,
 					},
 				})
@@ -163,7 +163,7 @@ func handleOras(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command,
 	}
 
 	_, ref := uri.Split(u)
-	sum, err := oras.ImageSHA(ctx, ref, &ociAuth)
+	sum, err := oras.ImageSHA(ctx, ref, ociAuth)
 	if err != nil {
 		return "", fmt.Errorf("failed to get SHA of %v: %v", u, err)
 	}
@@ -175,7 +175,7 @@ func handleOras(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command,
 	} else if !exists {
 		sylog.Infof("Downloading image with ORAS")
 
-		if err := oras.DownloadImage(cacheImagePath, ref, &ociAuth); err != nil {
+		if err := oras.DownloadImage(cacheImagePath, ref, ociAuth); err != nil {
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -263,7 +263,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 				NoHTTPS:           noHTTPS,
 				LibraryURL:        buildArgs.libraryURL,
 				LibraryAuthToken:  authToken,
-				DockerAuthConfig:  &authConf,
+				DockerAuthConfig:  authConf,
 				EncryptionKeyInfo: keyInfo,
 				FixPerms:          buildArgs.fixPerms,
 				SandboxTarget:     sandboxTarget,

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -232,7 +232,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 		}
 
-		err = singularity.OrasPull(ctx, imgCache, pullTo, ref, forceOverwrite, &ociAuth)
+		err = singularity.OrasPull(ctx, imgCache, pullTo, ref, forceOverwrite, ociAuth)
 		if err != nil {
 			sylog.Fatalf("While pulling image from oci registry: %v", err)
 		}
@@ -247,7 +247,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While creating Docker credentials: %v", err)
 		}
 
-		err = singularity.OciPull(ctx, imgCache, pullTo, pullFrom, tmpDir, &ociAuth, noHTTPS, buildArgs.noCleanUp)
+		err = singularity.OciPull(ctx, imgCache, pullTo, pullFrom, tmpDir, ociAuth, noHTTPS, buildArgs.noCleanUp)
 		if err != nil {
 			sylog.Fatalf("While making image from oci registry: %v", err)
 		}

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -93,7 +93,7 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}
 
-			if err := oras.UploadImage(file, ref, &ociAuth); err != nil {
+			if err := oras.UploadImage(file, ref, ociAuth); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")


### PR DESCRIPTION
## Description of the Pull Request (PR):

In #4544 some tidy up resulted in our DockerAuthConfig being
dealt with by value, not as a pointer. Unfortunately in
`containers/image` the test of whether to use the DockerAuthConfig
is against `nil`, and not a default/empty DockerAuthConfig.

We need to pass a nil pointer into `containers/image` routines, or it
will not fall back to other authentication sources, such as the
`.docker/config.json` file.

### This fixes or addresses the following GitHub issues:

 - Fixes #4860 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularityblob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

