### PR TITLE
CI: Add a short-integration-test make target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
           command: |-
             make -C ./builddir unit-test
 
-  integration_tests:
+  short_integration_tests:
     <<: *vm_defaults
     steps:
       - *attach_workspace
@@ -228,10 +228,10 @@ jobs:
       - run:
           <<: *install_singularity
       - run:
-          name: Run integration tests
+          name: Run short integration tests
           no_output_timeout: 20m
           command: |-
-            make -C ./builddir integration-test
+            make -C ./builddir short-integration-test
 
   e2e_tests:
     <<: *vm_defaults
@@ -277,7 +277,7 @@ workflows:
       - unit_tests:
           requires:
             - build_check_and_install
-      - integration_tests:
+      - short_integration_tests:
           requires:
             - build_check_and_install
       - e2e_tests:

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -74,6 +74,14 @@ integration-test:
 		./cmd/singularity ./pkg/network
 	@echo "       PASS"
 
+.PHONY: short-integration-test
+short-integration-test:
+	@echo " TEST sudo go test [short-integration]"
+	$(V)cd $(SOURCEDIR) && \
+		scripts/go-test -sudo -v -tags 'integration_test' \
+		./pkg/network
+	@echo "       PASS"
+
 .PHONY: test
 test:
 	@echo " TEST sudo go test [all]"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a short-integration-test make target running only network integration tests without CLI for circleci.
Integration tests are actually very redundant with e2e tests and are consuming a lot of time for basically the same tests.

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

