### PR TITLE
merge 3.5.3 docs changes into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ image builds that was blocking use by build systems such as Spack:
     was configured in a setuid installation.
   - Always allow key IDs and fingerprints to be specified with or without a `0x`
     prefix when using `singularity keys` 
+  - Fix an issue preventing joining an instance started with `--boot`.
 
 In addition, numerous improvements have been made to the test suites, allowing
 them to pass cleanly on a range of kernel versions and distributions that are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,47 @@ _The old changelog can be found in the `release-2.6` branch_
   - `%test` build section is executed the same manner as `singularity test image`.
   - `%post` build section inherit environment variables from the base image.
 
-# Changes Since v3.5.2
+
+# v3.5.3 - [2020.02.18]
 
 ## Changed defaults / behaviours
 
+The following minor behaviour changes have been made in 3.5.3 to allow
+correct operation on CRAY CLE6, and correct an issue with multi-stage
+image builds that was blocking use by build systems such as Spack:
+
+  - Container action scripts are no longer bound in from `etc/actions.d` on the
+    host. They are created dynamically and inserted at container startup.
   - `%files from ...` will no longer follow symlinks when copying between
-    stages. Copying from the host will still maintain previous behavior of
-    following links.
+    stages in a multi stage build, as symlinks should be copied so that they
+    resolve identically in later stages. Copying `%files` from the host will
+    still maintain previous behavior of following links.
+
+## Bug Fixes
+
+  - Bind additional CUDA 10.2 libs when using the `--nv` option without
+    `nvidia-container-cli`.
+  - Fix an NVIDIA persistenced socket bind error with `--writable`.
+  - Add detection of ceph to allow workarounds that avoid issues with
+    sandboxes on ceph filesystems.
+  - Ensure setgid is inherited during make install.
+  - Ensure the root directory of a build has owner write permissions,
+    regardless of the permissions in the bootstrap source.
+  - Fix a regression in `%post` and `%test` to honor the `-c` option.
+  - Fix an issue running `%post` when a container doesn't have
+    `/etc/resolv.conf` or `/etc/hosts` files.
+  - Fix an issue with UID detection on RHEL6 when running instances.
+  - Fix a logic error when a sandbox image is in an overlay incompatible
+    location, and both overlay and underlay are disabled globally.
+  - Fix an issue causing user namespace to always be used when `allow-setuid=no`
+    was configured in a setuid installation.
+  - Always allow key IDs and fingerprints to be specified with or without a `0x`
+    prefix when using `singularity keys` 
+
+In addition, numerous improvements have been made to the test suites, allowing
+them to pass cleanly on a range of kernel versions and distributions that are
+not covered by the open-source CI runs.
+
 
 # v3.5.2 - [2019.12.17]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ image builds that was blocking use by build systems such as Spack:
   - Always allow key IDs and fingerprints to be specified with or without a `0x`
     prefix when using `singularity keys` 
   - Fix an issue preventing joining an instance started with `--boot`.
+  - Provide a useful error message if an invalid library:// path is provided.
+  - Bring in multi-part upload client functionality that will address large
+    image upload / proxied upload issues with a future update to Sylabs cloud.
 
 In addition, numerous improvements have been made to the test suites, allowing
 them to pass cleanly on a range of kernel versions and distributions that are

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove `/u
 reinstalling it._
 
 ```
-$ export VERSION=1.13.5 OS=linux ARCH=amd64  # change this as you need
+$ export VERSION=1.13.7 OS=linux ARCH=amd64  # change this as you need
 
 $ wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz && \
   sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
@@ -89,7 +89,7 @@ $ mkdir -p ${GOPATH}/src/github.com/sylabs && \
 To build a stable version of Singularity, check out a [release tag](https://github.com/sylabs/singularity/tags) before compiling:
 
 ```
-$ git checkout v3.5.1
+$ git checkout v3.5.3
 ```
 
 ## Compiling Singularity
@@ -132,7 +132,7 @@ as shown above.  Then download the latest
 and use it to install the RPM like this: 
 
 ```
-$ export VERSION=3.4.2  # this is the singularity version, change as you need
+$ export VERSION=3.5.3  # this is the singularity version, change as you need
 
 $ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
     rpmbuild -tb singularity-${VERSION}.tar.gz && \
@@ -148,7 +148,7 @@ tarball and use it to install Singularity:
 $ cd $GOPATH/src/github.com/sylabs/singularity && \
   ./mconfig && \
   make -C builddir rpm && \
-  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.0.3-687.gf3da9de.el7.x86_64.rpm # or whatever version you built
+  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.5.3*.x86_64.rpm # or whatever version you built
 ```
 
 To build an rpm with an alternative install prefix set RPMPREFIX on the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md)
 - [Project License](LICENSE.md)
 - [Documentation](https://www.sylabs.io/docs/)
-- [Citation](http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0177459)
+- [Citation](#citing-singularity)
 
 Singularity is an open source container platform designed to be simple, fast,
 and secure. Singularity is optimized for compute focused enterprise and HPC
@@ -48,7 +48,7 @@ Portal](https://www.sylabs.io/singularity/community/).
 For additional support, [contact us](https://www.sylabs.io/contact/) to receive
 more information.
 
-## Cite as:
+## Citing Singularity
 
 ```
 Kurtzer GM, Sochat V, Bauer MW (2017) Singularity: Scientific containers for mobility of compute. PLoS ONE 12(5): e0177459. https://doi.org/10.1371/journal.pone.0177459
@@ -57,11 +57,15 @@ Kurtzer GM, Sochat V, Bauer MW (2017) Singularity: Scientific containers for mob
 We also have a Zenodo citation:
 
 ```
-Kurtzer, Gregory M.. (2016). Singularity 2.1.2 - Linux application and environment
-containers for science. 10.5281/zenodo.60736
-
-https://doi.org/10.5281/zenodo.60736
+Kurtzer, Gregory M. et. al. Singularity - Linux application and environment
+containers for science. 10.5281/zenodo.1310023
 ```
+
+https://doi.org/10.5281/zenodo.1310023
+
+This is an 'all versions' DOI. Follow the link to Zenodo to obtain a DOI specific
+to a particular version of Singularity.
+
 
 ## License
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Because of many far-reaching changes on `master` it is not possible to merge the `release-3.5` branch from 3.5.3 into `master`... the 3.5.3 maintenance release has a lot of conflicts.

This means we need to merge the 3.5.3 CHANGELOG etc. changes into master as a separate PR.