### PR TITLE
Fix regression when using `--writable-tmpfs`

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2060,6 +2060,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4836":            c.issue4836,           // https://github.com/sylabs/singularity/issues/4836
 		"issue 5211":            c.issue5211,           // https://github.com/sylabs/singularity/issues/5211
 		"issue 5228":            c.issue5228,           // https://github.com/sylabs/singularity/issues/5228
+		"issue 5271":            c.issue5271,           // https://github.com/sylabs/singularity/issues/5271
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/internal/pkg/cache"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
@@ -371,4 +372,19 @@ func (c actionTests) issue5211(t *testing.T) {
 		),
 	)
 
+}
+
+// Check that we can create a directory in container image with --writable-tmpfs.
+func (c actionTests) issue5271(t *testing.T) {
+	require.Filesystem(t, "overlay")
+
+	e2e.EnsureImage(t, c.env)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--writable-tmpfs", c.env.ImagePath, "mkdir", "/e2e-dir"),
+		e2e.ExpectExit(0),
+	)
 }

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -618,8 +618,6 @@ func (c *container) mountGeneric(mnt *mount.Point, tag mount.AuthorizedTag) (err
 					return imageDriver.Mount(params, c.rpcOps.Mount)
 				}
 			}
-			c.rpcOps.SetFsID(0, 0)
-			defer c.rpcOps.SetFsID(os.Getuid(), os.Getgid())
 		}
 	}
 
@@ -864,11 +862,6 @@ func (c *container) addRootfsMount(system *mount.System) error {
 
 func (c *container) overlayUpperWork(system *mount.System) error {
 	ov := c.session.Layer.(*overlay.Overlay)
-
-	if c.engine.EngineConfig.File.EnableOverlay != "driver" {
-		c.rpcOps.SetFsID(0, 0)
-		defer c.rpcOps.SetFsID(os.Getuid(), os.Getgid())
-	}
 
 	createUpperWork := func(path, label string) error {
 		fi, err := c.rpcOps.Lstat(path)

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -57,12 +57,6 @@ type HostnameArgs struct {
 	Hostname string
 }
 
-// SetFsIDArgs defines the arguments to setfsid.
-type SetFsIDArgs struct {
-	UID int
-	GID int
-}
-
 // ChdirArgs defines the arguments to chdir.
 type ChdirArgs struct {
 	Dir string

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -99,17 +99,6 @@ func (t *RPC) SetHostname(hostname string) (int, error) {
 	return reply, err
 }
 
-// SetFsID calls the setfsid RPC using the supplied arguments.
-func (t *RPC) SetFsID(uid int, gid int) (int, error) {
-	arguments := &args.SetFsIDArgs{
-		UID: uid,
-		GID: gid,
-	}
-	var reply int
-	err := t.Client.Call(t.Name+".SetFsID", arguments, &reply)
-	return reply, err
-}
-
 // Chdir calls the chdir RPC using the supplied arguments.
 func (t *RPC) Chdir(dir string) (int, error) {
 	arguments := &args.ChdirArgs{

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -203,15 +203,6 @@ func (t *Methods) SetHostname(arguments *args.HostnameArgs, reply *int) error {
 	return syscall.Sethostname([]byte(arguments.Hostname))
 }
 
-// SetFsID sets filesystem uid and gid.
-func (t *Methods) SetFsID(arguments *args.SetFsIDArgs, reply *int) error {
-	mainthread.Execute(func() {
-		syscall.Setfsuid(arguments.UID)
-		syscall.Setfsgid(arguments.GID)
-	})
-	return nil
-}
-
 // Chdir changes current working directory to path.
 func (t *Methods) Chdir(arguments *args.ChdirArgs, reply *int) error {
 	return mainthread.Chdir(arguments.Dir)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix regression when using `--writable-tmpfs` resulting in mounting overlay in read-only mode due to a fallback in kernel overlay code not being able to create work directory, before rework of RPC server privileges it was required to mount overlay as root user by switch filesystem UID/GID, now that RPC is running as current user with a set of capabilities the change of filesystem UID/GID is not required anymore and fix this regression.


### This fixes or addresses the following GitHub issues:

 - Fixes #5271 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

