### PR TITLE
Add embedded shell interpreter

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -13,25 +13,27 @@ import (
 
 // actionflags.go contains flag variables for action-like commands to draw from
 var (
-	AppName         string
-	BindPaths       []string
-	HomePath        string
-	OverlayPath     []string
-	ScratchPath     []string
-	WorkdirPath     string
-	PwdPath         string
-	ShellPath       string
-	Hostname        string
-	Network         string
-	NetworkArgs     []string
-	DNS             string
-	Security        []string
-	CgroupsPath     string
-	VMRAM           string
-	VMCPU           string
-	VMIP            string
-	ContainLibsPath []string
-	FuseMount       []string
+	AppName            string
+	BindPaths          []string
+	HomePath           string
+	OverlayPath        []string
+	ScratchPath        []string
+	WorkdirPath        string
+	PwdPath            string
+	ShellPath          string
+	Hostname           string
+	Network            string
+	NetworkArgs        []string
+	DNS                string
+	Security           []string
+	CgroupsPath        string
+	VMRAM              string
+	VMCPU              string
+	VMIP               string
+	ContainLibsPath    []string
+	FuseMount          []string
+	SingularityEnv     []string
+	SingularityEnvFile string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -613,6 +615,27 @@ var actionAllowSetuidFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
+// --env
+var actionEnvFlag = cmdline.Flag{
+	ID:           "actionEnvFlag",
+	Value:        &SingularityEnv,
+	DefaultValue: []string{},
+	Name:         "env",
+	Usage:        "pass environment variable to contained process",
+	ExcludedOS:   []string{cmdline.Darwin},
+}
+
+// --env-file
+var actionEnvFileFlag = cmdline.Flag{
+	ID:           "actionEnvFileFlag",
+	Value:        &SingularityEnvFile,
+	DefaultValue: "",
+	Name:         "env-file",
+	Usage:        "pass environment variables from file to contained process",
+	EnvKeys:      []string{"ENV_FILE"},
+	ExcludedOS:   []string{cmdline.Darwin},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -686,5 +709,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&dockerLoginFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerPasswordFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerUsernameFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionEnvFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionEnvFileFlag, actionsInstanceCmd...)
 	})
 }

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -500,6 +500,13 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			profile: e2e.UserProfile,
 		},
 		{
+			name:    "RunFromDockerWithoutShellOK",
+			command: "run",
+			argv:    []string{"docker://hello-world"},
+			exit:    0,
+			profile: e2e.UserProfile,
+		},
+		{
 			name:    "RunFromLibraryOK",
 			command: "run",
 			argv:    []string{"--bind", bind, "library://busybox:latest", size},

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,6 +9,9 @@
 package singularityenv
 
 import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -19,10 +22,18 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
+const (
+	defaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+)
+
 func (c ctx) singularityEnv(t *testing.T) {
+	// use a cache to not download images over and over
+	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
+	defer cleanCache(t)
+	c.env.ImgCacheDir = imgCacheDir
+
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
 	var defaultImage = "docker://alpine:3.8"
-	var defaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 	// This image sets a custom path.
 	var customImage = "docker://godlovedc/lolcow"
@@ -96,10 +107,284 @@ func (c ctx) singularityEnv(t *testing.T) {
 			e2e.WithProfile(e2e.UserProfile),
 			e2e.WithCommand("exec"),
 			e2e.WithEnv(tt.env),
-			e2e.WithArgs(tt.image, "env"),
+			e2e.WithArgs(tt.image, "/bin/sh", "-c", "echo $PATH"),
 			e2e.ExpectExit(
 				0,
-				e2e.ExpectOutput(e2e.ContainMatch, tt.path),
+				e2e.ExpectOutput(e2e.ExactMatch, tt.path),
+			),
+		)
+	}
+}
+
+func (c ctx) singularityEnvOption(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	imageDefaultPath := defaultPath + ":/go/bin:/usr/local/go/bin"
+
+	// use a cache to not download images over and over
+	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
+	defer cleanCache(t)
+	c.env.ImgCacheDir = imgCacheDir
+
+	var tests = []struct {
+		name     string
+		image    string
+		envOpt   []string
+		hostEnv  []string
+		matchEnv string
+		matchVal string
+	}{
+		{
+			name:     "DefaultPath",
+			image:    "docker://alpine:3.8",
+			matchEnv: "PATH",
+			matchVal: defaultPath,
+		},
+		{
+			name:     "DefaultPathOverride",
+			image:    "docker://alpine:3.8",
+			envOpt:   []string{"PATH=/"},
+			matchEnv: "PATH",
+			matchVal: "/",
+		},
+		{
+			name:     "AppendDefaultPath",
+			image:    "docker://alpine:3.8",
+			envOpt:   []string{"APPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: defaultPath + ":/foo",
+		},
+		{
+			name:     "PrependDefaultPath",
+			image:    "docker://alpine:3.8",
+			envOpt:   []string{"PREPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: "/foo:" + defaultPath,
+		},
+		{
+			name:     "DockerImage",
+			image:    "docker://godlovedc/lolcow",
+			matchEnv: "LC_ALL",
+			matchVal: "C",
+		},
+		{
+			name:     "DockerImageOverride",
+			image:    "docker://godlovedc/lolcow",
+			envOpt:   []string{"LC_ALL=foo"},
+			matchEnv: "LC_ALL",
+			matchVal: "foo",
+		},
+		{
+			name:     "DefaultPathTestImage",
+			image:    c.env.ImagePath,
+			matchEnv: "PATH",
+			matchVal: imageDefaultPath,
+		},
+		{
+			name:     "DefaultPathTestImageOverride",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"PATH=/"},
+			matchEnv: "PATH",
+			matchVal: "/",
+		},
+		{
+			name:     "AppendDefaultPathTestImage",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"APPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: imageDefaultPath + ":/foo",
+		},
+		{
+			name:     "AppendLiteralDefaultPathTestImage",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"PATH=$PATH:/foo"},
+			matchEnv: "PATH",
+			matchVal: imageDefaultPath + ":/foo",
+		},
+		{
+			name:     "PrependDefaultPathTestImage",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"PREPEND_PATH=/foo"},
+			matchEnv: "PATH",
+			matchVal: "/foo:" + imageDefaultPath,
+		},
+		{
+			name:     "PrependLiteralDefaultPathTestImage",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"PATH=/foo:$PATH"},
+			matchEnv: "PATH",
+			matchVal: "/foo:" + imageDefaultPath,
+		},
+		{
+			name:     "TestImageCgoEnabledDefault",
+			image:    c.env.ImagePath,
+			matchEnv: "CGO_ENABLED",
+			matchVal: "0",
+		},
+		{
+			name:     "TestImageCgoEnabledOverride",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"CGO_ENABLED=1"},
+			matchEnv: "CGO_ENABLED",
+			matchVal: "1",
+		},
+		{
+			name:     "TestImageCgoEnabledOverride_KO",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"CGO_ENABLED=1"},
+			matchEnv: "CGO_ENABLED",
+			matchVal: "0",
+		},
+		{
+			name:     "TestImageCgoEnabledOverrideFromEnv",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"SINGULARITYENV_CGO_ENABLED=1"},
+			matchEnv: "CGO_ENABLED",
+			matchVal: "1",
+		},
+		{
+			name:     "TestImageCgoEnabledOverrideEnvOptionPrecedence",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"SINGULARITYENV_CGO_ENABLED=1"},
+			envOpt:   []string{"CGO_ENABLED=2"},
+			matchEnv: "CGO_ENABLED",
+			matchVal: "2",
+		},
+		{
+			name:     "TestImageCgoEnabledOverrideEmpty",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"CGO_ENABLED="},
+			matchEnv: "CGO_ENABLED",
+			matchVal: "",
+		},
+		{
+			name:     "TestImageOverrideHost",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"FOO=bar"},
+			envOpt:   []string{"FOO=foo"},
+			matchEnv: "FOO",
+			matchVal: "foo",
+		},
+	}
+
+	for _, tt := range tests {
+		args := make([]string, 0)
+		if tt.envOpt != nil {
+			args = append(args, "--env", strings.Join(tt.envOpt, ","))
+		}
+		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithEnv(tt.hostEnv),
+			e2e.WithArgs(args...),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
+			),
+		)
+	}
+}
+
+func (c ctx) singularityEnvFile(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	imageDefaultPath := defaultPath + ":/go/bin:/usr/local/go/bin"
+
+	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
+	defer cleanup(t)
+	p := filepath.Join(dir, "env.file")
+
+	// use a cache to not download images over and over
+	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
+	defer cleanCache(t)
+	c.env.ImgCacheDir = imgCacheDir
+
+	var tests = []struct {
+		name     string
+		image    string
+		envFile  string
+		envOpt   []string
+		hostEnv  []string
+		matchEnv string
+		matchVal string
+	}{
+		{
+			name:     "DefaultPathOverride",
+			image:    c.env.ImagePath,
+			envFile:  "PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/",
+		},
+		{
+			name:     "DefaultPathOverrideEnvOptionPrecedence",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"PATH=/etc"},
+			envFile:  "PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/etc",
+		},
+		{
+			name:     "DefaultPathOverrideEnvOptionPrecedence",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"PATH=/etc"},
+			envFile:  "PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/etc",
+		},
+		{
+			name:     "AppendDefaultPath",
+			image:    c.env.ImagePath,
+			envFile:  "APPEND_PATH=/",
+			matchEnv: "PATH",
+			matchVal: imageDefaultPath + ":/",
+		},
+		{
+			name:     "AppendLiteralDefaultPath",
+			image:    c.env.ImagePath,
+			envFile:  `PATH="\$PATH:/"`,
+			matchEnv: "PATH",
+			matchVal: imageDefaultPath + ":/",
+		},
+		{
+			name:     "PrependLiteralDefaultPath",
+			image:    c.env.ImagePath,
+			envFile:  `PATH="/:\$PATH"`,
+			matchEnv: "PATH",
+			matchVal: "/:" + imageDefaultPath,
+		},
+		{
+			name:     "PrependDefaultPath",
+			image:    c.env.ImagePath,
+			envFile:  "PREPEND_PATH=/",
+			matchEnv: "PATH",
+			matchVal: "/:" + imageDefaultPath,
+		},
+	}
+
+	for _, tt := range tests {
+		args := make([]string, 0)
+		if tt.envOpt != nil {
+			args = append(args, "--env", strings.Join(tt.envOpt, ","))
+		}
+		if tt.envFile != "" {
+			ioutil.WriteFile(p, []byte(tt.envFile), 0644)
+			args = append(args, "--env-file", p)
+		}
+		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)
+
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithEnv(tt.hostEnv),
+			e2e.WithArgs(args...),
+			e2e.ExpectExit(
+				0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.matchVal),
 			),
 		)
 	}
