### PR TITLE
Allow app name with non alphanumeric characters

### DIFF
--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -46,6 +47,8 @@ var (
 		sectionLabels:  true,
 	}
 )
+
+var reg = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 const (
 	globalEnv94Base = `## App Global Exports For: %[1]s
@@ -286,18 +289,20 @@ func writeEnvFile(b *types.Bundle, a *App) error {
 }
 
 func globalAppEnv(b *types.Bundle, a *App) string {
-	content := fmt.Sprintf(globalEnv94Base, a.Name)
+	name := reg.ReplaceAllString(a.Name, "_")
+
+	content := fmt.Sprintf(globalEnv94Base, name)
 
 	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/env/90-environment.sh")); err == nil {
-		content += fmt.Sprintf(globalEnv94AppEnv, a.Name)
+		content += fmt.Sprintf(globalEnv94AppEnv, name)
 	}
 
 	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/labels.json")); err == nil {
-		content += fmt.Sprintf(globalEnv94AppLabels, a.Name)
+		content += fmt.Sprintf(globalEnv94AppLabels, name)
 	}
 
 	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/runscript")); err == nil {
-		content += fmt.Sprintf(globalEnv94AppRun, a.Name)
+		content += fmt.Sprintf(globalEnv94AppRun, name)
 	}
 
 	return content


### PR DESCRIPTION
## Description of the Pull Request (PR):

In 2.6 apps name can contain non alphanumeric characters, in v3 there is no special restriction just a bug when generating environment variables (`SCIF_APPDATA_app`, `SCIF_APPROOT_app` ...) name derived from the app name, which means that a app name `test-app` generates an invalid environment variable `SCIF_APPDATA_test-app` as `-` is not a valid character within an environment variable name, so this PR replace all non alphanumeric characters by `_`.

It's actually not clear why those variables need to be generated like this, as we load one app at a time and those variables are redundant with `SCIF_APPXXXX` variants.

### This fixes or addresses the following GitHub issues:

 - Fixes #4799 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

