### PR TITLE
Correct nc args to fix TestAddDelNetworks with OpenBSD nc

### DIFF
--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -554,7 +554,7 @@ func TestAddDelNetworks(t *testing.T) {
 		{
 			name:    "TestHTTPPortmap",
 			command: "nc",
-			args:    []string{"-l", "-p", "80"},
+			args:    []string{"-l", "80"},
 			runFunc: testHTTPPortmap,
 		},
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

In TestAddDelNetworks we are using `nc` to listen on port 80.

There are different versions of netcat on different distros. There is the 'traditional/nmap' version, and unpatched, or patched versions of the openbsd nc.

We are using the command `nc -l -p 80`. On a strict openbsd version of
`nc` this is not permitted. `-p` is the `source-port` and not valid for
using nc to listen. `-l` with `-p` happens to work on traditional and
patched versions of `nc`, but the correct options that work across all
versions are `nc -l 80`.


### This fixes or addresses the following GitHub issues:

 - Fixes #4894 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

