### PR TITLE
Add --no-hostfs actions flag

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -45,6 +45,7 @@ var (
 	Nvidia          bool
 	Rocm            bool
 	NoHome          bool
+	NoHostfs        bool
 	NoInit          bool
 	NoNvidia        bool
 	NoRocm          bool
@@ -437,6 +438,17 @@ var actionNoHomeFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
+// --no-hostfs
+var actionNoHostfsFlag = cmdline.Flag{
+	ID:           "actionNoHostfsFlag",
+	Value:        &NoHostfs,
+	DefaultValue: false,
+	Name:         "no-hostfs",
+	Usage:        "do NOT mount host filesystems even if hostfs true in singularity.conf",
+	EnvKeys:      []string{"NO_HOSTFS"},
+	ExcludedOS:   []string{cmdline.Darwin},
+}
+
 // --no-init
 var actionNoInitFlag = cmdline.Flag{
 	ID:           "actionNoInitFlag",
@@ -678,6 +690,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionNetworkArgsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNetworkFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoHomeFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoHostfsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoInitFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNONETFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoNvidiaFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -372,6 +372,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	engineConfig.SetOverlayImage(OverlayPath)
 	engineConfig.SetWritableImage(IsWritable)
 	engineConfig.SetNoHome(NoHome)
+	engineConfig.SetNoHostfs(NoHostfs)
 	engineConfig.SetNv(Nvidia)
 	engineConfig.SetRocm(Rocm)
 	engineConfig.SetAddCaps(AddCaps)

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -249,6 +249,12 @@ func (c actionTests) actionExec(t *testing.T) {
 			argv: []string{"--no-home", c.env.ImagePath, "ls", "-ld", user.Dir},
 			exit: 1,
 		},
+		// --no-hostfs should be a no-op with default config that does not set hostfs true
+		{
+			name: "NoHostfs",
+			argv: []string{"--no-hostfs", c.env.ImagePath, "true"},
+			exit: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1454,6 +1454,11 @@ func (c *container) addHostMount(system *mount.System) error {
 		return nil
 	}
 
+	if c.engine.EngineConfig.GetNoHostfs() {
+		sylog.Debugf("Skipping host file systems mount by user request.")
+		return nil
+	}
+
 	info, err := proc.GetMountPointMap("/proc/self/mountinfo")
 	if err != nil {
 		return err

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -147,6 +147,7 @@ type JSONConfig struct {
 	KeepPrivs         bool              `json:"keepPrivs,omitempty"`
 	NoPrivs           bool              `json:"noPrivs,omitempty"`
 	NoHome            bool              `json:"noHome,omitempty"`
+	NoHostfs          bool              `json:"noHostfs,omitempty"`
 	NoInit            bool              `json:"noInit,omitempty"`
 	DeleteImage       bool              `json:"deleteImage,omitempty"`
 	Fakeroot          bool              `json:"fakeroot,omitempty"`
@@ -545,6 +546,16 @@ func (e *EngineConfig) SetNoHome(val bool) {
 // GetNoHome returns if no-home flag is set or not.
 func (e *EngineConfig) GetNoHome() bool {
 	return e.JSON.NoHome
+}
+
+// SetNoHostfs sets no-hostfs flag to not mount host filesystems
+func (e *EngineConfig) SetNoHostfs(val bool) {
+	e.JSON.NoHostfs = val
+}
+
+// GetNoHostfs returns if no-hostfs flag is set or not.
+func (e *EngineConfig) GetNoHostfs() bool {
+	return e.JSON.NoHostfs
 }
 
 // SetNoInit set noinit flag to not start shim init process.


### PR DESCRIPTION
## Description of the Pull Request (PR)
    
Add a --no-hostfs so that if the global config specifies "mount hostfs
= yes" it is still possible to run a container without all the host
filesystems mounted.
    
An example of how this is useful - for containers that have
directories with generic names like `/data` inside the
container. `/data` is a mount point on my host so it's useful to be
able to turn off `mount hostfs` for these containers.

### This fixes or addresses the following GitHub issues:

 -   Closes: #5081

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

