### PR TITLE
Fixed OS versions/kernel req in TestDockerDefFile & e2e

### DIFF
--- a/cmd/singularity/docker_test.go
+++ b/cmd/singularity/docker_test.go
@@ -176,8 +176,11 @@ func TestDockerDefFile(t *testing.T) {
 	}{
 		{"Arch", 3, "dock0/arch:latest"},
 		{"BusyBox", 0, "busybox:latest"},
-		{"CentOS", 0, "centos:latest"},
-		{"Ubuntu", 0, "ubuntu:16.04"},
+		{"CentOS_6", 0, "centos:6"},
+		{"CentOS_7", 0, "centos:7"},
+		{"CentOS_8", 3, "centos:8"},
+		{"Ubuntu_1604", 0, "ubuntu:16.04"},
+		{"Ubuntu_1804", 3, "ubuntu:18.04"},
 	}
 
 	for _, tt := range tests {

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -268,14 +268,29 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			from:                "busybox:latest",
 		},
 		{
-			name:                "CentOS",
+			name:                "CentOS_6",
 			kernelMajorRequired: 0,
-			from:                "centos:latest",
+			from:                "centos:6",
 		},
 		{
-			name:                "Ubuntu",
+			name:                "CentOS_7",
+			kernelMajorRequired: 0,
+			from:                "centos:7",
+		},
+		{
+			name:                "CentOS_8",
+			kernelMajorRequired: 3,
+			from:                "centos:8",
+		},
+		{
+			name:                "Ubuntu_1604",
 			kernelMajorRequired: 0,
 			from:                "ubuntu:16.04",
+		},
+		{
+			name:                "Ubuntu_1804",
+			kernelMajorRequired: 3,
+			from:                "ubuntu:18.04",
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In order to fix a failure on RHEL6, where the kernel is
too old for centos:latest (8), and ensure we are testing
the LTS Ubuntu and CentOS releases:

 - Fix CentOS versions to supported 6, 7, 8 and mark 8 as
   requiring a 3.x kernel.

 - Add Ubuntu 18.04, requiring a 3.x kernel.

### This fixes or addresses the following GitHub issues:

 - Fixes #4901 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

