### PR TITLE
Fix SINGULARITYENV_ variables to always take precedence over host variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
+# Changes Since v3.5.3
+
+## Changed defaults / behaviours
+  - Environment variables prefixed with `SINGULARITYENV_` always take
+    precedence over variables without `SINGULARITYENV_` prefix.
+
+
 # Changes Since v3.5.2
 
 ## Changed defaults / behaviours

--- a/internal/pkg/util/env/clean_test.go
+++ b/internal/pkg/util/env/clean_test.go
@@ -43,13 +43,13 @@ func TestSetContainerEnv(t *testing.T) {
 				"SINGULARITY_NAME=lolcow.sif",
 			},
 			resultEnv: []string{
-				"HOME=/home/tester",
 				"PS1=test",
 				"TERM=xterm-256color",
 				"LANG=C",
 				"PWD=/tmp",
 				"LC_ALL=C",
-				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
 			},
 		},
 		{
@@ -70,7 +70,6 @@ func TestSetContainerEnv(t *testing.T) {
 				"SINGULARITY_NAME=lolcow.sif",
 			},
 			resultEnv: []string{
-				"HOME=/home/tester",
 				"PS1=test",
 				"SOCIOPATH=VolanDeMort",
 				"TERM=xterm-256color",
@@ -78,7 +77,8 @@ func TestSetContainerEnv(t *testing.T) {
 				"LD_LIBRARY_PATH=/my/custom/libs",
 				"PWD=/tmp",
 				"LC_ALL=C",
-				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
 			},
 		},
 		{
@@ -100,7 +100,6 @@ func TestSetContainerEnv(t *testing.T) {
 				"SINGULARITY_NAME=lolcow.sif",
 			},
 			resultEnv: []string{
-				"HOME=/home/tester",
 				"SING_USER_DEFINED_APPEND_PATH=/sylabs/container",
 				"PS1=test",
 				"TERM=xterm-256color",
@@ -109,7 +108,8 @@ func TestSetContainerEnv(t *testing.T) {
 				"PWD=/tmp",
 				"LC_ALL=C",
 				"SING_USER_DEFINED_PREPEND_PATH=/foo/bar",
-				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
 			},
 		},
 		{
@@ -131,11 +131,11 @@ func TestSetContainerEnv(t *testing.T) {
 				"CLEANENV=TRUE",
 			},
 			resultEnv: []string{
+				"LANG=C",
 				"TERM=xterm-256color",
 				"FOO=VAR",
 				"HOME=/home/tester",
-				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
-				"LANG=C",
+				"PATH=" + DefaultPath,
 			},
 		},
 		{
@@ -167,6 +167,7 @@ func TestSetContainerEnv(t *testing.T) {
 				"CLEANENV=TRUE",
 			},
 			resultEnv: []string{
+				"LANG=C",
 				"TERM=xterm-256color",
 				"http_proxy=http_proxy",
 				"https_proxy=https_proxy",
@@ -180,8 +181,100 @@ func TestSetContainerEnv(t *testing.T) {
 				"FTP_PROXY=ftp_proxy",
 				"FOO=VAR",
 				"HOME=/home/tester",
-				"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
+				"PATH=" + DefaultPath,
+			},
+		},
+		{
+			name:     "SINGULARITYENV_PATH",
+			cleanEnv: false,
+			homeDest: "/home/tester",
+			env: []string{
+				"SINGULARITYENV_PATH=/my/path",
+			},
+			resultEnv: []string{
+				"SING_USER_DEFINED_PATH=/my/path",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
+			},
+		},
+		{
+			name:     "SINGULARITYENV_LANG with cleanenv",
+			cleanEnv: true,
+			homeDest: "/home/tester",
+			env: []string{
+				"SINGULARITYENV_LANG=en",
+			},
+			resultEnv: []string{
+				"LANG=en",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
+			},
+		},
+		{
+			name:     "SINGULARITYENV_HOME",
+			cleanEnv: false,
+			homeDest: "/home/tester",
+			env: []string{
+				"SINGULARITYENV_HOME=/my/home",
+			},
+			resultEnv: []string{
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
+			},
+		},
+		{
+			name:     "SINGULARITYENV_LD_LIBRARY_PATH",
+			cleanEnv: false,
+			homeDest: "/home/tester",
+			env: []string{
+				"SINGULARITYENV_LD_LIBRARY_PATH=/my/libs",
+			},
+			resultEnv: []string{
+				"LD_LIBRARY_PATH=/my/libs",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
+			},
+		},
+		{
+			name:     "SINGULARITYENV_LD_LIBRARY_PATH with cleanenv",
+			cleanEnv: true,
+			homeDest: "/home/tester",
+			env: []string{
+				"SINGULARITYENV_LD_LIBRARY_PATH=/my/libs",
+			},
+			resultEnv: []string{
 				"LANG=C",
+				"LD_LIBRARY_PATH=/my/libs",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
+			},
+		},
+		{
+			name:     "SINGULARITYENV_HOST after HOST",
+			cleanEnv: false,
+			homeDest: "/home/tester",
+			env: []string{
+				"HOST=myhost",
+				"SINGULARITYENV_HOST=myhostenv",
+			},
+			resultEnv: []string{
+				"HOST=myhostenv",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
+			},
+		},
+		{
+			name:     "SINGULARITYENV_HOST before HOST",
+			cleanEnv: false,
+			homeDest: "/home/tester",
+			env: []string{
+				"SINGULARITYENV_HOST=myhostenv",
+				"HOST=myhost",
+			},
+			resultEnv: []string{
+				"HOST=myhostenv",
+				"HOME=/home/tester",
+				"PATH=" + DefaultPath,
 			},
 		},
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix SINGULARITYENV_ variables to always take precedence over host variables because a SINGULARITYENV_ prefixed variable can be placed before a host variable which is supposed to be overriden (eg: SINGULARITYENV_FOO must take precedence over FOO) and this behavior leads to some inconsistencies.

### This fixes or addresses the following GitHub issues:

- Related to #4827 (not a complete fix yet)


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

