### PR TITLE
Allow 0x or non-prefixed key IDs/fingerprints

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -280,17 +280,16 @@ Enterprise Performance Computing (EPC)`
 	KeySearchShort string = `Search for keys on a key server`
 	KeySearchLong  string = `
   The 'key search' command allows you to connect to a key server and look for
-  public keys matching the argument passed to the command line. You can also 
-  search for a key by fingerprint or key ID by adding '0x' before the
-  fingerprint. (Maximum 100 search entities)`
+  public keys matching the argument passed to the command line. You can  
+  search by name, email, or fingerprint / key ID. (Maximum 100 search entities)`
 	KeySearchExample string = `
   $ singularity key search sylabs.io
 
-  # note the '0x' before the fingerprint:
-  $ singularity key search 0x8883491F4268F173C6E5DC49EDECE4F3F38D871E
+  # search by fingerprint:
+  $ singularity key search 8883491F4268F173C6E5DC49EDECE4F3F38D871E
 
-  # search by key ID: (again, there's '0x' before the ID)
-  $ singularity key search 0xF38D871E`
+  # search by key ID:
+  $ singularity key search F38D871E`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// key pull

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -80,13 +80,23 @@ func (c *ctx) singularityKeySearch(t *testing.T) {
 			stdout: "^Search for keys on a key server",
 		},
 		{
-			name:   "key search <key id>",
+			name:   "key search 0x<key id>",
 			args:   []string{"search", "0x8BD91BEE"},
 			stdout: "^Showing 1 results",
 		},
 		{
-			name:   "key search <key fingerprint>",
+			name:   "key search <key id>",
+			args:   []string{"search", "8BD91BEE"},
+			stdout: "^Showing 1 results",
+		},
+		{
+			name:   "key search 0x<key fingerprint>",
 			args:   []string{"search", "0x7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
+			stdout: "^Showing 1 results",
+		},
+		{
+			name:   "key search <key fingerprint>",
+			args:   []string{"search", "7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
 			stdout: "^Showing 1 results",
 		},
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previously...

  - `keys remove` needed a key fingerprint *without* 0x prefix.
  - `keys search` needed a key fingerprint *with* a 0x prefix.

This is confusing, so handle either with our without a prefix in both
cases, and prefer without in the help messages.

We make the assumption in key search that a search term of 8+ hex digits
is a fingerprint... which should be quite safe.

### This fixes or addresses the following GitHub issues:

Closes issue #4968


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

