### PR TITLE
Remove http_proxy environment variable handling from yum bootstrap

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -36,7 +36,6 @@ type YumConveyor struct {
 	osversion string
 	include   string
 	gpg       string
-	httpProxy string
 }
 
 // YumConveyorPacker only needs to hold the conveyor to have the needed data to pack
@@ -163,7 +162,6 @@ func (c *YumConveyor) getBootstrapOptions() (err error) {
 
 	// look for http_proxy and gpg environment vars
 	c.gpg = os.Getenv("GPG")
-	c.httpProxy = os.Getenv("http_proxy")
 
 	// get mirrorURL, updateURL, OSVerison, and Includes components to definition
 	c.mirrorurl, ok = c.b.Recipe.Header["mirrorurl"]
@@ -202,10 +200,6 @@ func (c *YumConveyor) getBootstrapOptions() (err error) {
 
 func (c *YumConveyor) genYumConfig() (err error) {
 	fileContent := "[main]\n"
-	// http proxy
-	if c.httpProxy != "" {
-		fileContent += "proxy=" + c.httpProxy + "\n"
-	}
 	fileContent += "cachedir=/var/cache/yum-bootstrap\n"
 	fileContent += "keepcache=0\n"
 	fileContent += "debuglevel=2\n"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Remove http_proxy environment variable handling from yum bootstrap and delegate it to yum command directly as we pass current environment to yum bootstrap command.

### This fixes or addresses the following GitHub issues:

 - Fixes #5171 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

