### PR TITLE
Check PEM is valid before starting encrypted build

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -362,6 +362,12 @@ func getEncryptionMaterial(cmd *cobra.Command) (crypt.KeyInfo, error) {
 		}
 
 		sylog.Verbosef("Using pem path flag for encrypted container")
+
+		// Check it's a valid PEM we can load, before starting the build (#4173)
+		if _, err := crypt.LoadPEMPublicKey(encryptionPEMPath); err != nil {
+			sylog.Fatalf("Invalid encryption key: %v", err)
+		}
+
 		return crypt.KeyInfo{Format: crypt.PEM, Path: encryptionPEMPath}, nil
 	}
 

--- a/pkg/util/crypt/key.go
+++ b/pkg/util/crypt/key.go
@@ -71,7 +71,7 @@ func NewPlaintextKey(k KeyInfo) ([]byte, error) {
 func EncryptKey(k KeyInfo, plaintext []byte) ([]byte, error) {
 	switch k.Format {
 	case PEM:
-		pubKey, err := loadPEMPublicKey(k.Path)
+		pubKey, err := LoadPEMPublicKey(k.Path)
 		if err != nil {
 			return nil, fmt.Errorf("loading public key for key encryption: %v", err)
 		}
@@ -146,7 +146,7 @@ func loadPEMPrivateKey(fn string) (*rsa.PrivateKey, error) {
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
 
-func loadPEMPublicKey(fn string) (*rsa.PublicKey, error) {
+func LoadPEMPublicKey(fn string) (*rsa.PublicKey, error) {
 	b, err := ioutil.ReadFile(fn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of the Pull Request (PR):

At present a PEM private key can be specified for an encrypted build,
but it is not checked to see if it is usable before the build is run. If
an invalid file is provided the build should not start to avoid wasted
time.

### This fixes or addresses the following GitHub issues:

 - Fixes: #4173

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

