### PR TITLE
Do not follow symlinks while copying between stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes Since v3.5.2
 
+## Changed defaults / behaviours
+
+  - `%files from ...` will no longer follow symlinks when copying between
+    stages. Copying from the host will still maintain previous behavior of
+    following links.
+
 # v3.5.2 - [2019.12.17]
 
 ## [Security related fix](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2019-19724)

--- a/e2e/regressions/build.go
+++ b/e2e/regressions/build.go
@@ -157,6 +157,25 @@ func (c *regressionsTests) issue4524(t *testing.T) {
 	)
 }
 
+func (c *regressionsTests) issue4583(t *testing.T) {
+	image := filepath.Join(c.env.TestDir, "issue_4583.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(image, "testdata/regressions/issue_4583.def"),
+		e2e.PostRun(func(t *testing.T) {
+			defer os.Remove(image)
+
+			if t.Failed() {
+				return
+			}
+		}),
+		e2e.ExpectExit(0),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := regressionsTests{
@@ -167,5 +186,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4203": c.issue4203, // https://github.com/sylabs/singularity/issues/4203
 		"issue 4407": c.issue4407, // https://github.com/sylabs/singularity/issues/4407
 		"issue 4524": c.issue4524, // https://github.com/sylabs/singularity/issues/4524
+		"issue 4583": c.issue4583, // https://github.com/sylabs/singularity/issues/4583
 	}
 }

--- a/e2e/testdata/regressions/issue_4583.def
+++ b/e2e/testdata/regressions/issue_4583.def
@@ -1,0 +1,16 @@
+bootstrap: library
+from: alpine
+stage: one
+
+%post
+    mkdir /copy /original
+    touch /original/a_file
+    ln -s /original/a_file /copy/a_file
+
+bootstrap: library
+from: alpine
+stage: two
+
+%files from one
+    /original
+    /copy

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -526,10 +526,11 @@ func (s *stage) copyFiles(b *Build) error {
 
 			// copy each file into bundle rootfs
 			// prepend appropriate bundle path to supplied paths
+			// copying between stages should not follow symlinks
 			transfer.Src = files.AddPrefix(b.stages[stageIndex].b.RootfsPath, transfer.Src)
 			transfer.Dst = files.AddPrefix(s.b.RootfsPath, transfer.Dst)
 			sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
-			if err := files.Copy(transfer.Src, transfer.Dst); err != nil {
+			if err := files.Copy(transfer.Src, transfer.Dst, false); err != nil {
 				return err
 			}
 		}

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -42,7 +42,7 @@ func makeParentDir(path string, numSrcPaths int) error {
 // Copy calls cp with src and dst as its arguments
 // checks dst and creates parent directories if they do not exist
 // before calling cp
-func Copy(src, dst string) error {
+func Copy(src, dst string, followLinks bool) error {
 	// resolve any bash globbing in filepath
 	paths, err := expandPath(src)
 	if err != nil {
@@ -54,7 +54,10 @@ func Copy(src, dst string) error {
 	}
 
 	// set flags for cp
-	args := []string{"-fLr"}
+	args := []string{"-fr"}
+	if followLinks {
+		args = []string{"-fLr"}
+	}
 	// append file(s) to be copied
 	args = append(args, paths...)
 	// append dst as last arg

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -136,7 +136,7 @@ func TestCopyFile(t *testing.T) {
 
 			// manually concatenating because I don't want a Join function to clean the trailing slash
 			dst := dstDir + "/" + tt.dst
-			if err := Copy(tt.src, dst); err != nil {
+			if err := Copy(tt.src, dst, false); err != nil {
 				t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
 			}
 
@@ -201,7 +201,7 @@ func TestCopyDir(t *testing.T) {
 
 			// manually concatenating because I don't want a Join function to clean the trailing slash
 			dst := dstDir + "/" + tt.dst
-			if err := Copy(tt.src, dst); err != nil {
+			if err := Copy(tt.src, dst, false); err != nil {
 				t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
 			}
 
@@ -255,7 +255,7 @@ func TestCopyFail(t *testing.T) {
 			defer os.RemoveAll(dstDir)
 
 			dst := filepath.Join(dstDir, tt.dst)
-			if err := Copy(tt.src, dst); err == nil {
+			if err := Copy(tt.src, dst, false); err == nil {
 				t.Errorf("unexpected success running %s test: %s", t.Name(), err)
 			}
 		})

--- a/internal/pkg/runtime/engine/imgbuild/create_linux.go
+++ b/internal/pkg/runtime/engine/imgbuild/create_linux.go
@@ -248,9 +248,10 @@ func (e *EngineOperations) copyFiles() error {
 			transfer.Dst = transfer.Src
 		}
 		// copy each file into bundle rootfs
+		// copying from host to container should follow symlinks
 		transfer.Dst = files.AddPrefix(e.EngineConfig.RootfsPath, transfer.Dst)
 		sylog.Infof("Copying %v to %v", transfer.Src, transfer.Dst)
-		if err := files.Copy(transfer.Src, transfer.Dst); err != nil {
+		if err := files.Copy(transfer.Src, transfer.Dst, true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
'%files from ...' will no longer follow symlinks when copying between
stages. Copying from the host will still maintain previous behavior of
following links.

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>



### This fixes or addresses the following GitHub issues:

 - Fixes #4583 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

