### PR TITLE
Handle non-standard awk location for genmod.awk (Nix/Guix)

### DIFF
--- a/makeit/genmod.awk
+++ b/makeit/genmod.awk
@@ -1,4 +1,7 @@
-#!/usr/bin/awk -f
+#!/bin/sh
+true + /; exec -a "$0" awk -f "$0" -- "$@"; / {}
+# awk script starts here
+
 # Copyright (c) 2015-2018, Yannick Cote <yhcote@gmail.com>. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found
 # in the LICENSE file.
@@ -534,4 +537,5 @@ BEGIN {
 	genallrule(envar["makeitgendir"] "/" "all.mk")
 
 #	printmvars()
+	exit(0)
 }

--- a/makeit/genmod.awk
+++ b/makeit/genmod.awk
@@ -1,5 +1,5 @@
 #!/bin/sh
-true + /; exec -a "$0" awk -f "$0" -- "$@"; / {}
+true + /; exec awk -f "$0" -- "$@"; / {}
 # awk script starts here
 
 # Copyright (c) 2015-2018, Yannick Cote <yhcote@gmail.com>. All rights reserved.


### PR DESCRIPTION
## Description of the Pull Request (PR):

:dragon: Here be dragons! :fire: 

While looking at #5002 I decided to try and also make sure we can build Singularity on nix & guix as base OS - as well as trying to solve the profile vs host `ldconfig` issue. Nix and Guix only provide `/bin/sh` and `/usr/bin/env` and *not* `/usr/bin/awk` that we need in `mconfig`'s `genmod.awk`. Unfortunately `genmod.awk` takes multiple args so portable use of `/usr/bin/env` is not possible....

---

Under nix, guix, and maybe some other environments there is no
`/usr/bin/awk` - it has to be found on `PATH`.

The GNU `-S` option to `/usr/bin/env` allows use of shebangs with multiple
arguments passed to the interpreter (as is the case for genmod.awk),
but this is non POSIX so won't work under busybox etc.

To support bare POSIX environments as well as nix type environments the
`genmod.awk` can be made into a polygot program where some valid `sh`
calls the script again using `awk` on `PATH`.

Ref: https://unix.stackexchange.com/a/149801


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

