### PR TITLE
Call require.Network correctly in e2e ACTIONS/network

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -984,7 +984,7 @@ func (c actionTests) actionBasicProfiles(t *testing.T) {
 func (c actionTests) actionNetwork(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	e2e.Privileged(require.Network)
+	e2e.Privileged(require.Network)(t)
 
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Description of the Pull Request (PR):

In the ACTIONS/network test, the require.Network call is wrapped in an
e2.Privileged call. Privileged returns a func(t *Testing.t), so we need
to actually call it with (t) for the require.Network test to run.


Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.

### This fixes or addresses the following GitHub issues:

 - Fixes #4906 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

