### PR TITLE
Remove useless image driver support configuration

### DIFF
--- a/examples/plugins/ubuntu-userns-overlay-plugin/main.go
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -43,20 +42,13 @@ func ubuntuOvlRegister(unprivileged bool) error {
 func (d *ubuntuOvlDriver) Features() image.DriverFeature {
 	// if we are running unprivileged we are handling the overlay mount
 	if d.unprivileged {
-		return image.OverlayFeature | image.ImageFeature
+		return image.OverlayFeature
 	}
 	// privileged run are handled as usual by the singularity runtime
 	return 0
 }
 
 func (d *ubuntuOvlDriver) Mount(params *image.MountParams, fn image.MountFunc) error {
-	if params.Filesystem != "overlay" {
-		target, err := os.Readlink(params.Source)
-		if err != nil {
-			target = params.Source
-		}
-		return fmt.Errorf("%s driver can not mount image %q, only sandbox format is supported", driverName, target)
-	}
 	return fn(
 		params.Source,
 		params.Target,
@@ -84,10 +76,6 @@ func setConfiguration(_ string) error {
 	cmd = exec.Command("/proc/self/exe", "config", "global", "--set", "enable overlay", "driver")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("could not set 'enable overlay = driver' in singularity.conf")
-	}
-	cmd = exec.Command("/proc/self/exe", "config", "global", "--set", "image driver support", "overlay")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("could not set 'image driver support = overlay' in singularity.conf")
 	}
 	return nil
 }

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -46,7 +46,6 @@ type File struct {
 	MksquashfsMem           string   `directive:"mksquashfs mem"`
 	CryptsetupPath          string   `directive:"cryptsetup path"`
 	ImageDriver             string   `directive:"image driver"`
-	ImageDriverSupport      string   `default:"all" authorized:"all,image,overlay" directive:"image driver support"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF
@@ -336,9 +335,4 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 # If the driver name specified has not been registered via a plugin installation
 # the run-time will abort.
 image driver = {{ .ImageDriver }}
-
-# IMAGE DRIVER SUPPORT: [all/image/overlay]
-# DEFAULT: all
-# This option specifies if the image driver can handle image, overlay or both.
-image driver support = {{ .ImageDriverSupport }}
 `


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Remove `image driver support` directive because it overloads the configuration file for the only value of not loading the image driver plugins and is more confusing than it should, this PR removes and loads image driver plugins to get the supported features and take appropriate action.
- Also fixes ubuntu-overlay-plugin and restrict it to overlay feature only

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