@@ -113,5 +398,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 
 	return testhelper.Tests{
 		"environment manipulation": c.singularityEnv,
+		"environment option":       c.singularityEnvOption,
+		"environment file":         c.singularityEnvFile,
 	}
 }

--- a/e2e/testdata/Singularity
+++ b/e2e/testdata/Singularity
@@ -23,8 +23,8 @@ from: alpine:3.7
     export TESTAPP
 
 %appinstall testapp
-    echo 'echo $TESTAPP' > $SINGULARITY_APPROOT/bin/testapp.sh
-    chmod 0755 $SINGULARITY_APPROOT/bin/testapp.sh
+    echo 'echo $TESTAPP' > $SCIF_APPROOT/bin/testapp.sh
+    chmod 0755 $SCIF_APPROOT/bin/testapp.sh
 
 %apprun testapp
     $TESTAPP.sh

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.5
 	github.com/containers/image/v5 v5.2.1
-	github.com/creack/pty v1.1.9 // indirect
 	github.com/deislabs/oras v0.8.1
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/dsnet/compress v0.0.1 // indirect
@@ -57,14 +56,15 @@ require (
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	go.opencensus.io v0.22.2 // indirect
 	go4.org v0.0.0-20180417224846-9599cf28b011 // indirect
-	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
+	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
-	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
+	golang.org/x/sys v0.0.0-20200217220822-9197077df867
 	google.golang.org/genproto v0.0.0-20200122232147-0452cf42e150 // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools/v3 v3.0.2
 	k8s.io/client-go v0.0.0-20181010045704-56e7a63b5e38 // indirect
+	mvdan.cc/sh/v3 v3.0.1-0.20200218171337-23ddfbcf8b29
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -302,11 +302,15 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8 h1:AkaSdXYQOWeaO3neb8EM634ahkXXe3jYbVh/F9lq+GI=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
@@ -394,6 +398,7 @@ github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/diff v0.0.0-20190930165518-531926345625/go.mod h1:kFj35MyHn14a6pIgWhm46KVjJr5CHys3eEYxkuKD1EI=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -428,6 +433,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rootless-containers/proto v0.1.0 h1:gS1JOMEtk1YDYHCzBAf/url+olMJbac7MTrgSeP6zh4=
 github.com/rootless-containers/proto v0.1.0/go.mod h1:vgkUFZbQd0gcE/K/ZwtE4MYjZPu0UNHLXIQxhyqAFh8=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
@@ -626,8 +632,8 @@ golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
-golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867 h1:JoRuNIf+rpHl+VhScRQQvzbHed86tKkqwPMV34T8myw=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -677,6 +683,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.28 h1:n1tBJnnK2r7g9OW2btFH91V92STTUevLXYFb8gy9EMk=
 gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 h1:OAj3g0cR6Dx/R07QgQe8wkA9RNjB2u4i700xBkIT4e0=
@@ -706,3 +713,6 @@ k8s.io/client-go v0.0.0-20170217214107-bcde30fb7eae/go.mod h1:7vJpHMYJwNQCWgzmNV
 k8s.io/client-go v0.0.0-20181010045704-56e7a63b5e38 h1:KirVQhD3RM/NNQUJeinP5Bq4He0bv2RopF2RFxrC7Ck=
 k8s.io/client-go v0.0.0-20181010045704-56e7a63b5e38/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157/go.mod h1:Ge4atmRUYqueGppvJ7JNrtqpqokoJEFxYbP0Z+WeKS8=
+mvdan.cc/sh/v3 v3.0.1-0.20200218171337-23ddfbcf8b29 h1:21aXW8Ir3RmMkrddKVBLMto+lNDpoOa1jPIAYvXCp6E=
+mvdan.cc/sh/v3 v3.0.1-0.20200218171337-23ddfbcf8b29/go.mod h1:xatQts59OChqRbQueQfcnZelBYmaxa8Hza3lYdaK0wk=

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -158,9 +158,6 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 	if err := system.RunAfterTag(mount.SharedTag, c.chdirFinal); err != nil {
 		return err
 	}
-	if err := system.RunAfterTag(mount.RootfsTag, c.addActionsMount); err != nil {
-		return err
-	}
 
 	if err := c.addRootfsMount(system); err != nil {
 		return err
@@ -2046,50 +2043,6 @@ func (c *container) addHostnameMount(system *mount.System) error {
 		sylog.Debugf("Skipping hostname mount, not virtualizing UTS namespace on user request")
 	}
 	return nil
-}
-
-func (c *container) addActionsMount(system *mount.System) error {
-	actionSessionDir := "/actions"
-	containerDir := "/.singularity.d/actions"
-
-	actionsDir := filepath.Join(c.session.RootFsPath(), containerDir)
-	if !fs.IsDir(actionsDir) {
-		sylog.Debugf("Ignoring actions mount, %s doesn't exist", actionsDir)
-		return nil
-	}
-
-	scripts := map[string]string{
-		"exec":  files.ExecScript,
-		"shell": files.ShellScript,
-		"run":   files.RunScript,
-		"test":  files.TestScript,
-		"start": files.StartScript,
-	}
-
-	for name, script := range scripts {
-		path := filepath.Join(actionSessionDir, name)
-		if err := c.session.AddFile(path, []byte(script)); err != nil {
-			return fmt.Errorf("while adding action script %s: %s", path, err)
-		}
-		if err := c.session.Chmod(path, 0755); err != nil {
-			return fmt.Errorf("while changing permission for %s: %s", path, err)
-		}
-	}
-
-	if err := c.session.Update(); err != nil {
-		return fmt.Errorf("while updating session layer: %s", err)
-	}
-
-	dir, _ := c.session.GetPath(actionSessionDir)
-
-	flags := uintptr(syscall.MS_BIND | syscall.MS_RDONLY | syscall.MS_NOSUID | syscall.MS_NODEV)
-
-	err := system.Points.AddBind(mount.BindsTag, dir, containerDir, flags)
-	if err != nil {
-		return fmt.Errorf("unable to add %s to mount list: %s", containerDir, err)
-	}
-
-	return system.Points.AddRemount(mount.BindsTag, containerDir, flags)
 }
 
 func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(context.Context) error, error) {

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -5,13 +5,98 @@
 
 package files
 
-var ExecScript = `#!/bin/sh
+var ActionScript = `#!/bin/sh
 
-for script in /.singularity.d/env/*.sh; do
-    if [ -f "$script" ]; then
-        . "$script"
+declare -r oldenv=$(getallenv)
+declare -r cmd=${SINGULARITY_COMMAND:-}
+
+if test -n "${SINGULARITY_APPNAME:-}"; then
+    readonly SINGULARITY_APPNAME
+fi
+
+export PWD
+
+clear_env() {
+    local IFS=$'\n'
+
+    for e in ${oldenv}; do
+        key=$(getenvkey "${e}")
+        case "${key}" in
+        PWD|HOME|OPTIND|UID|SINGULARITY_APPNAME)
+            ;;
+        *)
+            unset "${key}"
+            ;;
+        esac
+    done
+}
+
+restore_env() {
+    local IFS=$'\n'
+
+    # restore environment variables which haven't been
+    # defined by docker or virtual file above, empty
+    # variables are also unset
+    for e in ${oldenv}; do
+        key=$(getenvkey "${e}")
+        if ! test -v "${key}"; then
+            export "${e}"
+        elif test -z "${!key}"; then
+            unset "${key}"
+        fi
+    done
+}
+
+clear_env
+
+if test -d "/.singularity.d/env"; then
+    for script in /.singularity.d/env/*.sh; do
+        if test -f "${script}"; then
+            sylog debug "Sourcing ${script}"
+
+            case "${script}" in
+            /.singularity.d/env/90-environment.sh)
+                # docker files below may not be present depending of image source
+                # and build, so we also fix the PATH if not defined here
+                if ! test -v PATH; then
+                    export PATH="$(fixpath)"
+                fi
+                source "${script}"
+                ;;
+            /.singularity.d/env/10-docker2singularity.sh| \
+            /.singularity.d/env/10-docker.sh)
+                source "${script}"
+                # append potential missing path from the default PATH
+                # used by Singularity
+                export PATH="$(fixpath)"
+                ;;
+            /.singularity.d/env/99-base.sh)
+                # this file is the common denominator in image built since
+                # Singularity 2.3, inject forwarded variables right after
+                source "${script}"
+                source "/.inject-singularity-env.sh"
+                ;;
+            *)
+                source "${script}"
+                ;;
+            esac
+        fi
+    done
+else
+    # this is for old images built with Singularity version prior to 2.3
+    if test -f "/environment"; then
+        source "/environment"
+        unset PATH
+        export PATH="$(fixpath)"
     fi
-done
+    source "/.inject-singularity-env.sh"
+fi
+
+if ! test -f "/.singularity.d/env/99-runtimevars.sh"; then
+    source "/.singularity.d/env/99-runtimevars.sh"
+fi
+
+restore_env
 
 # See https://github.com/sylabs/singularity/issues/2721,
 # as bash is often used as the current shell it may confuse
@@ -25,121 +110,83 @@ else
     export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
 fi
 
-exec "$@"
-`
+sylog debug "Running action command ${cmd}"
 
-var ShellScript = `#!/bin/sh
-
-for script in /.singularity.d/env/*.sh; do
-    if [ -f "$script" ]; then
-        . "$script"
+case "${cmd}" in
+exec)
+    exec "$@" ;;
+shell)
+    if test -n "${SINGULARITY_SHELL:-}" -a -x "${SINGULARITY_SHELL:-}"; then
+        exec "${SINGULARITY_SHELL:-}" "$@"
+    elif test -x "/bin/bash"; then
+        export SHELL=/bin/bash
+        exec "/bin/bash" --norc "$@"
+    elif test -x "/bin/sh"; then
+        export SHELL=/bin/sh
+        exec "/bin/sh" "$@"
     fi
-done
 
-# See https://github.com/sylabs/singularity/issues/2721,
-# as bash is often used as the current shell it may confuse
-# users when entering in singularity container via -s /bin/bash
-# implying to override PS1 set by singularity and we may end up
-# with a shell prompt identical to the host one, so we force PS1
-# through bash PROMPT_COMMAND
-if test -z "${PROMPT_COMMAND:-}"; then
-    export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
-else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
-fi
-
-if test -n "$SINGULARITY_SHELL" -a -x "$SINGULARITY_SHELL"; then
-    exec $SINGULARITY_SHELL "$@"
-
-    echo "ERROR: Failed running shell as defined by '\$SINGULARITY_SHELL'" 1>&2
-    exit 1
-
-elif test -x /bin/bash; then
-    SHELL=/bin/bash
-    PS1="Singularity $SINGULARITY_NAME:\\w> "
-    export SHELL PS1
-    exec /bin/bash --norc "$@"
-elif test -x /bin/sh; then
-    SHELL=/bin/sh
-    export SHELL
-    exec /bin/sh "$@"
-else
-    echo "ERROR: /bin/sh does not exist in container" 1>&2
-fi
-exit 1
-`
-
-var RunScript = `#!/bin/sh
-
-for script in /.singularity.d/env/*.sh; do
-    if [ -f "$script" ]; then
-        . "$script"
-    fi
-done
-
-# See https://github.com/sylabs/singularity/issues/2721,
-# if the runscript execute bash by default, it can give
-# a prompt identical to the host one which may confuse users
-# so we use PROMPT_COMMAND environment variable which is
-# used by bash to execute a command before command prompt
-# in order to set PS1 correctly before the first prompt
-if test -z "${PROMPT_COMMAND:-}"; then
-    export PROMPT_COMMAND="PS1=\"${PS1}\"; unset PROMPT_COMMAND"
-else
-    export PROMPT_COMMAND="${PROMPT_COMMAND:-}; PROMPT_COMMAND=\"\${PROMPT_COMMAND%%; PROMPT_COMMAND=*}\"; PS1=\"${PS1}\""
-fi
-
-if test -n "${SINGULARITY_APPNAME:-}"; then
-
-    if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript"; then
-        exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript" "$@"
-    else
-        echo "No runscript for contained app: ${SINGULARITY_APPNAME:-}"
+    sylog error "/bin/sh does not exist in container"
+    exit 1 ;;
+run)
+    if test -n "${SINGULARITY_APPNAME:-}"; then
+        if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript"; then
+            exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript" "$@"
+        fi
+        sylog error "no runscript for contained app: ${SINGULARITY_APPNAME:-}"
         exit 1
+    elif test -x "/.singularity.d/runscript"; then
+        exec "/.singularity.d/runscript" "$@"
+    elif test -x "/singularity"; then
+        exec "/singularity" "$@"
+    elif test -x "/bin/sh"; then
+        sylog info "No runscript found in container, executing /bin/sh"
+        exec "/bin/sh" "$@"
     fi
 
-elif test -x "/.singularity.d/runscript"; then
-    exec "/.singularity.d/runscript" "$@"
-else
-    echo "No runscript found in container, executing /bin/sh"
-    exec /bin/sh "$@"
-fi
-`
-
-var TestScript = `#!/bin/sh
-
-for script in /.singularity.d/env/*.sh; do
-    if [ -f "$script" ]; then
-        . "$script"
-    fi
-done
-
-
-if test -n "${SINGULARITY_APPNAME:-}"; then
-
-    if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test"; then
-        exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test" "$@"
-    else
-        echo "No tests for contained app: ${SINGULARITY_APPNAME:-}"
+    sylog error "No runscript and no /bin/sh executable found in container, aborting"
+    exit 1 ;;
+test)
+    if test -n "${SINGULARITY_APPNAME:-}"; then
+        if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test"; then
+            exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test" "$@"
+        fi
+        sylog error "No tests for contained app: ${SINGULARITY_APPNAME:-}"
         exit 1
+    elif test -x "/.singularity.d/test"; then
+        exec "/.singularity.d/test" "$@"
     fi
-elif test -x "/.singularity.d/test"; then
-    exec "/.singularity.d/test" "$@"
-else
-    echo "No test found in container, executing /bin/sh -c true"
-    exec /bin/sh -c true
-fi
+
+    sylog info "No test script found in container, exiting"
+    exit 0 ;;
+start)
+    if test -x "/.singularity.d/startscript"; then
+        exec "/.singularity.d/startscript" "$@"
+    fi
+
+    sylog info "No instance start script found in container"
+    exit 0 ;;
+*)
+    sylog error "Unknown action $cmd"
+    exit 1 ;;
+esac
 `
 
-var StartScript = `#!/bin/sh
-
-for script in /.singularity.d/env/*.sh; do
-    if [ -f "$script" ]; then
-        . "$script"
-    fi
-done
-
-if test -x "/.singularity.d/startscript"; then
-    exec "/.singularity.d/startscript" "$@"
+var RuntimeVars = `#!/bin/sh
+if test -n "${SING_USER_DEFINED_PREPEND_PATH:-}"; then
+    PATH="${SING_USER_DEFINED_PREPEND_PATH}:${PATH}"
+    unset SING_USER_DEFINED_PREPEND_PATH
 fi
+
+if test -n "${SING_USER_DEFINED_APPEND_PATH:-}"; then
+    PATH="${PATH}:${SING_USER_DEFINED_APPEND_PATH}"
+    unset SING_USER_DEFINED_APPEND_PATH
+fi
+
+if test -n "${SING_USER_DEFINED_PATH:-}"; then
+    PATH="${SING_USER_DEFINED_PATH}"
+    unset SING_USER_DEFINED_PATH
+fi
+
+export PATH
 `

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -1,0 +1,301 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license.  Please
+// consult LICENSE.md file distributed with the sources of this project regarding
+// your rights to use or distribute this software.
+
+package interpreter
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// ShellBuiltin defines function prototype for shell interpreter builtin registration.
+type ShellBuiltin func(ctx context.Context, args []string) error
+
+// OpenHandler defines function prototype for shell interpreter file handler registration.
+type OpenHandler func(path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error)
+
+// Shell defines the shell interpreter.
+type Shell struct {
+	shellBuiltins map[string]ShellBuiltin
+	openHandlers  map[string]OpenHandler
+	name          string
+	status        uint8
+	reader        io.Reader
+	runner        *interp.Runner
+}
+
+// execTimeout defines the execution timeout for commands executed by the
+// shell interpreter.
+var execTimeout = 5 * time.Second
+
+// defaultExecHandler is the default command execution handler if there is
+// no registered shell builtin.
+func defaultExecHandler(ctx context.Context, args []string) error {
+	hc := interp.HandlerCtx(ctx)
+	path, err := interp.LookPath(hc.Env, args[0])
+	if err != nil {
+		fmt.Fprintln(hc.Stderr, err)
+		return interp.NewExitStatus(127)
+	}
+
+	ectx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ectx, path, args[1:]...)
+	cmd.Env = append([]string{"PWD=" + hc.Dir}, GetEnv(hc)...)
+	cmd.Dir = hc.Dir
+	cmd.Stdin = hc.Stdin
+	cmd.Stdout = hc.Stdout
+	cmd.Stderr = hc.Stderr
+
+	err = cmd.Run()
+
+	switch x := err.(type) {
+	case *exec.ExitError:
+		if status, ok := x.Sys().(syscall.WaitStatus); ok {
+			if status.Signaled() && ectx.Err() != nil {
+				c := strings.Join(args, " ")
+				return fmt.Errorf("command %q was killed after %s timeout", c, execTimeout)
+			}
+			return interp.NewExitStatus(uint8(status.ExitStatus()))
+		}
+		return interp.NewExitStatus(1)
+	case *exec.Error:
+		c := strings.Join(args, " ")
+		return fmt.Errorf("command %q execution failed: %s", c, err)
+	}
+
+	return err
+}
+
+// GetEnv returns an the list of all exported environment variables within
+// the context of the shell interpreter.
+func GetEnv(hc interp.HandlerContext) []string {
+	envMap := make(map[string]expand.Variable)
+
+	// use of a map to remove duplicated variable, the latest wins
+	hc.Env.Each(func(name string, vr expand.Variable) bool {
+		envMap[name] = vr
+		return true
+	})
+
+	environ := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		if v.Exported && v.Kind == expand.String {
+			environ = append(environ, k+"="+v.Str)
+		}
+	}
+
+	sort.Strings(environ)
+
+	return environ
+}
+
+// New returns a shell interpreter instance.
+func New(r io.Reader, name string, args []string, envs []string, runnerOptions ...interp.RunnerOption) (s *Shell, err error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil reader")
+	}
+
+	s = &Shell{
+		reader: r,
+		name:   name,
+	}
+
+	opts := []interp.RunnerOption{
+		interp.StdIO(os.Stdin, os.Stdout, os.Stderr),
+		interp.ExecHandler(s.internalExecHandler()),
+		interp.OpenHandler(s.internalOpenHandler()),
+		interp.Params("--"),
+		interp.Env(expand.ListEnviron(envs...)),
+	}
+	opts = append(opts, runnerOptions...)
+	s.runner, err = interp.New(opts...)
+
+	if err != nil {
+		return nil, fmt.Errorf("while creating shell interpreter: %s", err)
+	}
+
+	s.runner.Dir, err = os.Getwd()
+	if err != nil {
+		s.runner.Dir = "/"
+	}
+
+	s.runner.Params = append(s.runner.Params, args...)
+
+	return s, err
+}
+
+// internalOpenHandler returns an ExecHandlerFunc used by default.
+func (s *Shell) internalExecHandler() interp.ExecHandlerFunc {
+	return func(ctx context.Context, args []string) error {
+		if s.runner.Exited() {
+			// special path for exec builtin keyword
+			if builtin, ok := s.shellBuiltins["exec"]; ok {
+				return builtin(ctx, args)
+			}
+		} else if builtin, ok := s.shellBuiltins[args[0]]; ok {
+			return builtin(ctx, args[1:])
+		}
+		return defaultExecHandler(ctx, args)
+	}
+}
+
+// internalOpenHandler returns an OpenHandlerFunc used by default.
+func (s *Shell) internalOpenHandler() interp.OpenHandlerFunc {
+	return func(ctx context.Context, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+		mc := interp.HandlerCtx(ctx)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(mc.Dir, path)
+		}
+		if handler, ok := s.openHandlers[path]; ok {
+			return handler(path, flag, perm)
+		}
+		return os.OpenFile(path, flag, perm)
+	}
+}
+
+// RegisterShellBuiltin registers a shell interpreter builtin.
+func (s *Shell) RegisterShellBuiltin(name string, builtin ShellBuiltin) {
+	if s.shellBuiltins == nil {
+		s.shellBuiltins = make(map[string]ShellBuiltin)
+	}
+	s.shellBuiltins[name] = builtin
+}
+
+// RegisterOpenHandler registers a shell interpreter file handler.
+func (s *Shell) RegisterOpenHandler(path string, handler OpenHandler) {
+	if s.openHandlers == nil {
+		s.openHandlers = make(map[string]OpenHandler)
+	}
+	s.openHandlers[path] = handler
+}
+
+// LookPath returns the absolute path for the command passed in argument
+// within the context of the shell interpreter.
+func (s *Shell) LookPath(ctx context.Context, cmd string) (string, error) {
+	hc := interp.HandlerCtx(ctx)
+	return interp.LookPath(hc.Env, cmd)
+}
+
+// Run runs the shell interpreter.
+func (s *Shell) Run() error {
+	ctx := context.TODO()
+
+	parser := syntax.NewParser()
+	node, err := parser.Parse(s.reader, s.name)
+	if err != nil {
+		return fmt.Errorf("while parsing script: %s", err)
+	}
+
+	if err := s.runner.Run(ctx, node); err != nil {
+		if status, ok := interp.IsExitStatus(err); ok {
+			s.status = status
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Status returns the exit code status of the shell interpreter.
+func (s *Shell) Status() uint8 {
+	return s.status
+}
+
+// nonExportedEnv allows to initialize shell interpreter with all environment
+// variables set as non exported variables.
+type nonExportedEnv struct {
+	envs map[string]expand.Variable
+}
+
+// newNonExportedEnv returns a localEnv instance associated to environment
+// passed in argument.
+func newNonExportedEnv(env []string) nonExportedEnv {
+	local := nonExportedEnv{
+		envs: make(map[string]expand.Variable),
+	}
+	for _, e := range env {
+		e := strings.SplitN(e, "=", 2)
+		local.envs[e[0]] = expand.Variable{Str: e[1], Kind: expand.String}
+	}
+	return local
+}
+
+// Get returns the named shell environment variable.
+func (e nonExportedEnv) Get(name string) expand.Variable {
+	if vr, ok := e.envs[name]; ok {
+		return vr
+	}
+	return expand.Variable{}
+}
+
+// Each iterates over all environment variables by calling the
+// function passed in argument for each variables.
+func (e nonExportedEnv) Each(fn func(name string, vr expand.Variable) bool) {
+	for name, vr := range e.envs {
+		if !fn(name, vr) {
+			return
+		}
+	}
+}
+
+// EvaluateEnv evaluates the environment variable script and returns
+// the list of variables set in the script. Command execution is disabled
+// along with redirection.
+func EvaluateEnv(script []byte, args []string, envs []string) ([]string, error) {
+	const stopBuiltin = "__stop__"
+
+	var env []string
+
+	// disable command execution and just handle stop builtin
+	execHandler := func(ctx context.Context, args []string) error {
+		if args[0] == stopBuiltin {
+			env = GetEnv(interp.HandlerCtx(ctx))
+			return nil
+		}
+		c := strings.Join(args, " ")
+		return fmt.Errorf("could not execute %q: execution is disabled", c)
+	}
+	openHandler := func(ctx context.Context, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+		return nil, fmt.Errorf("could not open/create/modify %q: file feature is disabled", path)
+	}
+
+	opts := []interp.RunnerOption{
+		interp.ExecHandler(execHandler),
+		interp.OpenHandler(openHandler),
+		interp.Env(newNonExportedEnv(envs)),
+	}
+
+	b := bytes.NewBuffer(script)
+	// append stop builtin to the end of the script
+	b.WriteString("\n" + stopBuiltin + "\n")
+
+	shell, err := New(b, "singularity", args, nil, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("while initializing shell interpreter: %s", err)
+	}
+	// set allexport option
+	interp.Params("-a")(shell.runner)
+
+	if err := shell.Run(); err != nil {
+		return nil, fmt.Errorf("while evaluating environment script: %s", err)
+	}
+
+	return env, nil
+}

--- a/internal/pkg/util/shell/interpreter/interpreter_test.go
+++ b/internal/pkg/util/shell/interpreter/interpreter_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license.  Please
+// consult LICENSE.md file distributed with the sources of this project regarding
+// your rights to use or distribute this software.
+
+package interpreter
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/interp"
+)
+
+func newIOStream() (io.Reader, io.ReadWriter, io.ReadWriter) {
+	var stdin bytes.Buffer
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	return &stdin, &stdout, &stderr
+}
+
+type bufferCloser struct {
+	bytes.Buffer
+}
+
+func (*bufferCloser) Close() error {
+	return nil
+}
+
+type testShellBuiltin struct {
+	builtin string
+	fn      func(*Shell) ShellBuiltin
+}
+
+type testOpenHandler struct {
+	path string
+	fn   func(*Shell) OpenHandler
+}
+
+func TestInterpreter(t *testing.T) {
+	var err error
+	var shell *Shell
+
+	_, err = New(nil, "empty_reader", nil, nil, interp.StdIO(newIOStream()))
+	if err == nil {
+		t.Fatalf("unexpected error with empty reader: %s", err)
+	}
+
+	tests := []struct {
+		name         string
+		argv         []string
+		env          []string
+		script       string
+		expectOut    string
+		expectErr    string
+		shellBuiltin *testShellBuiltin
+		openHandler  *testOpenHandler
+		expectExit   uint8
+	}{
+		{
+			name:      "hello stdout",
+			script:    "echo 'hello'",
+			expectOut: "hello",
+		},
+		{
+			name:      "hello stderr",
+			script:    "echo 'hello' 1>&2",
+			expectErr: "hello",
+		},
+		{
+			name:   "exit 0",
+			script: "exit 0",
+		},
+		{
+			name:       "exit 1",
+			script:     "exit 1",
+			expectExit: 1,
+		},
+		{
+			name:      "echo arg one",
+			script:    "echo ${1}",
+			argv:      []string{"arg1"},
+			expectOut: "arg1",
+		},
+		{
+			name:      "echo env",
+			script:    "echo $PATH",
+			env:       []string{"PATH=/bin"},
+			expectOut: "/bin",
+		},
+		{
+			name:   "spawn true",
+			script: "/bin/true",
+		},
+		{
+			name:       "spawn false",
+			script:     "/bin/false",
+			expectExit: 1,
+		},
+		{
+			name:      "exec builtin",
+			script:    "exec true && echo 'hello'",
+			env:       []string{"PATH=/bin"},
+			expectOut: "/bin/true",
+			shellBuiltin: &testShellBuiltin{
+				builtin: "exec",
+				fn: func(shell *Shell) ShellBuiltin {
+					return func(ctx context.Context, args []string) error {
+						hc := interp.HandlerCtx(ctx)
+						cmd, err := shell.LookPath(ctx, args[0])
+						if err != nil {
+							return err
+						}
+						fmt.Fprintf(hc.Stdout, "%s\n", cmd)
+						return nil
+					}
+				},
+			},
+		},
+		{
+			name:      "testing builtin",
+			script:    "testing argument",
+			expectOut: "argument",
+			shellBuiltin: &testShellBuiltin{
+				builtin: "testing",
+				fn: func(shell *Shell) ShellBuiltin {
+					return func(ctx context.Context, args []string) error {
+						hc := interp.HandlerCtx(ctx)
+						fmt.Fprintf(hc.Stdout, "%s\n", args[0])
+						return nil
+					}
+				},
+			},
+		},
+		{
+			name:   "export env",
+			script: "export FOO=bar && exec /bin/true",
+			shellBuiltin: &testShellBuiltin{
+				builtin: "exec",
+				fn: func(shell *Shell) ShellBuiltin {
+					return func(ctx context.Context, args []string) error {
+						hc := interp.HandlerCtx(ctx)
+						for _, env := range GetEnv(hc) {
+							if env == "FOO=bar" {
+								return nil
+							}
+						}
+						return fmt.Errorf("no FOO environment variable")
+					}
+				},
+			},
+		},
+		{
+			name:      "source handler",
+			script:    ". /virtual/file",
+			expectOut: "a virtual file",
+			openHandler: &testOpenHandler{
+				path: "/virtual/file",
+				fn: func(shell *Shell) OpenHandler {
+					return func(path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+						bc := new(bufferCloser)
+						bc.WriteString("echo 'a virtual file'\n")
+						return bc, nil
+					}
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var scriptBuf bytes.Buffer
+			var stdin bytes.Buffer
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			scriptBuf.WriteString(tt.script)
+
+			shell, err = New(&scriptBuf, "buffer", tt.argv, tt.env, interp.StdIO(&stdin, &stdout, &stderr))
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if tt.shellBuiltin != nil {
+				shell.RegisterShellBuiltin(tt.shellBuiltin.builtin, tt.shellBuiltin.fn(shell))
+			}
+			if tt.openHandler != nil {
+				shell.RegisterOpenHandler(tt.openHandler.path, tt.openHandler.fn(shell))
+			}
+			if err := shell.Run(); err != nil {
+				if tt.expectExit != 0 && shell.Status() != tt.expectExit {
+					t.Fatalf("unexpected exit status for %s: got %d instead of %d", tt.name, shell.Status(), tt.expectExit)
+				} else if tt.expectExit == 0 {
+					t.Fatalf("unexpected error: %s", err)
+				}
+			}
+
+			errStr := strings.TrimSpace(stderr.String())
+			outStr := strings.TrimSpace(stdout.String())
+
+			if tt.expectErr != "" && errStr != tt.expectErr {
+				t.Fatalf("unexpected stderr: %s instead of %s", errStr, tt.expectErr)
+			}
+			if tt.expectOut != "" && outStr != tt.expectOut {
+				t.Fatalf("unexpected stdout: %s instead of %s", outStr, tt.expectOut)
+			}
+		})
+	}
+}
+
+func TestEvaluateEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    string
+		argv      []string
+		env       []string
+		resultEnv []string
+		expectErr bool
+	}{
+		{
+			name:      "EmptyScript",
+			script:    "",
+			resultEnv: []string{},
+		},
+		{
+			name:      "SingleEnv",
+			script:    "FOO=bar",
+			resultEnv: []string{"FOO=bar"},
+		},
+		{
+			name:      "ExternalEnv",
+			env:       []string{"FOO=bar"},
+			script:    "BAR=$FOO",
+			resultEnv: []string{"BAR=bar"},
+		},
+		{
+			name:      "ExternalEnvExport",
+			env:       []string{"FOO=bar"},
+			script:    "BAR=foo && export FOO",
+			resultEnv: []string{"FOO=bar", "BAR=foo"},
+		},
+		{
+			name:      "ExternalEnvOverwrite",
+			env:       []string{"FOO=bar"},
+			script:    "FOO=overwrite",
+			resultEnv: []string{"FOO=overwrite"},
+		},
+		{
+			name:      "ExecFailure",
+			script:    "/bin/true",
+			resultEnv: []string{},
+			expectErr: true,
+		},
+		{
+			name:      "OpenFailure",
+			script:    "echo hello > /tmp/hello",
+			resultEnv: []string{},
+			expectErr: true,
+		},
+		{
+			name:      "NonExistentVar",
+			script:    "FOO=$FAKE",
+			resultEnv: []string{"FOO="},
+		},
+		{
+			name:      "ArgZeroVar",
+			script:    "FOO=$0",
+			resultEnv: []string{"FOO=singularity"},
+		},
+		{
+			name:      "ArgOneVar",
+			argv:      []string{"bar"},
+			script:    "FOO=$1",
+			resultEnv: []string{"FOO=bar"},
+		},
+		{
+			name:      "AllArgVar",
+			argv:      []string{"bar", "-a", "foo"},
+			script:    "FOO=\"$@\"",
+			resultEnv: []string{"FOO=bar -a foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := EvaluateEnv([]byte(tt.script), tt.argv, tt.env)
+			if !tt.expectErr && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			} else if tt.expectErr && err == nil {
+				t.Fatalf("unexpected success")
+			} else if !tt.expectErr {
+				sort.Strings(tt.resultEnv)
+				sort.Strings(env)
+				if !reflect.DeepEqual(tt.resultEnv, env) {
+					t.Fatalf("unexpected variables:\nwant %v\ngot %v", tt.resultEnv, env)
+				}
+			}
+		})
+	}
+}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -102,53 +102,54 @@ func (b *BindPath) Readonly() bool {
 
 // JSONConfig stores engine specific confguration that is allowed to be set by the user.
 type JSONConfig struct {
-	ScratchDir        []string      `json:"scratchdir,omitempty"`
-	OverlayImage      []string      `json:"overlayImage,omitempty"`
-	NetworkArgs       []string      `json:"networkArgs,omitempty"`
-	Security          []string      `json:"security,omitempty"`
-	FilesPath         []string      `json:"filesPath,omitempty"`
-	LibrariesPath     []string      `json:"librariesPath,omitempty"`
-	FuseMount         []FuseMount   `json:"fuseMount,omitempty"`
-	ImageList         []image.Image `json:"imageList,omitempty"`
-	BindPath          []BindPath    `json:"bindpath,omitempty"`
-	UnixSocketPair    [2]int        `json:"unixSocketPair,omitempty"`
-	OpenFd            []int         `json:"openFd,omitempty"`
-	TargetGID         []int         `json:"targetGID,omitempty"`
-	Image             string        `json:"image"`
-	Workdir           string        `json:"workdir,omitempty"`
-	CgroupsPath       string        `json:"cgroupsPath,omitempty"`
-	HomeSource        string        `json:"homedir,omitempty"`
-	HomeDest          string        `json:"homeDest,omitempty"`
-	Command           string        `json:"command,omitempty"`
-	Shell             string        `json:"shell,omitempty"`
-	TmpDir            string        `json:"tmpdir,omitempty"`
-	AddCaps           string        `json:"addCaps,omitempty"`
-	DropCaps          string        `json:"dropCaps,omitempty"`
-	Hostname          string        `json:"hostname,omitempty"`
-	Network           string        `json:"network,omitempty"`
-	DNS               string        `json:"dns,omitempty"`
-	Cwd               string        `json:"cwd,omitempty"`
-	SessionLayer      string        `json:"sessionLayer,omitempty"`
-	EncryptionKey     []byte        `json:"encryptionKey,omitempty"`
-	TargetUID         int           `json:"targetUID,omitempty"`
-	WritableImage     bool          `json:"writableImage,omitempty"`
-	WritableTmpfs     bool          `json:"writableTmpfs,omitempty"`
-	Contain           bool          `json:"container,omitempty"`
-	Nv                bool          `json:"nv,omitempty"`
-	Rocm              bool          `json:"rocm,omitempty"`
-	CustomHome        bool          `json:"customHome,omitempty"`
-	Instance          bool          `json:"instance,omitempty"`
-	InstanceJoin      bool          `json:"instanceJoin,omitempty"`
-	BootInstance      bool          `json:"bootInstance,omitempty"`
-	RunPrivileged     bool          `json:"runPrivileged,omitempty"`
-	AllowSUID         bool          `json:"allowSUID,omitempty"`
-	KeepPrivs         bool          `json:"keepPrivs,omitempty"`
-	NoPrivs           bool          `json:"noPrivs,omitempty"`
-	NoHome            bool          `json:"noHome,omitempty"`
-	NoInit            bool          `json:"noInit,omitempty"`
-	DeleteImage       bool          `json:"deleteImage,omitempty"`
-	Fakeroot          bool          `json:"fakeroot,omitempty"`
-	SignalPropagation bool          `json:"signalPropagation,omitempty"`
+	ScratchDir        []string          `json:"scratchdir,omitempty"`
+	OverlayImage      []string          `json:"overlayImage,omitempty"`
+	NetworkArgs       []string          `json:"networkArgs,omitempty"`
+	Security          []string          `json:"security,omitempty"`
+	FilesPath         []string          `json:"filesPath,omitempty"`
+	LibrariesPath     []string          `json:"librariesPath,omitempty"`
+	FuseMount         []FuseMount       `json:"fuseMount,omitempty"`
+	ImageList         []image.Image     `json:"imageList,omitempty"`
+	BindPath          []BindPath        `json:"bindpath,omitempty"`
+	SingularityEnv    map[string]string `json:"singularityEnv,omitempty"`
+	UnixSocketPair    [2]int            `json:"unixSocketPair,omitempty"`
+	OpenFd            []int             `json:"openFd,omitempty"`
+	TargetGID         []int             `json:"targetGID,omitempty"`
+	Image             string            `json:"image"`
+	Workdir           string            `json:"workdir,omitempty"`
+	CgroupsPath       string            `json:"cgroupsPath,omitempty"`
+	HomeSource        string            `json:"homedir,omitempty"`
+	HomeDest          string            `json:"homeDest,omitempty"`
+	Command           string            `json:"command,omitempty"`
+	Shell             string            `json:"shell,omitempty"`
+	TmpDir            string            `json:"tmpdir,omitempty"`
+	AddCaps           string            `json:"addCaps,omitempty"`
+	DropCaps          string            `json:"dropCaps,omitempty"`
+	Hostname          string            `json:"hostname,omitempty"`
+	Network           string            `json:"network,omitempty"`
+	DNS               string            `json:"dns,omitempty"`
+	Cwd               string            `json:"cwd,omitempty"`
+	SessionLayer      string            `json:"sessionLayer,omitempty"`
+	EncryptionKey     []byte            `json:"encryptionKey,omitempty"`
+	TargetUID         int               `json:"targetUID,omitempty"`
+	WritableImage     bool              `json:"writableImage,omitempty"`
+	WritableTmpfs     bool              `json:"writableTmpfs,omitempty"`
+	Contain           bool              `json:"container,omitempty"`
+	Nv                bool              `json:"nv,omitempty"`
+	Rocm              bool              `json:"rocm,omitempty"`
+	CustomHome        bool              `json:"customHome,omitempty"`
+	Instance          bool              `json:"instance,omitempty"`
+	InstanceJoin      bool              `json:"instanceJoin,omitempty"`
+	BootInstance      bool              `json:"bootInstance,omitempty"`
+	RunPrivileged     bool              `json:"runPrivileged,omitempty"`
+	AllowSUID         bool              `json:"allowSUID,omitempty"`
+	KeepPrivs         bool              `json:"keepPrivs,omitempty"`
+	NoPrivs           bool              `json:"noPrivs,omitempty"`
+	NoHome            bool              `json:"noHome,omitempty"`
+	NoInit            bool              `json:"noInit,omitempty"`
+	DeleteImage       bool              `json:"deleteImage,omitempty"`
+	Fakeroot          bool              `json:"fakeroot,omitempty"`
+	SignalPropagation bool              `json:"signalPropagation,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -802,4 +803,16 @@ func (e *EngineConfig) SetUnixSocketPair(fds [2]int) {
 // in stage one by the engine.
 func (e *EngineConfig) GetUnixSocketPair() [2]int {
 	return e.JSON.UnixSocketPair
+}
+
+// SetSingularityEnv sets singularity environment variables
+// as a key/value string map.
+func (e *EngineConfig) SetSingularityEnv(senv map[string]string) {
+	e.JSON.SingularityEnv = senv
+}
+
+// GetSingularityEnv returns singularity environment variables
+// as a key/value string map.
+func (e *EngineConfig) GetSingularityEnv() map[string]string {
+	return e.JSON.SingularityEnv
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Add shell interpreter able to interpret /.singularity.d/env files and execute action scripts without the need for `/bin/sh` in container image. 
- Add `--env` option to specify environment variables to pass for container environment setup:
  - allow literal for evaluation during container environment setup:
    - `--env PATH=/a/bind/path:\$PATH` where `$PATH` is replaced by `PATH` during container setup allowing to append/prepend value to the final path environment variables
    - `--env PATH=/a/bind/path:$PATH` take path from current environment
- Add `--env-file` option to specify environment variables from file:
  - allow literal for evaluation during container environment setup
  - command execution and file creation/modification are disabled during variable evaluation, but shell builtins remains available

### This fixes or addresses the following GitHub issues:

- Fixes #5040 
- Fixes #4827

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

