### PR TITLE
Fix instance join for instances started with --boot

### DIFF
--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -372,5 +372,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				})
 			}
 		},
+		"issue 5033": c.issue5033, // https://github.com/sylabs/singularity/issues/4836
 	}
 }

--- a/e2e/instance/regressions.go
+++ b/e2e/instance/regressions.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package instance
+
+import (
+	"fmt"
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+func (c *ctx) issue5033(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	c.profile = e2e.RootProfile
+
+	// pick up a random name
+	instanceName := uuid.NewV4().String()
+	joinName := fmt.Sprintf("instance://%s", instanceName)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs("--boot", c.env.ImagePath, instanceName),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(joinName, "/bin/true"),
+		e2e.ExpectExit(0),
+	)
+
+	c.stopInstance(t, instanceName)
+}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -763,21 +763,21 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 		if st.Uid != uint32(uid) || st.Gid != uint32(gid) {
 			return fmt.Errorf("parent instance process owned by %d:%d instead of %d:%d", st.Uid, st.Gid, uid, gid)
 		}
-	}
 
-	path, err = filepath.Abs("comm")
-	if err != nil {
-		return fmt.Errorf("failed to determine absolute path for comm: %s", err)
-	}
+		path, err = filepath.Abs("comm")
+		if err != nil {
+			return fmt.Errorf("failed to determine absolute path for comm: %s", err)
+		}
 
-	// we must read "sinit\n"
-	b, err := ioutil.ReadFile("comm")
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %s", path, err)
-	}
-	// check that we are currently joining sinit process
-	if "sinit" != strings.Trim(string(b), "\n") {
-		return fmt.Errorf("sinit not found in %s, wrong instance process", path)
+		// we must read "sinit\n"
+		b, err := ioutil.ReadFile("comm")
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %s", path, err)
+		}
+		// check that we are currently joining sinit process
+		if "sinit" != strings.Trim(string(b), "\n") {
+			return fmt.Errorf("sinit not found in %s, wrong instance process", path)
+		}
 	}
 
 	// tell starter that we are joining an instance


### PR DESCRIPTION
## Description of the Pull Request (PR):

Move comm name for setuid workflow only during instance join as it avoid to join instance started with       `--boot`.

### This fixes or addresses the following GitHub issues:

 - Fixes #5033 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

