### PR TITLE
Raise `max loop devices` in e2e/config test

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -421,7 +421,7 @@ func (c configTests) configFile(t *testing.T) {
 			name:    "MaxLoopDevicesOK",
 			argv:    []string{c.env.ImagePath, "true"},
 			profile: e2e.RootProfile,
-			conf:    "max loop devices = 10\n",
+			conf:    "max loop devices = 128\n",
 			exit:    0,
 		},
 		{


### PR DESCRIPTION
## Description of the Pull Request (PR):

When we are on a system with a lot of cores, and/or loop devices are
consumed by snaps, flatpak apps etc. then the test setting of `max loop
devices = 10` may not be sufficient to find a free loop device.

Setting it to `128` which is 1/2 of the default. Resolves issue running
tests on a 48 thread machine with Fedora 32 / VM Ubuntu 20.04.

### This fixes or addresses the following GitHub issues:

 - Fixes: #5370

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

