### PR TITLE
3.6.0-rc.1 markdown doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
-# Changes Since v3.5.3
+# v3.6.0-rc.1 - [2020-04-27] (pre-release)
 
 ## New features / functionalities
   - Singularity now supports the execution of minimal Docker/OCI

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ that you are building/compiling.
 
 For full instructions on installation, check out our
 [installation
-guide](https://sylabs.io/guides/3.5/admin-guide/installation.html).
+guide](https://sylabs.io/guides/3.6/admin-guide/installation.html).
 
 ## Install system dependencies
 
@@ -89,7 +89,7 @@ $ mkdir -p ${GOPATH}/src/github.com/sylabs && \
 To build a stable version of Singularity, check out a [release tag](https://github.com/sylabs/singularity/tags) before compiling:
 
 ```
-$ git checkout v3.5.3
+$ git checkout v3.6.0
 ```
 
 ## Compiling Singularity
@@ -132,7 +132,7 @@ as shown above.  Then download the latest
 and use it to install the RPM like this: 
 
 ```
-$ export VERSION=3.5.3  # this is the singularity version, change as you need
+$ export VERSION=3.6.0  # this is the singularity version, change as you need
 
 $ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
     rpmbuild -tb singularity-${VERSION}.tar.gz && \
@@ -148,7 +148,7 @@ tarball and use it to install Singularity:
 $ cd $GOPATH/src/github.com/sylabs/singularity && \
   ./mconfig && \
   make -C builddir rpm && \
-  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.5.3*.x86_64.rpm # or whatever version you built
+  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.6.0*.x86_64.rpm # or whatever version you built
 ```
 
 To build an rpm with an alternative install prefix set RPMPREFIX on the

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ cases of Singularity](https://sylabs.io/case-studies) on our website.
 
 To install Singularity from source, see the [installation
 instructions](INSTALL.md). For other installation options, see [our
-guide](https://www.sylabs.io/guides/3.5/admin-guide/installation.html).
+guide](https://www.sylabs.io/guides/3.6/admin-guide/installation.html).
 
 System administrators can learn how to configure Singularity, and get an
 overview of its architecture and security features in the [administrator
-guide](https://www.sylabs.io/guides/3.5/admin-guide/).
+guide](https://www.sylabs.io/guides/3.6/admin-guide/).
 
 For users, see the [user
-guide](https://www.sylabs.io/guides/3.5/user-guide/) for details on how to use
+guide](https://www.sylabs.io/guides/3.6/user-guide/) for details on how to use
 and build Singularity containers.
 
 ## Contributing to Singularity


### PR DESCRIPTION
Bump versions in markdown docs for the 3.6.0-rc.1 - merging this to the newly branched `release-3.6` branch on which the `v3.6.0-rc.1` tag will be applied.

Note: The URLs to 3.6 docs *are not working yet* - a flurry of docs work will fill these in prior to the stable release. The install / checkout instructions will be valid when the `3.6.0` release is made.