### PR TITLE
Fix configuration parser for empty slice and default value

### DIFF
--- a/pkg/util/singularityconf/parser.go
+++ b/pkg/util/singularityconf/parser.go
@@ -97,6 +97,8 @@ func GetConfig(directives Directives) (*File, error) {
 			authorized = strings.Split(v, ",")
 		}
 
+		kind := typeField.Type.Kind()
+
 		value := []string{}
 		if len(directives[dir]) > 0 {
 			for _, dv := range directives[dir] {
@@ -105,12 +107,12 @@ func GetConfig(directives Directives) (*File, error) {
 				}
 			}
 		} else {
-			if defaultValue != "" {
+			if defaultValue != "" && (kind != reflect.Slice || directives == nil) {
 				value = append(value, strings.Split(defaultValue, ",")...)
 			}
 		}
 
-		switch typeField.Type.Kind() {
+		switch kind {
 		case reflect.Bool:
 			found := false
 			for _, a := range authorized {


### PR DESCRIPTION
## Description of the Pull Request (PR):

For slice type configuration directive, if there is a default value and no value is set in the configuration file for the corresponding directive, the directive is always set to the default value instead of empty.
For example it's currently impossible to set an empty `bind path`, we always get the default values.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

