### PR TITLE
Specify required cryptsetup version if older version found

### DIFF
--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -29,7 +29,7 @@ type Device struct{}
 var (
 	// ErrUnsupportedCryptsetupVersion is the error raised when the available version
 	// of cryptsetup is not compatible with the Singularity encryption mechanism.
-	ErrUnsupportedCryptsetupVersion = errors.New("available cryptsetup is not supported")
+	ErrUnsupportedCryptsetupVersion = errors.New("installed version of cryptsetup is not supported, >=2.0.0 required")
 
 	// ErrInvalidPassphrase raised when the passed key is not valid to open requested
 	// encrypted device.

--- a/pkg/util/crypt/crypt_dev_test.go
+++ b/pkg/util/crypt/crypt_dev_test.go
@@ -106,7 +106,7 @@ func TestEncrypt(t *testing.T) {
 			devPath, err := dev.EncryptFilesystem(tt.path, tt.key)
 			if tt.shallPass && err != nil {
 				if err == ErrUnsupportedCryptsetupVersion {
-					t.Skip("the version of cryptsetup available is not compatible")
+					t.Skip("installed version of cryptsetup is not supported, >=2.0.0 required")
 				} else {
 					t.Fatalf("test %s expected to succeed but failed: %s", tt.name, err)
 				}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Specify required cryptsetup version if older version found

### This fixes or addresses the following GitHub issues:

 - Fixes #4621 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

