### PR TITLE
Fix travis Go install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,7 @@ sudo: required
 dist: xenial
 
 go:
-  - "1.13"
-
-# Make sure user forks of singularity build correctly
-go_import_path: github.com/sylabs/singularity
+  - 1.13.x
 
 addons:
   apt:
@@ -37,8 +34,8 @@ services:
 before_install:
   - .travis/before_install
 
-install:
-  - # override the default go install target
+# disable default travis go install dependencies
+install: true
 
 script:
   - .travis/script


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR disable the default install script (travis_install_go_dependencies) setup by travis because we can't run `go get ./...` in singularity repo without failure

### This fixes or addresses the following GitHub issues:

 - Related to #5005 and #5006 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

