### PR TITLE
Fix setgid group inheritance during make install

### DIFF
--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -28,7 +28,7 @@ $(singularity): $(singularity_build_config) $(singularity_deps) $(singularity_SO
 singularity_INSTALL := $(DESTDIR)$(BINDIR)/singularity
 $(singularity_INSTALL): $(singularity)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0755 $(singularity) $(singularity_INSTALL) # set cp to install
 
 CLEANFILES += $(singularity)
@@ -48,7 +48,7 @@ $(bash_completion): $(singularity_build_config)
 bash_completion_INSTALL := $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/singularity
 $(bash_completion_INSTALL): $(bash_completion)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 CLEANFILES += $(bash_completion)
@@ -69,7 +69,7 @@ $(config): $(singularity_build_config) $(SOURCEDIR)/etc/conf/gen.go $(SOURCEDIR)
 
 $(config_INSTALL): $(config)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(config_INSTALL)
@@ -81,7 +81,7 @@ remote_config := $(SOURCEDIR)/etc/remote.yaml
 remote_config_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/remote.yaml
 $(remote_config_INSTALL): $(remote_config)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(remote_config_INSTALL)

--- a/mlocal/frags/build_network.mk
+++ b/mlocal/frags/build_network.mk
@@ -17,7 +17,7 @@ cni_config_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/network
 
 .PHONY: cniplugins
 cniplugins:
-	$(V)install -d $(cni_builddir)
+	$(V)umask 0022 && mkdir -p $(cni_builddir)
 	$(V)for p in $(cni_plugins); do \
 		name=`basename $$p`; \
 		cniplugin=$(cni_builddir)/$$name; \
@@ -30,12 +30,12 @@ cniplugins:
 
 $(cni_plugins_INSTALL): $(cni_plugins_EXECUTABLES)
 	@echo " INSTALL CNI PLUGIN" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0755 $(cni_builddir)/$(@F) $@
 
 $(cni_config_INSTALL): $(cni_config_LIST)
 	@echo " INSTALL CNI CONFIGURATION FILES"
-	$(V)install -d $(cni_config_INSTALL)
+	$(V)umask 0022 && mkdir -p $(cni_config_INSTALL)
 	$(V)install -m 0644 $? $@
 
 CLEANFILES += $(cni_plugins_EXECUTABLES)

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -31,7 +31,7 @@ $(starter): $(BUILDDIR)/.clean-starter $(singularity_build_config) $(starter_dep
 starter_INSTALL := $(DESTDIR)$(LIBEXECDIR)/singularity/bin/starter
 $(starter_INSTALL): $(starter)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0755 $(starter) $@
 
 CLEANFILES += $(starter)
@@ -43,7 +43,7 @@ ALL += $(starter)
 sessiondir_INSTALL := $(DESTDIR)$(LOCALSTATEDIR)/singularity/mnt/session
 $(sessiondir_INSTALL):
 	@echo " INSTALL" $@
-	$(V)install -d $@
+	$(V)umask 0022 && mkdir -p $@
 
 INSTALLFILES += $(sessiondir_INSTALL)
 
@@ -54,7 +54,7 @@ run_singularity := $(SOURCEDIR)/scripts/run-singularity
 run_singularity_INSTALL := $(DESTDIR)$(BINDIR)/run-singularity
 $(run_singularity_INSTALL): $(run_singularity)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0755 $< $@
 
 INSTALLFILES += $(run_singularity_INSTALL)
@@ -64,7 +64,7 @@ INSTALLFILES += $(run_singularity_INSTALL)
 capability_config_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/capability.json
 $(capability_config_INSTALL):
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)touch $@
 
 INSTALLFILES += $(capability_config_INSTALL)
@@ -76,7 +76,7 @@ syecl_config := $(SOURCEDIR)/internal/pkg/syecl/syecl.toml.example
 syecl_config_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/ecl.toml
 $(syecl_config_INSTALL): $(syecl_config)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(syecl_config_INSTALL)
@@ -89,7 +89,7 @@ action_scripts := $(SOURCEDIR)/etc/actions/exec $(SOURCEDIR)/etc/actions/run $(S
 action_scripts_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/actions
 $(action_scripts_INSTALL): $(action_scripts)
 	@echo " INSTALL" $@
-	$(V)install -d $@
+	$(V)umask 0022 && mkdir -p $@
 	$(V)install -m 0755 $? $@
 
 INSTALLFILES += $(action_scripts_INSTALL)
@@ -101,7 +101,7 @@ seccomp_profile := $(SOURCEDIR)/etc/seccomp-profiles/default.json
 seccomp_profile_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/seccomp-profiles/default.json
 $(seccomp_profile_INSTALL): $(seccomp_profile)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(seccomp_profile_INSTALL)
@@ -113,7 +113,7 @@ nvidia_liblist := $(SOURCEDIR)/etc/nvliblist.conf
 nvidia_liblist_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/nvliblist.conf
 $(nvidia_liblist_INSTALL): $(nvidia_liblist)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(nvidia_liblist_INSTALL)
@@ -125,7 +125,7 @@ rocm_liblist := $(SOURCEDIR)/etc/rocmliblist.conf
  rocm_liblist_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/rocmliblist.conf
 $(rocm_liblist_INSTALL): $(rocm_liblist)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(rocm_liblist_INSTALL)
@@ -137,7 +137,7 @@ cgroups_config := $(SOURCEDIR)/internal/pkg/cgroups/example/cgroups.toml
 cgroups_config_INSTALL := $(DESTDIR)$(SYSCONFDIR)/singularity/cgroups/cgroups.toml
 $(cgroups_config_INSTALL): $(cgroups_config)
 	@echo " INSTALL" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(cgroups_config_INSTALL)

--- a/mlocal/frags/build_runtime_suid.mk
+++ b/mlocal/frags/build_runtime_suid.mk
@@ -12,7 +12,7 @@ $(starter_suid): $(starter)
 
 $(starter_suid_INSTALL): $(starter_suid)
 	@echo " INSTALL SUID" $@
-	$(V)install -d $(@D)
+	$(V)umask 0022 && mkdir -p $(@D)
 	$(V)install $(starter_suid) $(starter_suid_INSTALL)
 	@if [ `id -u` -ne 0 ] ; then \
 		echo "$(starter_suid_INSTALL) -- installed with incorrect permissions"; \


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use `umask 0022 && mkdir -p` instead of `install -d` to respect and inherit setgid bit while creating sub directories.

### This fixes or addresses the following GitHub issues:

 - Fixes #4940 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

