### PR TITLE
Don't -failfast by default in tests

### DIFF
--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -128,7 +128,6 @@ rc=0
 	-count=1 \
 	-timeout=30m \
 	-tags "${GO_TAGS}" \
-	-failfast \
 	-cover \
 	-race \
 	${sudo_exec} \


### PR DESCRIPTION
## Description of the Pull Request (PR):

For some time `-failfast` has been set in `scripts/go-test` so that testing stops when we hit an 
issue. 

This causes significant pain when working on alternate architectures (ppc64le / arm64) or in other cases we can't yet expect 100% clean passes (but are working toward that goal).

Also, where large changes are made to the codebase it is useful to see *all* failing tests easily, so they can be addressed without extensive iteration over test->fix->re-test.

Am proposing to remove `-failfast` here. Note the runtime impact with a failing workflow in CI is lessened these days, as we are running things in parallel better.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

