### PR TITLE
Merge release-3.6 to master at 3.6.0-rc.2 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
-# Changes Since v3.5.3
+# v3.6.0-rc.1 - [2020-04-27] (pre-release)
 
 ## New features / functionalities
   - Singularity now supports the execution of minimal Docker/OCI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
-# v3.6.0-rc.1 - [2020-04-27] (pre-release)
+# v3.6.0-rc.2 - [2020-04-29] (pre-release)
 
 ## New features / functionalities
   - Singularity now supports the execution of minimal Docker/OCI
@@ -68,6 +68,7 @@ _The old changelog can be found in the `release-2.6` branch_
   - Use the `base` metapackage for arch bootstrap builds - arch no longer has a
     `base` group.
   - Ensure library client messages are logged with `--debug`.
+  - Do not mount `$HOME` with `--fakeroot --contain`.
 
 
 # v3.5.3 - [2020.02.18]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ that you are building/compiling.
 
 For full instructions on installation, check out our
 [installation
-guide](https://sylabs.io/guides/3.5/admin-guide/installation.html).
+guide](https://sylabs.io/guides/3.6/admin-guide/installation.html).
 
 ## Install system dependencies
 
@@ -89,7 +89,7 @@ $ mkdir -p ${GOPATH}/src/github.com/sylabs && \
 To build a stable version of Singularity, check out a [release tag](https://github.com/sylabs/singularity/tags) before compiling:
 
 ```
-$ git checkout v3.5.3
+$ git checkout v3.6.0
 ```
 
 ## Compiling Singularity
@@ -132,7 +132,7 @@ as shown above.  Then download the latest
 and use it to install the RPM like this: 
 
 ```
-$ export VERSION=3.5.3  # this is the singularity version, change as you need
+$ export VERSION=3.6.0  # this is the singularity version, change as you need
 
 $ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
     rpmbuild -tb singularity-${VERSION}.tar.gz && \
@@ -148,7 +148,7 @@ tarball and use it to install Singularity:
 $ cd $GOPATH/src/github.com/sylabs/singularity && \
   ./mconfig && \
   make -C builddir rpm && \
-  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.5.3*.x86_64.rpm # or whatever version you built
+  sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.6.0*.x86_64.rpm # or whatever version you built
 ```
 
 To build an rpm with an alternative install prefix set RPMPREFIX on the

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ cases of Singularity](https://sylabs.io/case-studies) on our website.
 
 To install Singularity from source, see the [installation
 instructions](INSTALL.md). For other installation options, see [our
-guide](https://www.sylabs.io/guides/3.5/admin-guide/installation.html).
+guide](https://www.sylabs.io/guides/3.6/admin-guide/installation.html).
 
 System administrators can learn how to configure Singularity, and get an
 overview of its architecture and security features in the [administrator
-guide](https://www.sylabs.io/guides/3.5/admin-guide/).
+guide](https://www.sylabs.io/guides/3.6/admin-guide/).
 
 For users, see the [user
-guide](https://www.sylabs.io/guides/3.5/user-guide/) for details on how to use
+guide](https://www.sylabs.io/guides/3.6/user-guide/) for details on how to use
 and build Singularity containers.
 
 ## Contributing to Singularity

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -300,13 +300,13 @@ var actionContainLibsFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
-// --fusemount, hidden for now while experimental
+// --fusemount
 var actionFuseMountFlag = cmdline.Flag{
 	ID:           "actionFuseMountFlag",
 	Value:        &FuseMount,
 	DefaultValue: []string{},
 	Name:         "fusemount",
-	Usage:        "a FUSE filesystem mount specification. Begins with the source of the FUSE driver followed by a colon; currently must be 'container:'.  After the colon is the command to run to implement a libfuse3- based filesystem. The last space- separated part of the string is a mountpoint that will be pre-mounted and replaced with a /dev/fd path to the FUSE file descriptor.  Implies --pid.",
+	Usage:        "A FUSE filesystem mount specification of the form '<type>:<fuse command> <mountpoint>' - where <type> is 'container' or 'host', specifying where the mount will be performed ('container-daemon' or 'host-daemon' will run the FUSE process detached). <fuse command> is the path to the FUSE executable, plus options for the mount. <mountpoint> is the location in the container to which the FUSE mount will be attached. E.g. 'container:sshfs 10.0.0.1:/ /sshfs'. Implies --pid.",
 	EnvKeys:      []string{"FUSESPEC"},
 	ExcludedOS:   []string{cmdline.Darwin},
 }

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -265,6 +265,23 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 			matchEnv: "FOO",
 			matchVal: "foo",
 		},
+		{
+			name:     "TestMultiLine",
+			image:    c.env.ImagePath,
+			hostEnv:  []string{"MULTI=Hello\nWorld"},
+			matchEnv: "MULTI",
+			matchVal: "Hello\nWorld",
+		},
+		{
+			name:  "TestInvalidKey",
+			image: c.env.ImagePath,
+			// We try to set an invalid env var... and make sure
+			// we have no error output from the interpreter as it
+			// should be ignored, not passed into the container.
+			hostEnv:  []string{"BASH_FUNC_ml%%=TEST"},
+			matchEnv: "BASH_FUNC_ml%%",
+			matchVal: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -272,7 +289,7 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 		if tt.envOpt != nil {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
 		}
-		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)
+		args = append(args, tt.image, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -43,7 +43,7 @@ restore_env() {
     for e in ${__exported_env__}; do
         key=$(getenvkey "${e}")
         if ! test -v "${key}"; then
-            export "${e}"
+            export "$(unescape ${e})"
         elif test -z "${!key}"; then
             unset "${key}"
         fi


### PR DESCRIPTION
Hopefully 3.6.0-rc.2 should be out there for a week or two to get a decent amount of testing without too many issues :-D

At this point merge the `release-3.6` branch back into `master` to capture the 2 fixes made from `3.6.0-rc.1` and result in `master` builds reporting a version of `3.6.0-rc.2+nnnnn` based on the closest tag, instead of a `3.5` version.