### PR TITLE
Nicer encryption error messages

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -334,12 +334,13 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 			keyInfo, err := getEncryptionMaterial(cobraCmd)
 			if err != nil {
-				sylog.Fatalf("While handling encryption material: %v", err)
+				sylog.Fatalf("Cannot load key for decryption: %v", err)
 			}
 
 			plaintextKey, err := crypt.PlaintextKey(keyInfo, engineConfig.GetImage())
 			if err != nil {
-				sylog.Fatalf("Cannot retrieve key from image %s: %+v", engineConfig.GetImage(), err)
+				sylog.Errorf("Cannot decrypt %s: %v", engineConfig.GetImage(), err)
+				sylog.Fatalf("Please check you are providing the correct key for decryption")
 			}
 
 			engineConfig.SetEncryptionKey(plaintextKey)

--- a/pkg/util/crypt/key_test.go
+++ b/pkg/util/crypt/key_test.go
@@ -128,7 +128,7 @@ func TestPlaintextKey(t *testing.T) {
 		{
 			name:          "invalid pem",
 			keyInfo:       KeyInfo{Format: PEM, Path: invalidPemPath},
-			expectedError: errors.Wrap(fmt.Errorf("open nothing: no such file or directory"), "loading private key for key decryption"),
+			expectedError: fmt.Errorf("could not load PEM private key: open nothing: no such file or directory"),
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Stop using github.com/pkg/errors Wrap in the encryption code, as this
adds a stack trace to error output for common issues such as an
incorrect key being supplied. Also try to make some of the error message
a bit simpler.

We can use Go 1.13 %w when we want to have nice wrapped errors, but for
now avoid this and use %v as RHEL8 doesn't have 1.13 as an app stream
yet.

### This fixes or addresses the following GitHub issues:

 - Fixes: #5058


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

