### PR TITLE
Adjust container capabilities based on latest capability available

### DIFF
--- a/cmd/starter/c/include/capability.h
+++ b/cmd/starter/c/include/capability.h
@@ -14,7 +14,10 @@
 
 #include <linux/capability.h>
 
-#define CAPSET_MAX  40
+/* 2.6.32 kernel is the minimal kernel version supported where latest cap is 33 */
+#define CAPSET_MIN  33
+/* 37 is the latest cap since many kernel versions */
+#define CAPSET_MAX  37
 
 /* Support only 64 bits sets, since kernel 2.6.25 */
 #ifdef _LINUX_CAPABILITY_VERSION_3


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR clear bits in all set of capabilities to match the last available capability of the system and fix regression observed in #5305. This is precaution done in C starter code but ideally capabilities should be already set correctly from Go inside runtime engines, this is a technical debt to fix for a next release as it involves a biggest PR.

### This fixes or addresses the following GitHub issues:

 - Fixes #5305 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

