### PR TITLE
Fix build post/test -c section parameter regression

### DIFF
--- a/e2e/regressions/build.go
+++ b/e2e/regressions/build.go
@@ -191,6 +191,25 @@ func (c *regressionsTests) issue4943(t *testing.T) {
 
 }
 
+// Test -c section parameter is correctly handled.
+func (c *regressionsTests) issue4967(t *testing.T) {
+	image := filepath.Join(c.env.TestDir, "issue_4967.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(image, "testdata/regressions/issue_4967.def"),
+		e2e.PostRun(func(t *testing.T) {
+			os.Remove(image)
+		}),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ContainMatch, "function foo"),
+		),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := regressionsTests{
@@ -203,5 +222,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4524": c.issue4524, // https://github.com/sylabs/singularity/issues/4524
 		"issue 4583": c.issue4583, // https://github.com/sylabs/singularity/issues/4583
 		"issue 4943": c.issue4943, // https://github.com/sylabs/singularity/issues/4943
+		"issue 4967": c.issue4967, // https://github.com/sylabs/singularity/issues/4967
 	}
 }

--- a/e2e/testdata/regressions/issue_4967.def
+++ b/e2e/testdata/regressions/issue_4967.def
@@ -1,0 +1,9 @@
+bootstrap: docker
+from: alpine:3.10
+
+%post
+    apk add --update-cache bash
+
+%test -c /bin/bash
+    function foo { echo "function foo"; }
+    foo


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix from #4777 introduced a regression for `%post` and `%test` sections, as we use a temporary script instead of passing build script over stdin, the `-c` section parameter is not correctly handled.

### This fixes or addresses the following GitHub issues:

 - Fixes #4967 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

