### PR TITLE
Ensure build destination path is not empty

### DIFF
--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -97,7 +97,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 
 	// check if target collides with existing file
 	if err := checkBuildTarget(dest); err != nil {
-		sylog.Fatalf("%s", err)
+		sylog.Fatalf("While checking build target: %s", err)
 	}
 
 	if buildArgs.remote {

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1087,5 +1087,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5166":                      c.issue5166,                 // https://github.com/sylabs/singularity/issues/5166
 		"issue 5172":                      c.issue5172,                 // https://github.com/sylabs/singularity/issues/5172
 		"issue 5315":                      c.issue5315,                 // https://github.com/sylabs/singularity/issues/5315
+		"issue 5435":                      c.issue5435,                 // https://github.com/hpcng/singularity/issues/5435
 	}
 }

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/util/fs/proc"
 	"github.com/sylabs/singularity/pkg/util/singularityconf"
 
@@ -77,7 +78,7 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 	oldumask := syscall.Umask(0002)
 	defer syscall.Umask(oldumask)
 
-	dest, err := filepath.Abs(conf.Dest)
+	dest, err := fs.Abs(conf.Dest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine absolute path for %q: %v", conf.Dest, err)
 	}

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -19,6 +19,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Abs resolves a path to an absolute path.
+// The supplied path can not be an empty string.
+func Abs(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+
+	return filepath.Abs(path)
+}
+
 // EnsureFileWithPermission takes a file path, and 1. Creates it with
 // the specified permission, or 2. ensures a file is the specified
 // permission.

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -356,7 +356,7 @@ func lockSection(i *Image, section Section) error {
 
 // ResolvePath returns a resolved absolute path.
 func ResolvePath(path string) (string, error) {
-	abspath, err := filepath.Abs(path)
+	abspath, err := fs.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to get absolute path: %s", err)
 	}


### PR DESCRIPTION
- Add fs helper to catch empty paths when resolving abs paths
- Update image package to use this new helper
- Add regression test

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>


### This fixes or addresses the following GitHub issues:

 - Fixes #5435 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

