### PR TITLE
Allow to force E2E run via FORCE_E2E in should-e2e-run script

### DIFF
--- a/scripts/should-e2e-run
+++ b/scripts/should-e2e-run
@@ -17,6 +17,12 @@ usage() {
 	EOT
 }
 
+# Give the possibility to force E2E run
+if ! test -z "${FORCE_E2E}" ; then
+    echo "FORCE_E2E set, forcing e2e tests."
+    exit 0
+fi
+
 # Skip e2e by default
 require_e2e=false
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Specifying `FORCE_E2E` trigger e2e tests no matter changes applied.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

