### PR TITLE
Fix e2e test broken by #5064

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -907,7 +907,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	err := e2e.CheckCryptsetupVersion()
 	if err != nil {
 		expectedExitCode = 255
-		expectedStderr = ": available cryptsetup is not supported"
+		expectedStderr = ": installed version of cryptsetup is not supported, >=2.0.0 required"
 	}
 
 	// First with the command line argument, only using --passphrase


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix e2e test broken by #5064 and that was missed as the PR didn't run e2e

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

