### PR TITLE
Improve tests on arm64/ppc64le

### DIFF
--- a/cmd/singularity/actions_test.go
+++ b/cmd/singularity/actions_test.go
@@ -261,7 +261,7 @@ func testSTDINPipe(t *testing.T) {
 		// testing run command properly hands arguments
 		{"sh", "arguments", []string{"-c", fmt.Sprintf("singularity run %s foo | grep foo", imagePath)}, 0},
 		// Stdin to URI based image
-		{"sh", "library", []string{"-c", "echo true | singularity shell library://busybox"}, 0},
+		{"sh", "library", []string{"-c", "echo true | singularity shell library://busybox:1.31.1"}, 0},
 		{"sh", "docker", []string{"-c", "echo true | singularity shell docker://busybox"}, 0},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"sh", "shub", []string{"-c", "echo true | singularity shell shub://singularityhub/busybox"}, 0},
@@ -317,29 +317,29 @@ func testRunFromURI(t *testing.T) {
 	}{
 		// Run from supported URI's and check the runscript call works
 		{"RunFromDockerOK", "docker://busybox:latest", "run", []string{size}, runOpts, true},
-		{"RunFromLibraryOK", "library://busybox:latest", "run", []string{size}, runOpts, true},
+		{"RunFromLibraryOK", "library://busybox:1.31.1", "run", []string{size}, runOpts, true},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"RunFromShubOK", "shub://singularityhub/busybox", "run", []string{size}, runOpts, true},
 		{"RunFromDockerKO", "docker://busybox:latest", "run", []string{"0"}, runOpts, false},
-		{"RunFromLibraryKO", "library://busybox:latest", "run", []string{"0"}, runOpts, false},
+		{"RunFromLibraryKO", "library://busybox:1.31.1", "run", []string{"0"}, runOpts, false},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"RunFromShubKO", "shub://singularityhub/busybox", "run", []string{"0"}, runOpts, false},
 		// exec from a supported URI's and check the exit code
 		{"trueDocker", "docker://busybox:latest", "exec", []string{"true"}, opts{}, true},
-		{"trueLibrary", "library://busybox:latest", "exec", []string{"true"}, opts{}, true},
+		{"trueLibrary", "library://busybox:1.31.1", "exec", []string{"true"}, opts{}, true},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"trueShub", "shub://singularityhub/busybox", "exec", []string{"true"}, opts{}, true},
 		{"falseDocker", "docker://busybox:latest", "exec", []string{"false"}, opts{}, false},
-		{"falselibrary", "library://busybox:latest", "exec", []string{"false"}, opts{}, false},
+		{"falselibrary", "library://busybox:1.31.1", "exec", []string{"false"}, opts{}, false},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"falseShub", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{}, false},
 		// exec from URI with user namespace enabled
 		{"trueDockerUserns", "docker://busybox:latest", "exec", []string{"true"}, opts{userns: true}, true},
-		{"trueLibraryUserns", "library://busybox:latest", "exec", []string{"true"}, opts{userns: true}, true},
+		{"trueLibraryUserns", "library://busybox:1.31.1", "exec", []string{"true"}, opts{userns: true}, true},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"trueShubUserns", "shub://singularityhub/busybox", "exec", []string{"true"}, opts{userns: true}, true},
 		{"falseDockerUserns", "docker://busybox:latest", "exec", []string{"false"}, opts{userns: true}, false},
-		{"falselibraryUserns", "library://busybox:latest", "exec", []string{"false"}, opts{userns: true}, false},
+		{"falselibraryUserns", "library://busybox:1.31.1", "exec", []string{"false"}, opts{userns: true}, false},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {"falseShubUserns", "shub://singularityhub/busybox", "exec", []string{"false"}, opts{userns: true}, false},
 	}
