### PR TITLE
Remove setns compilation check and define custom setns wrapper

### DIFF
--- a/cmd/starter/c/include/setns.h
+++ b/cmd/starter/c/include/setns.h
@@ -17,34 +17,46 @@
 #ifndef __SETNS_H_
 #define __SETNS_H_
 
-#ifndef __NR_setns
-#  if defined (__x86_64__)
+#if defined(__linux__) && !defined(__NR_setns)
+#  if defined(__x86_64__)
 #    define __NR_setns 308
-#  elif defined (__i386__)
+#  elif defined(__i386__)
 #    define __NR_setns 346
-#  elif defined (__alpha__)
+#  elif defined(__alpha__)
 #    define __NR_setns 501
-#  elif defined (__arm__)
+#  elif defined(__arm__)
 #    define __NR_setns 375
-#  elif defined (__aarch64__)
+#  elif defined(__aarch64__)
 #    define __NR_setns 375
-#  elif defined (__ia64__)
+#  elif defined(__ia64__)
 #    define __NR_setns 1330
-#  elif defined (__sparc__)
+#  elif defined(__sparc__)
 #    define __NR_setns 337
-#  elif defined (__powerpc__)
+#  elif defined(__powerpc__)
 #    define __NR_setns 350
-#  elif defined (__s390__)
+#  elif defined(__s390__) || defined(__s390x__)
 #    define __NR_setns 339
+#  elif defined(__mips__)
+#    if _MIPS_SIM == _ABIO32
+#      define __NR_setns 4344
+#    elif _MIPS_SIM == _ABI64
+#      define __NR_setns 5303
+#    elif _MIPS_SIM == _ABIN32
+#      define __NR_setns 6308
+#    endif
+#  elif defined(__m68k__)
+#    define __NR_setns 344
+#  elif defined(__hppa__)
+#    define __NR_setns 328
+#  elif defined(__sh__) && (!defined(__SH5__) || __SH5__ == 32)
+#    define __NR_setns 364
+#  elif defined(__sh__) && defined(__SH5__) && __SH5__ == 64
+#    define __NR_setns 375
+#  elif defined(__bfin__)
+#    define __NR_setns 379
+#  else
+#    error Please determine the syscall number of setns on your architecture
 #  endif
-#endif
-
-#ifdef __NR_setns
-
-extern int setns(int fd, int nstype);
-
-#else /* !__NR_setns */
-#  error Please determine the syscall number for setns on your architecture
 #endif
 
 #endif /* __SETNS_H_ */

--- a/cmd/starter/c/setns.c
+++ b/cmd/starter/c/setns.c
@@ -19,26 +19,23 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/syscall.h>
-
+#include "include/setns.h"
 #include "include/message.h"
 
-#if defined (SINGULARITY_NO_SETNS) && defined (SINGULARITY_SETNS_SYSCALL)
+#ifdef __NR_setns
 
-#include "include/setns.h"
-
-int setns(int fd, int nstype) {
-    singularity_message(DEBUG, "Using syscall() wrapped __NR_setns\n");
+int xsetns(int fd, int nstype) {
     return syscall(__NR_setns, fd, nstype);
 }
 
-#elif defined (SINGULARITY_NO_SETNS) && !defined (SINGULARITY_SETNS_SYSCALL)
+#else
 
-int setns(int fd, int nstype) {
+int xsetns(int fd, int nstype) {
     (void)fd;
     (void)nstype;
-    singularity_message(VERBOSE, "setns() not supported at compile time by kernel at time of building\n");
+    singularity_message(WARNING, "setns() not supported at compile time by kernel at time of building\n");
     errno = ENOSYS;
     return -1;
 }
 
-#endif /* SINGULARITY_NO_SETNS && SINGULARITY_SETNS_SYSCALL */
+#endif /* __NR_setns */

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -482,7 +482,7 @@ static int enter_namespace(char *nspath, int nstype) {
         return(-1);
     }
 
-    if ( setns(ns_fd, nstype) < 0 ) {
+    if ( xsetns(ns_fd, nstype) < 0 ) {
         int err = errno;
         close(ns_fd);
         errno = err;

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -288,24 +288,6 @@ else
 fi
 
 ########################
-# function setns
-########################
-printf " checking: function setns... "
-symb=`nm -g \`$tgtcc --print-file-name=libc.a\` 2>/dev/null | awk '$2 == "T" && $3 == "setns" {print $3}'`
-if [ "X$symb" = "Xsetns" ]; then
-	echo "yes"
-else
-	echo "no"
-	config_add_def SINGULARITY_NO_SETNS 1
-	if ! test -d "/proc/self/ns"; then
-		echo "WARNING: instance feature is disabled due to lack of kernel support"
-		echo
-	else
-		config_add_def SINGULARITY_SETNS_SYSCALL 1
-	fi
-fi
-
-########################
 # libseccomp dev
 ########################
 printf " checking: libseccomp+headers... "


### PR DESCRIPTION
## Description of the Pull Request (PR):

Remove setns compilation check and define custom setns wrapper to not rely on setns libc wrapper anymore.

### This fixes or addresses the following GitHub issues:

 - Fixes #5047 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

