### PR TITLE
Update CHANGELOG pre-release version for 3.6.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
-# v3.6.0-rc.3 - [2020-05-15] (pre-release)
+# v3.6.0-rc.4 - [2020-06-01] (pre-release)
 
 ## New features / functionalities
   - Singularity now supports the execution of minimal Docker/OCI


### PR DESCRIPTION
CHANGELOG is not modified as the fixes made since RC3 are for
regressions from 3.5 that have been fixed in the RC period - so they
are not bug fixes over the last stable release.
