### PR TITLE
Fix CLI command root user check for unprivileged installation

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -40,13 +40,6 @@ import (
 	"github.com/sylabs/singularity/pkg/util/rlimit"
 )
 
-// EnsureRootPriv ensures that a command is executed with root privileges.
-func EnsureRootPriv(cmd *cobra.Command, args []string) {
-	if os.Geteuid() != 0 {
-		sylog.Fatalf("%q command requires root privileges", cmd.CommandPath())
-	}
-}
-
 func convertImage(filename string, unsquashfsPath string) (string, error) {
 	img, err := imgutil.Init(filename, false)
 	if err != nil {

--- a/cmd/internal/cli/config_fakeroot_linux.go
+++ b/cmd/internal/cli/config_fakeroot_linux.go
@@ -63,7 +63,7 @@ var fakerootConfigDisableFlag = cmdline.Flag{
 var configFakerootCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		username := args[0]
 		var op singularity.FakerootConfigOp

--- a/cmd/internal/cli/config_global_linux.go
+++ b/cmd/internal/cli/config_global_linux.go
@@ -74,7 +74,7 @@ var globalConfigDryRunFlag = cmdline.Flag{
 var configGlobalCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(1, 2),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRootOrUnpriv,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var op singularity.GlobalConfigOp
 

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -168,7 +168,7 @@ func init() {
 var OciCreateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciCreate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
@@ -184,7 +184,7 @@ var OciCreateCmd = &cobra.Command{
 var OciRunCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.TODO()
 
@@ -202,7 +202,7 @@ var OciRunCmd = &cobra.Command{
 var OciStartCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciStart(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -218,7 +218,7 @@ var OciStartCmd = &cobra.Command{
 var OciDeleteCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.TODO()
 
@@ -236,7 +236,7 @@ var OciDeleteCmd = &cobra.Command{
 var OciKillCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		timeout := int(ociArgs.KillTimeout)
 		killSignal := ""
@@ -262,7 +262,7 @@ var OciKillCmd = &cobra.Command{
 var OciStateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciState(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
@@ -278,7 +278,7 @@ var OciStateCmd = &cobra.Command{
 var OciAttachCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.TODO()
 
@@ -296,7 +296,7 @@ var OciAttachCmd = &cobra.Command{
 var OciExecCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciExec(args[0], args[1:]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -312,7 +312,7 @@ var OciExecCmd = &cobra.Command{
 var OciUpdateCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciUpdate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
@@ -328,7 +328,7 @@ var OciUpdateCmd = &cobra.Command{
 var OciPauseCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciPauseResume(args[0], true); err != nil {
 			sylog.Fatalf("%s", err)
@@ -344,7 +344,7 @@ var OciPauseCmd = &cobra.Command{
 var OciResumeCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciPauseResume(args[0], false); err != nil {
 			sylog.Fatalf("%s", err)
@@ -360,7 +360,7 @@ var OciResumeCmd = &cobra.Command{
 var OciMountCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(2),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciMount(args[0], args[1]); err != nil {
 			sylog.Fatalf("%s", err)
@@ -376,7 +376,7 @@ var OciMountCmd = &cobra.Command{
 var OciUmountCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                EnsureRootPriv,
+	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := singularity.OciUmount(args[0]); err != nil {
 			sylog.Fatalf("%s", err)

--- a/cmd/internal/cli/plugin_disable_linux.go
+++ b/cmd/internal/cli/plugin_disable_linux.go
@@ -19,7 +19,7 @@ import (
 //
 // singularity plugin disable <name>
 var PluginDisableCmd = &cobra.Command{
-	PreRun: EnsureRootPriv,
+	PreRun: CheckRootOrUnpriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := singularity.DisablePlugin(args[0], buildcfg.LIBEXECDIR)
 		if err != nil {

--- a/cmd/internal/cli/plugin_enable_linux.go
+++ b/cmd/internal/cli/plugin_enable_linux.go
@@ -18,7 +18,7 @@ import (
 //
 // singularity plugin enable <name>
 var PluginEnableCmd = &cobra.Command{
-	PreRun: EnsureRootPriv,
+	PreRun: CheckRootOrUnpriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := singularity.EnablePlugin(args[0])
 		if err != nil {

--- a/cmd/internal/cli/plugin_install_linux.go
+++ b/cmd/internal/cli/plugin_install_linux.go
@@ -35,7 +35,7 @@ func init() {
 //
 // singularity plugin install <path> [-n name]
 var PluginInstallCmd = &cobra.Command{
-	PreRun: EnsureRootPriv,
+	PreRun: CheckRootOrUnpriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := singularity.InstallPlugin(args[0], pluginName)
 		if err != nil {

--- a/cmd/internal/cli/plugin_uninstall_linux.go
+++ b/cmd/internal/cli/plugin_uninstall_linux.go
@@ -19,7 +19,7 @@ import (
 //
 // singularity plugin uninstall <name>
 var PluginUninstallCmd = &cobra.Command{
-	PreRun: EnsureRootPriv,
+	PreRun: CheckRootOrUnpriv,
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
 		err := singularity.UninstallPlugin(name)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -593,3 +593,18 @@ func singularityExec(image string, args []string) (string, error) {
 
 	return stdout.String(), nil
 }
+
+// CheckRoot ensures that a command is executed with root privileges.
+func CheckRoot(cmd *cobra.Command, args []string) {
+	if os.Geteuid() != 0 {
+		sylog.Fatalf("%q command requires root privileges", cmd.CommandPath())
+	}
+}
+
+// CheckRootOrUnpriv ensures that a command is executed with root
+// privileges or that Singularity is installed unprivileged.
+func CheckRootOrUnpriv(cmd *cobra.Command, args []string) {
+	if os.Geteuid() != 0 && buildcfg.SINGULARITY_SUID_INSTALL == 1 {
+		sylog.Fatalf("%q command requires root privileges or an unprivileged installation", cmd.CommandPath())
+	}
+}

--- a/docs/content.go
+++ b/docs/content.go
@@ -1008,7 +1008,7 @@ Enterprise Performance Computing (EPC)`
   $ singularity config fakeroot --enable vagrant`
 
 	ConfigGlobalUse   string = `global <option> <directive> [value,...]`
-	ConfigGlobalShort string = `Edit singularity.conf from command line (root user only)`
+	ConfigGlobalShort string = `Edit singularity.conf from command line (root user only or unprivileged installation)`
 	ConfigGlobalLong  string = `
   The config global command allow administrators to set/unset/get/reset configuration
   directives of singularity.conf from command line.`


### PR DESCRIPTION
## Description of the Pull Request (PR):

Disable root check for unprivilege installation with commands `config global` and `plugin install/enable/disable/uninstall`


### This fixes or addresses the following GitHub issues:

 - Fixes #4962 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

