### PR TITLE
Fix network_linux_test where bridge not available / setup fails on RHEL6

### DIFF
--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -597,6 +597,9 @@ func TestAddDelNetworks(t *testing.T) {
 		nsPath := fmt.Sprintf("/proc/%d/ns/net", cmd.Process.Pid)
 		if err := c.runFunc(nsPath, cniPath, stdinPipe, stdoutPipe); err != nil {
 			t.Errorf("unexpected failure for %q: %s", c.name, err)
+			if err := cmd.Process.Kill(); err != nil {
+				t.Fatalf("error killing process %q: %s", cmdPath, err)
+			}
 		}
 
 		stdoutPipe.Close()

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -518,14 +518,14 @@ func TestAddDelNetworks(t *testing.T) {
 	test.EnsurePrivilege(t)
 
 	// centos 6 doesn't support brigde/veth, only macvlan
-	// just skip tests on centos 6
+	// just skip tests on centos 6, rhel 6
 	b, err := ioutil.ReadFile("/etc/system-release-cpe")
 	if err == nil {
 		fields := strings.Split(string(b), ":")
 		switch fields[2] {
-		case "centos":
+		case "centos", "redhat":
 			if strings.HasPrefix(fields[4], "6") {
-				t.SkipNow()
+				t.Skipf("RHEL6/CentOS6 don't support CNI bridge/veth - skipping")
 			}
 		}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Kill helper process in network_linux_test on error

If the network setup fails with an error, our helper process such as nc,
may be stuck. E.g. in the tests using nc we are expecting it to end once
a connection is made and closed. If the network setup failed we need to
kill it explicitly to avoid a freeze.

- Protect tests needing CNI bridge on RHEL 6 as well as CentOS 6


### This fixes or addresses the following GitHub issues:

 - Fixes #4897 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

