### PR TITLE
Add ceph to filesystems needing st_dev workaround

### DIFF
--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -118,7 +118,7 @@ func parseMountInfoLine(line string) MountInfoEntry {
 	// different from those shown in mountinfo, to fix that
 	// we need to get major/minor directly from a stat call
 	// on the corresponding mount point
-	if entry.FSType == "btrfs" || entry.FSType == "overlay" {
+	if entry.FSType == "btrfs" || entry.FSType == "overlay" || entry.FSType == "ceph" {
 		fi, err := os.Stat(entry.Point)
 		if err == nil {
 			st := fi.Sys().(*syscall.Stat_t)


### PR DESCRIPTION
## Description of the Pull Request (PR):

As detailed in #4918, ceph needs the same stat workaround for incorrect
st_dev numbers in mountinfo.

Fix was verified via @DrDaveD creating a patched rpm and the user testing.

### This fixes or addresses the following GitHub issues:

 - Fixes #4918 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

