### PR TITLE
Add build command sanity check to close #3502

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -266,14 +266,10 @@ func checkBuildTarget(path string) error {
 		}
 		if !buildArgs.update && !forceOverwrite {
 
-			var question string
+			question := fmt.Sprintf("Build target '%s' already exists. Do you want to overwrite? [N/y]", f.Name())
 
-			isDefFile, _ := parser.IsValidDefinition(path)
-			if isDefFile {
-				question = "Build target '" + f.Name() + "' is a definition file that will be overwritten. Do you still want to overwrite? [N/y]"
-			} else {
-
-				question = "Build target '" + f.Name() + "' already exists. Do you want to overwrite? [N/y]"
+			if isDefFile, _ := parser.IsValidDefinition(path); isDefFile {
+				question = fmt.Sprintf("Build target '%s' is a definition file that will be overwritten. Do you still want to overwrite? [N/y]", f.Name())
 			}
 
 			input, err := interactive.AskYNQuestion("n", question)

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -265,7 +265,17 @@ func checkBuildTarget(path string) error {
 			return fmt.Errorf("only sandbox update is supported: %s is not a directory", path)
 		}
 		if !buildArgs.update && !forceOverwrite {
-			question := "Build target already exists. Do you want to overwrite? [N/y] "
+
+			var question string
+
+			isDefFile, _ := parser.IsValidDefinition(path)
+			if isDefFile {
+				question = "Build target is a valid definition file that will be overwritten. Do you still want to overwrite? [N/y]"
+			} else {
+
+				question = "Build target already exists. Do you want to overwrite? [N/y] "
+			}
+
 			input, err := interactive.AskYNQuestion("n", question)
 			if err != nil {
 				return fmt.Errorf("while reading the input: %s", err)

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -270,10 +270,10 @@ func checkBuildTarget(path string) error {
 
 			isDefFile, _ := parser.IsValidDefinition(path)
 			if isDefFile {
-				question = "Build target is a valid definition file that will be overwritten. Do you still want to overwrite? [N/y]"
+				question = "Build target '" + f.Name() + "' is a definition file that will be overwritten. Do you still want to overwrite? [N/y]"
 			} else {
 
-				question = "Build target already exists. Do you want to overwrite? [N/y] "
+				question = "Build target '" + f.Name() + "' already exists. Do you want to overwrite? [N/y]"
 			}
 
 			input, err := interactive.AskYNQuestion("n", question)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Addresses #3502
Modified the `checkBuildTarget` function to first try and parse the target as a def file if build target already exists and force overwrite flag is false. This method is insensitive to filenaming and is based on the content of the file itself.

### This fixes or addresses the following GitHub issues:

 - Closes #3502

Attn: @singularity-maintainers

