### PR TITLE
Check existing sandbox directory content before build

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -281,7 +281,7 @@ func checkBuildTarget(path string) error {
 					}
 				}
 				if required != 4 {
-					return fmt.Errorf("%s is not empty and is not a Singularity image, check its content first and use --force if you want to overwrite it", path)
+					return fmt.Errorf("%s is not empty and is not a Singularity sandbox, check its content first and use --force if you want to overwrite it", path)
 				}
 			}
 		}

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -14,8 +14,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
-
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
@@ -1044,30 +1042,6 @@ func (c imgBuildTests) buildUpdateSandbox(t *testing.T) {
 	}
 }
 
-func (c imgBuildTests) issue4837(t *testing.T) {
-	sandboxName := uuid.NewV4().String()
-	u := e2e.FakerootProfile.HostUser(t)
-
-	def, err := filepath.Abs("testdata/Singularity")
-	if err != nil {
-		t.Fatalf("failed to retrieve absolute path for testdata/Singularity: %s", err)
-	}
-
-	c.env.RunSingularity(
-		t,
-		e2e.WithProfile(e2e.FakerootProfile),
-		e2e.WithDir(u.Dir),
-		e2e.WithCommand("build"),
-		e2e.WithArgs("--sandbox", sandboxName, def),
-		e2e.PostRun(func(t *testing.T) {
-			if !t.Failed() {
-				os.RemoveAll(filepath.Join(u.Dir, sandboxName))
-			}
-		}),
-		e2e.ExpectExit(0),
-	)
-}
-
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := imgBuildTests{
@@ -1084,6 +1058,14 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"multistage":                      c.buildMultiStageDefinition, // multistage build from definition templates
 		"non-root build":                  c.nonRootBuild,              // build sifs from non-root
 		"build and update sandbox":        c.buildUpdateSandbox,        // build/update sandbox
+		"issue 4203":                      c.issue4203,                 // https://github.com/sylabs/singularity/issues/4203
+		"issue 4407":                      c.issue4407,                 // https://github.com/sylabs/singularity/issues/4407
+		"issue 4524":                      c.issue4524,                 // https://github.com/sylabs/singularity/issues/4524
+		"issue 4583":                      c.issue4583,                 // https://github.com/sylabs/singularity/issues/4583
 		"issue 4837":                      c.issue4837,                 // https://github.com/sylabs/singularity/issues/4837
+		"issue 4943":                      c.issue4943,                 // https://github.com/sylabs/singularity/issues/4943
+		"issue 4967":                      c.issue4967,                 // https://github.com/sylabs/singularity/issues/4967
+		"issue 4969":                      c.issue4969,                 // https://github.com/sylabs/singularity/issues/4969
+		"issue 5166":                      c.issue5166,                 // https://github.com/sylabs/singularity/issues/5166
 	}
 }

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -35,7 +35,6 @@ import (
 	"github.com/sylabs/singularity/e2e/plugin"
 	"github.com/sylabs/singularity/e2e/pull"
 	"github.com/sylabs/singularity/e2e/push"
-	"github.com/sylabs/singularity/e2e/regressions"
 	"github.com/sylabs/singularity/e2e/remote"
 	"github.com/sylabs/singularity/e2e/run"
 	"github.com/sylabs/singularity/e2e/runhelp"
@@ -169,7 +168,6 @@ func Run(t *testing.T) {
 	suite.AddGroup("PLUGIN", plugin.E2ETests)
 	suite.AddGroup("PULL", pull.E2ETests)
 	suite.AddGroup("PUSH", push.E2ETests)
-	suite.AddGroup("REGRESSIONS", regressions.E2ETests)
 	suite.AddGroup("REMOTE", remote.E2ETests)
 	suite.AddGroup("RUN", run.E2ETests)
 	suite.AddGroup("RUNHELP", runhelp.E2ETests)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ensure that sandbox build directory has a Singularity image layout before asking for overwrite and invite user to use `--force` if the sandbox directory doesn't look like a Singularity image.

### This fixes or addresses the following GitHub issues:

 - Fixes #5166 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

