### PR TITLE
Fix e2e instance profile race

### DIFF
--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -334,12 +334,16 @@ func (c *ctx) applyCgroupsInstance(t *testing.T) {
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := &ctx{
-		env:     env,
-		profile: e2e.UserProfile,
+		env: env,
 	}
 
 	return testhelper.Tests{
 		"ordered": func(t *testing.T) {
+			c := &ctx{
+				env:     env,
+				profile: e2e.UserProfile,
+			}
+
 			e2e.EnsureImage(t, c.env)
 
 			// Define and loop through tests.


### PR DESCRIPTION
## Description of the Pull Request (PR):

There is now two e2e tests running in parallel for instances and both manipulate profile of the same instance leading to :

```
WARNING: DATA RACE
Write at 0x00c00037a078 by goroutine 127:
  github.com/sylabs/singularity/e2e/instance.E2ETests.func1.1()
      github.com/sylabs/singularity@/e2e/instance/instance.go:368 +0x5e
  testing.tRunner()
      testing/testing.go:909 +0x199

Previous write at 0x00c00037a078 by goroutine 72:
  github.com/sylabs/singularity/e2e/instance.(*ctx).issue5033()
      github.com/sylabs/singularity@/e2e/instance/regressions.go:19 +0x115
  github.com/sylabs/singularity/e2e/instance.(*ctx).issue5033-fm()
      github.com/sylabs/singularity@/e2e/instance/regressions.go:16 +0x4b
  github.com/sylabs/singularity/e2e/internal/testhelper.(*Suite).Run.func1.1.1()
      github.com/sylabs/singularity@/e2e/internal/testhelper/testhelper.go:76 +0x5e
  testing.tRunner()
      testing/testing.go:909 +0x199
```

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

