### PR TITLE
Protect additional e2e tests needing UserNS, overlay with require.xxx

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -486,6 +486,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		command string
 		argv    []string
 		exit    int
+		profile e2e.Profile
 	}{
 		// Run from supported URI's and check the runscript call works
 		{
@@ -493,12 +494,14 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "run",
 			argv:    []string{"--bind", bind, "docker://busybox:latest", size},
 			exit:    0,
+			profile: e2e.UserProfile,
 		},
 		{
 			name:    "RunFromLibraryOK",
 			command: "run",
 			argv:    []string{"--bind", bind, "library://busybox:latest", size},
 			exit:    0,
+			profile: e2e.UserProfile,
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -506,24 +509,28 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		// 	command: "run",
 		// 	argv:    []string{"--bind", bind, "shub://singularityhub/busybox", size},
 		// 	exit:    0,
+		// 	profile: e2e.UserProfile,
 		// },
 		{
 			name:    "RunFromOrasOK",
 			command: "run",
 			argv:    []string{"--bind", bind, c.env.OrasTestImage, size},
 			exit:    0,
+			profile: e2e.UserProfile,
 		},
 		{
 			name:    "RunFromDockerKO",
 			command: "run",
 			argv:    []string{"--bind", bind, "docker://busybox:latest", "0"},
 			exit:    1,
+			profile: e2e.UserProfile,
 		},
 		{
 			name:    "RunFromLibraryKO",
 			command: "run",
 			argv:    []string{"--bind", bind, "library://busybox:latest", "0"},
 			exit:    1,
+			profile: e2e.UserProfile,
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -531,12 +538,14 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		// 	command: "run",
 		// 	argv:    []string{"--bind", bind, "shub://singularityhub/busybox", "0"},
 		// 	exit:    1,
+		// 	profile: e2e.UserProfile,
 		// },
 		{
 			name:    "RunFromOrasKO",
 			command: "run",
 			argv:    []string{"--bind", bind, c.env.OrasTestImage, "0"},
 			exit:    1,
+			profile: e2e.UserProfile,
 		},
 
 		// exec from a supported URI's and check the exit code
@@ -545,12 +554,14 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "exec",
 			argv:    []string{"docker://busybox:latest", "true"},
 			exit:    0,
+			profile: e2e.UserProfile,
 		},
 		{
 			name:    "ExecTrueLibrary",
 			command: "exec",
 			argv:    []string{"library://busybox:latest", "true"},
 			exit:    0,
+			profile: e2e.UserProfile,
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -558,24 +569,28 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		// 	command: "exec",
 		// 	argv:    []string{"shub://singularityhub/busybox", "true"},
 		// 	exit:    0,
+		// 	profile: e2e.UserProfile,
 		// },
 		{
 			name:    "ExecTrueOras",
 			command: "exec",
 			argv:    []string{c.env.OrasTestImage, "true"},
 			exit:    0,
+			profile: e2e.UserProfile,
 		},
 		{
 			name:    "ExecFalseDocker",
 			command: "exec",
 			argv:    []string{"docker://busybox:latest", "false"},
 			exit:    1,
+			profile: e2e.UserProfile,
 		},
 		{
 			name:    "ExecFalseLibrary",
 			command: "exec",
 			argv:    []string{"library://busybox:latest", "false"},
 			exit:    1,
+			profile: e2e.UserProfile,
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -583,64 +598,74 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		// 	command: "exec",
 		// 	argv:    []string{"shub://singularityhub/busybox", "false"},
 		// 	exit:    1,
+		// 	profile: e2e.UserProfile,
 		// },
 		{
 			name:    "ExecFalseOras",
 			command: "exec",
 			argv:    []string{c.env.OrasTestImage, "false"},
 			exit:    1,
+			profile: e2e.UserProfile,
 		},
 
 		// exec from URI with user namespace enabled
 		{
 			name:    "ExecTrueDockerUserns",
 			command: "exec",
-			argv:    []string{"--userns", "docker://busybox:latest", "true"},
+			argv:    []string{"docker://busybox:latest", "true"},
 			exit:    0,
+			profile: e2e.UserNamespaceProfile,
 		},
 		{
 			name:    "ExecTrueLibraryUserns",
 			command: "exec",
-			argv:    []string{"--userns", "library://busybox:latest", "true"},
+			argv:    []string{"library://busybox:latest", "true"},
 			exit:    0,
+			profile: e2e.UserNamespaceProfile,
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
 		// 	name:    "ExecTrueShubUserns",
 		// 	command: "exec",
-		// 	argv:    []string{"--userns", "shub://singularityhub/busybox", "true"},
+		// 	argv:    []string{"shub://singularityhub/busybox", "true"},
 		// 	exit:    0,
+		// 	profile: e2e.UserNamespaceProfile,
 		// },
 		{
 			name:    "ExecTrueOrasUserns",
 			command: "exec",
-			argv:    []string{"--userns", c.env.OrasTestImage, "true"},
+			argv:    []string{c.env.OrasTestImage, "true"},
 			exit:    0,
+			profile: e2e.UserNamespaceProfile,
 		},
 		{
 			name:    "ExecFalseDockerUserns",
 			command: "exec",
-			argv:    []string{"--userns", "docker://busybox:latest", "false"},
+			argv:    []string{"docker://busybox:latest", "false"},
 			exit:    1,
+			profile: e2e.UserNamespaceProfile,
 		},
 		{
 			name:    "ExecFalseLibraryUserns",
 			command: "exec",
-			argv:    []string{"--userns", "library://busybox:latest", "false"},
+			argv:    []string{"library://busybox:latest", "false"},
 			exit:    1,
+			profile: e2e.UserNamespaceProfile,
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
 		// 	name:    "ExecFalseShubUserns",
 		// 	command: "exec",
-		// 	argv:    []string{"--userns", "shub://singularityhub/busybox", "false"},
+		// 	argv:    []string{"shub://singularityhub/busybox", "false"},
 		// 	exit:    1,
+		// 	profile: e2e.UserNamespaceProfile,
 		// },
 		{
 			name:    "ExecFalseOrasUserns",
 			command: "exec",
-			argv:    []string{"--userns", c.env.OrasTestImage, "false"},
+			argv:    []string{c.env.OrasTestImage, "false"},
 			exit:    1,
+			profile: e2e.UserNamespaceProfile,
 		},
 	}
 
@@ -648,7 +673,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(tt.profile),
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
 			e2e.ExpectExit(tt.exit),

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -48,6 +48,7 @@ func (c *ctx) checkOciState(t *testing.T, containerID, state string) {
 }
 
 func genericOciMount(t *testing.T, c *ctx) (string, func()) {
+	require.Filesystem(t, "overlay")
 	bundleDir, err := ioutil.TempDir(c.env.TestDir, "bundle-")
 	if err != nil {
 		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Protect additional e2e tests needing UserNS, overlay with require.xxx

### This fixes or addresses the following GitHub issues:

 - Fixes #4904 
 - Fixes #4907


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

