### PR TITLE
Check correct descriptor for e2e encryption tests

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -810,7 +810,7 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 }
 
 func (c *imgBuildTests) ensureImageIsEncrypted(t *testing.T, imgPath string) {
-	sifID := "2" // Which SIF descriptor slots contains encryption information
+	sifID := "3" // Which SIF descriptor slot contains the (encrypted) rootfs
 	cmdArgs := []string{"info", sifID, imgPath}
 	c.env.RunSingularity(
 		t,


### PR DESCRIPTION
## Description of the Pull Request (PR):

SIF rootfs descriptor is now expected to be 3, not 2, due to presence of additional JSON descriptor ahead of it.

### This fixes or addresses the following GitHub issues:

 - Fixes #5368 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

