### PR TITLE
Provide a way to determine plugin installation path

### DIFF
--- a/cmd/internal/cli/plugin_install_linux.go
+++ b/cmd/internal/cli/plugin_install_linux.go
@@ -10,34 +10,16 @@ import (
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
-	"github.com/sylabs/singularity/pkg/cmdline"
 )
-
-// -n|--name
-var pluginName string
-var pluginInstallNameFlag = cmdline.Flag{
-	ID:           "pluginInstallNameFlag",
-	Value:        &pluginName,
-	DefaultValue: "",
-	Name:         "name",
-	ShortHand:    "n",
-	Usage:        "name to install the plugin as, defaults to the value in the manifest",
-}
-
-func init() {
-	addCmdInit(func(cmdManager *cmdline.CommandManager) {
-		cmdManager.RegisterFlagForCmd(&pluginInstallNameFlag, PluginInstallCmd)
-	})
-}
 
 // PluginInstallCmd takes a compiled plugin.sif file and installs it
 // in the appropriate location.
 //
-// singularity plugin install <path> [-n name]
+// singularity plugin install <path>
 var PluginInstallCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := singularity.InstallPlugin(args[0], pluginName)
+		err := singularity.InstallPlugin(args[0])
 		if err != nil {
 			sylog.Fatalf("Failed to install plugin %q: %s.", args[0], err)
 		}

--- a/docs/plugin.go
+++ b/docs/plugin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -35,7 +35,7 @@ const (
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// plugin install command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	PluginInstallUse   string = `install [install options...] <plugin_path>`
+	PluginInstallUse   string = `install <plugin_path>`
 	PluginInstallShort string = `Install a compiled Singularity plugin`
 	PluginInstallLong  string = `
   The 'plugin install' command installs the compiled plugin found at plugin_path

--- a/e2e/plugin/plugin.go
+++ b/e2e/plugin/plugin.go
@@ -19,10 +19,7 @@ type ctx struct {
 }
 
 func (c ctx) testPluginBasic(t *testing.T) {
-	const (
-		pluginName       = "github.com/sylabs/singularity/e2e-plugin"
-		pluginCustomName = "github.com/sylabs/singularity/e2e-custom-plugin"
-	)
+	pluginName := "github.com/sylabs/singularity/e2e-plugin"
 
 	// plugin code directory
 	pluginDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "plugin-dir-", "")
@@ -74,21 +71,6 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			args:       []string{},
 			expectExit: 0,
 			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, pluginName),
-		},
-		{
-			name:       "InstallCustomName",
-			profile:    e2e.RootProfile,
-			command:    "plugin install",
-			args:       []string{"--name", pluginCustomName, sifFile},
-			expectExit: 0,
-		},
-		{
-			name:       "ListCustom",
-			profile:    e2e.UserProfile,
-			command:    "plugin list",
-			args:       []string{},
-			expectExit: 0,
-			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, pluginCustomName),
 		},
 		{
 			name:       "Disable",
@@ -146,13 +128,6 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			args:       []string{pluginName},
 			expectExit: 0,
 		},
-		{
-			name:       "UninstallCustomName",
-			profile:    e2e.RootProfile,
-			command:    "plugin uninstall",
-			args:       []string{pluginCustomName},
-			expectExit: 0,
-		},
 	}
 
 	for _, tt := range tests {
@@ -169,7 +144,7 @@ func (c ctx) testPluginBasic(t *testing.T) {
 
 func (c ctx) testCLICallbacks(t *testing.T) {
 	pluginDir := "./plugin/testdata/cli"
-	pluginName := "e2e-cli/plugin"
+	pluginName := "github.com/sylabs/singularity/e2e-cli-plugin"
 
 	// plugin sif file
 	sifFile := filepath.Join(c.env.TestDir, "plugin.sif")
@@ -193,7 +168,7 @@ func (c ctx) testCLICallbacks(t *testing.T) {
 			name:       "Install",
 			profile:    e2e.RootProfile,
 			command:    "plugin install",
-			args:       []string{"--name", pluginName, sifFile},
+			args:       []string{sifFile},
 			expectExit: 0,
 		},
 		{
@@ -235,7 +210,7 @@ func (c ctx) testSingularityCallbacks(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	pluginDir := "./plugin/testdata/runtime_singularity"
-	pluginName := "e2e-runtime-singularity/plugin"
+	pluginName := "github.com/sylabs/singularity/e2e-runtime-plugin"
 
 	// plugin sif file
 	sifFile := filepath.Join(c.env.TestDir, "plugin.sif")
@@ -259,7 +234,7 @@ func (c ctx) testSingularityCallbacks(t *testing.T) {
 			name:       "Install",
 			profile:    e2e.RootProfile,
 			command:    "plugin install",
-			args:       []string{"--name", pluginName, sifFile},
+			args:       []string{sifFile},
 			expectExit: 0,
 		},
 		{

--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -24,6 +24,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/plugin"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	pluginapi "github.com/sylabs/singularity/pkg/plugin"
 )
 
 const version = "v0.0.0"
@@ -216,12 +217,15 @@ func CompilePlugin(sourceDir, destSif, buildTags string, disableMinorCheck bool)
 func buildPlugin(sourceDir string, bTool buildToolchain) (string, error) {
 	// assuming that sourceDir is within trimpath for now
 	out := pluginObjPath(sourceDir)
+	// set pluginRootDirVar variable if required by the plugin
+	pluginRootDirVar := fmt.Sprintf("-X main.%s=%s", pluginapi.PluginRootDirSymbol, buildcfg.PLUGIN_ROOTDIR)
 
 	args := []string{
 		"build",
 		"-a",
 		"-o", out,
 		"-mod=readonly",
+		"-ldflags", pluginRootDirVar,
 		"-trimpath",
 		"-buildmode=plugin",
 		"-tags", bTool.buildTags,

--- a/internal/app/singularity/plugin_install_linux.go
+++ b/internal/app/singularity/plugin_install_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,6 +13,6 @@ import (
 // the singularity plugin installation directory.
 //
 // Installing a plugin will also automatically enable it.
-func InstallPlugin(pluginPath, pluginName string) error {
-	return plugin.Install(pluginPath, pluginName)
+func InstallPlugin(pluginPath string) error {
+	return plugin.Install(pluginPath)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -5,6 +5,12 @@
 
 package plugin
 
+// PluginRootDirSymbol is the name of a variable of type string which
+// a plugin may define if it want to obtain the plugin root directory.
+// Concatenated with the manifest name it allows to retrieve the path
+// where the plugin is currently installed.
+const PluginRootDirSymbol = "PluginRootDir"
+
 // PluginSymbol is the name of a variable of type plugin.Plugin which all
 // plugin implementations MUST define.
 const PluginSymbol = "Plugin"


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Add new symbol `PluginRootDir` variable for plugin API allowing plugins to retrieve plugin root directory in order to concatenate with the plugin manifest name to determine the current plugin installation directory.
- Remove --name option from `singularity plugin install` for now, at best if it needs to be changed this should be done at compilation time but not at installation because manifest name differ from the one used by Singularity internals and could lead to confusion during debugging by example.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

