### PR TITLE
Use statfs by default to retrieve mount options

### DIFF
--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -112,13 +112,13 @@ func parseMountInfoLine(line string) MountInfoEntry {
 	// super block options field
 	entry.SuperOptions = strings.Split(fields[index+3], ",")
 
-	// major/minor number reported in mountinfo may
-	// be wrong for btrfs filesystem as it uses virtual
+	// major/minor number reported in mountinfo may be wrong
+	// for btrfs/overlay filesystems as it uses virtual
 	// device numbers, st_dev from stat will return numbers
 	// different from those shown in mountinfo, to fix that
 	// we need to get major/minor directly from a stat call
 	// on the corresponding mount point
-	if entry.FSType == "btrfs" {
+	if entry.FSType == "btrfs" || entry.FSType == "overlay" {
 		fi, err := os.Stat(entry.Point)
 		if err == nil {
 			st := fi.Sys().(*syscall.Stat_t)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use statfs by default to retrieve mount options for bind mount and fallback to `/proc/self/mountinfo` method in case of failure.
Add overlay filesystem to handle st_dev wrong value for `/proc/self/mountinfo` method.

### This fixes or addresses the following GitHub issues:

 - Fixes #4876 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

