### PR TITLE
Handle invalid env var keys and multi-line values

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -265,6 +265,23 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 			matchEnv: "FOO",
 			matchVal: "foo",
 		},
+		{
+			name:     "TestMultiLine",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"MULTI=Hello\nWorld"},
+			matchEnv: "MULTI",
+			matchVal: "Hello\nWorld",
+		},
+		{
+			name:  "TestInvalidKey",
+			image: c.env.ImagePath,
+			// We try to set an invalid env var... and make sure
+			// we have no error output from the interpreter as it
+			// should be ignored, not passed into the container.
+			hostEnv:  []string{"BASH_FUNC_ml%%=TEST"},
+			matchEnv: "BASH_FUNC_ml%%",
+			matchVal: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -272,7 +289,7 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 		if tt.envOpt != nil {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
 		}
-		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)
+		args = append(args, tt.image, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -43,7 +43,7 @@ restore_env() {
     for e in ${__exported_env__}; do
         key=$(getenvkey "${e}")
         if ! test -v "${key}"; then
-            export "${e}"
+            export "$(unescape ${e})"
         elif test -z "${!key}"; then
             unset "${key}"
         fi


### PR DESCRIPTION
## Description of the Pull Request (PR):

When exporting environment into the container we need to:

 - Escape and then unescape newlines so that multi-line env vars are
   correct in the container environment.
 - Not attempt to put env vars with invalid names, such as exported
   bash functions, into the container.


### This fixes or addresses the following GitHub issues:

 - Fixes: #5253


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

