### PR TITLE
Avoid use of overlay when not available in mount and oci bundle tests

### DIFF
--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	testCache "github.com/sylabs/singularity/internal/pkg/test/tool/cache"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 )
 
 func TestFromSif(t *testing.T) {
@@ -72,33 +73,51 @@ func TestFromSif(t *testing.T) {
 		t.Errorf("unexpected success while creating OCI bundle")
 	}
 
-	// create OCI bundle from SIF
-	bundle, err = FromSif(sifFile, bundlePath, true)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		writable bool
+	}{
+		{"FromSif", false},
+		{"FromSifWritable", true},
 	}
-	// generate a default configuration
-	g, err := generate.New(runtime.GOOS)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// remove seccomp filter for CI
-	g.Config.Linux.Seccomp = nil
-	g.SetProcessArgs([]string{tools.RunScript, "id"})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	if err := bundle.Create(g.Config); err != nil {
-		// check if cleanup occurred
-		t.Fatal(err)
+			if tt.writable {
+				require.Filesystem(t, "overlay")
+			}
+
+			// create OCI bundle from SIF
+			bundle, err = FromSif(sifFile, bundlePath, tt.writable)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// generate a default configuration
+			g, err := generate.New(runtime.GOOS)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// remove seccomp filter for CI
+			g.Config.Linux.Seccomp = nil
+			g.SetProcessArgs([]string{tools.RunScript, "id"})
+
+			if err := bundle.Create(g.Config); err != nil {
+				// check if cleanup occurred
+				t.Fatal(err)
+			}
+
+			// execute oci run command
+			args = []string{"oci", "run", "-b", bundlePath, filepath.Base(sifFile)}
+			cmd = exec.Command(sing, args...)
+			if err := cmd.Run(); err != nil {
+				t.Error(err)
+			}
+
+			if err := bundle.Delete(); err != nil {
+				t.Error(err)
+			}
+
+		})
 	}
 
-	// execute oci run command
-	args = []string{"oci", "run", "-b", bundlePath, filepath.Base(sifFile)}
-	cmd = exec.Command(sing, args...)
-	if err := cmd.Run(); err != nil {
-		t.Error(err)
-	}
-
-	if err := bundle.Delete(); err != nil {
-		t.Error(err)
-	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Avoid use of overlay when not available in mount and oci bundle tests.

Modifies order in mount test, to skip the overlay-required test last.

Try writable true & false where possible in oci bundle FromSif test.


### This fixes or addresses the following GitHub issues:

 - Fixes #4886 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

