### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,22 +86,12 @@ aliases:
   - &attach_workspace
     attach_workspace:
       at: ~/go
-  - &restore_cache
-    restore_cache:
-      keys:
-        - go-vm-mod-{{ checksum "go.sum" }}
-  - &save_cache
-    save_cache:
-      key: go-vm-mod-{{ checksum "go.sum" }}
-      paths:
-        - ~/go/pkg
 
 jobs:
-  cache_go_mod:
+  check_go_mod:
     <<: *vm_defaults
     steps:
       - checkout
-      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -109,7 +99,6 @@ jobs:
       - run:
           name: Check go.mod
           command: scripts/check-go.mod
-      - *save_cache
 
   go113-stretch:
     <<: *defaults
@@ -167,7 +156,6 @@ jobs:
     <<: *vm_defaults
     steps:
       - checkout
-      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -181,13 +169,13 @@ jobs:
       - persist_to_workspace:
           root: ~/go
           paths:
+            - pkg/mod
             - singularity
 
   unit_tests:
     <<: *vm_defaults
     steps:
       - *attach_workspace
-      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -205,7 +193,6 @@ jobs:
     <<: *vm_defaults
     steps:
       - *attach_workspace
-      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -226,7 +213,6 @@ jobs:
     <<: *vm_defaults
     steps:
       - *attach_workspace
-      - *restore_cache
       - run:
           <<: *setup_environment
       - run:
@@ -252,10 +238,8 @@ workflows:
       - go113-stretch
       - go113-alpine
       - go113-macos
-      - cache_go_mod
-      - build_check_and_install:
-          requires:
-            - cache_go_mod
+      - check_go_mod
+      - build_check_and_install
       - unit_tests:
           requires:
             - build_check_and_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,11 +82,6 @@ x-run:
           ;;
       esac
 
-aliases:
-  - &attach_workspace
-    attach_workspace:
-      at: ~/go
-
 jobs:
   check_go_mod:
     docker:
@@ -149,7 +144,7 @@ jobs:
           command: |-
             make -C ./builddir check
 
-  build_check_and_install:
+  unit_tests:
     <<: *vm_defaults
     steps:
       - checkout
@@ -162,24 +157,6 @@ jobs:
       - run:
           <<: *build_singularity
       - run:
-          <<: *check_singularity
-      - persist_to_workspace:
-          root: ~/go
-          paths:
-            - pkg/mod
-            - singularity
-
-  unit_tests:
-    <<: *vm_defaults
-    steps:
-      - *attach_workspace
-      - run:
-          <<: *setup_environment
-      - run:
-          <<: *update_go
-      - run:
-          <<: *fetch_deb_deps
-      - run:
           <<: *install_singularity
       - run:
           name: Run unit tests
@@ -189,7 +166,7 @@ jobs:
   short_integration_tests:
     <<: *vm_defaults
     steps:
-      - *attach_workspace
+      - checkout
       - run:
           <<: *setup_environment
       - run:
@@ -198,6 +175,8 @@ jobs:
           <<: *update_go
       - run:
           <<: *fetch_deb_deps
+      - run:
+          <<: *build_singularity
       - run:
           <<: *install_singularity
       - run:
@@ -209,7 +188,7 @@ jobs:
   e2e_tests:
     <<: *vm_defaults
     steps:
-      - *attach_workspace
+      - checkout
       - run:
           <<: *setup_environment
       - run:
@@ -218,6 +197,8 @@ jobs:
           <<: *update_go
       - run:
           <<: *fetch_deb_deps
+      - run:
+          <<: *build_singularity
       - run:
           <<: *install_singularity
       - run:
@@ -236,13 +217,6 @@ workflows:
       - go113-alpine
       - go113-macos
       - check_go_mod
-      - build_check_and_install
-      - unit_tests:
-          requires:
-            - build_check_and_install
-      - short_integration_tests:
-          requires:
-            - build_check_and_install
-      - e2e_tests:
-          requires:
-            - build_check_and_install
+      - unit_tests
+      - short_integration_tests
+      - e2e_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,10 @@ aliases:
 
 jobs:
   check_go_mod:
-    <<: *vm_defaults
+    docker:
+      - image: golang:1.13
     steps:
       - checkout
-      - run:
-          <<: *setup_environment
-      - run:
-          <<: *update_go
       - run:
           name: Check go.mod
           command: scripts/check-go.mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,21 +97,10 @@ aliases:
         - ~/go/pkg
 
 jobs:
-  get_source:
-    <<: *defaults
-    docker:
-      - image: sylabsio/golang:1.13.1-stretch
-    steps:
-      - checkout
-      - persist_to_workspace:
-          root: ~/go
-          paths:
-            - singularity
-
   cache_go_mod:
     <<: *vm_defaults
     steps:
-      - *attach_workspace
+      - checkout
       - *restore_cache
       - run:
           <<: *setup_environment
@@ -127,7 +116,7 @@ jobs:
     docker:
       - image: sylabsio/golang:1.13.1-stretch
     steps:
-      - *attach_workspace
+      - checkout
       - run:
           <<: *build_singularity
       - run:
