### PR TITLE
Allow to specify another configuration file

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -148,9 +148,9 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	engineConfig := singularityConfig.NewConfig()
 
-	engineConfig.File, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
-	if err != nil {
-		sylog.Fatalf("Unable to parse singularity.conf file: %s", err)
+	engineConfig.File = singularityconf.GetCurrentConfig()
+	if engineConfig.File == nil {
+		sylog.Fatalf("Unable to get singularity configuration")
 	}
 
 	ociConfig := &oci.Config{}
@@ -376,6 +376,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	engineConfig.SetRocm(Rocm)
 	engineConfig.SetAddCaps(AddCaps)
 	engineConfig.SetDropCaps(DropCaps)
+	engineConfig.SetConfigurationFile(configurationFile)
 
 	checkPrivileges(AllowSUID, "--allow-setuid", func() {
 		engineConfig.SetAllowSUID(AllowSUID)

--- a/cmd/internal/cli/config_global_linux.go
+++ b/cmd/internal/cli/config_global_linux.go
@@ -90,7 +90,7 @@ var configGlobalCmd = &cobra.Command{
 			return fmt.Errorf("you must specify an option (eg: --set/--unset)")
 		}
 
-		if err := singularity.GlobalConfig(args, globalConfigDryRun, op); err != nil {
+		if err := singularity.GlobalConfig(args, configurationFile, globalConfigDryRun, op); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 

--- a/internal/app/singularity/config_global_linux.go
+++ b/internal/app/singularity/config_global_linux.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 	"golang.org/x/sys/unix"
 )
@@ -67,7 +66,7 @@ func generateConfig(path string, directives singularityconf.Directives, dry bool
 
 // GlobalConfig allows to set/unset/reset a configuration directive value
 // in singularity.conf
-func GlobalConfig(args []string, dry bool, op GlobalConfigOp) error {
+func GlobalConfig(args []string, configFile string, dry bool, op GlobalConfigOp) error {
 	directive := args[0]
 	value := ""
 
@@ -81,8 +80,6 @@ func GlobalConfig(args []string, dry bool, op GlobalConfigOp) error {
 	if !singularityconf.HasDirective(directive) {
 		return fmt.Errorf("%q is not a valid configuration directive", directive)
 	}
-
-	configFile := buildcfg.SINGULARITY_CONF_FILE
 
 	f, err := os.OpenFile(configFile, os.O_RDONLY, 0644)
 	if err != nil {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -90,7 +90,15 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		return fmt.Errorf("no root filesystem image provided")
 	}
 
-	engine.EngineConfig.File, err = singularityconf.Parse(buildcfg.SINGULARITY_CONF_FILE)
+	configurationFile := buildcfg.SINGULARITY_CONF_FILE
+	if buildcfg.SINGULARITY_SUID_INSTALL == 0 || os.Geteuid() == 0 {
+		configFile := engine.EngineConfig.GetConfigurationFile()
+		if configFile != "" {
+			configurationFile = configFile
+		}
+	}
+
+	engine.EngineConfig.File, err = singularityconf.Parse(configurationFile)
 	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)
 	}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -70,6 +70,13 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	}
 
 	configurationFile := buildcfg.SINGULARITY_CONF_FILE
+	if buildcfg.SINGULARITY_SUID_INSTALL == 0 || os.Geteuid() == 0 {
+		configFile := e.EngineConfig.GetConfigurationFile()
+		if configFile != "" {
+			configurationFile = configFile
+		}
+	}
+
 	e.EngineConfig.File, err = singularityconf.Parse(configurationFile)
 	if err != nil {
 		return fmt.Errorf("unable to parse singularity.conf file: %s", err)

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -54,12 +54,17 @@ func cryptsetup(cfgpath string) (string, error) {
 		return "", errCryptsetupNotFound
 	}
 
-	cfg, err := singularityconf.Parse(cfgpath)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to parse singularity configuration file")
-	}
+	path := ""
 
-	path := cfg.CryptsetupPath
+	if cfg := singularityconf.GetCurrentConfig(); cfg != nil {
+		path = cfg.CryptsetupPath
+	} else {
+		cfg, err := singularityconf.Parse(cfgpath)
+		if err != nil {
+			return "", errors.Wrap(err, "unable to parse singularity configuration file")
+		}
+		path = cfg.CryptsetupPath
+	}
 
 	if path == "" {
 		if buildcfg.CRYPTSETUP_PATH == "" {

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -15,14 +15,29 @@ import (
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 )
 
+func getConfig() (*singularityconf.File, error) {
+	// if the caller has set the current config use it
+	// otherwise parse the default configuration file
+	cfg := singularityconf.GetCurrentConfig()
+	if cfg == nil {
+		var err error
+
+		configFile := buildcfg.SINGULARITY_CONF_FILE
+		cfg, err = singularityconf.Parse(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse singularity.conf file: %s", err)
+		}
+	}
+	return cfg, nil
+}
+
 // GetPath figures out where the mksquashfs binary is
 // and return an error is not available or not usable.
 func GetPath() (string, error) {
 	// Parse singularity configuration file
-	configFile := buildcfg.SINGULARITY_CONF_FILE
-	c, err := singularityconf.Parse(configFile)
+	c, err := getConfig()
 	if err != nil {
-		return "", fmt.Errorf("unable to parse singularity.conf file: %s", err)
+		return "", err
 	}
 
 	// p is either "" or the string value in the conf file
@@ -38,10 +53,9 @@ func GetPath() (string, error) {
 }
 
 func GetProcs() (uint, error) {
-	configFile := buildcfg.SINGULARITY_CONF_FILE
-	c, err := singularityconf.Parse(configFile)
+	c, err := getConfig()
 	if err != nil {
-		return 0, fmt.Errorf("unable to parse singularity.conf file: %s", err)
+		return 0, err
 	}
 	// proc is either "" or the string value in the conf file
 	proc := c.MksquashfsProcs
@@ -50,10 +64,9 @@ func GetProcs() (uint, error) {
 }
 
 func GetMem() (string, error) {
-	configFile := buildcfg.SINGULARITY_CONF_FILE
-	c, err := singularityconf.Parse(configFile)
+	c, err := getConfig()
 	if err != nil {
-		return "", fmt.Errorf("unable to parse singularity.conf file: %s", err)
+		return "", err
 	}
 	// mem is either "" or the string value in the conf file
 	mem := c.MksquashfsMem

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -130,6 +130,7 @@ type JSONConfig struct {
 	DNS               string            `json:"dns,omitempty"`
 	Cwd               string            `json:"cwd,omitempty"`
 	SessionLayer      string            `json:"sessionLayer,omitempty"`
+	ConfigurationFile string            `json:"configurationFile,omitempty"`
 	EncryptionKey     []byte            `json:"encryptionKey,omitempty"`
 	TargetUID         int               `json:"targetUID,omitempty"`
 	WritableImage     bool              `json:"writableImage,omitempty"`
@@ -815,4 +816,15 @@ func (e *EngineConfig) SetSingularityEnv(senv map[string]string) {
 // as a key/value string map.
 func (e *EngineConfig) GetSingularityEnv() map[string]string {
 	return e.JSON.SingularityEnv
+}
+
+// SetConfigurationFile sets the singularity configuration file to
+// use instead of the default one.
+func (e *EngineConfig) SetConfigurationFile(filename string) {
+	e.JSON.ConfigurationFile = filename
+}
+
+// GetConfigurationFile returns the singularity configuration file to use.
+func (e *EngineConfig) GetConfigurationFile() string {
+	return e.JSON.ConfigurationFile
 }

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -5,6 +5,21 @@
 
 package singularityconf
 
+// currentConfig corresponds to the current configuration, may
+// be useful for packages requiring to share the same configuration.
+var currentConfig *File
+
+// SetCurrentConfig sets the provided configuration as the current
+// configuration.
+func SetCurrentConfig(config *File) {
+	currentConfig = config
+}
+
+// GetCurrentConfig returns the current configuration if any.
+func GetCurrentConfig() *File {
+	return currentConfig
+}
+
 // File describes the singularity.conf file options
 type File struct {
 	AllowSetuid             bool     `default:"yes" authorized:"yes,no" directive:"allow setuid"`


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR allows to specify another `singularity.conf` file via a global flag `-c`/`--config` and can only be used by root user (or fakeroot by nesting execution) or for unprivileged installation.

This flag would be useful to execute build `post` section with the help of `exec` command without being dependent of the current configuration in order to have consistent execution of the `post` section.
In the meantime it also addresses the issue #4403.

### This fixes or addresses the following GitHub issues:

 - Fixes #4403


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

