### PR TITLE
Testing: fix E2E test suite

### DIFF
--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -202,7 +202,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 			insType: "--environment",
 			compareFn: func(t *testing.T, meta *inspect.Metadata) {
 				envFile := "/.singularity.d/env/90-environment.sh"
-				out := "#!/bin/sh\n#Custom environment shell code should follow\n\n\nexport test=\"testing\"\nexport e2e=\"e2e testing\""
+				out := "#!/bin/sh\n# Custom environment shell code should follow\n\n\nexport test=\"testing\"\nexport e2e=\"e2e testing\""
 				v := meta.Attributes.Environment[envFile]
 				if v != out {
 					t.Errorf("unexpected environment for %s, got %s instead of %s", envFile, v, out)


### PR DESCRIPTION
The E2E test suite references [library://alpine:latest](https://cloud.sylabs.io/library/library/default/alpine), which was recently updated. The contents of `90-environment.sh` was changed in #3746, and this appears to be causing a test failure.