### PR TITLE
Switch to multi-arch test docker containers

### DIFF
--- a/cmd/singularity/docker_test.go
+++ b/cmd/singularity/docker_test.go
@@ -67,7 +67,7 @@ func TestDockerAUFS(t *testing.T) {
 	imagePath := path.Join(testDir, "container")
 	defer os.Remove(imagePath)
 
-	b, err := imageBuild(imgCache, buildOpts{}, imagePath, "docker://dctrud/docker-aufs-sanity")
+	b, err := imageBuild(imgCache, buildOpts{}, imagePath, "docker://sylabsio/aufs-sanity")
 	if err != nil {
 		t.Log(string(b))
 		t.Fatalf("unexpected failure: %v", err)
@@ -108,7 +108,7 @@ func TestDockerPermissions(t *testing.T) {
 	imagePath := path.Join(testDir, "container")
 	defer os.Remove(imagePath)
 
-	b, err := imageBuild(imgCache, buildOpts{}, imagePath, "docker://dctrud/docker-singularity-userperms")
+	b, err := imageBuild(imgCache, buildOpts{}, imagePath, "docker://sylabsio/userperms")
 	if err != nil {
 		t.Log(string(b))
 		t.Fatalf("unexpected failure: %v", err)
@@ -148,7 +148,7 @@ func TestDockerWhiteoutSymlink(t *testing.T) {
 	imagePath := path.Join(testDir, "container")
 	defer os.Remove(imagePath)
 
-	b, err := imageBuild(imgCache, buildOpts{}, imagePath, "docker://dctrud/docker-singularity-linkwh")
+	b, err := imageBuild(imgCache, buildOpts{}, imagePath, "docker://sylabsio/linkwh")
 	if err != nil {
 		t.Log(string(b))
 		t.Fatalf("unexpected failure: %v", err)

--- a/cmd/singularity/env_test.go
+++ b/cmd/singularity/env_test.go
@@ -25,7 +25,7 @@ func TestSingularityEnv(t *testing.T) {
 	var defaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 	// This image sets a custom path.
-	var customImage = "docker://godlovedc/lolcow"
+	var customImage = "docker://sylabsio/lolcow"
 	var customPath = "/usr/games:" + defaultPath
 
 	// Append or prepend this path.

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -126,7 +126,7 @@ func (c ctx) testDockerAUFS(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-aufs-sanity"}...),
+		e2e.WithArgs([]string{imagePath, "docker://sylabsio/aufs-sanity"}...),
 		e2e.ExpectExit(0),
 	)
 
@@ -173,7 +173,7 @@ func (c ctx) testDockerPermissions(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-singularity-userperms"}...),
+		e2e.WithArgs([]string{imagePath, "docker://sylabsio/userperms"}...),
 		e2e.ExpectExit(0),
 	)
 
@@ -219,7 +219,7 @@ func (c ctx) testDockerWhiteoutSymlink(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs([]string{imagePath, "docker://dctrud/docker-singularity-linkwh"}...),
+		e2e.WithArgs([]string{imagePath, "docker://sylabsio/linkwh"}...),
 		e2e.PostRun(func(t *testing.T) {
 			if t.Failed() {
 				return

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -36,7 +36,7 @@ func (c ctx) singularityEnv(t *testing.T) {
 	var defaultImage = "docker://alpine:3.8"
 
 	// This image sets a custom path.
-	var customImage = "docker://godlovedc/lolcow"
+	var customImage = "docker://sylabsio/lolcow"
 	var customPath = "/usr/games:" + defaultPath
 
 	// Append or prepend this path.
@@ -163,13 +163,13 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 		},
 		{
 			name:     "DockerImage",
-			image:    "docker://godlovedc/lolcow",
+			image:    "docker://sylabsio/lolcow",
 			matchEnv: "LC_ALL",
 			matchVal: "C",
 		},
 		{
 			name:     "DockerImageOverride",
-			image:    "docker://godlovedc/lolcow",
+			image:    "docker://sylabsio/lolcow",
 			envOpt:   []string{"LC_ALL=foo"},
 			matchEnv: "LC_ALL",
 			matchVal: "foo",

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -16,6 +16,7 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 )
 
 // This test will build an image from a multi-stage definition
@@ -198,6 +199,9 @@ func (c imgBuildTests) issue4837(t *testing.T) {
 }
 
 func (c *imgBuildTests) issue4943(t *testing.T) {
+
+	require.Arch(t, "amd64")
+
 	const (
 		image = "docker://gitlab-registry.cern.ch/linuxsupport/cc7-base:20191107"
 	)

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -7,6 +7,7 @@ package require
 
 import (
 	"os/exec"
+	"runtime"
 	"testing"
 
 	"github.com/containerd/cgroups"
@@ -69,4 +70,13 @@ func Seccomp(t *testing.T) {
 	if !seccomp.Enabled() {
 		t.Skipf("seccomp disabled, Singularity was compiled without the seccomp library")
 	}
+}
+
+// Arch checks the test machine has the specified architecture.
+// If not, the test is skipped with a message.
+func Arch(t *testing.T, arch string) {
+	if runtime.GOARCH != arch {
+		t.Skipf("test requires architecture %s", arch)
+	}
+
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

From the work done on #5339 we now have multi-arch versions of the docker containers used in tests.

Switch all possible tests to use these, and for the CERN SL test case (out of our control), wrap with an `amd64` requirement.


### This fixes or addresses the following GitHub issues:

 - Fixes #5357


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

