### PR TITLE
Fix missing warning when using --writable-tmpfs with underlay.

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2061,6 +2061,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5211":            c.issue5211,           // https://github.com/sylabs/singularity/issues/5211
 		"issue 5228":            c.issue5228,           // https://github.com/sylabs/singularity/issues/5228
 		"issue 5271":            c.issue5271,           // https://github.com/sylabs/singularity/issues/5271
+		"issue 5307":            c.issue5307,           // https://github.com/sylabs/singularity/issues/5307
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -388,3 +388,19 @@ func (c actionTests) issue5271(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 }
+
+// Check that we get a warning when using --writable-tmpfs with underlay.
+func (c actionTests) issue5307(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserNamespaceProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--writable-tmpfs", c.env.ImagePath, "true"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectError(e2e.ContainMatch, "Disabling --writable-tmpfs"),
+		),
+	)
+}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1115,32 +1115,34 @@ func (e *EngineOperations) loadImages(starterConfig *starter.Config) error {
 		// C starter code will position current working directory
 		starterConfig.SetWorkingDirectoryFd(int(img.Fd))
 
-		if err := overlay.CheckLower(img.Path); overlay.IsIncompatible(err) {
-			layer := singularityConfig.UnderlayLayer
-			if !e.EngineConfig.File.EnableUnderlay {
-				sylog.Debugf("Could not fallback to underlay, disabled by configuration ('enable underlay = no')")
-				layer = singularityConfig.DefaultLayer
-			}
-			e.EngineConfig.SetSessionLayer(layer)
-
-			// show a warning message if --writable-tmpfs or overlay images
-			// are requested otherwise make it verbose to not annoy users
-			if e.EngineConfig.GetWritableTmpfs() || len(e.EngineConfig.GetOverlayImage()) > 0 {
-				sylog.Warningf("Fallback to %s layer: %s", layer, err)
-
-				if e.EngineConfig.GetWritableTmpfs() {
-					e.EngineConfig.SetWritableTmpfs(false)
-					sylog.Warningf("--writable-tmpfs disabled due to sandbox filesystem incompatibility with overlay")
+		if e.EngineConfig.GetSessionLayer() == singularityConfig.OverlayLayer {
+			if err := overlay.CheckLower(img.Path); overlay.IsIncompatible(err) {
+				layer := singularityConfig.UnderlayLayer
+				if !e.EngineConfig.File.EnableUnderlay {
+					sylog.Warningf("Could not fallback to underlay, disabled by configuration ('enable underlay = no')")
+					layer = singularityConfig.DefaultLayer
 				}
-				if len(e.EngineConfig.GetOverlayImage()) > 0 {
-					e.EngineConfig.SetOverlayImage(nil)
-					sylog.Warningf("overlay image(s) not loaded due to sandbox filesystem incompatibility with overlay")
+				e.EngineConfig.SetSessionLayer(layer)
+
+				// show a warning message if --writable-tmpfs or overlay images
+				// are requested otherwise make it verbose to not annoy users
+				if e.EngineConfig.GetWritableTmpfs() || len(e.EngineConfig.GetOverlayImage()) > 0 {
+					sylog.Warningf("Fallback to %s layer: %s", layer, err)
+
+					if e.EngineConfig.GetWritableTmpfs() {
+						e.EngineConfig.SetWritableTmpfs(false)
+						sylog.Warningf("--writable-tmpfs disabled due to sandbox filesystem incompatibility with overlay")
+					}
+					if len(e.EngineConfig.GetOverlayImage()) > 0 {
+						e.EngineConfig.SetOverlayImage(nil)
+						sylog.Warningf("overlay image(s) not loaded due to sandbox filesystem incompatibility with overlay")
+					}
+				} else {
+					sylog.Verbosef("Fallback to %s layer: %s", layer, err)
 				}
-			} else {
-				sylog.Verbosef("Fallback to %s layer: %s", layer, err)
+			} else if err != nil {
+				return fmt.Errorf("while checking image compatibility with overlay: %s", err)
 			}
-		} else if err != nil {
-			return fmt.Errorf("while checking image compatibility with overlay: %s", err)
 		}
 	} else if img.Type == image.SIF {
 		// query the ECL module, proceed if an ecl config file is found
@@ -1176,12 +1178,18 @@ func (e *EngineOperations) loadImages(starterConfig *starter.Config) error {
 		}
 	}
 
-	if e.EngineConfig.GetSessionLayer() == singularityConfig.OverlayLayer {
+	switch e.EngineConfig.GetSessionLayer() {
+	case singularityConfig.OverlayLayer:
 		overlayImages, err := e.loadOverlayImages(starterConfig, writableOverlayPath)
 		if err != nil {
 			return fmt.Errorf("while loading overlay images: %s", err)
 		}
 		images = append(images, overlayImages...)
+	case singularityConfig.UnderlayLayer:
+		if e.EngineConfig.GetWritableTmpfs() {
+			sylog.Warningf("Disabling --writable-tmpfs as it can't be used in conjunction with underlay")
+			e.EngineConfig.SetWritableTmpfs(false)
+		}
 	}
 
 	bindImages, err := e.loadBindImages(starterConfig)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix missing warning when using --writable-tmpfs with underlay.

### This fixes or addresses the following GitHub issues:

 - Fixes #5307 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

