### PR TITLE
Mark GPFS as incompatible for overlay lower and upper

### DIFF
--- a/internal/pkg/util/fs/overlay/overlay.go
+++ b/internal/pkg/util/fs/overlay/overlay.go
@@ -33,6 +33,7 @@ const (
 	fuse         = 0x65735546
 	ecrypt       = 0xF15F
 	lustre       = 0x0BD00BD0
+	gpfs         = 0x47504653
 )
 
 var incompatibleFs = map[int64]fs{
@@ -54,6 +55,11 @@ var incompatibleFs = map[int64]fs{
 	// LUSTRE filesystem
 	lustre: {
 		name:       "LUSTRE",
+		overlayDir: lowerDir | upperDir,
+	},
+	// GPFS filesystem
+	gpfs: {
+		name:       "GPFS",
 		overlayDir: lowerDir | upperDir,
 	},
 }

--- a/internal/pkg/util/fs/overlay/overlay_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_test.go
@@ -125,6 +125,24 @@ func TestCheckLowerUpper(t *testing.T) {
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
+		{
+			name:                  "GPFS mock lower",
+			path:                  "/",
+			fsName:                "GPFS",
+			dir:                   lowerDir,
+			fsType:                gpfs,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
+		{
+			name:                  "GPFS mock upper",
+			path:                  "/",
+			fsName:                "GPFS",
+			dir:                   upperDir,
+			fsType:                gpfs,
+			expectedSuccess:       false,
+			expectIncompatibleErr: true,
+		},
 	}
 
 	if IsIncompatible(nil) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

When used as the lowerdir for an overlay in a mount namespace as we do, GPFS gives an NFS stale file handle error. It does not trigger the code in the kernel overlayfs source that gives a more specific error and directly denies overlay mount for other filesystems such as lustre.

We need to blacklist GPFS from overlay lower and upper usage, until we can confirm exactly what is intended to be supported by IBM.

### This fixes or addresses the following GitHub issues:

 - Fixes #5274


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

