### PR TITLE
Skip inaccessible loop devices in shared loop code

### DIFF
--- a/pkg/util/loop/loop_linux.go
+++ b/pkg/util/loop/loop_linux.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/util/fs/lock"
 )
 
@@ -76,7 +77,8 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 			status, err := GetStatusFromFd(uintptr(loopFd))
 			if err != nil {
 				syscall.Close(loopFd)
-				return err
+				sylog.Debugf("Could not get loop device %d status: %s", device, err)
+				continue
 			}
 			// there is no associated image with loop device, save indice so second loop
 			// iteration will start from this device
@@ -91,6 +93,7 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 				// keep the reference to the loop device file descriptor to
 				// be sure that the loop device won't be released between this
 				// check and the mount of the filesystem
+				sylog.Debugf("Sharing loop device %d", device)
 				return nil
 			}
 			syscall.Close(loopFd)


### PR DESCRIPTION
It's possible for a loop device to become inaccessible under some
circumstances that have been reported to us, such as swapping out a
symlinked image that resides on AFS.

Instead of this causing a fatal error when using shared loop devices,
skip over the inaccessible loop device and move on to consider the next
one.

Also adding a debug statement when we find a shared loop device to use
to make that more obvious in any bug reports.

### This fixes or addresses the following GitHub issues:

 - Fixes #5380


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

