### PR TITLE
Document removal of check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,7 @@ This point release addresses the following issues:
   - Removed deprecated `singularity create` command
   - Removed deprecated `singularity bootstrap` command
   - Removed deprecated `singularity mount` command
+  - Removed deprecated `singularity check` command
 
 ## New Commands
   - Added `singularity run-help <image path>` command to output an image's `help` message


### PR DESCRIPTION
This commit documents the removal of the `singularity check` command in version 3.0.

Attn: @singularity-maintainers

