### PR TITLE
Fix zenodo DOI link to not be outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md)
 - [Project License](LICENSE.md)
 - [Documentation](https://www.sylabs.io/docs/)
-- [Citation](http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0177459)
+- [Citation](#citing-singularity)
 
 Singularity is an open source container platform designed to be simple, fast,
 and secure. Singularity is optimized for compute focused enterprise and HPC
@@ -49,7 +49,7 @@ Portal](https://www.sylabs.io/singularity/community/).
 For additional support, [contact us](https://www.sylabs.io/contact/) to receive
 more information.
 
-## Cite as:
+## Citing Singularity
 
 ```
 Kurtzer GM, Sochat V, Bauer MW (2017) Singularity: Scientific containers for mobility of compute. PLoS ONE 12(5): e0177459. https://doi.org/10.1371/journal.pone.0177459
@@ -58,11 +58,15 @@ Kurtzer GM, Sochat V, Bauer MW (2017) Singularity: Scientific containers for mob
 We also have a Zenodo citation:
 
 ```
-Kurtzer, Gregory M.. (2016). Singularity 2.1.2 - Linux application and environment
-containers for science. 10.5281/zenodo.60736
-
-https://doi.org/10.5281/zenodo.60736
+Kurtzer, Gregory M. et. al. Singularity - Linux application and environment
+containers for science. 10.5281/zenodo.1310023
 ```
+
+https://doi.org/10.5281/zenodo.1310023
+
+This is an 'all versions' DOI. Follow the link to Zenodo to obtain a DOI specific
+to a particular version of Singularity.
+
 
 ## License
 


### PR DESCRIPTION
 - In readme, make Citation link go to the section further down in the
doc.

 - Give the Zenodo 'all versions' DOI, from which people can find version
specific DOIs, instead of an old 2.x specific DOI.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #1739


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