@@ -138,7 +127,7 @@ jobs:
     docker:
       - image: sylabsio/golang:1.13.1-alpine
     steps:
-      - *attach_workspace
+      - checkout
       - run:
           <<: *build_singularity
       - run:
@@ -177,7 +166,7 @@ jobs:
   build_check_and_install:
     <<: *vm_defaults
     steps:
-      - *attach_workspace
+      - checkout
       - *restore_cache
       - run:
           <<: *setup_environment
@@ -260,17 +249,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - get_source
-      - go113-stretch:
-          requires:
-            - get_source
-      - go113-alpine:
-          requires:
-            - get_source
+      - go113-stretch
+      - go113-alpine
       - go113-macos
-      - cache_go_mod:
-          requires:
-            - get_source
+      - cache_go_mod
       - build_check_and_install:
           requires:
             - cache_go_mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,6 @@ vm_defaults: &vm_defaults
     image: ubuntu-1604:201903-01
 
 x-run:
-  debug_env: &debug_env
-    name: Debug environment
-    command: |-
-      set -x
-      env | sed -e 's,^,ENV: ,' | sort
-      test -n "$BASH_ENV" -a -e "$BASH_ENV" && sed -e 's,^,BASH_ENV: ,' < $BASH_ENV || echo "$BASH_ENV not found"
-
   setup_environment: &setup_environment
     name: Setup environment
     command: |-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,7 @@
 version: 2.1
 
-defaults: &defaults
-  working_directory: ~/go/singularity
-
 vm_defaults: &vm_defaults
-  <<: *defaults
+  working_directory: ~/go/singularity
   machine:
     image: ubuntu-1604:201903-01
 
@@ -86,22 +83,32 @@ jobs:
           command: scripts/check-go.mod
 
   go113-stretch:
-    <<: *defaults
     docker:
-      - image: sylabsio/golang:1.13.1-stretch
+      - image: golang:1.13-stretch
     steps:
       - checkout
+      - run:
+          name: Install golangci-lint
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+      - run:
+          name: Fetch deps
+          command: apt-get -q update && apt-get -q install -y build-essential libssl-dev uuid-dev squashfs-tools cryptsetup-bin
       - run:
           <<: *build_singularity
       - run:
           <<: *check_singularity
 
   go113-alpine:
-    <<: *defaults
     docker:
-      - image: sylabsio/golang:1.13.1-alpine
+      - image: golang:1.13-alpine
     steps:
       - checkout
+      - run:
+          name: Install golangci-lint
+          command: wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+      - run:
+          name: Fetch deps
+          command: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
       - run:
           <<: *build_singularity
       - run:


### PR DESCRIPTION
Modify CircleCI configuration with the aim of reducing time-to-finish.

### TLDR;

Before: ~11.5 minutes without `e2e_tests`, ~19 minutes with `e2e_tests`.

<img width="969" alt="Screen Shot 2020-04-23 at 8 12 16 AM" src="https://user-images.githubusercontent.com/9903835/80098032-3743a980-853a-11ea-9fc8-c9dd2a47cd33.png">

After:  ~6 minutes without `e2e_tests`, ~14 minutes with `e2e_tests`.

<img width="219" alt="Screen Shot 2020-04-23 at 8 11 49 AM" src="https://user-images.githubusercontent.com/9903835/80098033-37dc4000-853a-11ea-808b-c34c379d9d78.png">

## Full Description

Detailed modifications are as follows:

- Replace `get_source` job with independent `checkout` steps in each job. The `get_source` job did a `checkout` and then `persist_to_workspace`. In practice, `checkout` takes around the same amount of time as a `persist_to_workspace`/`attach_workspace` round trip, but removing the `get_source` job entirely saves approximately one minute in overall workflow runtime.
- Rename `cache_go_mod` job to `check_go_mod`. `cache_go_mod` ran `scripts/check-go.mod` and then used `save_cache` to save `$GOPATH/pkg/mod`. By removing CircleCI cache usage, each job will instead pull Go modules from the [Go Module Mirror](https://proxy.golang.org/). This allows for jobs that previously relied on `cache_go_mod` to start roughly one minute earlier.
- Remove `build_check_and_install` job, which built Singularity and then ran `make check`. In theory, building Singularity once before fanning out to `e2e_tests`/`unit_tests`/`short_integration_tests` is a good idea. In practice however, `make install` currently requires a populated `$GOPATH/pkg/mod` to install Singularity, and it is overall faster to simply build Singularity in `e2e_tests`/`unit_tests`/`short_integration_tests` jobs. `make check` is run in both `go113-alpine` and `go113-stretch`, so removing `build_check_and_install` reduces duplication of effort there. Overall, this change adds approximately one minute to `e2e_tests`/`unit_tests`/`short_integration_tests` jobs, but allows them to start approximately four and a half minutes faster.
- Replace usage of `sylabsio/golang*` with official `golang` images, to leverage updates and simplify the upgrade path to future versions of Go. This seems to result in higher cache hit rates on the image layers, resulting in faster startup. When combined with extra steps necessary to install software, the total time per job is roughly equivalent.
- Remove some unused YAML anchor cruft.