### PR TITLE
Handle correct public/private key check for build/actions

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -363,9 +363,16 @@ func getEncryptionMaterial(cmd *cobra.Command) (crypt.KeyInfo, error) {
 
 		sylog.Verbosef("Using pem path flag for encrypted container")
 
-		// Check it's a valid PEM we can load, before starting the build (#4173)
-		if _, err := crypt.LoadPEMPublicKey(encryptionPEMPath); err != nil {
-			sylog.Fatalf("Invalid encryption key: %v", err)
+		// Check it's a valid PEM public key we can load, before starting the build (#4173)
+		if cmd.Name() == "build" {
+			if _, err := crypt.LoadPEMPublicKey(encryptionPEMPath); err != nil {
+				sylog.Fatalf("Invalid encryption public key: %v", err)
+			}
+			// or a valid private key before launching the engine for actions on a container (#5221)
+		} else {
+			if _, err := crypt.LoadPEMPrivateKey(encryptionPEMPath); err != nil {
+				sylog.Fatalf("Invalid encryption private key: %v", err)
+			}
 		}
 
 		return crypt.KeyInfo{Format: crypt.PEM, Path: encryptionPEMPath}, nil

--- a/pkg/util/crypt/key.go
+++ b/pkg/util/crypt/key.go
@@ -100,7 +100,7 @@ func EncryptKey(k KeyInfo, plaintext []byte) ([]byte, error) {
 func PlaintextKey(k KeyInfo, image string) ([]byte, error) {
 	switch k.Format {
 	case PEM:
-		privateKey, err := loadPEMPrivateKey(k.Path)
+		privateKey, err := LoadPEMPrivateKey(k.Path)
 		if err != nil {
 			return nil, fmt.Errorf("could not load PEM private key: %v", err)
 		}
@@ -132,7 +132,7 @@ func PlaintextKey(k KeyInfo, image string) ([]byte, error) {
 	}
 }
 
-func loadPEMPrivateKey(fn string) (*rsa.PrivateKey, error) {
+func LoadPEMPrivateKey(fn string) (*rsa.PrivateKey, error) {
 	b, err := ioutil.ReadFile(fn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of the Pull Request (PR):

We were always checking for a valid public key (after adding a pre-check
of the key before a build). The pre-check flow runs on run/exec/etc. so
needs to check for a valid private key in that case.

This was not surfaced by the e2e checks because the CI environments don't support cryptsetup 2.0 and consequently those tests are skipped.

### This fixes or addresses the following GitHub issues:

  - Fixes: #5221

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

