### PR TITLE
Log scs-library-client to sylog.debug via DebugLogger

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 
+	golog "github.com/go-log/log"
 	"github.com/spf13/cobra"
 	scslibrary "github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/docs"
@@ -81,6 +82,7 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom, librar
 	c := &scslibrary.Config{
 		AuthToken: authToken,
 		BaseURL:   libraryURL,
+		Logger:    (golog.Logger)(sylog.DebugLogger{}),
 	}
 	return library.Pull(ctx, imgCache, pullFrom, runtime.GOARCH, tmpDir, c, keyServerURL)
 }

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	golog "github.com/go-log/log"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/docs"
@@ -78,6 +79,7 @@ var deleteImageCmd = &cobra.Command{
 		libraryConfig := &client.Config{
 			BaseURL:   deleteLibraryURI,
 			AuthToken: authToken,
+			Logger:    (golog.Logger)(sylog.DebugLogger{}),
 		}
 
 		y, err := interactive.AskYNQuestion("n", "Are you sure you want to delete %s arch[%s] [N/y] ", imageRef, deleteImageArch)

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	golog "github.com/go-log/log"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/docs"
@@ -212,6 +213,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 		libraryConfig := &client.Config{
 			BaseURL:   pullLibraryURI,
 			AuthToken: authToken,
+			Logger:    (golog.Logger)(sylog.DebugLogger{}),
 		}
 
 		_, err = library.PullToFile(ctx, imgCache, pullTo, pullFrom, pullArch, tmpDir, libraryConfig, keyServerURL)

--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"context"
 
+	golog "github.com/go-log/log"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/docs"
@@ -53,6 +54,7 @@ var SearchCmd = &cobra.Command{
 		libraryClient, err := client.NewClient(&client.Config{
 			BaseURL:   SearchLibraryURI,
 			AuthToken: authToken,
+			Logger:    (golog.Logger)(sylog.DebugLogger{}),
 		})
 		if err != nil {
 			sylog.Fatalf("Error initializing library client: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.9.0
 	github.com/garyburd/redigo v1.6.0 // indirect
+	github.com/go-log/log v0.2.0
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 
+	golog "github.com/go-log/log"
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/sif/pkg/sif"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
@@ -91,6 +92,7 @@ func LibraryPush(ctx context.Context, file, dest, authToken, libraryURI, keyServ
 	libraryClient, err := client.NewClient(&client.Config{
 		BaseURL:   libraryURI,
 		AuthToken: authToken,
+		Logger:    (golog.Logger)(sylog.DebugLogger{}),
 	})
 	if err != nil {
 		return fmt.Errorf("error initializing library client: %v", err)

--- a/internal/pkg/build/remotebuilder/remotebuilder.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	golog "github.com/go-log/log"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
 	buildclient "github.com/sylabs/scs-build-client/client"
@@ -142,6 +143,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 		c, err := client.NewClient(&client.Config{
 			BaseURL:   bi.LibraryURL,
 			AuthToken: rb.AuthToken,
+			Logger:    (golog.Logger)(sylog.DebugLogger{}),
 		})
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error initializing library client: %v", err))

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"runtime"
 
+	golog "github.com/go-log/log"
+
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/internal/pkg/client/library"
 	"github.com/sylabs/singularity/internal/pkg/sylog"
@@ -54,6 +56,7 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 	libraryConfig := &client.Config{
 		BaseURL:   libraryURL,
 		AuthToken: authToken,
+		Logger:    (golog.Logger)(sylog.DebugLogger{}),
 	}
 
 	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, libraryConfig, "")

--- a/internal/pkg/sylog/sylog.go
+++ b/internal/pkg/sylog/sylog.go
@@ -205,3 +205,18 @@ func Writer() io.Writer {
 
 	return os.Stderr
 }
+
+// DebugLogger is an implementation of the go-log/log Logger interface that will
+// output log messages via sylog.debug when required by external packages such
+// as the scs-library-client
+type DebugLogger struct{}
+
+// Output a log message via sylog.Debugf
+func (t DebugLogger) Log(v ...interface{}) {
+	writef(os.Stderr, debug, "%s", fmt.Sprint(v...))
+}
+
+// Output a formatted log message via sylog.Debugf
+func (t DebugLogger) Logf(format string, v ...interface{}) {
+	writef(os.Stderr, debug, format, v...)
+}

--- a/internal/pkg/sylog/sylog_dummy.go
+++ b/internal/pkg/sylog/sylog_dummy.go
@@ -8,7 +8,6 @@
 package sylog
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -49,10 +48,21 @@ func GetLevel() int {
 // GetEnvVar is a dummy function returning environment variable
 // with lowest message level.
 func GetEnvVar() string {
-	return fmt.Sprintf("SINGULARITY_MESSAGELEVEL=-1")
+	return "SINGULARITY_MESSAGELEVEL=-1"
 }
 
 // Writer is a dummy function returning ioutil.Discard writer.
 func Writer() io.Writer {
 	return ioutil.Discard
 }
+
+// DebugLogger is an implementation of the go-log/log Logger interface that will
+// output log messages via sylog.debug when required by external packages such
+// as the scs-library-client
+type DebugLogger struct {}
+
+// Dummy of a log message via sylog.Debugf
+func (t DebugLogger) Log(v ...interface{}) {}
+
+// Dummy of a formatted log message via sylog.Debugf
+func (t DebugLogger) Logf(format string, v ...interface{}) {}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a DebugLogger to sylog, which implements the go-log/log Logger
interface that scs-library client expects to log to. Write all messages
out via sylog.Debugf

This allows scs-library-client log messages to be seen with the `-d` /
`--debug` option to the CLI.

### This fixes or addresses the following GitHub issues:

 - Fixes: #5141


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

