### PR TITLE
Add e2e.WithGlobalOptions to specify global option for singularity command

### DIFF
--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -305,6 +305,7 @@ func (c actionTests) issue4823(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
+			e2e.WithGlobalOptions("--debug"),
 			e2e.WithProfile(e2e.UserProfile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(srv.URL+tt.urlPath, "/bin/true"),


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add e2e.WithGlobalOptions to specify global option like `--debug`, `--silent` ... for singularity command

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

