### PR TITLE
Remove log of expected error in TestCryptsetup

### DIFF
--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -64,8 +64,6 @@ func TestCryptsetup(t *testing.T) {
 
 			path, err := cryptsetup(f.Name())
 
-			t.Log(path, err)
-
 			switch {
 			case tc.expectSuccess && err == nil:
 				// expect success, no error, check path
@@ -83,11 +81,6 @@ func TestCryptsetup(t *testing.T) {
 				// expect failure, got no error
 				t.Errorf("unexpected result calling cryptsetup with config = %q, got path = %s",
 					cfg, path)
-
-			case !tc.expectSuccess && err != nil:
-				// expect failure, got error
-				t.Logf("got expected failure calling cryptsetup with config = %q, err = %+v",
-					cfg, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In `TestCryptsetup` don't noisily log expected output / expected errors. The handling of unexpected test results provides sufficient information for diagnosing a failure.


### This fixes or addresses the following GitHub issues:

 - Fixes: #4896


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

