### PR TITLE
WIP: Allow no-setuid fuse mount

### DIFF
--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -460,7 +460,7 @@ func (c *container) setupImageDriver(system *mount.System) error {
 			)
 
 			sylog.Debugf("Add FUSE mount for image driver with options %s", opts)
-			err := c.rpcOps.Mount("fuse", sp, "fuse", syscall.MS_NOSUID|syscall.MS_NODEV, opts)
+			err := c.rpcOps.Mount("fuse", sp, "fuse", c.suidFlag|syscall.MS_NODEV, opts)
 			if err != nil {
 				return fmt.Errorf("while mounting fuse image driver: %s", err)
 			}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow fuse mount to work in unprivileged mode when the kernel allows it.

### This fixes or addresses the following GitHub issues:

 - Fixes #5206


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

