### PR TITLE
Fix build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,7 +99,7 @@ You can build Singularity using the following commands:
 ```
 $ cd ${GOPATH}/src/github.com/sylabs/singularity && \
   ./mconfig && \
-  cd ./builddir && \
+  cd ./buildtree && \
   make && \
   sudo make install
 ```


### PR DESCRIPTION
## Description of the Pull Request (PR):

At least with Go 3.5.3, the expected build directory is `buildtree`, not `builddir`.

#### Before submitting a PR, make sure you have done the following:

Do I really need to add myself to `CONTRIBUTORS.md`? This fixes a minor typo.

Attn: @singularity-maintainers

