### PR TITLE
Handle existing old-style cache entry directories

### DIFF
--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -10,12 +10,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sylabs/singularity/internal/pkg/util/fs"
-
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/internal/pkg/cache"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
 type cacheTests struct {
@@ -282,5 +281,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	return testhelper.Tests{
 		"interactive commands":     np(c.testInteractiveCacheCmds),
 		"non-interactive commands": np(c.testNoninteractiveCacheCmds),
+		"issue5097":                np(c.issue5097),
 	}
 }

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cache
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/sylabs/scs-library-client/client"
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
+)
+
+// issue5097 - need to handle an existing directory entry present in the cache
+// from older singularity versions.
+func (c cacheTests) issue5097(t *testing.T) {
+	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
+	defer cleanCache(t)
+	c.env.ImgCacheDir = imgCacheDir
+
+	tempDir, imgStoreCleanup := e2e.MakeTempDir(t, "", "", "image store")
+	defer imgStoreCleanup(t)
+	imagePath := filepath.Join(tempDir, imgName)
+
+	// Pull through the cache - will give us a new style file in the cache
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs([]string{"--force", imagePath, imgURL}...),
+		e2e.ExpectExit(0),
+	)
+
+	// Replace the cache entry with a directory, containing the image,
+	// like in older versions of singularity
+	hash, err := client.ImageHash(imagePath)
+	if err != nil {
+		t.Fatalf("Could not calculate hash of test image: %v", err)
+	}
+	cachePath := path.Join(imgCacheDir, "cache", "library", hash)
+	err = os.Remove(cachePath)
+	if err != nil {
+		t.Fatalf("Could not remove cached image '%s': %v", cachePath, err)
+	}
+	err = os.Mkdir(cachePath, 0700)
+	if err != nil {
+		t.Fatalf("Could not create directory '%s': %v", cachePath, err)
+	}
+	err = fs.CopyFile(imagePath, path.Join(cachePath, hash), 0700)
+	if err != nil {
+		t.Fatalf("Could not copy file to directory '%s': %v", cachePath, err)
+	}
+
+	// Pull through the cache - it should work as we now remove the directory and
+	// re-pull a file into the cache
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs([]string{"--force", imagePath, imgURL}...),
+		e2e.ExpectExit(0),
+	)
+
+	if !fs.IsFile(cachePath) {
+		t.Fatalf("Cache entry '%s' is not a file", cachePath)
+	}
+
+}

--- a/internal/pkg/cache/entry.go
+++ b/internal/pkg/cache/entry.go
@@ -10,9 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sylabs/singularity/internal/pkg/util/fs"
-
 	"github.com/sylabs/singularity/internal/pkg/sylog"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
 // Entry is a structure representing an entry in the cache. An entry is a file under the

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -53,10 +53,10 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 	} else {
 		cacheEntry, err := imgCache.GetEntry(cache.LibraryCacheType, libraryImage.Hash)
-		defer cacheEntry.CleanTmp()
 		if err != nil {
 			return "", fmt.Errorf("unable to check if %v exists in cache: %v", libraryImage.Hash, err)
 		}
+		defer cacheEntry.CleanTmp()
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading library image")
 

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -139,10 +139,10 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 	} else {
 		cacheEntry, err := imgCache.GetEntry(cache.NetCacheType, hash)
-		defer cacheEntry.CleanTmp()
 		if err != nil {
 			return "", fmt.Errorf("unable to check if %v exists in cache: %v", hash, err)
 		}
+		defer cacheEntry.CleanTmp()
 
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading network image")

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -40,10 +40,10 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 	} else {
 
 		cacheEntry, err := imgCache.GetEntry(cache.OciTempCacheType, hash)
-		defer cacheEntry.CleanTmp()
 		if err != nil {
 			return "", fmt.Errorf("unable to check if %v exists in cache: %v", hash, err)
 		}
+		defer cacheEntry.CleanTmp()
 		if !cacheEntry.Exists {
 			sylog.Infof("Converting OCI blobs to SIF format")
 

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -32,10 +32,10 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 	} else {
 		cacheEntry, err := imgCache.GetEntry(cache.OrasCacheType, hash)
-		defer cacheEntry.CleanTmp()
 		if err != nil {
 			return "", fmt.Errorf("unable to check if %v exists in cache: %v", hash, err)
 		}
+		defer cacheEntry.CleanTmp()
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading oras image")
 

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -141,10 +141,10 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		imagePath = directTo
 	} else {
 		cacheEntry, err := imgCache.GetEntry(cache.ShubCacheType, manifest.Commit)
-		defer cacheEntry.CleanTmp()
 		if err != nil {
 			return "", fmt.Errorf("unable to check if %v exists in cache: %v", manifest.Commit, err)
 		}
+		defer cacheEntry.CleanTmp()
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading shub image")
 


### PR DESCRIPTION
Handle existing old-style cache entry directories

Fixes: #5097

Also moves defer statements after error checks when getting a cacheEntry
to avoid panics on tmpCleanup with a nil cacheEntry.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

