### PR TITLE
Automatically handle overlay read-only option based on filesystem

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -828,9 +828,9 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 			profile: e2e.RootProfile,
 		},
 		{
-			name:    "overlay_squashFS_find_fail_without_ro",
-			argv:    []string{"--overlay", squashfsImage, c.env.ImagePath, "true"},
-			exit:    255,
+			name:    "overlay_squashFS_find_without_ro",
+			argv:    []string{"--overlay", squashfsImage, c.env.ImagePath, "test", "-f", fmt.Sprintf("/%s", squashMarkerFile)},
+			exit:    0,
 			profile: e2e.RootProfile,
 		},
 		{

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -155,7 +155,14 @@ func (f *squashfsFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	}
 
 	if img.Writable {
-		return fmt.Errorf("could not set image writable: squashfs is a read-only filesystem")
+		// we set Writable to appropriate value to match the
+		// image open mode as some code may want to ignore this
+		// error by using IsReadOnlyFilesytem check
+		img.Writable = false
+
+		return &readOnlyFilesystemError{
+			"could not set " + img.Path + " image writable: squashfs is a read-only filesystem",
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix bug introduced in #4365 requiring to add `:ro` as overlay image option when overlay image is of type squashfs, it was possible before. Restore this behavior but always return an error in image init handler to let the decision to the caller, so different code path will get the error and could decide to ignore it or not.

### This fixes or addresses the following GitHub issues:

 - Fixes #4956 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

