### PR TITLE
Cherry pick test fixes to 3.5.3

### DIFF
--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -364,6 +364,7 @@ func testRunFromURI(t *testing.T) {
 
 // testPersistentOverlay test the --overlay function
 func testPersistentOverlay(t *testing.T) {
+	require.Filesystem(t, "overlay")
 	const squashfsImage = "squashfs.simg"
 	//  Create the overlay dir
 	cwd, err := os.Getwd()

--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 )
 
 // build base image for tests
@@ -345,6 +346,10 @@ func testRunFromURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, test.WithoutPrivilege(func(t *testing.T) {
+			if tt.opts.userns {
+				require.UserNamespace(t)
+			}
+
 			_, stderr, exitCode, err := imageExec(t, tt.action, tt.opts, tt.image, tt.argv)
 			if tt.expectSuccess && (exitCode != 0) {
 				t.Log(stderr)

--- a/cmd/singularity/docker_test.go
+++ b/cmd/singularity/docker_test.go
@@ -176,8 +176,11 @@ func TestDockerDefFile(t *testing.T) {
 	}{
 		{"Arch", 3, "dock0/arch:latest"},
 		{"BusyBox", 0, "busybox:latest"},
-		{"CentOS", 0, "centos:latest"},
-		{"Ubuntu", 0, "ubuntu:16.04"},
+		{"CentOS_6", 0, "centos:6"},
+		{"CentOS_7", 0, "centos:7"},
+		{"CentOS_8", 3, "centos:8"},
+		{"Ubuntu_1604", 0, "ubuntu:16.04"},
+		{"Ubuntu_1804", 3, "ubuntu:18.04"},
 	}
 
 	for _, tt := range tests {

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -959,7 +959,7 @@ func (c actionTests) actionBasicProfiles(t *testing.T) {
 func (c actionTests) actionNetwork(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	e2e.Privileged(require.Network)
+	e2e.Privileged(require.Network)(t)
 
 	tests := []struct {
 		name       string

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,0 +1,400 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/internal/pkg/util/user"
+)
+
+type configTests struct {
+	env e2e.TestEnv
+}
+
+func (c configTests) configGlobal(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	setDirective := func(t *testing.T, directive, value string) {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("config global"),
+			e2e.WithArgs("--set", directive, value),
+			e2e.ExpectExit(0),
+		)
+	}
+	resetDirective := func(t *testing.T, directive string) {
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("config global"),
+			e2e.WithArgs("--reset", directive),
+			e2e.ExpectExit(0),
+		)
+	}
+
+	u := e2e.UserProfile.HostUser(t)
+	g, err := user.GetGrGID(u.GID)
+	if err != nil {
+		t.Fatalf("could not retrieve user group information: %s", err)
+	}
+
+	tests := []struct {
+		name           string
+		argv           []string
+		profile        e2e.Profile
+		cwd            string
+		directive      string
+		directiveValue string
+		exit           int
+		resultOp       e2e.SingularityCmdResultOp
+	}{
+		{
+			name:           "AllowSetuid",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow setuid",
+			directiveValue: "no",
+			exit:           0,
+		},
+		{
+			name:           "MaxLoopDevices",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "max loop devices",
+			directiveValue: "0",
+			exit:           255,
+		},
+		{
+			name:           "AllowPidNsNo",
+			argv:           []string{"--pid", "--no-init", c.env.ImagePath, "/bin/sh", "-c", "echo $$"},
+			profile:        e2e.UserProfile,
+			directive:      "allow pid ns",
+			directiveValue: "no",
+			exit:           0,
+			resultOp:       e2e.ExpectOutput(e2e.UnwantedMatch, "1"),
+		},
+		{
+			name:           "AllowPidNsYes",
+			argv:           []string{"--pid", "--no-init", c.env.ImagePath, "/bin/sh", "-c", "echo $$"},
+			profile:        e2e.UserProfile,
+			directive:      "allow pid ns",
+			directiveValue: "yes",
+			exit:           0,
+			resultOp:       e2e.ExpectOutput(e2e.ExactMatch, "1"),
+		},
+		{
+			name:           "ConfigPasswdNo",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config passwd",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "ConfigPasswdYes",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config passwd",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "ConfigGroupNo",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config group",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "ConfigGroupYes",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config group",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "ConfigResolvConfNo",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config resolv_conf",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "ConfigResolvConfYes",
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "config resolv_conf",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountProcNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/proc/self"},
+			profile:        e2e.UserProfile,
+			directive:      "mount proc",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountProcYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/proc/self"},
+			profile:        e2e.UserProfile,
+			directive:      "mount proc",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountSysNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/sys/kernel"},
+			profile:        e2e.UserProfile,
+			directive:      "mount sys",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountSysYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/sys/kernel"},
+			profile:        e2e.UserProfile,
+			directive:      "mount sys",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountDevNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", "/dev/pts"},
+			profile:        e2e.UserProfile,
+			directive:      "mount dev",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountDevMinimal",
+			argv:           []string{c.env.ImagePath, "test", "-b", "/dev/loop0"},
+			profile:        e2e.UserProfile,
+			directive:      "mount dev",
+			directiveValue: "minimal",
+			exit:           1,
+		},
+		{
+			name:           "MountDevYes",
+			argv:           []string{c.env.ImagePath, "test", "-b", "/dev/loop0"},
+			profile:        e2e.UserProfile,
+			directive:      "mount dev",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		// just test 'mount devpts = no' as yes depends of kernel version
+		{
+			name:           "MountDevPtsNo",
+			argv:           []string{"-C", c.env.ImagePath, "test", "-d", "/dev/pts"},
+			profile:        e2e.UserProfile,
+			directive:      "mount devpts",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountHomeNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", u.Dir},
+			profile:        e2e.UserProfile,
+			cwd:            "/",
+			directive:      "mount home",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountHomeYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", u.Dir},
+			profile:        e2e.UserProfile,
+			cwd:            "/",
+			directive:      "mount home",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "MountTmpNo",
+			argv:           []string{c.env.ImagePath, "test", "-d", c.env.TestDir},
+			profile:        e2e.UserProfile,
+			directive:      "mount tmp",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "MountTmpYes",
+			argv:           []string{c.env.ImagePath, "test", "-d", c.env.TestDir},
+			profile:        e2e.UserProfile,
+			directive:      "mount tmp",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "BindPathPasswd",
+			argv:           []string{c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserProfile,
+			directive:      "bind path",
+			directiveValue: "/etc/passwd:/passwd",
+			exit:           0,
+		},
+		{
+			name:           "UserBindControlNo",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserProfile,
+			directive:      "user bind control",
+			directiveValue: "no",
+			exit:           1,
+		},
+		{
+			name:           "UserBindControlYes",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserProfile,
+			directive:      "user bind control",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		// overlay may or not be available, just test with no
+		{
+			name:           "EnableOverlayNo",
+			argv:           []string{c.env.ImagePath, "grep", "\\- overlay overlay", "/proc/self/mountinfo"},
+			profile:        e2e.UserProfile,
+			directive:      "enable overlay",
+			directiveValue: "no",
+			exit:           1,
+		},
+		// use user namespace profile to force underlay use
+		{
+			name:           "EnableUnderlayNo",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "enable underlay",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "EnableUnderlayYes",
+			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "enable underlay",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		// test image is owned by root:root
+		{
+			name:           "LimitContainerOwnersUser",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container owners",
+			directiveValue: u.Name,
+			exit:           255,
+		},
+		{
+			name:           "LimitContainerOwnersUserAndRoot",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container owners",
+			directiveValue: u.Name + ", root",
+			exit:           0,
+		},
+		{
+			name:           "LimitContainerGroupsUser",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container groups",
+			directiveValue: g.Name,
+			exit:           255,
+		},
+		{
+			name:           "LimitContainerGroupsUserAndRoot",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container groups",
+			directiveValue: g.Name + ", root",
+			exit:           0,
+		},
+		{
+			name:           "LimitContainerPathsProc",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container paths",
+			directiveValue: "/proc",
+			exit:           255,
+		},
+		{
+			name:           "LimitContainerPathsTestdir",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "limit container paths",
+			directiveValue: c.env.TestDir,
+			exit:           0,
+		},
+		{
+			name:           "AllowContainerSquashfsNo",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container squashfs",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowContainerSquashfsYes",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow container squashfs",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
+			name:           "AllowContainerDirNo",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "allow container dir",
+			directiveValue: "no",
+			exit:           255,
+		},
+		{
+			name:           "AllowContainerDirYes",
+			argv:           []string{c.env.ImagePath, "true"},
+			profile:        e2e.UserNamespaceProfile,
+			directive:      "allow container dir",
+			directiveValue: "yes",
+			exit:           0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithDir(tt.cwd),
+			e2e.PreRun(func(t *testing.T) {
+				setDirective(t, tt.directive, tt.directiveValue)
+			}),
+			e2e.PostRun(func(t *testing.T) {
+				resetDirective(t, tt.directive)
+			}),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(tt.argv...),
+			e2e.ExpectExit(tt.exit, tt.resultOp),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) func(*testing.T) {
+	c := configTests{
+		env: env,
+	}
+
+	return testhelper.TestRunner(map[string]func(*testing.T){
+		"config global": c.configGlobal, // test various global configuration
+	})
+}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -97,7 +97,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigPasswdNo",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config passwd",
 			directiveValue: "no",
@@ -105,7 +105,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigPasswdYes",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/passwd.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config passwd",
 			directiveValue: "yes",
@@ -113,7 +113,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigGroupNo",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config group",
 			directiveValue: "no",
@@ -121,7 +121,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigGroupYes",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/group", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/group.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config group",
 			directiveValue: "yes",
@@ -129,7 +129,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigResolvConfNo",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config resolv_conf",
 			directiveValue: "no",
@@ -137,7 +137,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigResolvConfYes",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config resolv_conf",
 			directiveValue: "yes",

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -262,14 +262,29 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			from:                "busybox:latest",
 		},
 		{
-			name:                "CentOS",
+			name:                "CentOS_6",
 			kernelMajorRequired: 0,
-			from:                "centos:latest",
+			from:                "centos:6",
 		},
 		{
-			name:                "Ubuntu",
+			name:                "CentOS_7",
+			kernelMajorRequired: 0,
+			from:                "centos:7",
+		},
+		{
+			name:                "CentOS_8",
+			kernelMajorRequired: 3,
+			from:                "centos:8",
+		},
+		{
+			name:                "Ubuntu_1604",
 			kernelMajorRequired: 0,
 			from:                "ubuntu:16.04",
+		},
+		{
+			name:                "Ubuntu_1804",
+			kernelMajorRequired: 3,
+			from:                "ubuntu:18.04",
 		},
 	}
 

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/pkg/runtime/engine/config"
+	"golang.org/x/sys/unix"
+)
+
+func SetupDefaultConfig(t *testing.T, path string) {
+	c, err := config.ParseFile("")
+	if err != nil {
+		t.Fatalf("while generating singularity configuration: %s", err)
+	}
+
+	Privileged(func(t *testing.T) {
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatalf("while creating singularity configuration: %s", err)
+		}
+
+		if err := config.Generate(f, "", c); err != nil {
+			t.Fatalf("while generating singularity configuration: %s", err)
+		}
+
+		f.Close()
+
+		if err := unix.Mount(path, buildcfg.SINGULARITY_CONF_FILE, "", unix.MS_BIND, ""); err != nil {
+			t.Fatalf("while mounting %s to %s: %s", path, buildcfg.SINGULARITY_CONF_FILE, err)
+		}
+	})(t)
+}

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -32,7 +32,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 		EnsureImage(t, env)
 
 		dockerDefinition := "testdata/Docker_registry.def"
-		dockerImage := filepath.Join(env.TestDir, "docker-e2e.sif")
+		dockerImage := filepath.Join(env.TestDir, "docker-registry")
 
 		env.RunSingularity(
 			t,
@@ -48,7 +48,7 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 			t,
 			WithProfile(RootProfile),
 			WithCommand("instance start"),
-			WithArgs("-w", "-B", "/sys", dockerImage, dockerInstanceName),
+			WithArgs("-w", dockerImage, dockerInstanceName),
 			PreRun(func(t *testing.T) {
 				umountFn = shadowInstanceDirectory(t, env)
 			}),

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -45,6 +45,8 @@ const (
 	ContainMatch MatchType = iota
 	// ExactMatch is for exact match
 	ExactMatch
+	// UnwantedMatch is for unwanted match
+	UnwantedMatch
 	// RegexMatch is for regular expression match
 	RegexMatch
 )
@@ -55,6 +57,8 @@ func (m MatchType) String() string {
 		return "ContainMatch"
 	case ExactMatch:
 		return "ExactMatch"
+	case UnwantedMatch:
+		return "UnwantedMatch"
 	case RegexMatch:
 		return "RegexMatch"
 	default:
@@ -98,6 +102,13 @@ func (r *SingularityCmdResult) expectMatch(mt MatchType, stream streamType, patt
 		if strings.TrimSuffix(output, "\n") != pattern {
 			return errors.Errorf(
 				"Command %q:\nExpect %s stream exact match:\n%s\nCommand %s output:\n%s",
+				r.FullCmd, streamName, pattern, streamName, output,
+			)
+		}
+	case UnwantedMatch:
+		if strings.TrimSuffix(output, "\n") == pattern {
+			return errors.Errorf(
+				"Command %q:\nExpect %s stream not matching:\n%s\nCommand %s output:\n%s",
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -22,6 +22,7 @@ import (
 	e2ebuildcfg "github.com/sylabs/singularity/e2e/buildcfg"
 	"github.com/sylabs/singularity/e2e/cache"
 	"github.com/sylabs/singularity/e2e/cmdenvvars"
+	"github.com/sylabs/singularity/e2e/config"
 	"github.com/sylabs/singularity/e2e/delete"
 	"github.com/sylabs/singularity/e2e/docker"
 	singularityenv "github.com/sylabs/singularity/e2e/env"
@@ -74,30 +75,6 @@ func Run(t *testing.T) {
 		return filepath.Join(buildcfg.SYSCONFDIR, "singularity", fn)
 	}
 
-	// e2e tests need to run in a somehow agnostic environment, so we
-	// don't use environment of user executing tests in order to not
-	// wrongly interfering with cache stuff, sylabs library tokens,
-	// PGP keys
-	e2e.SetupHomeDirectories(t)
-
-	// Ensure config files are installed
-	configFiles := []string{
-		sysconfdir("singularity.conf"),
-		sysconfdir("ecl.toml"),
-		sysconfdir("capability.json"),
-		sysconfdir("nvliblist.conf"),
-	}
-
-	for _, cf := range configFiles {
-		if fi, err := os.Stat(cf); err != nil {
-			log.Fatalf("%s is not installed on this system: %v", cf, err)
-		} else if !fi.Mode().IsRegular() {
-			log.Fatalf("%s is not a regular file", cf)
-		} else if fi.Sys().(*syscall.Stat_t).Uid != 0 {
-			log.Fatalf("%s must be owned by root", cf)
-		}
-	}
-
 	// Make temp dir for tests
 	name, err := ioutil.TempDir("", "stest.")
 	if err != nil {
@@ -116,6 +93,33 @@ func Run(t *testing.T) {
 		log.Fatalf("failed to chmod temporary directory: %v", err)
 	}
 	testenv.TestDir = name
+
+	// e2e tests need to run in a somehow agnostic environment, so we
+	// don't use environment of user executing tests in order to not
+	// wrongly interfering with cache stuff, sylabs library tokens,
+	// PGP keys
+	e2e.SetupHomeDirectories(t)
+
+	// generate singularity.conf with default values
+	e2e.SetupDefaultConfig(t, filepath.Join(testenv.TestDir, "singularity.conf"))
+
+	// Ensure config files are installed
+	configFiles := []string{
+		sysconfdir("singularity.conf"),
+		sysconfdir("ecl.toml"),
+		sysconfdir("capability.json"),
+		sysconfdir("nvliblist.conf"),
+	}
+
+	for _, cf := range configFiles {
+		if fi, err := os.Stat(cf); err != nil {
+			log.Fatalf("%s is not installed on this system: %v", cf, err)
+		} else if !fi.Mode().IsRegular() {
+			log.Fatalf("%s is not a regular file", cf)
+		} else if fi.Sys().(*syscall.Stat_t).Uid != 0 {
+			log.Fatalf("%s must be owned by root", cf)
+		}
+	}
 
 	// Build a base image for tests
 	imagePath := path.Join(name, "test.sif")
@@ -147,6 +151,7 @@ func Run(t *testing.T) {
 		"BUILD":       imgbuild.E2ETests(testenv),
 		"CACHE":       cache.E2ETests(testenv),
 		"CMDENVVARS":  cmdenvvars.E2ETests(testenv),
+		"CONFIG":      config.E2ETests(testenv),
 		"DELETE":      delete.E2ETests(testenv),
 		"DOCKER":      docker.E2ETests(testenv),
 		"ENV":         singularityenv.E2ETests(testenv),

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -2,34 +2,18 @@ bootstrap: docker
 from: registry:2.7.1
 
 %post
-    apk add docker
-    # prevent docker to add iptables rules because it
-    # add few rules even with --iptables=false
-    rm -f /sbin/iptables
+    apk add runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+            img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 %startscript
-    # if there is no docker0 bridge, we could safely
-    # remove the created one after the docker daemon
-    # started
-    if ! brctl show docker0; then
-        DELETE_BRIDGE=1
-    fi
-
-    dockerd --iptables=false --ip-forward=false --ip-masq=false --storage-driver=vfs &
     /.singularity.d/runscript &
 
     # wait until docker registry is up
     while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.5; done
 
-    # delete bridge if docker0 was not previously present
-    if [ ! -z "${DELETE_BRIDGE}" ]; then
-        ip link set docker0 down || true
-        brctl delbr docker0 || true
-    fi
-
-    docker pull busybox || kill -TERM 1
-    docker tag busybox localhost:5000/my-busybox || kill -TERM 1
-    docker push localhost:5000/my-busybox || kill -TERM 1
+    img pull busybox || kill -TERM 1
+    img tag busybox localhost:5000/my-busybox || kill -TERM 1
+    img push localhost:5000/my-busybox || kill -TERM 1
 
     # e2e PrepRegistry will repeatedly trying to connect to this port
     # giving indication that it can start

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -597,6 +597,9 @@ func TestAddDelNetworks(t *testing.T) {
 		nsPath := fmt.Sprintf("/proc/%d/ns/net", cmd.Process.Pid)
 		if err := c.runFunc(nsPath, cniPath, stdinPipe, stdoutPipe); err != nil {
 			t.Errorf("unexpected failure for %q: %s", c.name, err)
+			if err := cmd.Process.Kill(); err != nil {
+				t.Fatalf("error killing process %q: %s", cmdPath, err)
+			}
 		}
 
 		stdoutPipe.Close()

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -554,7 +554,7 @@ func TestAddDelNetworks(t *testing.T) {
 		{
 			name:    "TestHTTPPortmap",
 			command: "nc",
-			args:    []string{"-l", "-p", "80"},
+			args:    []string{"-l", "80"},
 			runFunc: testHTTPPortmap,
 		},
 		{

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -518,14 +518,14 @@ func TestAddDelNetworks(t *testing.T) {
 	test.EnsurePrivilege(t)
 
 	// centos 6 doesn't support brigde/veth, only macvlan
-	// just skip tests on centos 6
+	// just skip tests on centos 6, rhel 6
 	b, err := ioutil.ReadFile("/etc/system-release-cpe")
 	if err == nil {
 		fields := strings.Split(string(b), ":")
 		switch fields[2] {
-		case "centos":
+		case "centos", "redhat":
 			if strings.HasPrefix(fields[4], "6") {
-				t.SkipNow()
+				t.Skipf("RHEL6/CentOS6 don't support CNI bridge/veth - skipping")
 			}
 		}
 	}

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/client/cache"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	testCache "github.com/sylabs/singularity/internal/pkg/test/tool/cache"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 )
 
 func TestFromSif(t *testing.T) {
@@ -72,33 +73,51 @@ func TestFromSif(t *testing.T) {
 		t.Errorf("unexpected success while creating OCI bundle")
 	}
 
-	// create OCI bundle from SIF
-	bundle, err = FromSif(sifFile, bundlePath, true)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		writable bool
+	}{
+		{"FromSif", false},
+		{"FromSifWritable", true},
 	}
-	// generate a default configuration
-	g, err := generate.New(runtime.GOOS)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// remove seccomp filter for CI
-	g.Config.Linux.Seccomp = nil
-	g.SetProcessArgs([]string{tools.RunScript, "id"})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	if err := bundle.Create(g.Config); err != nil {
-		// check if cleanup occurred
-		t.Fatal(err)
+			if tt.writable {
+				require.Filesystem(t, "overlay")
+			}
+
+			// create OCI bundle from SIF
+			bundle, err = FromSif(sifFile, bundlePath, tt.writable)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// generate a default configuration
+			g, err := generate.New(runtime.GOOS)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// remove seccomp filter for CI
+			g.Config.Linux.Seccomp = nil
+			g.SetProcessArgs([]string{tools.RunScript, "id"})
+
+			if err := bundle.Create(g.Config); err != nil {
+				// check if cleanup occurred
+				t.Fatal(err)
+			}
+
+			// execute oci run command
+			args = []string{"oci", "run", "-b", bundlePath, filepath.Base(sifFile)}
+			cmd = exec.Command(sing, args...)
+			if err := cmd.Run(); err != nil {
+				t.Error(err)
+			}
+
+			if err := bundle.Delete(); err != nil {
+				t.Error(err)
+			}
+
+		})
 	}
 
-	// execute oci run command
-	args = []string{"oci", "run", "-b", bundlePath, filepath.Base(sifFile)}
-	cmd = exec.Command(sing, args...)
-	if err := cmd.Run(); err != nil {
-		t.Error(err)
-	}
-
-	if err := bundle.Delete(); err != nil {
-		t.Error(err)
-	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

These fixes add the config command tests, and fixes created during the PRO 3.5 workup that will allow tests to run across more distros without failing, which is likely to be beneficial when troubleshooting distro specific things. Most of them don't affect the CI running tests on Ubuntu.

#4916 - Fix e2e config test with grep match
#4914 - AllowSetuid no test requires user namespace to succeed
#4912 - Call require.Network correctly in e2e ACTIONS/network
#4910 - Fix e2e security capabilities regular expression match on old kernels
#4909 - Protect additional e2e tests needing UserNS, overlay with require.xxx
#4908 - Use img instead of docker to run e2e tests registry on RHEL 6
#4902 - Fixed OS versions/kernel req in TestDockerDefFile & e2e
#4900 - Skip testPersistentOverlay if no overlay support
#4898 - Fix network_linux_test where bridge not available / setup fails on RHEL6
#4895 - Correct nc args to fix TestAddDelNetworks with OpenBSD nc
#4889 - Avoid use of overlay when not available in mount and oci bundle tests
#4888 - Return current UID instead of error in namespaces.HostUID
#4884 - Check for userns availability in actions_test.go
#4760 - Add e2e tests for various configuration directives