### PR TITLE
Add VFS for session layer manager

### DIFF
--- a/internal/pkg/runtime/engine/oci/create_linux.go
+++ b/internal/pkg/runtime/engine/oci/create_linux.go
@@ -543,19 +543,19 @@ func (c *container) addCgroups(pid int, system *mount.System) error {
 		createSymlinks := func(*mount.System) error {
 			cgroupPath := filepath.Join(c.rpcRoot, c.rootfs, m.Destination)
 			if _, err := os.Stat(filepath.Join(cgroupPath, "cpu")); err != nil && os.IsNotExist(err) {
-				if _, err := c.rpcOps.Symlink("cpu,cpuacct", filepath.Join(c.rootfs, m.Destination, "cpu")); err != nil {
+				if err := c.rpcOps.Symlink("cpu,cpuacct", filepath.Join(c.rootfs, m.Destination, "cpu")); err != nil {
 					return err
 				}
-				if _, err := c.rpcOps.Symlink("cpu,cpuacct", filepath.Join(c.rootfs, m.Destination, "cpuacct")); err != nil {
+				if err := c.rpcOps.Symlink("cpu,cpuacct", filepath.Join(c.rootfs, m.Destination, "cpuacct")); err != nil {
 					return err
 				}
 			}
 
 			if _, err := os.Stat(filepath.Join(cgroupPath, "net_cls")); err != nil && os.IsNotExist(err) {
-				if _, err := c.rpcOps.Symlink("net_cls,net_prio", filepath.Join(c.rootfs, m.Destination, "net_cls")); err != nil {
+				if err := c.rpcOps.Symlink("net_cls,net_prio", filepath.Join(c.rootfs, m.Destination, "net_cls")); err != nil {
 					return err
 				}
-				if _, err := c.rpcOps.Symlink("net_cls,net_prio", filepath.Join(c.rootfs, m.Destination, "net_prio")); err != nil {
+				if err := c.rpcOps.Symlink("net_cls,net_prio", filepath.Join(c.rootfs, m.Destination, "net_prio")); err != nil {
 					return err
 				}
 			}
@@ -671,7 +671,7 @@ func (c *container) addDefaultDevices(system *mount.System) error {
 		if _, err := os.Lstat(path); os.IsNotExist(err) {
 			if c.userNS {
 				path = filepath.Join(c.rootfs, symlink.new)
-				if _, err := c.rpcOps.Symlink(symlink.old, path); err != nil {
+				if err := c.rpcOps.Symlink(symlink.old, path); err != nil {
 					return err
 				}
 			} else {
@@ -912,7 +912,7 @@ func (c *container) mount(point *mount.Point, system *mount.System) error {
 				if _, err := os.Stat(dir); os.IsNotExist(err) {
 					sylog.Debugf("Creating parent %s", dir)
 					if c.userNS {
-						if _, err := c.rpcOps.Mkdir(filepath.Dir(dest), 0755); err != nil {
+						if err := c.rpcOps.Mkdir(filepath.Dir(dest), 0755); err != nil {
 							return err
 						}
 					} else {
@@ -930,7 +930,7 @@ func (c *container) mount(point *mount.Point, system *mount.System) error {
 				case syscall.S_IFDIR:
 					sylog.Debugf("Creating dir %s", filepath.Base(procDest))
 					if c.userNS {
-						if _, err := c.rpcOps.Mkdir(dest, 0755); err != nil {
+						if err := c.rpcOps.Mkdir(dest, 0755); err != nil {
 							return err
 						}
 					} else {

--- a/internal/pkg/runtime/engine/oci/rpc/args.go
+++ b/internal/pkg/runtime/engine/oci/rpc/args.go
@@ -5,12 +5,6 @@
 
 package rpc
 
-// SymlinkArgs defines the arguments to symlink.
-type SymlinkArgs struct {
-	Old string
-	New string
-}
-
 // TouchArgs defines the arguments to touch.
 type TouchArgs struct {
 	Path string

--- a/internal/pkg/runtime/engine/oci/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/oci/rpc/client/client.go
@@ -29,17 +29,6 @@ func (t *RPC) MkdirAll(path string, perm os.FileMode) (int, error) {
 	return reply, err
 }
 
-// Symlink calls the mkdir RPC using the supplied arguments.
-func (t *RPC) Symlink(old string, new string) (int, error) {
-	arguments := &ociargs.SymlinkArgs{
-		Old: old,
-		New: new,
-	}
-	var reply int
-	err := t.Client.Call(t.Name+".Symlink", arguments, &reply)
-	return reply, err
-}
-
 // Touch calls the touch RPC using the supplied arguments.
 func (t *RPC) Touch(path string) (int, error) {
 	arguments := &ociargs.TouchArgs{

--- a/internal/pkg/runtime/engine/oci/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/oci/rpc/server/server_linux.go
@@ -32,11 +32,6 @@ func (t *Methods) MkdirAll(arguments *args.MkdirArgs, reply *int) (err error) {
 	return err
 }
 
-// Symlink performs a symlink with the specified arguments.
-func (t *Methods) Symlink(arguments *ociargs.SymlinkArgs, reply *int) (err error) {
-	return os.Symlink(arguments.Old, arguments.New)
-}
-
 // Touch performs a touch with the specified arguments.
 func (t *Methods) Touch(arguments *ociargs.TouchArgs, reply *int) (err error) {
 	return fs.Touch(arguments.Path)

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -6,10 +6,8 @@
 package client
 
 import (
-	"encoding/gob"
 	"net/rpc"
 	"os"
-	"syscall"
 
 	args "github.com/sylabs/singularity/internal/pkg/runtime/engine/singularity/rpc"
 	"github.com/sylabs/singularity/pkg/util/loop"
@@ -58,14 +56,12 @@ func (t *RPC) Decrypt(offset uint64, path string, key []byte, masterPid int) (st
 }
 
 // Mkdir calls the mkdir RPC using the supplied arguments.
-func (t *RPC) Mkdir(path string, perm os.FileMode) (int, error) {
+func (t *RPC) Mkdir(path string, perm os.FileMode) error {
 	arguments := &args.MkdirArgs{
 		Path: path,
 		Perm: perm,
 	}
-	var reply int
-	err := t.Client.Call(t.Name+".Mkdir", arguments, &reply)
-	return reply, err
+	return t.Client.Call(t.Name+".Mkdir", arguments, nil)
 }
 
 // Chroot calls the chroot RPC using the supplied arguments.
@@ -125,16 +121,13 @@ func (t *RPC) Chdir(dir string) (int, error) {
 }
 
 // Stat calls the stat RPC using the supplied arguments.
-func (t *RPC) Stat(path string) (*syscall.Stat_t, error) {
+func (t *RPC) Stat(path string) (os.FileInfo, error) {
 	arguments := &args.StatArgs{
 		Path: path,
 	}
 	var reply args.StatReply
 	err := t.Client.Call(t.Name+".Stat", arguments, &reply)
-	if err == nil {
-		err = reply.Err
-	}
-	return &reply.St, err
+	return reply.Fi, err
 }
 
 // SendFuseFd calls the SendFuseFd RPC using the supplied arguments.
@@ -158,8 +151,82 @@ func (t *RPC) OpenSendFuseFd(socket int) (int, error) {
 	return reply, err
 }
 
-func init() {
-	var sysErrnoType syscall.Errno
-	// register syscall.Errno as a type we need to get back
-	gob.Register(sysErrnoType)
+// Symlink calls the mkdir RPC using the supplied arguments.
+func (t *RPC) Symlink(old string, new string) error {
+	arguments := &args.SymlinkArgs{
+		Old: old,
+		New: new,
+	}
+	return t.Client.Call(t.Name+".Symlink", arguments, nil)
+}
+
+// ReadDir calls the readdir RPC using the supplied arguments.
+func (t *RPC) ReadDir(dir string) ([]os.FileInfo, error) {
+	arguments := &args.ReadDirArgs{
+		Dir: dir,
+	}
+	var reply args.ReadDirReply
+	err := t.Client.Call(t.Name+".ReadDir", arguments, &reply)
+	return reply.Files, err
+}
+
+// Chown calls the chown RPC using the supplied arguments.
+func (t *RPC) Chown(name string, uid int, gid int) error {
+	arguments := &args.ChownArgs{
+		Name: name,
+		UID:  uid,
+		GID:  gid,
+	}
+	return t.Client.Call(t.Name+".Chown", arguments, nil)
+}
+
+// Lchown calls the lchown RPC using the supplied arguments.
+func (t *RPC) Lchown(name string, uid int, gid int) error {
+	arguments := &args.ChownArgs{
+		Name: name,
+		UID:  uid,
+		GID:  gid,
+	}
+	return t.Client.Call(t.Name+".Lchown", arguments, nil)
+}
+
+// EvalRelative calls the evalrelative RPC using the supplied arguments.
+func (t *RPC) EvalRelative(name string, root string) string {
+	arguments := &args.EvalRelativeArgs{
+		Name: name,
+		Root: root,
+	}
+	var reply string
+	t.Client.Call(t.Name+".EvalRelative", arguments, &reply)
+	return reply
+}
+
+// Lchown calls the lchown RPC using the supplied arguments.
+func (t *RPC) Readlink(name string) (string, error) {
+	arguments := &args.ReadlinkArgs{
+		Name: name,
+	}
+	var reply string
+	err := t.Client.Call(t.Name+".Readlink", arguments, &reply)
+	return reply, err
+}
+
+// Umask calls the umask RPC using the supplied arguments.
+func (t *RPC) Umask(mask int) int {
+	arguments := &args.UmaskArgs{
+		Mask: mask,
+	}
+	var reply int
+	t.Client.Call(t.Name+".Umask", arguments, &reply)
+	return reply
+}
+
+// WriteFile calls the writefile RPC using the supplied arguments.
+func (t *RPC) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	arguments := &args.WriteFileArgs{
+		Filename: filename,
+		Data:     data,
+		Perm:     perm,
+	}
+	return t.Client.Call(t.Name+".WriteFile", arguments, nil)
 }

--- a/internal/pkg/util/fs/layout/manager_test.go
+++ b/internal/pkg/util/fs/layout/manager_test.go
@@ -21,7 +21,7 @@ func TestLayout(t *testing.T) {
 	uid := os.Getuid()
 	gid := os.Getgid()
 
-	session := &Manager{}
+	session := &Manager{VFS: DefaultVFS}
 
 	groups, err := os.Getgroups()
 	if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

In order to have the fakeroot hybrid workflow functional with FUSE image driver and `allow_other` option, this add a VFS interface in the session layer manager to further redirect calls to the RPC server and address issue commented https://github.com/sylabs/singularity/blob/master/internal/pkg/runtime/engine/singularity/container_linux.go#L429

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

