### PR TITLE
Don't attempt impossible home mount of '/'

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2058,6 +2058,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4797":            c.issue4797,           // https://github.com/sylabs/singularity/issues/4797
 		"issue 4823":            c.issue4823,           // https://github.com/sylabs/singularity/issues/4823
 		"issue 4836":            c.issue4836,           // https://github.com/sylabs/singularity/issues/4836
+		"issue 5228":            c.issue5228,           // https://github.com/sylabs/singularity/issues/5228
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -316,3 +316,22 @@ func (c actionTests) issue4823(t *testing.T) {
 		)
 	}
 }
+
+// Check that we can run a container when the home mount is '/' as it is for 'nobody'
+// We should just not do that mount which would clobber the whole container fs
+func (c actionTests) issue5228(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	u := e2e.UserProfile.HostUser(t)
+
+	// We don't actually switch user to one with `/` - we put this mount in using `--home`
+	// which has the same effect.
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithDir(u.Dir),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--home", "/", c.env.ImagePath, "/bin/true"),
+		e2e.ExpectExit(0),
+	)
+}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1663,6 +1663,12 @@ func (c *container) addHomeMount(system *mount.System) error {
 		return fmt.Errorf("unable to get home source/destination: %v", err)
 	}
 
+	// issue #5228 - don't attempt to mount a '/' home dir like 'nobody' has
+	if dest == "/" {
+		sylog.Warningf("Skipping impossible home directory mount to '/'")
+		return nil
+	}
+
 	stagingDir, err := c.addHomeStagingDir(system, source, dest)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description of the Pull Request (PR):

The 'nobody' user generally has a home directory set to '/' which can't
be mounted as it will clobber the entire container fs. Refuse to mount
$HOME if the destination is '/' so running as nobody works without
--no-home.

### This fixes or addresses the following GitHub issues:

Fixes: #5228

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

