### PR TITLE
Allow to specify a buildcfg parameter to get parameter value directly

### DIFF
--- a/cmd/internal/cli/buildconfig.go
+++ b/cmd/internal/cli/buildconfig.go
@@ -22,39 +22,68 @@ func init() {
 // BuildConfigCmd outputs a list of the compile-time parameters with which
 // singularity was compiled
 var BuildConfigCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
-		printParam("PACKAGE_NAME", buildcfg.PACKAGE_NAME)
-		printParam("PACKAGE_VERSION", buildcfg.PACKAGE_VERSION)
-		printParam("BUILDDIR", buildcfg.BUILDDIR)
-		printParam("PREFIX", buildcfg.PREFIX)
-		printParam("EXECPREFIX", buildcfg.EXECPREFIX)
-		printParam("BINDIR", buildcfg.BINDIR)
-		printParam("SBINDIR", buildcfg.SBINDIR)
-		printParam("LIBEXECDIR", buildcfg.LIBEXECDIR)
-		printParam("DATAROOTDIR", buildcfg.DATAROOTDIR)
-		printParam("DATADIR", buildcfg.DATADIR)
-		printParam("SYSCONFDIR", buildcfg.SYSCONFDIR)
-		printParam("SHAREDSTATEDIR", buildcfg.SHAREDSTATEDIR)
-		printParam("LOCALSTATEDIR", buildcfg.LOCALSTATEDIR)
-		printParam("RUNSTATEDIR", buildcfg.RUNSTATEDIR)
-		printParam("INCLUDEDIR", buildcfg.INCLUDEDIR)
-		printParam("DOCDIR", buildcfg.DOCDIR)
-		printParam("INFODIR", buildcfg.INFODIR)
-		printParam("LIBDIR", buildcfg.LIBDIR)
-		printParam("LOCALEDIR", buildcfg.LOCALEDIR)
-		printParam("MANDIR", buildcfg.MANDIR)
-		printParam("SINGULARITY_CONFDIR", buildcfg.SINGULARITY_CONFDIR)
-		printParam("SESSIONDIR", buildcfg.SESSIONDIR)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+		if err := printParam(name); err != nil {
+			return err
+		}
+		return nil
 	},
 	DisableFlagsInUseLine: true,
 
 	Hidden:  true,
-	Args:    cobra.ExactArgs(0),
-	Use:     "buildcfg",
+	Args:    cobra.MaximumNArgs(1),
+	Use:     "buildcfg [parameter]",
 	Short:   "Output the currently set compile-time parameters",
 	Example: "$ singularity buildcfg",
 }
 
-func printParam(n, v string) {
-	fmt.Printf("%s=%s\n", n, v)
+func printParam(name string) error {
+	params := []struct {
+		name  string
+		value string
+	}{
+		{"PACKAGE_NAME", buildcfg.PACKAGE_NAME},
+		{"PACKAGE_VERSION", buildcfg.PACKAGE_VERSION},
+		{"BUILDDIR", buildcfg.BUILDDIR},
+		{"PREFIX", buildcfg.PREFIX},
+		{"EXECPREFIX", buildcfg.EXECPREFIX},
+		{"BINDIR", buildcfg.BINDIR},
+		{"SBINDIR", buildcfg.SBINDIR},
+		{"LIBEXECDIR", buildcfg.LIBEXECDIR},
+		{"DATAROOTDIR", buildcfg.DATAROOTDIR},
+		{"DATADIR", buildcfg.DATADIR},
+		{"SYSCONFDIR", buildcfg.SYSCONFDIR},
+		{"SHAREDSTATEDIR", buildcfg.SHAREDSTATEDIR},
+		{"LOCALSTATEDIR", buildcfg.LOCALSTATEDIR},
+		{"RUNSTATEDIR", buildcfg.RUNSTATEDIR},
+		{"INCLUDEDIR", buildcfg.INCLUDEDIR},
+		{"DOCDIR", buildcfg.DOCDIR},
+		{"INFODIR", buildcfg.INFODIR},
+		{"LIBDIR", buildcfg.LIBDIR},
+		{"LOCALEDIR", buildcfg.LOCALEDIR},
+		{"MANDIR", buildcfg.MANDIR},
+		{"SINGULARITY_CONFDIR", buildcfg.SINGULARITY_CONFDIR},
+		{"SESSIONDIR", buildcfg.SESSIONDIR},
+		{"PLUGIN_ROOTDIR", buildcfg.PLUGIN_ROOTDIR},
+		{"SINGULARITY_CONF_FILE", buildcfg.SINGULARITY_CONF_FILE},
+		{"SINGULARITY_SUID_INSTALL", fmt.Sprintf("%d", buildcfg.SINGULARITY_SUID_INSTALL)},
+	}
+
+	if name != "" {
+		for _, p := range params {
+			if p.name == name {
+				fmt.Println(p.value)
+				return nil
+			}
+		}
+		return fmt.Errorf("no variable named %q", name)
+	}
+	for _, p := range params {
+		fmt.Printf("%s=%s\n", p.name, p.value)
+	}
+	return nil
 }

--- a/e2e/buildcfg/buildcfg.go
+++ b/e2e/buildcfg/buildcfg.go
@@ -10,22 +10,51 @@ import (
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 )
 
 type buildcfgTests struct {
 	env e2e.TestEnv
 }
 
-func (c buildcfgTests) buildcfgTests(t *testing.T) {
+func (c buildcfgTests) buildcfgBasic(t *testing.T) {
 	tests := []struct {
-		name           string
-		cmdArgs        []string
-		expectedOutput string
+		name    string
+		cmdArgs []string
+		exit    int
+		op      e2e.SingularityCmdResultOp
 	}{
 		{
-			name:           "help",
-			cmdArgs:        []string{"--help"},
-			expectedOutput: "Output the currently set compile-time parameters",
+			name:    "help",
+			cmdArgs: []string{"--help"},
+			exit:    0,
+			op: e2e.ExpectOutput(
+				e2e.RegexMatch,
+				"^Output the currently set compile-time parameters",
+			),
+		},
+		{
+			name:    "sessiondir",
+			cmdArgs: []string{"SESSIONDIR"},
+			exit:    0,
+			op: e2e.ExpectOutput(
+				e2e.ExactMatch,
+				buildcfg.SESSIONDIR,
+			),
+		},
+		{
+			name:    "unknown",
+			cmdArgs: []string{"UNKNOWN"},
+			exit:    1,
+		},
+		{
+			name:    "all",
+			cmdArgs: []string{},
+			exit:    0,
+			op: e2e.ExpectOutput(
+				e2e.ContainMatch,
+				"SESSIONDIR="+buildcfg.SESSIONDIR,
+			),
 		},
 	}
 
@@ -37,8 +66,8 @@ func (c buildcfgTests) buildcfgTests(t *testing.T) {
 			e2e.WithCommand("buildcfg"),
 			e2e.WithArgs(tt.cmdArgs...),
 			e2e.ExpectExit(
-				0,
-				e2e.ExpectOutput(e2e.RegexMatch, `^`+tt.expectedOutput),
+				tt.exit,
+				tt.op,
 			),
 		)
 	}
@@ -51,6 +80,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	}
 
 	return testhelper.Tests{
-		"buildcfgHelp": c.buildcfgTests,
+		"basic": c.buildcfgBasic,
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow to specify a buildcfg parameter to get parameter value directly.
Show `SINGULARITY_SUID_INSTALL` value.

### This fixes or addresses the following GitHub issues:

 - Fixes #5161


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

