### PR TITLE
Build: use buffered chan for signal notification

### DIFF
--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -307,7 +307,7 @@ func (b *Build) Full(ctx context.Context) error {
 	sylog.Infof("Starting build...")
 
 	// monitor build for termination signal and clean up
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c


### PR DESCRIPTION
While working on #5233, I noticed an un-buffered channel being used with `signal.Notify()` in another part of the code. Strictly speaking, this could cause a `SIGTERM` to be missed. Submitting in a separate PR as this is not related to the bug documented in #5231.