### PR TITLE
ECL Improvements

### DIFF
--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -218,6 +218,7 @@ func (ecl *EclConfig) ShouldRun(cpath string) (ok bool, err error) {
 	if err != nil {
 		return false, err
 	}
+	defer fp.Close()
 
 	return shouldRun(ecl, fp)
 }

--- a/internal/pkg/syecl/syecl_test.go
+++ b/internal/pkg/syecl/syecl_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,11 +6,17 @@
 package syecl
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+
+	"gotest.tools/v3/golden"
 )
 
 const (
@@ -25,134 +31,343 @@ var (
 )
 
 var (
-	testEclFileName  string // pathname of the Ecl config file
-	testEclFileName2 string // pathname of the Ecl config file
-	testEclDirPath1  string // dirname of the first Ecl execgroup
-	testEclDirPath2  string // dirname of the second Ecl execgroup
-	testEclDirPath3  string // dirname of the third Ecl execgroup
-	testContainer1   string // pathname of the first test container
-	testContainer2   string // pathname of the second test container
-	testContainer3   string // pathname of the third test container
-	testContainer4   string // pathname of the forth test container
+	testEclDirPath1 string // dirname of the first Ecl execgroup
+	testEclDirPath2 string // dirname of the second Ecl execgroup
+	testEclDirPath3 string // dirname of the third Ecl execgroup
+	testContainer1  string // pathname of the first test container
+	testContainer2  string // pathname of the second test container
+	testContainer3  string // pathname of the third test container
+	testContainer4  string // pathname of the forth test container
 )
 
-var testEclConfig = EclConfig{
-	Activated: true,
-	ExecGroups: []execgroup{
-		{"group1", "whitelist", "", []string{KeyFP1, KeyFP2}},
-		{"group2", "whitestrict", "", []string{KeyFP1, KeyFP2}},
-		{"group3", "blacklist", "", []string{KeyFP1}},
-	},
-}
-
-var testEclConfig2 = EclConfig{
-	Activated: true,
-	ExecGroups: []execgroup{
-		{"pathdup", "whitelist", "/tmp", nil},
-		{"pathdup", "whitelist", "/tmp", nil},
-	},
-}
-
 func TestAPutConfig(t *testing.T) {
-	err := PutConfig(testEclConfig, testEclFileName)
-	if err != nil {
-		t.Error(`PutConfig(testEclConfig, testEclFileName):`, err)
+	wl := execgroup{
+		TagName:  "name",
+		ListMode: "whitelist",
+		DirPath:  "/var/data1",
+		KeyFPs:   []string{KeyFP1, KeyFP2},
 	}
-	err = PutConfig(testEclConfig2, testEclFileName2)
-	if err != nil {
-		t.Error(`PutConfig(testEclConfig2, testEclFileName2):`, err)
+	wls := execgroup{
+		TagName:  "name",
+		ListMode: "whitestrict",
+		DirPath:  "/var/data2",
+		KeyFPs:   []string{KeyFP1, KeyFP2},
+	}
+	bl := execgroup{
+		TagName:  "name",
+		ListMode: "blacklist",
+		DirPath:  "/var/data3",
+		KeyFPs:   []string{KeyFP1},
+	}
+
+	tests := []struct {
+		name string
+		c    EclConfig
+	}{
+		{
+			name: "Deactivated",
+			c:    EclConfig{Activated: false},
+		},
+		{
+			name: "Activated",
+			c:    EclConfig{Activated: true},
+		},
+		{
+			name: "WhiteList",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{wl}},
+		},
+		{
+			name: "WhiteStrict",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{wls}},
+		},
+		{
+			name: "BlackList",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{bl}},
+		},
+		{
+			name: "KitchenSink",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{wl, wls, bl}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tf, err := ioutil.TempFile("", "eclconfig-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tf.Name())
+			tf.Close()
+
+			if err := PutConfig(tt.c, tf.Name()); err != nil {
+				t.Fatal(err)
+			}
+
+			b, err := ioutil.ReadFile(tf.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			filename := path.Join(strings.Split(t.Name(), "/")...) + ".golden"
+			golden.AssertBytes(t, b, filename)
+		})
 	}
 }
 
 func TestLoadConfig(t *testing.T) {
-	ecl, err := LoadConfig(testEclFileName)
-	if err != nil {
-		t.Error(`LoadConfig(testEclFileName):`, err)
+	wl := execgroup{
+		TagName:  "name",
+		ListMode: "whitelist",
+		DirPath:  "/var/data1",
+		KeyFPs:   []string{KeyFP1, KeyFP2},
 	}
-	if ecl.Activated == false {
-		t.Error("the ECL should be activated")
+	wls := execgroup{
+		TagName:  "name",
+		ListMode: "whitestrict",
+		DirPath:  "/var/data2",
+		KeyFPs:   []string{KeyFP1, KeyFP2},
 	}
-	if ecl.ExecGroups[0].DirPath != testEclDirPath1 {
-		t.Error("the path was expected to be:", testEclDirPath1)
+	bl := execgroup{
+		TagName:  "name",
+		ListMode: "blacklist",
+		DirPath:  "/var/data3",
+		KeyFPs:   []string{KeyFP1},
 	}
-	if ecl.ExecGroups[0].KeyFPs[0] != KeyFP1 {
-		t.Error("the entity was expected to be:", KeyFP1)
+
+	tests := []struct {
+		name       string
+		path       string
+		wantConfig EclConfig
+	}{
+		{
+			name:       "Deactivated",
+			wantConfig: EclConfig{Activated: false},
+		},
+		{
+			name:       "Activated",
+			wantConfig: EclConfig{Activated: true},
+		},
+		{
+			name:       "WhiteList",
+			wantConfig: EclConfig{Activated: true, ExecGroups: []execgroup{wl}},
+		},
+		{
+			name:       "WhiteStrict",
+			wantConfig: EclConfig{Activated: true, ExecGroups: []execgroup{wls}},
+		},
+		{
+			name:       "BlackList",
+			wantConfig: EclConfig{Activated: true, ExecGroups: []execgroup{bl}},
+		},
+		{
+			name:       "KitchenSink",
+			wantConfig: EclConfig{Activated: true, ExecGroups: []execgroup{wl, wls, bl}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join("testdata", "input", fmt.Sprintf("%s.toml", tt.name))
+			c, err := LoadConfig(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(c, tt.wantConfig) {
+				t.Errorf("got config %v, want %v", c, tt.wantConfig)
+			}
+		})
 	}
 }
 
 func TestValidateConfig(t *testing.T) {
-	// Validate properly formed config file
-	ecl, err := LoadConfig(testEclFileName)
-	if err != nil {
-		t.Error(`LoadConfig(testEclFileName):`, err)
+	wl := execgroup{
+		TagName:  "name",
+		ListMode: "whitelist",
+		DirPath:  testEclDirPath1,
+		KeyFPs:   []string{KeyFP1, KeyFP2},
 	}
-	if err = ecl.ValidateConfig(); err != nil {
-		t.Error(`ecl.ValidateConfig():`, err)
+	wls := execgroup{
+		TagName:  "name",
+		ListMode: "whitestrict",
+		DirPath:  testEclDirPath2,
+		KeyFPs:   []string{KeyFP1, KeyFP2},
+	}
+	bl := execgroup{
+		TagName:  "name",
+		ListMode: "blacklist",
+		DirPath:  testEclDirPath3,
+		KeyFPs:   []string{KeyFP1},
 	}
 
-	// Validate config file with duplicated dirpaths
-	ecl, err = LoadConfig(testEclFileName2)
-	if err != nil {
-		t.Error(`LoadConfig(testEclFileName2):`, err)
+	tests := []struct {
+		name    string
+		c       EclConfig
+		wantErr bool
+	}{
+		{
+			name: "DuplicatePaths",
+			c: EclConfig{ExecGroups: []execgroup{
+				{DirPath: "/var/data"},
+				{DirPath: "/var/data"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "RelativePath",
+			c: EclConfig{ExecGroups: []execgroup{
+				{DirPath: "testdata"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "BadMode",
+			c: EclConfig{ExecGroups: []execgroup{
+				{ListMode: "bad"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "BadMode",
+			c: EclConfig{ExecGroups: []execgroup{
+				{ListMode: "whitelist", KeyFPs: []string{"bad"}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "Deactivated",
+			c:    EclConfig{Activated: false},
+		},
+		{
+			name: "Activated",
+			c:    EclConfig{Activated: true},
+		},
+		{
+			name: "WhiteList",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{wl}},
+		},
+		{
+			name: "WhiteStrict",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{wls}},
+		},
+		{
+			name: "BlackList",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{bl}},
+		},
+		{
+			name: "KitchenSink",
+			c:    EclConfig{Activated: true, ExecGroups: []execgroup{wl, wls, bl}},
+		},
 	}
-	if err = ecl.ValidateConfig(); err == nil {
-		t.Error(`ecl.ValidateConfig(): Should have detected duplicated dirpaths`, err)
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.c.ValidateConfig(); (err != nil) != tt.wantErr {
+				t.Errorf("got error %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 
 func TestShouldRun(t *testing.T) {
-	ecl, err := LoadConfig(testEclFileName)
-	if err != nil {
-		t.Error(`LoadConfig(testEclFileName):`, err)
+	eclDeactivated := EclConfig{Activated: false}
+	eclBadListMode := EclConfig{
+		Activated: true,
+		ExecGroups: []execgroup{
+			{
+				ListMode: "bad",
+			},
+		},
+	}
+	eclDirPath := EclConfig{
+		Activated: true,
+		ExecGroups: []execgroup{
+			{
+				TagName:  "group1",
+				ListMode: "whitelist",
+				DirPath:  testEclDirPath1,
+				KeyFPs:   []string{KeyFP1, KeyFP2},
+			},
+			{
+				TagName:  "group2",
+				ListMode: "whitestrict",
+				DirPath:  testEclDirPath2,
+				KeyFPs:   []string{KeyFP1, KeyFP2},
+			},
+			{
+				TagName:  "group3",
+				ListMode: "blacklist",
+				DirPath:  testEclDirPath3,
+				KeyFPs:   []string{KeyFP1},
+			},
+		},
+	}
+	eclNoDirPath := EclConfig{
+		Activated: true,
+		ExecGroups: []execgroup{
+			{
+				TagName:  "group1",
+				ListMode: "whitelist",
+				DirPath:  "",
+				KeyFPs:   []string{KeyFP1, KeyFP2},
+			},
+		},
 	}
 
-	if err = ecl.ValidateConfig(); err != nil {
-		t.Error(`ecl.ValidateConfig():`, err)
+	tests := []struct {
+		name    string
+		c       EclConfig
+		path    string
+		wantRun bool
+		wantErr bool
+	}{
+		{"BadListMode", eclBadListMode, testContainer1, false, true},
+		{"Deactivated", eclDeactivated, testContainer1, true, false},
+		{"DirPathTestContainer1", eclDirPath, testContainer1, true, false},
+		{"DirPathTestContainer2", eclDirPath, testContainer2, true, false},
+		{"DirPathTestContainer3", eclDirPath, testContainer3, false, true},
+		{"DirPathTestContainer4", eclDirPath, testContainer4, false, true},
+		{"DirPathSrcContainer1", eclDirPath, srcContainer1, false, true},
+		{"DirPathSrcContainer2", eclDirPath, srcContainer2, false, true},
+		{"DirPathSrcContainer3", eclDirPath, srcContainer3, false, true},
+		{"NoDirPathSrcContainer1", eclNoDirPath, srcContainer1, true, false},
+		{"NoDirPathSrcContainer2", eclNoDirPath, srcContainer2, true, false},
+		{"NoDirPathSrcContainer3", eclNoDirPath, srcContainer3, true, false},
 	}
 
-	// check container1 authorization
-	run, err := ecl.ShouldRun(testContainer1)
-	if err != nil {
-		t.Error(`ecl.ShouldRun(testContainer1):`, err)
-	}
-	if !run {
-		t.Error(testContainer1, "should be allowed to run")
-	}
-	// check container2 authorization
-	run, err = ecl.ShouldRun(testContainer2)
-	if err != nil {
-		t.Error(`ecl.ShouldRun(testContainer2):`, err)
-	}
-	if !run {
-		t.Error(testContainer2, "should be allowed to run")
-	}
-	// check container3 authorization (fails with KeyFP)
-	run, err = ecl.ShouldRun(testContainer3)
-	if err == nil || run == true {
-		t.Error(testContainer3, "should NOT be allowed to run")
-	}
-	// check srcContainer1 authorization (fails with dirpath)
-	run, err = ecl.ShouldRun(srcContainer1)
-	if err == nil || run == true {
-		t.Error(srcContainer1, "should NOT be allowed to run")
-	}
-	// check container4 authorization (fails with blacklist)
-	run, err = ecl.ShouldRun(testContainer4)
-	if err == nil || run == true {
-		t.Error(testContainer4, "should NOT be allowed to run")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test ShouldRun (takes path).
+			got, err := tt.c.ShouldRun(tt.path)
 
-	// in this second round of tests, set DirPath to "", and test container in testdata/
-	ecl.ExecGroups[0].DirPath = ""
-	ecl.ExecGroups[1].DirPath = ""
+			if got != tt.wantRun {
+				t.Errorf("got run %v, want %v", got, tt.wantRun)
+			}
 
-	// check container1 authorization (outside of defined dirpath)
-	run, err = ecl.ShouldRun(srcContainer1)
-	if err != nil {
-		t.Error(`ecl.ShouldRun(srcContainer1):`, err)
-	}
-	if !run {
-		t.Error(srcContainer1, "should be allowed to run")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Test ShouldRun (takes file descriptor).
+			f, err := os.Open(tt.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			got, err = tt.c.ShouldRunFp(f)
+
+			if got != tt.wantRun {
+				t.Errorf("got run %v, want %v", got, tt.wantRun)
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -177,20 +392,7 @@ func copyFile(dst, src string) error {
 }
 
 func setup() error {
-	// Use TempFile to create a placeholder for the ECL config test files
-	tmpfile, err := ioutil.TempFile("", "eclconfig-test")
-	if err != nil {
-		return nil
-	}
-	testEclFileName = tmpfile.Name()
-	tmpfile.Close()
-
-	tmpfile, err = ioutil.TempFile("", "eclconfig2-test")
-	if err != nil {
-		return nil
-	}
-	testEclFileName2 = tmpfile.Name()
-	tmpfile.Close()
+	var err error
 
 	// Create three directories where we put test containers
 	testEclDirPath1, err = ioutil.TempDir("", "ecldir1-")
@@ -207,11 +409,6 @@ func setup() error {
 	if err != nil {
 		return err
 	}
-
-	// Set the just created Dirpaths in the EclConfig struct to marshal
-	testEclConfig.ExecGroups[0].DirPath = testEclDirPath1
-	testEclConfig.ExecGroups[1].DirPath = testEclDirPath2
-	testEclConfig.ExecGroups[2].DirPath = testEclDirPath3
 
 	// prepare and copy test containers from testdata/* to their test dirpaths
 	testContainer1 = filepath.Join(testEclDirPath1, filepath.Base(srcContainer1))
@@ -231,8 +428,6 @@ func setup() error {
 }
 
 func shutdown() {
-	os.Remove(testEclFileName)
-	os.Remove(testEclFileName2)
 	os.RemoveAll(testEclDirPath1)
 	os.RemoveAll(testEclDirPath2)
 	os.RemoveAll(testEclDirPath3)

--- a/internal/pkg/syecl/testdata/TestAPutConfig/Activated.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/Activated.golden
@@ -1,0 +1,1 @@
+activated = true

--- a/internal/pkg/syecl/testdata/TestAPutConfig/BlackList.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/BlackList.golden
@@ -1,0 +1,7 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data3"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B"]
+  mode = "blacklist"
+  tagname = "name"

--- a/internal/pkg/syecl/testdata/TestAPutConfig/Deactivated.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/Deactivated.golden
@@ -1,0 +1,1 @@
+activated = false

--- a/internal/pkg/syecl/testdata/TestAPutConfig/KitchenSink.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/KitchenSink.golden
@@ -1,0 +1,19 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data1"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitelist"
+  tagname = "name"
+
+[[execgroup]]
+  dirpath = "/var/data2"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitestrict"
+  tagname = "name"
+
+[[execgroup]]
+  dirpath = "/var/data3"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B"]
+  mode = "blacklist"
+  tagname = "name"

--- a/internal/pkg/syecl/testdata/TestAPutConfig/WhiteList.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/WhiteList.golden
@@ -1,0 +1,7 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data1"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitelist"
+  tagname = "name"

--- a/internal/pkg/syecl/testdata/TestAPutConfig/WhiteStrict.golden
+++ b/internal/pkg/syecl/testdata/TestAPutConfig/WhiteStrict.golden
@@ -1,0 +1,7 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data2"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitestrict"
+  tagname = "name"

--- a/internal/pkg/syecl/testdata/input/Activated.toml
+++ b/internal/pkg/syecl/testdata/input/Activated.toml
@@ -1,0 +1,1 @@
+activated = true

--- a/internal/pkg/syecl/testdata/input/BlackList.toml
+++ b/internal/pkg/syecl/testdata/input/BlackList.toml
@@ -1,0 +1,7 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data3"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B"]
+  mode = "blacklist"
+  tagname = "name"

--- a/internal/pkg/syecl/testdata/input/Deactivated.toml
+++ b/internal/pkg/syecl/testdata/input/Deactivated.toml
@@ -1,0 +1,1 @@
+activated = false

--- a/internal/pkg/syecl/testdata/input/KitchenSink.toml
+++ b/internal/pkg/syecl/testdata/input/KitchenSink.toml
@@ -1,0 +1,19 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data1"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitelist"
+  tagname = "name"
+
+[[execgroup]]
+  dirpath = "/var/data2"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitestrict"
+  tagname = "name"
+
+[[execgroup]]
+  dirpath = "/var/data3"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B"]
+  mode = "blacklist"
+  tagname = "name"

--- a/internal/pkg/syecl/testdata/input/WhiteList.toml
+++ b/internal/pkg/syecl/testdata/input/WhiteList.toml
@@ -1,0 +1,7 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data1"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitelist"
+  tagname = "name"

--- a/internal/pkg/syecl/testdata/input/WhiteStrict.toml
+++ b/internal/pkg/syecl/testdata/input/WhiteStrict.toml
@@ -1,0 +1,7 @@
+activated = true
+
+[[execgroup]]
+  dirpath = "/var/data2"
+  keyfp = ["5994BE54C31CF1B5E1994F987C52CF6D055F072B", "7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+  mode = "whitestrict"
+  tagname = "name"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix file descriptor leak in `(*EclConfig).ShouldRun()`. Re-write tests so they are not order dependent and are [table-driven](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests). Improve test coverage by exploring unhappy paths (79.3%->88.6%).

### This fixes or addresses the following GitHub issues:

 - Fixes #5377 

Attn: @singularity-maintainers