### PR TITLE
Wrap docker environment variable value with double quotes

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -403,12 +403,12 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 		export := ""
 		envParts := strings.SplitN(element, "=", 2)
 		if len(envParts) == 1 {
-			export = fmt.Sprintf("export %s=${%s:-}\n", envParts[0], envParts[0])
+			export = fmt.Sprintf("export %s=\"${%s:-}\"\n", envParts[0], envParts[0])
 		} else {
 			if envParts[0] == "PATH" {
 				export = fmt.Sprintf("export %s=%q\n", envParts[0], shell.Escape(envParts[1]))
 			} else {
-				export = fmt.Sprintf("export %s=${%s:-%q}\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
+				export = fmt.Sprintf("export %s=\"${%s:-%q}\"\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
 			}
 		}
 		_, err = f.WriteString(export)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Posix shell can't assign value containing spaces within an assignment like :

```
A="d e f"
export A=${A:-"a b c"}
```

And need to wrap value between double quote like this :

```
export A="${A:-"a b c"}"
```

Note: this is not an issue with the shell interpreter

### This fixes or addresses the following GitHub issues:

 - Fixes #5108 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

