### PR TITLE
Fix e2e config test with grep match

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -91,7 +91,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigPasswdNo",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config passwd",
 			directiveValue: "no",
@@ -99,7 +99,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigPasswdYes",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config passwd",
 			directiveValue: "yes",
@@ -107,7 +107,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigGroupNo",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config group",
 			directiveValue: "no",
@@ -115,7 +115,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigGroupYes",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config group",
 			directiveValue: "yes",
@@ -123,7 +123,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigResolvConfNo",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config resolv_conf",
 			directiveValue: "no",
@@ -131,7 +131,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigResolvConfYes",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config resolv_conf",
 			directiveValue: "yes",


### PR DESCRIPTION
## Description of the Pull Request (PR):

Grep match returns false positive when underlay is used by default (eg: RHEL6) and always return a line for `grep /etc/passwd /proc/self/mountinfo`. This PR fixes match by adding `.*- tmpfs` to be sure we are looking for the session file and ensure we exclude underlay bind mount.

### This fixes or addresses the following GitHub issues:

 - Fixes #4915 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

