### PR TITLE
Remove reference to unavailable 'bc' package (opensuse example def file)

### DIFF
--- a/examples/opensuse/Singularity
+++ b/examples/opensuse/Singularity
@@ -9,4 +9,3 @@ Include: zypper
 
 %post
     echo "Hello from inside the container"
-    zypper -n install bc


### PR DESCRIPTION
## Description of the Pull Request (PR):

Remove reference to unavailable `bc` package in bootstrap installation.

Resolves issue #4954 

Attn: @singularity-maintainers

