### PR TITLE
Detect current PID user-namespace in overlay checks #5315

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1069,5 +1069,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4969":                      c.issue4969,                 // https://github.com/sylabs/singularity/issues/4969
 		"issue 5166":                      c.issue5166,                 // https://github.com/sylabs/singularity/issues/5166
 		"issue 5172":                      c.issue5172,                 // https://github.com/sylabs/singularity/issues/5172
+		"issue 5315":                      c.issue5315,                 // https://github.com/sylabs/singularity/issues/5315
 	}
 }

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -369,3 +369,23 @@ func (c *imgBuildTests) issue4820(t *testing.T) {
 		),
 	)
 }
+
+// When running a %test section under fakeroot we must recognize the engine
+// is running under a user namespace and avoid overlay.
+func (c *imgBuildTests) issue5315(t *testing.T) {
+	image := filepath.Join(c.env.TestDir, "issue_5315.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(image, "testdata/regressions/issue_5315.def"),
+		e2e.PostRun(func(t *testing.T) {
+			os.Remove(image)
+		}),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ContainMatch, "TEST OK"),
+		),
+	)
+}

--- a/e2e/testdata/regressions/issue_5315.def
+++ b/e2e/testdata/regressions/issue_5315.def
@@ -1,0 +1,5 @@
+Bootstrap: library
+From: alpine
+
+%test
+    echo "TEST OK"

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -1016,10 +1016,12 @@ func (e *EngineOperations) setSessionLayer(img *image.Image) error {
 
 	// NEED FIX: on ubuntu until 4.15 kernel it was possible to mount overlay
 	// with the current workflow, since 4.18 we get an operation not permitted
-	for _, ns := range e.EngineConfig.OciConfig.Linux.Namespaces {
-		if ns.Type == specs.UserNamespace {
-			userNS = true
-			break
+	if !userNS {
+		for _, ns := range e.EngineConfig.OciConfig.Linux.Namespaces {
+			if ns.Type == specs.UserNamespace {
+				userNS = true
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When considering overlay support in `internal/pkg/runtime/engine/singularity/prepare_linux.go` detect whether the current process is running in a user namespace, rather than looking only at OCIConfig.

This is required with the changes in 3.6 that mean the build engine is not separate, and we are running builds, and any contained tests, under the singularity engine. Failure to do this means that `%test` blocks in a build will fail due to attempting to use overlay.

### This fixes or addresses the following GitHub issues:

 - Fixes #5315

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

