### PR TITLE
Use img instead of docker to run e2e tests registry on RHEL 6

### DIFF
--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -35,7 +35,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 		EnsureImage(t, env)
 
 		dockerDefinition := "testdata/Docker_registry.def"
-		dockerImage := filepath.Join(env.TestDir, "docker-e2e.sif")
+		dockerImage := filepath.Join(env.TestDir, "docker-registry")
 
 		env.RunSingularity(
 			t,
@@ -51,7 +51,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 			t,
 			WithProfile(RootProfile),
 			WithCommand("instance start"),
-			WithArgs("-w", "-B", "/sys", dockerImage, dockerInstanceName),
+			WithArgs("-w", dockerImage, dockerInstanceName),
 			PreRun(func(t *testing.T) {
 				umountFn = shadowInstanceDirectory(t, env)
 			}),

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -2,34 +2,18 @@ bootstrap: docker
 from: registry:2.7.1
 
 %post
-    apk add docker
-    # prevent docker to add iptables rules because it
-    # add few rules even with --iptables=false
-    rm -f /sbin/iptables
+    apk add runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+            img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 %startscript
-    # if there is no docker0 bridge, we could safely
-    # remove the created one after the docker daemon
-    # started
-    if ! brctl show docker0; then
-        DELETE_BRIDGE=1
-    fi
-
-    dockerd --iptables=false --ip-forward=false --ip-masq=false --storage-driver=vfs &
     /.singularity.d/runscript &
 
     # wait until docker registry is up
     while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.5; done
 
-    # delete bridge if docker0 was not previously present
-    if [ ! -z "${DELETE_BRIDGE}" ]; then
-        ip link set docker0 down || true
-        brctl delbr docker0 || true
-    fi
-
-    docker pull busybox || kill -TERM 1
-    docker tag busybox localhost:5000/my-busybox || kill -TERM 1
-    docker push localhost:5000/my-busybox || kill -TERM 1
+    img pull busybox || kill -TERM 1
+    img tag busybox localhost:5000/my-busybox || kill -TERM 1
+    img push localhost:5000/my-busybox || kill -TERM 1
 
     # e2e PrepRegistry will repeatedly trying to connect to this port
     # giving indication that it can start


### PR DESCRIPTION
## Description of the Pull Request (PR):

Docker is initially installed and run as daemon for e2e registry image essentially to run and populate registry with pull/tag/push image commands, but as docker doesn't work on system like RHEL6, this PR use img (https://github.com/genuinetools/img) to populate registry and run it as instance for e2e tests. The drawback is that it takes more time to build the registry image.

### This fixes or addresses the following GitHub issues:

 - Fixes #4905 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

