### PR TITLE
Honor insecure registries in /etc/containers/registries.conf

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -374,8 +374,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			t,
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs([]string{imagePath, defFile}...),
-			e2e.WithEnv(append(os.Environ(), "SINGULARITY_NOHTTPS=true")),
+			e2e.WithArgs("--nohttps", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
 				defer os.Remove(imagePath)
 				defer os.Remove(defFile)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1067,5 +1067,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4967":                      c.issue4967,                 // https://github.com/sylabs/singularity/issues/4967
 		"issue 4969":                      c.issue4969,                 // https://github.com/sylabs/singularity/issues/4969
 		"issue 5166":                      c.issue5166,                 // https://github.com/sylabs/singularity/issues/5166
+		"issue 5172":                      c.issue5172,                 // https://github.com/sylabs/singularity/issues/5172
 	}
 }

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -56,11 +56,18 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		return err
 	}
 
+	// DockerInsecureSkipTLSVerify is set only if --nohttps is specified to honor
+	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
+	// can have three possible values true/false and undefined, so we left it as undefined instead
+	// of forcing it to false in order to delegate decision to /etc/containers/registries.conf:
+	// https://github.com/sylabs/singularity/issues/5172
 	cp.sysCtx = &types.SystemContext{
-		OCIInsecureSkipTLSVerify:    cp.b.Opts.NoHTTPS,
-		DockerInsecureSkipTLSVerify: types.NewOptionalBool(cp.b.Opts.NoHTTPS),
-		DockerAuthConfig:            cp.b.Opts.DockerAuthConfig,
-		OSChoice:                    "linux",
+		OCIInsecureSkipTLSVerify: cp.b.Opts.NoHTTPS,
+		DockerAuthConfig:         cp.b.Opts.DockerAuthConfig,
+		OSChoice:                 "linux",
+	}
+	if cp.b.Opts.NoHTTPS {
+		cp.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
 	}
 
 	// add registry and namespace to reference if specified

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -20,10 +20,17 @@ import (
 
 // pull will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
 func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
+	// DockerInsecureSkipTLSVerify is set only if --nohttps is specified to honor
+	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
+	// can have three possible values true/false and undefined, so we left it as undefined instead
+	// of forcing it to false in order to delegate decision to /etc/containers/registries.conf:
+	// https://github.com/sylabs/singularity/issues/5172
 	sysCtx := &ocitypes.SystemContext{
-		OCIInsecureSkipTLSVerify:    noHTTPS,
-		DockerInsecureSkipTLSVerify: ocitypes.NewOptionalBool(noHTTPS),
-		DockerAuthConfig:            ociAuth,
+		OCIInsecureSkipTLSVerify: noHTTPS,
+		DockerAuthConfig:         ociAuth,
+	}
+	if noHTTPS {
+		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)
 	}
 
 	hash, err := oci.ImageSHA(ctx, pullFrom, sysCtx)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Insecure docker registries set in `/etc/containers/registries.conf` were ignored due to value forced in the image system context for both `build` and `pull` commands.

### This fixes or addresses the following GitHub issues:

 - Fixes #5172 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

