### PR TITLE
[e2e] Pin to a 0.5.7 version of img in DockerRegistry.def

### DIFF
--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -2,8 +2,14 @@ bootstrap: docker
 from: registry:2.7.1
 
 %post
-    apk add runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-            img --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+    apk add runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+
+    # Install v0.5.7 of img (latest will not talk to http registries)
+    export IMG_SHA256="41aa98ab28be55ba3d383cb4e8f86dceac6d6e92102ee4410a6b43514f4da1fa"
+    # Download and check the sha256sum.
+    wget "https://github.com/genuinetools/img/releases/download/v0.5.7/img-linux-amd64" -O "/usr/local/bin/img" \
+	  && echo "${IMG_SHA256}  /usr/local/bin/img" | sha256sum -c - \
+	  && chmod a+x "/usr/local/bin/img"
 
 %startscript
     /.singularity.d/runscript &


### PR DESCRIPTION
Description of the Pull Request (PR):

Pin to a 0.5.7 version of img in DockerRegistry.def

The current version that is brought in (0.5.10) does not pull from an http registry, even with `--insecure-registry` set. This means that the registry instance used in tests is never initialized properly.

Installation of 0.5.7 is adapted from code at:

https://github.com/genuinetools/img/releases/tag/v0.5.7

### This fixes or addresses the following GitHub issues:

 - Fixes: #5302


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

