### PR TITLE
Bind /etc/hosts or create a default one with --contain flag

### DIFF
--- a/internal/pkg/util/fs/files/default_hosts.go
+++ b/internal/pkg/util/fs/files/default_hosts.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package files
+
+var defaultContent = `127.0.0.1   localhost
+::1         localhost ip6-localhost ip6-loopback
+ff02::1     ip6-allnodes
+ff02::2     ip6-allrouters
+`
+
+// DefaultHosts creates the default hosts file.
+func DefaultHosts() []byte {
+	return []byte(defaultContent)
+}

--- a/pkg/runtime/engine/config/config.go
+++ b/pkg/runtime/engine/config/config.go
@@ -160,7 +160,9 @@ mount hostfs = {{ if eq .MountHostfs true }}yes{{ else }}no{{ end }}
 # the container. The file or directory must exist within the container on
 # which to attach to. you can specify a different source and destination
 # path (respectively) with a colon; otherwise source and dest are the same.
-# NOTE: these are ignored if singularity is invoked with --contain.
+# NOTE: these are ignored if singularity is invoked with --contain except
+# for /etc/hosts and /etc/localtime. When invoked with --contain and --net,
+# /etc/hosts would contain a default generated content for localhost resolution.
 #bind path = /etc/singularity/default-nsswitch.conf:/etc/nsswitch.conf
 #bind path = /opt
 #bind path = /scratch


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bind `/etc/hosts` with `--contain` flag or create a minimal staging hosts file if a network namespace is requested with `--contain`.

### This fixes or addresses the following GitHub issues:

 - Fixes #1707

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