@@ -504,6 +504,9 @@ func testPersistentOverlay(t *testing.T) {
 }
 
 func TestSingularityActions(t *testing.T) {
+	// TODO - busybox example has arch hard coded
+	require.Arch(t, "amd64")
+
 	test.EnsurePrivilege(t)
 
 	imgCache, cleanup := setupCache(t)

--- a/cmd/singularity/docker_test.go
+++ b/cmd/singularity/docker_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -172,19 +173,24 @@ func TestDockerDefFile(t *testing.T) {
 	tests := []struct {
 		name                string
 		kernelMajorRequired int
+		archRequired        string
 		from                string
 	}{
-		{"Arch", 3, "dock0/arch:latest"},
-		{"BusyBox", 0, "busybox:latest"},
-		{"CentOS_6", 0, "centos:6"},
-		{"CentOS_7", 0, "centos:7"},
-		{"CentOS_8", 3, "centos:8"},
-		{"Ubuntu_1604", 0, "ubuntu:16.04"},
-		{"Ubuntu_1804", 3, "ubuntu:18.04"},
+		// This Arch is only for amd64
+		{"Arch", 3, "amd64", "dock0/arch:latest"},
+		{"BusyBox", 0, "", "busybox:latest"},
+		// CentOS 6 only has amd64 (and i386)
+		{"CentOS_6", 0, "amd64", "centos:6"},
+		{"CentOS_7", 0, "", "centos:7"},
+		{"CentOS_8", 3, "", "centos:8"},
+		{"Ubuntu_1604", 0, "", "ubuntu:16.04"},
+		{"Ubuntu_1804", 3, "", "ubuntu:18.04"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, test.WithPrivilege(func(t *testing.T) {
+			require.Arch(t, tt.archRequired)
+
 			imgCache, cleanup := setupCache(t)
 			defer cleanup()
 

--- a/cmd/singularity/instance_test.go
+++ b/cmd/singularity/instance_test.go
@@ -404,7 +404,7 @@ func testInstanceFromURI(t *testing.T) {
 		},
 		{
 			name: "test_from_library",
-			uri:  "library://busybox",
+			uri:  "library://busybox:1.31.1",
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -358,14 +358,14 @@ func (c actionTests) STDPipe(t *testing.T) {
 		{
 			name:    "TrueLibrary",
 			command: "shell",
-			argv:    []string{"library://busybox"},
+			argv:    []string{"library://busybox:1.31.1"},
 			input:   "true",
 			exit:    0,
 		},
 		{
 			name:    "FalseLibrary",
 			command: "shell",
-			argv:    []string{"library://busybox"},
+			argv:    []string{"library://busybox:1.31.1"},
 			input:   "false",
 			exit:    1,
 		},
@@ -509,7 +509,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "RunFromLibraryOK",
 			command: "run",
-			argv:    []string{"--bind", bind, "library://busybox:latest", size},
+			argv:    []string{"--bind", bind, "library://busybox:1.31.1", size},
 			exit:    0,
 			profile: e2e.UserProfile,
 		},
@@ -538,7 +538,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "RunFromLibraryKO",
 			command: "run",
-			argv:    []string{"--bind", bind, "library://busybox:latest", "0"},
+			argv:    []string{"--bind", bind, "library://busybox:1.31.1", "0"},
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
@@ -569,7 +569,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecTrueLibrary",
 			command: "exec",
-			argv:    []string{"library://busybox:latest", "true"},
+			argv:    []string{"library://busybox:1.31.1", "true"},
 			exit:    0,
 			profile: e2e.UserProfile,
 		},
@@ -598,7 +598,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecFalseLibrary",
 			command: "exec",
-			argv:    []string{"library://busybox:latest", "false"},
+			argv:    []string{"library://busybox:1.31.1", "false"},
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
@@ -629,7 +629,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecTrueLibraryUserns",
 			command: "exec",
-			argv:    []string{"library://busybox:latest", "true"},
+			argv:    []string{"library://busybox:1.31.1", "true"},
 			exit:    0,
 			profile: e2e.UserNamespaceProfile,
 		},
@@ -658,7 +658,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecFalseLibraryUserns",
 			command: "exec",
-			argv:    []string{"library://busybox:latest", "false"},
+			argv:    []string{"library://busybox:1.31.1", "false"},
 			exit:    1,
 			profile: e2e.UserNamespaceProfile,
 		},
@@ -2017,7 +2017,8 @@ func (c actionTests) bindImage(t *testing.T) {
 			name:    "SifWithID",
 			profile: e2e.UserProfile,
 			args: []string{
-				"--bind", c.env.ImagePath + ":/rootfs:id=2",
+				// rootfs ID is now '3'
+				"--bind", c.env.ImagePath + ":/rootfs:id=3",
 				c.env.ImagePath,
 				"test", "-d", "/rootfs/etc",
 			},

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"golang.org/x/sys/unix"
 )
@@ -255,11 +256,14 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 	tests := []struct {
 		name                string
 		kernelMajorRequired int
+		archRequired        string
 		from                string
 	}{
+		// This only provides Arch for amd64
 		{
 			name:                "Arch",
 			kernelMajorRequired: 3,
+			archRequired:        "amd64",
 			from:                "dock0/arch:latest",
 		},
 		{
@@ -267,9 +271,11 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			kernelMajorRequired: 0,
 			from:                "busybox:latest",
 		},
+		// CentOS6 is for amd64 (or i386) only
 		{
 			name:                "CentOS_6",
 			kernelMajorRequired: 0,
+			archRequired:        "amd64",
 			from:                "centos:6",
 		},
 		{
@@ -307,6 +313,7 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			e2e.WithCommand("build"),
 			e2e.WithArgs([]string{imagePath, deffile}...),
 			e2e.PreRun(func(t *testing.T) {
+				require.Arch(t, tt.archRequired)
 				if getKernelMajor(t) < tt.kernelMajorRequired {
 					t.Skipf("kernel >=%v.x required", tt.kernelMajorRequired)
 				}

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 )
 
@@ -53,13 +54,16 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 	// `singularity build -s /tmp/sand/ docker://alpine` works,
 	// see https://github.com/sylabs/singularity/issues/4407
 	tt := []struct {
-		name       string
-		dependency string
-		buildSpec  string
+		name        string
+		dependency  string
+		buildSpec   string
+		requireArch string
 	}{
 		{
 			name:      "BusyBox",
 			buildSpec: "../examples/busybox/Singularity",
+			// TODO: example has arch hard coded in download URL
+			requireArch: "amd64",
 		},
 		{
 			name:       "Debootstrap",
@@ -96,6 +100,9 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 			name:       "Yum",
 			dependency: "yum",
 			buildSpec:  "../examples/centos/Singularity",
+			// TODO - Centos puts non-amd64 at a different mirror location
+			// need multiple def files to test on other archs
+			requireArch: "amd64",
 		},
 		{
 			name:       "Zypper",
@@ -126,6 +133,8 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 					e2e.WithCommand("build"),
 					e2e.WithArgs(args...),
 					e2e.PreRun(func(t *testing.T) {
+						require.Arch(t, tc.requireArch)
+
 						if tc.dependency == "" {
 							return
 						}
@@ -151,31 +160,32 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 
 func (c imgBuildTests) nonRootBuild(t *testing.T) {
 	tt := []struct {
-		name      string
-		buildSpec string
-		args      []string
+		name        string
+		buildSpec   string
+		args        []string
+		requireArch string
 	}{
+		// TODO: our sif in git repo is amd64 only - add other archs
 		{
-			name:      "local sif",
-			buildSpec: "testdata/busybox.sif",
+			name:        "local sif",
+			buildSpec:   "testdata/busybox.sif",
+			requireArch: "amd64",
 		},
+		// TODO: our sif in git repo is amd64 only - add other archs
 		{
-			name:      "local sif to sandbox",
-			buildSpec: "testdata/busybox.sif",
-			args:      []string{"--sandbox"},
+			name:        "local sif to sandbox",
+			buildSpec:   "testdata/busybox.sif",
+			args:        []string{"--sandbox"},
+			requireArch: "amd64",
 		},
 		{
 			name:      "library sif",
-			buildSpec: "library://sylabs/tests/busybox:1.0.0",
+			buildSpec: "library://busybox:1.31.1",
 		},
 		{
 			name:      "library sif sandbox",
-			buildSpec: "library://sylabs/tests/busybox:1.0.0",
+			buildSpec: "library://busybox:1.31.1",
 			args:      []string{"--sandbox"},
-		},
-		{
-			name:      "library sif sha",
-			buildSpec: "library://sylabs/tests/busybox:sha256.8b5478b0f2962eba3982be245986eb0ea54f5164d90a65c078af5b83147009ba",
 		},
 		// TODO: uncomment when shub is working
 		//{
@@ -202,6 +212,13 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 			e2e.WithProfile(e2e.UserProfile),
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
+			e2e.PreRun(func(t *testing.T) {
+				if tc.requireArch != "" {
+					require.Arch(t, tc.requireArch)
+
+				}
+			}),
+
 			e2e.PostRun(func(t *testing.T) {
 				c.env.ImageVerify(t, imagePath, e2e.UserProfile)
 			}),

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -130,7 +130,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 		{
 			name:      "label_org.label-schema.usage.singularity.deffile.from",
 			insType:   "--labels",
-			compareFn: compareLabel("org.label-schema.usage.singularity.deffile.from", "alpine:latest", ""),
+			compareFn: compareLabel("org.label-schema.usage.singularity.deffile.from", "alpine:3.11.5", ""),
 		},
 		{
 			name:      "label_org.label-schema.usage.singularity.runscript.help",

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -202,7 +202,7 @@ func (c *ctx) testInstanceFromURI(t *testing.T) {
 		},
 		{
 			name: "test_from_library",
-			uri:  "library://busybox",
+			uri:  "library://busybox:1.31.1",
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -325,10 +325,14 @@ func (c *ctx) applyCgroupsInstance(t *testing.T) {
 		e2e.WithProfile(c.profile),
 		e2e.WithCommand("exec"),
 		e2e.WithArgs(joinName, "cat", "/dev/null"),
+		e2e.PostRun(func(t *testing.T) {
+			if t.Failed() {
+				return
+			}
+			c.stopInstance(t, instanceName)
+		}),
 		e2e.ExpectExit(1),
 	)
-
-	c.stopInstance(t, instanceName)
 }
 
 // E2ETests is the main func to trigger the test suite

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 )
 
 const dockerInstanceName = "e2e-docker-instance"
@@ -27,6 +28,11 @@ var registrySetup struct {
 // PrepRegistry run a docker registry and push a busybox
 // image and the test image with oras transport.
 func PrepRegistry(t *testing.T, env TestEnv) {
+	// The docker registry container is only available for amd64 and arm
+	// See: https://hub.docker.com/_/registry?tab=tags
+	// Skip on other architectures
+	require.ArchIn(t, []string{"amd64", "arm64"})
+
 	registrySetup.Lock()
 	defer registrySetup.Unlock()
 

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -7,6 +7,7 @@ package e2e
 
 import (
 	"os"
+	"runtime"
 	"sync"
 	"testing"
 )
@@ -45,9 +46,13 @@ func EnsureImage(t *testing.T, env TestEnv) {
 }
 
 // PullImage will pull a test image.
-func PullImage(t *testing.T, env TestEnv, imageURL string, path string) {
+func PullImage(t *testing.T, env TestEnv, imageURL string, arch string, path string) {
 	pullMutex.Lock()
 	defer pullMutex.Unlock()
+
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
 
 	switch _, err := os.Stat(path); {
 	case err == nil:
@@ -66,7 +71,7 @@ func PullImage(t *testing.T, env TestEnv, imageURL string, path string) {
 		t,
 		WithProfile(UserProfile),
 		WithCommand("pull"),
-		WithArgs("--force", "--allow-unsigned", path, imageURL),
+		WithArgs("--force", "--allow-unsigned", "--arch", arch, path, imageURL),
 		ExpectExit(0),
 	)
 }

--- a/e2e/internal/e2e/init/init_linux.go
+++ b/e2e/internal/e2e/init/init_linux.go
@@ -139,6 +139,7 @@ __attribute__((constructor)) static void init(void) {
 
 	if ( getuid() != 0 ) {
 		fprintf(stderr, "tests must be executed as root user\n");
+		fprintf(stderr, "%d %d", uid, gid);
 		exit(1);
 	}
 	if ( getUnprivIDs(getppid(), &uid, &gid) < 0 ) {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -66,7 +66,7 @@ var tests = []testStruct{
 	// --force tests
 	{
 		desc:             "force existing file",
-		srcURI:           "library://alpine:3.8",
+		srcURI:           "library://alpine:3.11.5",
 		force:            true,
 		createDst:        true,
 		unauthenticated:  true,
@@ -74,7 +74,7 @@ var tests = []testStruct{
 	},
 	{
 		desc:             "force non-existing file",
-		srcURI:           "library://alpine:3.8",
+		srcURI:           "library://alpine:3.11.5",
 		force:            true,
 		createDst:        false,
 		unauthenticated:  true,
@@ -106,7 +106,7 @@ var tests = []testStruct{
 	// --dir tests
 	{
 		desc:             "dir no image path",
-		srcURI:           "library://alpine:3.9",
+		srcURI:           "library://alpine:3.11.5",
 		unauthenticated:  true,
 		setPullDir:       true,
 		setImagePath:     false,
@@ -121,7 +121,7 @@ var tests = []testStruct{
 		// the directory /tmp/a/b/c/tmp/a/b does not exist, it fails to create the file
 		// image.sif in there.
 		desc:             "dir image path",
-		srcURI:           "library://alpine:3.9",
+		srcURI:           "library://alpine:3.11.5",
 		unauthenticated:  true,
 		setPullDir:       true,
 		setImagePath:     true,
@@ -177,13 +177,13 @@ var tests = []testStruct{
 	// pulling with library URI argument
 	{
 		desc:             "bad library URI",
-		srcURI:           "library://busybox",
+		srcURI:           "library://busybox:1.31.1",
 		library:          "https://bad-library.sylabs.io",
 		expectedExitCode: 255,
 	},
 	{
 		desc:             "default library URI",
-		srcURI:           "library://busybox",
+		srcURI:           "library://busybox:1.31.1",
 		library:          "https://library.sylabs.io",
 		force:            true,
 		expectedExitCode: 0,

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -46,7 +46,8 @@ func (c *ctx) prepareImage(t *testing.T) (string, func(*testing.T)) {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}
 	imgPath := filepath.Join(tempDir, imgName)
-	e2e.PullImage(t, c.env, imgURL, imgPath)
+	// We should be able to pull an image and sign it on other archs
+	e2e.PullImage(t, c.env, imgURL, "amd64", imgPath)
 
 	return filepath.Join(tempDir, "testImage.sif"), func(t *testing.T) {
 		err := os.RemoveAll(tempDir)

--- a/e2e/testdata/Singularity
+++ b/e2e/testdata/Singularity
@@ -1,5 +1,5 @@
 bootstrap: library
-from: alpine:3.7
+from: alpine:3.11.5
 
 %labels
     maintainer "Sylabs Team <support@sylabs.io>"
@@ -56,7 +56,7 @@ export HELLOTHISIS
     echo "RUNNING FOO"
 
 %startscript
-    exec nc -l -k -p $1 -e /bin/cat 2>/dev/null
+    exec nc -l -k -p $1 -e /bin/cat
 
 %runscript
     echo "Running command: $*"

--- a/e2e/testdata/inspecter_container.def
+++ b/e2e/testdata/inspecter_container.def
@@ -1,5 +1,5 @@
 bootstrap: library
-from: alpine:latest
+from: alpine:3.11.5
 
 %help
 This is a e2e test container used for testing the 'inspect'

--- a/e2e/testdata/regressions/issue_4583.def
+++ b/e2e/testdata/regressions/issue_4583.def
@@ -1,5 +1,5 @@
 bootstrap: library
-from: alpine
+from: alpine:3.11.5
 stage: one
 
 %post

--- a/e2e/testdata/regressions/issue_5315.def
+++ b/e2e/testdata/regressions/issue_5315.def
@@ -1,5 +1,5 @@
 Bootstrap: library
-From: alpine
+From: alpine:3.11.5
 
 %test
     echo "TEST OK"

--- a/e2e/testdata/seccomp-profile.json
+++ b/e2e/testdata/seccomp-profile.json
@@ -7,6 +7,12 @@
                 "SCMP_ARCH_X86",
                 "SCMP_ARCH_X32"
             ]
+        },
+        {
+            "architecture": "SCMP_ARCH_AARCH64",
+            "subArchitectures": [
+                "SCMP_ARCH_ARM"
+            ]
         }
     ],
     "syscalls": [

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -366,8 +366,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	return testhelper.Tests{
 		"ordered": func(t *testing.T) {
 			// We pull the two images required for the tests once
-			e2e.PullImage(t, c.env, successURL, c.successImage)
-			e2e.PullImage(t, c.env, corruptedURL, c.corruptedImage)
+			// We should be able to sign amd64 on other archs too!
+			e2e.PullImage(t, c.env, successURL, "amd64", c.successImage)
+			e2e.PullImage(t, c.env, corruptedURL, "amd64", c.corruptedImage)
 
 			t.Run("checkAllOption", c.checkAllOption)
 			t.Run("singularityVerifyAllKeyNum", c.singularityVerifyAllKeyNum)

--- a/examples/instances/Singularity
+++ b/examples/instances/Singularity
@@ -1,5 +1,5 @@
-BootStrap: busybox
-MirrorURL: https://www.busybox.net/downloads/binaries/1.26.2-defconfig-multiarch/busybox-x86_64
+BootStrap: library
+From: busybox:1.31.1
 
 %startscript
     exec nc -ll -p $1 -e /bin/cat 2>/dev/null

--- a/examples/library/Singularity
+++ b/examples/library/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: library
-From: alpine:3.7
+From: alpine:3.11.5
 
 %runscript
     echo "$@"

--- a/examples/multistage/Singularity
+++ b/examples/multistage/Singularity
@@ -35,7 +35,7 @@ EOF
 #
 # Install go application into image without golang installed
 Bootstrap: library
-From: alpine:3.9
+From: alpine:3.11.5
 Stage: two
 
 

--- a/internal/pkg/build/sources/conveyorPacker_arch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/build/sources"
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/build/types/parser"
 )
@@ -25,6 +26,10 @@ func TestArchConveyor(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+
+	// TODO: non amd64 Arch Linux ports are in completely separate repositories
+	// so we need logic to choose correct one (if exists) on non-amd64 machines
+	require.Arch(t, "amd64")
 
 	if _, err := exec.LookPath("pacstrap"); err != nil {
 		t.Skip("skipping test, pacstrap not installed")
@@ -60,6 +65,10 @@ func TestArchConveyor(t *testing.T) {
 }
 
 func TestArchPacker(t *testing.T) {
+	// TODO: non amd64 Arch Linux ports are in completely separate repositories
+	// so we need logic to choose correct one (if exists) on non-amd64 machines
+	require.Arch(t, "amd64")
+
 	if _, err := exec.LookPath("pacstrap"); err != nil {
 		t.Skip("skipping test, pacstrap not installed")
 	}

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sylabs/singularity/internal/pkg/build/sources"
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/build/types/parser"
 )
@@ -24,6 +25,9 @@ func TestBusyBoxConveyor(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+
+	// TODO - busybox example has arch hard coded
+	require.Arch(t, "amd64")
 
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
@@ -55,6 +59,9 @@ func TestBusyBoxConveyor(t *testing.T) {
 }
 
 func TestBusyBoxPacker(t *testing.T) {
+	// TODO - busybox example has arch hard coded
+	require.Arch(t, "amd64")
+
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/test"
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/build/types/parser"
 )
@@ -20,6 +21,10 @@ import (
 const yumDef = "../../../../examples/centos/Singularity"
 
 func TestYumConveyor(t *testing.T) {
+	// TODO - Centos puts non-amd64 at a different mirror location
+	// need multiple def files to test on other archs
+	require.Arch(t, "amd64")
+
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -60,6 +65,10 @@ func TestYumConveyor(t *testing.T) {
 }
 
 func TestYumPacker(t *testing.T) {
+	// TODO - Centos puts non-amd64 at a different mirror location
+	// need multiple def files to test on other archs
+	require.Arch(t, "amd64")
+
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -8,6 +8,7 @@ package require
 import (
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/containerd/cgroups"
@@ -75,8 +76,22 @@ func Seccomp(t *testing.T) {
 // Arch checks the test machine has the specified architecture.
 // If not, the test is skipped with a message.
 func Arch(t *testing.T, arch string) {
-	if runtime.GOARCH != arch {
+	if arch != "" && runtime.GOARCH != arch {
 		t.Skipf("test requires architecture %s", arch)
 	}
 
+}
+
+// ArchIn checks the test machine is one of the specified archs.
+// If not, the test is skipped with a message.
+func ArchIn(t *testing.T, archs []string) {
+	if len(archs) > 0 {
+		b := runtime.GOARCH
+		for _, a := range archs {
+			if b == a {
+				return
+			}
+		}
+		t.Skipf("test requires architecture %s", strings.Join(archs, "|"))
+	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Modify tests so that we can get a lot closer to a clean pass on arm64 and ppc64le

 - Switch to test images in library:// locations that are built for
   multiple architectures.
 - Don't execute tests that can only succeed on amd64 on other
   architectures. Mark the amd64 requirement with a TODO for further
   improvement.
 - Limit tests needing the use of a docker registry to amd64 and arm64
   as the registry images aren't available for others. 32-bit arm is
   actually available, but we aren't likely to consistently test there
   yet.

See comments below - we have some outstanding issues, but these appear to be more fundamentally related to issues with interactive testing that should be addressed separately. Similar things are also being reported by @tri-adam on amd64.

### This fixes or addresses the following GitHub issues:

 - Fixes #5338 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

