### PR TITLE
Bump github.com/spf13/cobra to 1.0.0

### DIFF
--- a/e2e/plugin/testdata/cli/go.mod
+++ b/e2e/plugin/testdata/cli/go.mod
@@ -3,7 +3,7 @@ module github.com/sylabs/singularity/e2e-cli-plugin
 go 1.13
 
 require (
-	github.com/spf13/cobra v0.0.5
+	github.com/spf13/cobra v1.0.0
 	github.com/sylabs/singularity v0.0.0
 )
 

--- a/e2e/plugin/testdata/runtime_singularity/go.mod
+++ b/e2e/plugin/testdata/runtime_singularity/go.mod
@@ -3,7 +3,7 @@ module github.com/sylabs/singularity/e2e-cli-plugin
 go 1.13
 
 require (
-	github.com/spf13/cobra v0.0.5
+	github.com/spf13/cobra v1.0.0
 	github.com/sylabs/singularity v0.0.0
 )
 

--- a/examples/plugins/cli-plugin/go.mod
+++ b/examples/plugins/cli-plugin/go.mod
@@ -3,7 +3,7 @@ module github.com/sylabs/singularity/cli-example-plugin
 go 1.13
 
 require (
-	github.com/spf13/cobra v0.0.5
+	github.com/spf13/cobra v1.0.0
 	github.com/sylabs/singularity v0.0.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/seccomp/containers-golang v0.4.1
 	github.com/seccomp/libseccomp-golang v0.9.1
-	github.com/spf13/cobra v0.0.7
+	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/sylabs/json-resp v0.6.0
 	github.com/sylabs/scs-build-client v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKv
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v0.0.7 h1:FfTH+vuMXOas8jmfb5/M7dzEYx7LpcLb7a0LPe34uOU=
-github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
+github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=


### PR DESCRIPTION
Use stable version of `github.com/spf13/cobra`.