### PR TITLE
Do go clean -modcache before removing old rpm build root

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -80,8 +80,14 @@ containers that can be used across host environments.
 export RPM_BUILD_ROOT="%{buildroot}"
 %endif
 
+if [ -d %{name}-%{version} ]; then
+    # Clean up old build root
+    # First clean go's modcache because directories are unwritable
+    GOPATH=$PWD/%{name}-%{version}/gopath go clean -modcache
+    rm -rf %{name}-%{version}
+fi
+
 # Create our build root
-rm -rf %{name}-%{version}
 mkdir %{name}-%{version}
 
 %build


### PR DESCRIPTION
## Description of the Pull Request (PR):

Doing two rpmbuilds in a row was failing to remove pkg/mod files because directories were unwritable.  This PR changes it to do go clean -modcache before removing the rest of the old build root.


### This fixes or addresses the following GitHub issues:

 - None


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

