### PR TITLE
Fix e2e security capabilities regular expression match on old kernels

### DIFF
--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -157,7 +157,7 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 			name:     "capabilities_keep",
 			argv:     []string{"grep", "^CapEff:", "/proc/self/status"},
 			opts:     []string{"--keep-privs"},
-			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+0000003fffffffff\n`),
+			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[3f]fffffffff\n`),
 		},
 		{
 			// this might break if new capabilities are
@@ -171,7 +171,7 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 			name:     "capabilities_drop",
 			argv:     []string{"grep", "^CapEff:", "/proc/self/status"},
 			opts:     []string{"--drop-caps", "CAP_NET_RAW"},
-			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+0000003fffffdfff\n`),
+			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[3f]fffffdfff\n`),
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

On old kernels like (eg: RHEL6) capabilities shown in `/proc/self/status` have their upper bits set to `1` while on more recent kernel those bits are to `0` leading e2e security tests to not match capabilities correctly with the following regex: https://github.com/sylabs/singularity/blob/369c061f7f899b3c7e0d68cbb124aea26f4ec884/e2e/security/security.go#L160


### This fixes or addresses the following GitHub issues:

 - Fixes #4903 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

