### PR TITLE
Fix configuration parser regular expression to exclude newlines and carriage returns

### DIFF
--- a/pkg/util/singularityconf/parser.go
+++ b/pkg/util/singularityconf/parser.go
@@ -21,7 +21,7 @@ import (
 // holding directives mapped to their respective values.
 type Directives map[string][]string
 
-var parserReg = regexp.MustCompile(`(?m)^\s*([a-zA-Z _]+)\s*=\s*(.*)$`)
+var parserReg = regexp.MustCompile(`(?m)^\s*([a-zA-Z _]+)[[:blank:]]*=[[:blank:]]*(.*)$`)
 
 // GetDirectives parses configuration directives from reader
 // and returns a directive map with associated values.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Actually if the configuration contains something like

```
image driver =

# a comment
```

`image driver` take `# a comment` as value because the regular expression use `\s` for matching instead of matching whitespaces and tabs only.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

