### PR TITLE
Replace +dirty by -dirty to be compatible with semantic version

### DIFF
--- a/scripts/get-version
+++ b/scripts/get-version
@@ -38,7 +38,7 @@ if test -n "${head}" ; then
 	# cannot pass --dirty when using commit-ish
 	dirty_info=${current_commit}
 else
-	dirty_info=$(gitdesc --dirty=+dirty)
+	dirty_info=$(gitdesc --dirty)
 fi
 
 # First figure out if the current commit matches a tag:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Replace `+dirty` by `-dirty` to be compatible with semantic version. @mem do you see any side effects with this change ?

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

