### PR TITLE
Image driver fixes

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -611,7 +611,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	// convert image file to sandbox if we are using user
 	// namespace or if we are currently running inside a
 	// user namespace
-	if (UserNamespace || insideUserNs) && fs.IsFile(image) {
+	if (UserNamespace || insideUserNs) && fs.IsFile(image) && engineConfig.File.ImageDriver == "" {
 		unsquashfsPath := ""
 		if engineConfig.File.MksquashfsPath != "" {
 			d := filepath.Dir(engineConfig.File.MksquashfsPath)


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Fix image driver start where a driver is started too early before the session is created.
- Rework privileges handling in starter, RPC and master process
now keep the original user/group ID and keep only required capabilities,
it's necessary because when we are using FUSE mount points the access
control in the kernel check if the real uid/gid, effective uid/gid and
saved uid/gid are identical to user_id/group_id FUSE mount options, so
we can't use setresuid/setresgid with setuid workflow because the saved
uid/gid for the master process is 0 and the effective uid is 0 for the
RPC process.
- Fix condition by adding image driver check on image conversion when using
unprivileged workflow.

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

