### PR TITLE
Load command tree in RootCmd() used by doc gen code

### DIFF
--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -63,6 +63,10 @@ func main() {
 		Use:       "makeDocs {markdown | man | rst}",
 		Short:     "Generates Singularity documentation",
 		Run: func(cmd *cobra.Command, args []string) {
+			// We must Init() as loading commands etc. is deferred until this is called.
+			// Using true here will result in local docs including any content for installed
+			// plugins.
+			cli.Init(true)
 			rootCmd := cli.RootCmd()
 			switch args[0] {
 			case "markdown":


### PR DESCRIPTION
## Description of the Pull Request (PR):

With changes in #4924 the command tree loading is deferred until
Init() is called - so we need to call it in RootCmd() which is
used for docs and coverage generation.

### This fixes or addresses the following GitHub issues:

 - Fixes #5427 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

