### PR TITLE
Fix _FORTIFY_SOURCE=2 runtime failure and enable security hardening features

### DIFF
--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -3,7 +3,7 @@ GO111MODULE := on
 GO_TAGS := containers_image_openpgp sylog oci_engine singularity_engine fakeroot_engine
 GO_TAGS_SUID := containers_image_openpgp sylog singularity_engine fakeroot_engine
 GO_LDFLAGS :=
-GO_BUILDMODE := -buildmode=default
+GO_BUILDMODE := -buildmode=pie
 GO_GCFLAGS := -gcflags=github.com/sylabs/singularity/...="-trimpath $(SOURCEDIR)=>github.com/sylabs/singularity@v0.0.0"
 GO_ASMFLAGS := -asmflags=github.com/sylabs/singularity/...="-trimpath $(SOURCEDIR)=>github.com/sylabs/singularity@v0.0.0"
 GO_MODFLAGS := $(if $(wildcard $(SOURCEDIR)/vendor/modules.txt),-mod=vendor,-mod=readonly)

--- a/mlocal/frags/go_runtime_opts.mk
+++ b/mlocal/frags/go_runtime_opts.mk
@@ -1,0 +1,1 @@
+CGO_CFLAGS += -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector --param ssp-buffer-size=4


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Move child stack in the BSS section, stack usage seems is around 80 bytes (the actual stack size is unchanged: 4096)
- Switch `buildmode=default` to `buildmode=pie` to leverage kernel ASLR
- Add `_FORTIFY_SOURCE=2` and `fstack-protector` to `CGO_CFLAGS`

### This fixes or addresses the following GitHub issues:

- Fixes #5429
- Fixes #5346 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

