### PR TITLE
Use cp -H symlink behaviour in multi-stage Copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ _The old changelog can be found in the `release-2.6` branch_
 ## Changed defaults / behaviours
   - Environment variables prefixed with `SINGULARITYENV_` always take
     precedence over variables without `SINGULARITYENV_` prefix.
+  - `%files from ...` will now follow symlinks for sources that are directly
+    specified, or directly resolved from a glob pattern. It will not follow
+    symlinks found through directory traversal. This mirrors Docker multi-stage
+    COPY behaviour.
 
 
 # Changes Since v3.5.2

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -40,8 +40,12 @@ func makeParentDir(path string, numSrcPaths int) error {
 }
 
 // Copy calls cp with src and dst as its arguments
-// checks dst and creates parent directories if they do not exist
-// before calling cp
+// Checks dst and creates parent directories if they do not exist
+// before calling cp.
+// If followLinks is true, the -L flag to cp will follow all symlinks
+// If followLinks is false, the -H flag to cp will only follow links for specified
+// files or files that resolve directly from a glob pattern. It will not follow
+// links found during directory traversal.
 func Copy(src, dst string, followLinks bool) error {
 	// resolve any bash globbing in filepath
 	paths, err := expandPath(src)
@@ -54,7 +58,7 @@ func Copy(src, dst string, followLinks bool) error {
 	}
 
 	// set flags for cp
-	args := []string{"-fr"}
+	args := []string{"-fHr"}
 	if followLinks {
 		args = []string{"-fLr"}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In a multi-stage build up until 3.5.3 we would follow all symlinks when
copying files, using cp -L. This was changed so that symlinks were not
followed in 3.5.3 via #4873.

In #5059 it was noted this breaks some NVIDIA container maker builds.
Also, Docker will follow symlinks in multi-stage build COPY if they
are specified directly, or via glob. It will not follow symlinks that
are copied as a result of directory traversal. This is the cp -H
behaviour, and it makes sense to follow it for least surprise vs Docker
multi-stage builds.

### This fixes or addresses the following GitHub issues:

 - Fixes: #5059  

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

