### PR TITLE
Fix SIGURG Handling

### DIFF
--- a/internal/app/starter/master_linux.go
+++ b/internal/app/starter/master_linux.go
@@ -123,7 +123,9 @@ func Master(rpcSocket, masterSocket int, containerPid int, e *engine.Engine) {
 	// we could receive signal from child with CreateContainer call so we
 	// set the signal handler earlier to queue signals until MonitorContainer
 	// is called to handle them
-	signals := make(chan os.Signal, 1)
+	// Use a channel size of two here, since we may receive SIGURG, which is
+	// used for non-cooperative goroutine preemption starting with Go 1.14.
+	signals := make(chan os.Signal, 2)
 	signal.Notify(signals)
 
 	ctx := context.TODO()

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -261,6 +261,11 @@ func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (sy
 				continue
 			}
 			return status, nil
+		case syscall.SIGURG:
+			// Ignore SIGURG, which is used for non-cooperative goroutine
+			// preemption starting with Go 1.14. For more information, see
+			// https://github.com/golang/go/issues/24543.
+			break
 		default:
 			if err := syscall.Kill(pid, s.(syscall.Signal)); err != nil {
 				return status, fmt.Errorf("interrupted by signal %s", s.String())

--- a/internal/pkg/runtime/engine/oci/monitor_linux.go
+++ b/internal/pkg/runtime/engine/oci/monitor_linux.go
@@ -36,6 +36,11 @@ func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (sy
 				continue
 			}
 			return status, nil
+		case syscall.SIGURG:
+			// Ignore SIGURG, which is used for non-cooperative goroutine
+			// preemption starting with Go 1.14. For more information, see
+			// https://github.com/golang/go/issues/24543.
+			break
 		default:
 			if err := syscall.Kill(pid, s.(syscall.Signal)); err != nil {
 				return status, fmt.Errorf("interrupted by signal %s", s.String())

--- a/internal/pkg/runtime/engine/singularity/monitor_linux.go
+++ b/internal/pkg/runtime/engine/singularity/monitor_linux.go
@@ -48,6 +48,11 @@ func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (sy
 				continue
 			}
 			return status, nil
+		case syscall.SIGURG:
+			// Ignore SIGURG, which is used for non-cooperative goroutine
+			// preemption starting with Go 1.14. For more information, see
+			// https://github.com/golang/go/issues/24543.
+			break
 		default:
 			if e.EngineConfig.GetSignalPropagation() {
 				if err := syscall.Kill(pid, s.(syscall.Signal)); err != nil {


### PR DESCRIPTION
Ignore `SIGURG`, which is used for non-cooperative goroutine preemption starting with Go 1.14 (more info available [here](https://github.com/golang/go/issues/24543)).

Fixes #5231