### PR TITLE
Fix performance regression due to unwanted globbing in shell interpreter

### DIFF
--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -19,6 +19,13 @@ export PWD
 clear_env() {
     local IFS=$'\n'
 
+    # disable globbing as __exported_env__ may contain
+    # wildcard evaluated by shell. It can cause serious
+    # performance issue when the current directory contains
+    # a lot of files/directories, see:
+    # https://github.com/hpcng/singularity/issues/5389
+    set -o noglob
+
     for e in ${__exported_env__}; do
         key=$(getenvkey "${e}")
         case "${key}" in
@@ -32,10 +39,19 @@ clear_env() {
             ;;
         esac
     done
+
+    set +o noglob
 }
 
 restore_env() {
     local IFS=$'\n'
+
+    # disable globbing as __exported_env__ and the export
+    # statement below may contain wildcard evaluated by shell.
+    # It can cause serious performance issue when the current
+    # directory contains a lot of files/directories, see:
+    # https://github.com/hpcng/singularity/issues/5389
+    set -o noglob
 
     # restore environment variables which haven't been
     # defined by docker or virtual file above, empty
@@ -48,6 +64,8 @@ restore_env() {
             unset "${key}"
         fi
     done
+
+    set +o noglob
 }
 
 clear_env


### PR DESCRIPTION
## Description of the Pull Request (PR):

Disable globbing in clear_env and restore_env function within action script to avoid wildcard evaluation which may be contained in environment variables value, it fixes a performance regression
issue observed in #5389 when the current working directory contains a large number of files/directories.

### This fixes or addresses the following GitHub issues:

 - Fixes #5389 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

