### PR TITLE
Remove go report badge (service misbehaving)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/sylabs/singularity.svg?branch=master)](https://travis-ci.org/sylabs/singularity)
 [![CircleCI](https://circleci.com/gh/sylabs/singularity/tree/master.svg?style=svg)](https://circleci.com/gh/sylabs/singularity/tree/master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/singularity)](https://goreportcard.com/report/github.com/sylabs/singularity)
 
 - [Guidelines for Contributing](CONTRIBUTING.md)
 - [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md)


### PR DESCRIPTION
Fixes: #5315

Our go report badge on the README is showing an 'F' recently, instead of the previous 'A'. We haven't done anything to go from A -> F - the issue is that the go report checks are running out of memory on their server, and failing:

https://github.com/gojp/goreportcard/issues/313

```
An error occurred while running this test (AddError: could not parse "_repos/src/github.com/sylabs/singularity/etc/conf/fatal error: runtime: out of memory:1::warning: file is not gofmted with -s (gofmt)" - strconv.Atoi: parsing " runtime": invalid syntax)
```

We should probably disable the badge until this is fixed, and contact go report.