### PR TITLE
Fix regression in e2e coverage command introduced by 4924

### DIFF
--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -229,6 +229,9 @@ func createCmdsFiles() (string, string, error) {
 		return "", "", fmt.Errorf("failed to create command text file: %s", err)
 	}
 	defer textFile.Close()
+
+	// iniatialize singularity CLI by registering all commands without plugins
+	cli.Init(false)
 	cli.RootCmd().InitDefaultHelpCmd()
 	cli.RootCmd().InitDefaultVersionFlag()
 

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -303,7 +303,8 @@ func persistentPreRun(*cobra.Command, []string) {
 	handleRemoteConf(syfs.RemoteConf())
 }
 
-func initCommands(loadPlugins bool) {
+// Init initializes and registers all singularity commands.
+func Init(loadPlugins bool) {
 	cmdManager := cmdline.NewCommandManager(singularityCmd)
 
 	singularityCmd.Flags().SetInterspersed(false)
@@ -386,7 +387,7 @@ func RootCmd() *cobra.Command {
 // flags appropriately. This is called by main.main(). It only needs to happen
 // once to the root command (singularity).
 func ExecuteSingularity() {
-	initCommands(true)
+	Init(true)
 
 	if cmd, err := singularityCmd.ExecuteC(); err != nil {
 		name := cmd.Name()
@@ -409,7 +410,7 @@ func ExecuteSingularity() {
 
 // GenBashCompletionFile
 func GenBashCompletion(w io.Writer) error {
-	initCommands(false)
+	Init(false)
 	return singularityCmd.GenBashCompletion(w)
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

e2e coverage command is broken and can't parse CLI command tree after merge of #4924.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

