### PR TITLE
Return current UID instead of error in namespaces.HostUID

### DIFF
--- a/pkg/util/namespaces/user_linux.go
+++ b/pkg/util/namespaces/user_linux.go
@@ -69,7 +69,11 @@ func HostUID() (int, error) {
 
 	f, err := os.Open(uidMap)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read: %s: %s", uidMap, err)
+		if !os.IsNotExist(err) {
+			return 0, fmt.Errorf("failed to read: %s: %s", uidMap, err)
+		}
+		// user namespace not supported
+		return currentUID, nil
 	}
 	defer f.Close()
 


### PR DESCRIPTION
### Description of the Pull Request (PR):

Return current UID instead of error in namespaces.HostUID if `/proc/self/uid_map` is not present


### This fixes or addresses the following GitHub issues:

 - Fixes #4885 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

