### PR TITLE
Use context cancellation for CLI -> Client download cleanup

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -6,7 +6,6 @@
 package cli
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -169,7 +168,7 @@ var PullCmd = &cobra.Command{
 }
 
 func pullRun(cmd *cobra.Command, args []string) {
-	ctx := context.TODO()
+	ctx := cmd.Context()
 
 	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
 	if imgCache == nil {

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -46,7 +46,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 	if directTo != "" {
 		sylog.Infof("Downloading library image")
-		if err = DownloadImage(ctx, c, directTo, arch, imageRef, client.ProgressBarCallback()); err != nil {
+		if err = DownloadImage(ctx, c, directTo, arch, imageRef, client.ProgressBarCallback(ctx)); err != nil {
 			return "", fmt.Errorf("unable to download image: %v", err)
 		}
 		imagePath = directTo
@@ -60,7 +60,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading library image")
 
-			if err := DownloadImage(ctx, c, cacheEntry.TmpPath, runtime.GOARCH, imageRef, client.ProgressBarCallback()); err != nil {
+			if err := DownloadImage(ctx, c, cacheEntry.TmpPath, runtime.GOARCH, imageRef, client.ProgressBarCallback(ctx)); err != nil {
 				return "", fmt.Errorf("unable to download image: %v", err)
 			}
 

--- a/internal/pkg/client/shub/pull_test.go
+++ b/internal/pkg/client/shub/pull_test.go
@@ -6,6 +6,7 @@
 package shub
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestDownloadImage(t *testing.T) {
 		t.Fatalf("failed to get manifest from shub: %s", err)
 	}
 
-	err = DownloadImage(manifest, shubImgPath, shubImageURI, false, false)
+	err = DownloadImage(context.Background(), manifest, shubImgPath, shubImageURI, false, false)
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

In the caching re-write, cleanup of interrupted downloads using buried
interrupt handlers was removed. This returns cleanup by using context
cancellation, with an interrupt handler at the top level of the CLI code


### This fixes or addresses the following GitHub issues:

- Fixes: #5096


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

