### PR TITLE
Fix e2e instance test race

### DIFF
--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -31,11 +31,6 @@ type ctx struct {
 	profile e2e.Profile
 }
 
-// Test that no instances are running.
-func (c *ctx) testNoInstances(t *testing.T) {
-	c.expectedNumberOfInstances(t, 0)
-}
-
 // Test that a basic echo server instance can be started, communicated with,
 // and stopped.
 func (c *ctx) testBasicEchoServer(t *testing.T) {
@@ -80,10 +75,9 @@ func (c *ctx) testCreateManyInstances(t *testing.T) {
 			}),
 			e2e.ExpectExit(0),
 		)
-	}
 
-	// Verify all instances started.
-	c.expectedNumberOfInstances(t, n)
+		c.expectInstance(t, instanceName, 1)
+	}
 }
 
 // Test stopping all running instances.
@@ -353,14 +347,12 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				name     string
 				function func(*testing.T)
 			}{
-				{"InitialNoInstances", c.testNoInstances},
 				{"BasicEchoServer", c.testBasicEchoServer},
 				{"BasicOptions", c.testBasicOptions},
 				{"Contain", c.testContain},
 				{"InstanceFromURI", c.testInstanceFromURI},
 				{"CreateManyInstances", c.testCreateManyInstances},
 				{"StopAll", c.testStopAll},
-				{"FinalNoInstances", c.testNoInstances},
 				{"GhostInstance", c.testGhostInstance},
 				{"ApplyCgroupsInstance", c.applyCgroupsInstance},
 			}

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -53,7 +53,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 			WithCommand("instance start"),
 			WithArgs("-w", dockerImage, dockerInstanceName),
 			PreRun(func(t *testing.T) {
-				umountFn = ShadowInstanceDirectory(t, env)
+				umountFn = shadowInstanceDirectory(t, env)
 			}),
 			PostRun(func(t *testing.T) {
 				if umountFn != nil {
@@ -109,7 +109,7 @@ func KillRegistry(t *testing.T, env TestEnv) {
 		WithCommand("instance stop"),
 		WithArgs("-s", "KILL", dockerInstanceName),
 		PreRun(func(t *testing.T) {
-			umountFn = ShadowInstanceDirectory(t, env)
+			umountFn = shadowInstanceDirectory(t, env)
 		}),
 		PostRun(func(t *testing.T) {
 			if umountFn != nil {

--- a/e2e/internal/e2e/home_linux.go
+++ b/e2e/internal/e2e/home_linux.go
@@ -135,10 +135,10 @@ func SetupHomeDirectories(t *testing.T) {
 	})(t)
 }
 
-// ShadowInstanceDirectory creates a temporary instances directory which
+// shadowInstanceDirectory creates a temporary instances directory which
 // will be bound on top of current user home directory in order to execute
 // a "shadow" instance (eg: docker registry).
-func ShadowInstanceDirectory(t *testing.T, env TestEnv) func(t *testing.T) {
+func shadowInstanceDirectory(t *testing.T, env TestEnv) func(t *testing.T) {
 	u := CurrentUser(t)
 
 	// $TESTDIR/.singularity directory

--- a/e2e/testdata/sshfs.def
+++ b/e2e/testdata/sshfs.def
@@ -37,5 +37,7 @@ EOF
 
     chmod +x /sshfs-wrapper /wrapped/*
 
-%startscript
-    exec dropbear -R -E -s -p 127.0.0.1:2022
+%runscript
+    dropbear -R -E -s -p 127.0.0.1:2022
+    # wait until we receive something on stdin
+    cat > /dev/null


### PR DESCRIPTION
## Description of the Pull Request (PR):

Get rid of NoInstance tests which is a wrong approach and instead track instances one by one with unique name so tests won't conflict with others running in parallel, #4953 introduced more race error by using an instance within e2e fuse tests.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

