### PR TITLE
Fix issue triggered when using a FUSE image driver/writable overlay/fakeroot

### DIFF
--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -70,7 +70,8 @@ type ChdirArgs struct {
 
 // StatReply defines the reply for stat.
 type StatReply struct {
-	Fi os.FileInfo
+	Fi  os.FileInfo
+	Err error
 }
 
 // StatArgs defines the arguments to stat.
@@ -186,4 +187,7 @@ func init() {
 	gob.Register(syscall.Errno(0))
 	gob.Register((*fileInfo)(nil))
 	gob.Register((*syscall.Stat_t)(nil))
+	gob.Register((*os.PathError)(nil))
+	gob.Register((*os.SyscallError)(nil))
+	gob.Register((*os.LinkError)(nil))
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -127,7 +127,23 @@ func (t *RPC) Stat(path string) (os.FileInfo, error) {
 	}
 	var reply args.StatReply
 	err := t.Client.Call(t.Name+".Stat", arguments, &reply)
-	return reply.Fi, err
+	if err != nil {
+		return nil, err
+	}
+	return reply.Fi, reply.Err
+}
+
+// Lstat calls the lstat RPC using the supplied arguments.
+func (t *RPC) Lstat(path string) (os.FileInfo, error) {
+	arguments := &args.StatArgs{
+		Path: path,
+	}
+	var reply args.StatReply
+	err := t.Client.Call(t.Name+".Lstat", arguments, &reply)
+	if err != nil {
+		return nil, err
+	}
+	return reply.Fi, reply.Err
 }
 
 // SendFuseFd calls the SendFuseFd RPC using the supplied arguments.

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -219,11 +219,20 @@ func (t *Methods) Chdir(arguments *args.ChdirArgs, reply *int) error {
 
 // Stat gets file status.
 func (t *Methods) Stat(arguments *args.StatArgs, reply *args.StatReply) error {
-	fi, err := os.Stat(arguments.Path)
-	if fi != nil {
-		reply.Fi = args.FileInfo(fi)
+	reply.Fi, reply.Err = os.Stat(arguments.Path)
+	if reply.Fi != nil {
+		reply.Fi = args.FileInfo(reply.Fi)
 	}
-	return err
+	return nil
+}
+
+// Lstat gets file status.
+func (t *Methods) Lstat(arguments *args.StatArgs, reply *args.StatReply) error {
+	reply.Fi, reply.Err = os.Lstat(arguments.Path)
+	if reply.Fi != nil {
+		reply.Fi = args.FileInfo(reply.Fi)
+	}
+	return nil
 }
 
 // SendFuseFd send fuse file descriptor over unix socket.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix issue triggered when using a FUSE image driver and creating writable overlay layout with fakeroot hybrid workflow, upper and work directory were created based on stat call done from master process running in host user namespace leading to permission denied error and falsely reporting
upper/work directories as not existing by `fs.IsDir` call. A Lstat method was added to RPC methods to get information from RPC process living in user namespace.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

