### PR TITLE
fix 5211: don't mount home when --fakeroot and --contain are given

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,6 +76,7 @@
     - Richard Neuboeck <hawk@tbi.univie.ac.at>
     - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
     - Satish Chebrolu  <satish@sylabs.io>
+    - Shane Loretz <sloretz@openrobotics.org>, <shane.loretz@gmail.com>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
     - Tru Huynh <tru@pasteur.fr>

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -410,11 +410,6 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	homeFlag := cobraCmd.Flag("home")
 	engineConfig.SetCustomHome(homeFlag.Changed)
 
-	if !homeFlag.Changed && IsFakeroot {
-		engineConfig.SetCustomHome(true)
-		HomePath = fmt.Sprintf("%s:/root", HomePath)
-	}
-
 	// set home directory for the targeted UID if it exists on host system
 	if !homeFlag.Changed && targetUID != 0 {
 		if targetUID > 500 {

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -410,6 +410,16 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	homeFlag := cobraCmd.Flag("home")
 	engineConfig.SetCustomHome(homeFlag.Changed)
 
+	// If we have fakeroot & the home flag has not been used then we have the standard
+	// /root location for the root user $HOME in the container.
+	// This doesn't count as a SetCustomHome(true), as we are mounting from the real
+	// user's standard $HOME -> /root and we want to respect --contain not mounting
+	// the $HOME in this case.
+	// See https://github.com/sylabs/singularity/pull/5227
+	if !homeFlag.Changed && IsFakeroot {
+		HomePath = fmt.Sprintf("%s:/root", HomePath)
+	}
+
 	// set home directory for the targeted UID if it exists on host system
 	if !homeFlag.Changed && targetUID != 0 {
 		if targetUID > 500 {

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2058,6 +2058,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4797":            c.issue4797,           // https://github.com/sylabs/singularity/issues/4797
 		"issue 4823":            c.issue4823,           // https://github.com/sylabs/singularity/issues/4823
 		"issue 4836":            c.issue4836,           // https://github.com/sylabs/singularity/issues/4836
+		"issue 5211":            c.issue5211,           // https://github.com/sylabs/singularity/issues/5211
 		"issue 5228":            c.issue5228,           // https://github.com/sylabs/singularity/issues/5228
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -357,4 +357,18 @@ func (c actionTests) issue5211(t *testing.T) {
 		e2e.WithArgs("--fakeroot", "--contain", c.env.ImagePath, "test", "!", "-d", filepath.Join("/root", canaryBasename)),
 		e2e.ExpectExit(0),
 	)
+
+	// Check we preserve `$HOME` as /root even when we `--contain` with `--fakeroot`
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithDir(u.Dir),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--fakeroot", "--contain", c.env.ImagePath, "sh", "-c", "echo $HOME"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ExactMatch, "/root"),
+		),
+	)
+
 }

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -351,20 +351,20 @@ func (c actionTests) issue5211(t *testing.T) {
 
 	c.env.RunSingularity(
 		t,
-		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithDir(u.Dir),
 		e2e.WithCommand("exec"),
-		e2e.WithArgs("--fakeroot", "--contain", c.env.ImagePath, "test", "!", "-d", filepath.Join("/root", canaryBasename)),
+		e2e.WithArgs("--contain", c.env.ImagePath, "test", "!", "-d", filepath.Join("/root", canaryBasename)),
 		e2e.ExpectExit(0),
 	)
 
 	// Check we preserve `$HOME` as /root even when we `--contain` with `--fakeroot`
 	c.env.RunSingularity(
 		t,
-		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithDir(u.Dir),
 		e2e.WithCommand("exec"),
-		e2e.WithArgs("--fakeroot", "--contain", c.env.ImagePath, "sh", "-c", "echo $HOME"),
+		e2e.WithArgs("--contain", c.env.ImagePath, "sh", "-c", "echo $HOME"),
 		e2e.ExpectExit(
 			0,
 			e2e.ExpectOutput(e2e.ExactMatch, "/root"),

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -335,3 +335,26 @@ func (c actionTests) issue5228(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 }
+
+// Check that home directory is not mounted under `/root` when --fakeroot and
+// --contain are both given.
+func (c actionTests) issue5211(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	u := e2e.UserProfile.HostUser(t)
+
+	// Make non-hidden file in host home to check if it was mounted in container
+	canaryDir, cleanup := e2e.MakeTempDir(t, u.Dir, "singularity-issue5211-dir-", "")
+	defer cleanup(t)
+
+	canaryBasename := filepath.Base(canaryDir)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithDir(u.Dir),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--fakeroot", "--contain", c.env.ImagePath, "test", "!", "-d", filepath.Join("/root", canaryBasename)),
+		e2e.ExpectExit(0),
+	)
+}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1558,7 +1558,7 @@ func (c *container) getHomePaths() (source string, dest string, err error) {
 		dest = filepath.Clean(c.engine.EngineConfig.GetHomeDest())
 		source, err = filepath.Abs(filepath.Clean(c.engine.EngineConfig.GetHomeSource()))
 	} else {
-		pw, err := user.Current()
+		pw, err := user.CurrentOriginal()
 		if err == nil {
 			source = pw.Dir
 			if c.engine.EngineConfig.GetFakeroot() {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1560,8 +1560,12 @@ func (c *container) getHomePaths() (source string, dest string, err error) {
 	} else {
 		pw, err := user.Current()
 		if err == nil {
-			dest = pw.Dir
 			source = pw.Dir
+			if c.engine.EngineConfig.GetFakeroot() {
+				dest = "/root"
+			} else {
+				dest = pw.Dir
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This is an attempt to fix #5211. It moves the logic mapping `host home -> /root` to avoid calling `SetCustomHome()`. It seems to fix the issue (manual testing); though, I'm unable to figure out how to run the regressions test suite. I can't say I'm confident the new regression test actually tests what it's supposed to.


### This fixes or addresses the following GitHub issues:

 - Fixes #5211


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
  - *Not sure it's necessary*
- [ ] Added tests to validate this PR and tested this PR locally with a `make testall`
  - *Added test, but unable to run e2e tests*. Not all tests pass running `make testall` on my machine, but I diff'd with test results on `master` to make sure no new tests failed.
- [x] Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- [x] Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers


#### Run e2e tests locally?

I'm unable to run the e2e tests on my machine. Anything I need to set up beforehand?

<details><summary>e2e-test target output</summary>

```
> make -C builddir/ e2e-test
make: Entering directory '/home/sloretz/projects/singularity/builddir'
 TEST sudo go test [e2e]
=== RUN   TestE2E
    TestE2E: e2e.go:14: Running E2E tests for Singularity
    TestE2E: home_linux.go:123: failed to bind mount home directory: no such file or directory
        bind mounting source directory from "/home/sloretz/projects/singularity/installdir/var/singularity/mnt/session/root" to "/root"
        github.com/sylabs/singularity/e2e/internal/e2e.SetupHomeDirectories.func1
        	github.com/sylabs/singularity/e2e/internal/e2e/home_linux.go:122
        github.com/sylabs/singularity/e2e/internal/e2e.Privileged.func1
        	github.com/sylabs/singularity/e2e/internal/e2e/priv_linux.go:53
        github.com/sylabs/singularity/e2e/internal/e2e.SetupHomeDirectories
        	github.com/sylabs/singularity/e2e/internal/e2e/home_linux.go:143
        github.com/sylabs/singularity/e2e.Run
        	github.com/sylabs/singularity/e2e/suite.go:102
        github.com/sylabs/singularity/e2e.RunE2ETests
        	github.com/sylabs/singularity/e2e/e2e.go:15
        github.com/sylabs/singularity/e2e.TestE2E
        	github.com/sylabs/singularity/e2e/e2e_test.go:41
        testing.tRunner
        	testing/testing.go:991
        runtime.goexit
        	runtime/asm_amd64.s:1373
    TestE2E: suite.go:86: Test failed, not removing /tmp/stest.167854194
--- FAIL: TestE2E (0.00s)
FAIL
coverage: 33.8% of statements
FAIL	github.com/sylabs/singularity/e2e	0.038s
FAIL
Makefile:534: recipe for target 'e2e-test' failed
make: *** [e2e-test] Error 1
make: Leaving directory '/home/sloretz/projects/singularity/builddir'
```
</details>
