### PR TITLE
Update --fusemount help. Fixes #5255

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -300,13 +300,13 @@ var actionContainLibsFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
-// --fusemount, hidden for now while experimental
+// --fusemount
 var actionFuseMountFlag = cmdline.Flag{
 	ID:           "actionFuseMountFlag",
 	Value:        &FuseMount,
 	DefaultValue: []string{},
 	Name:         "fusemount",
-	Usage:        "a FUSE filesystem mount specification. Begins with the source of the FUSE driver followed by a colon; currently must be 'container:'.  After the colon is the command to run to implement a libfuse3- based filesystem. The last space- separated part of the string is a mountpoint that will be pre-mounted and replaced with a /dev/fd path to the FUSE file descriptor.  Implies --pid.",
+	Usage:        "A FUSE filesystem mount specification of the form '<type>:<fuse command> <mountpoint>' - where <type> is 'container' or 'host', specifying where the mount will be performed ('container-daemon' or 'host-daemon' will run the FUSE process detached). <fuse command> is the path to the FUSE executable, plus options for the mount. <mountpoint> is the location in the container to which the FUSE mount will be attached. E.g. 'container:sshfs 10.0.0.1:/ /sshfs'. Implies --pid.",
 	EnvKeys:      []string{"FUSESPEC"},
 	ExcludedOS:   []string{cmdline.Darwin},
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update --fusemount help. 

```
      --fusemount strings      A FUSE filesystem mount specification of
                               the form '<type>:<fuse command>
                               <mountpoint>' - where <type> is 'container'
                               or 'host', specifying where the mount will
                               be performed ('container-daemon' or
                               'host-daemon' will run the FUSE process
                               detached). <fuse command> is the path to
                               the FUSE executable, plus options for the
                               mount. <mountpoint> is the location in the
                               container to which the FUSE mount will be
                               attached. E.g. 'container:sshfs 10.0.0.1:/
                               /sshfs'. Implies --pid.

```


### This fixes or addresses the following GitHub issues:

 - Fixes #5255


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

