### PR TITLE
Don't unset PATH in legacy /environment file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _The old changelog can be found in the `release-2.6` branch_
   - Use squashfs mem and processor limits in squashfs gzip check.
   - Ensure build destination path is not an empty string - do
     not overwrite CWD.
+  - Don't unset PATH when interpreting legacy /environment files.
 
 
 # v3.6.0 - [2020-07-14]

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -417,5 +417,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"environment manipulation": c.singularityEnv,
 		"environment option":       c.singularityEnvOption,
 		"environment file":         c.singularityEnvFile,
+		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
+
 	}
 }

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package singularityenv
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/internal/pkg/util/fs"
+)
+
+// Check that an old-style `/environment` file is interpreted
+// and can set PATH.
+func (c ctx) issue5426(t *testing.T) {
+	sandboxDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "sandbox-", "")
+	defer cleanup(t)
+
+	// Build a current sandbox
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--force", "--sandbox", sandboxDir, "library://alpine:3.11.5"),
+		e2e.ExpectExit(0),
+	)
+
+	// Remove the /.singularity.d
+	if err := os.RemoveAll(path.Join(sandboxDir, ".singularity.d")); err != nil {
+		t.Fatalf("Could not remove sandbox /.singularity.d: %s", err)
+	}
+	// Remove the /environment symlink
+	if err := os.Remove(path.Join(sandboxDir, "environment")); err != nil {
+		t.Fatalf("Could not remove sandbox /environment symlink: %s", err)
+	}
+	// Copy in the test environment file
+	testEnvironment := path.Join("testdata", "regressions", "legacy-environment")
+	if err := fs.CopyFile(testEnvironment, path.Join(sandboxDir, "environment"), 0755); err != nil {
+		t.Fatalf("Could not add legacy /environment to sandbox: %s", err)
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(sandboxDir, "/bin/sh", "-c", "echo $PATH"),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.ContainMatch, "/canary/path")),
+	)
+}

--- a/e2e/testdata/regressions/legacy-environment
+++ b/e2e/testdata/regressions/legacy-environment
@@ -1,0 +1,7 @@
+if test -z "$SINGULARITY_INIT"; then
+    PATH="/canary/path:$PATH"
+    PS1="$PS1"
+    SINGULARITY_INIT=1
+    export PATH PS1 SINGULARITY_INIT
+fi
+

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -107,7 +107,6 @@ else
     # this is for old images built with Singularity version prior to 2.3
     if test -f "/environment"; then
         source "/environment"
-        unset PATH
         export PATH="$(fixpath)"
     fi
     source "/.inject-singularity-env.sh"


### PR DESCRIPTION
## Description of the Pull Request (PR):

PATH appeared to be unset in error in the new environment handling code, so that 2.2 images that use an `/environment` file cannot set PATH.

I looked to make an e2e regression test here, but I can't successfully compile Singularity 2.2 on the machines I'm sitting at. Will have to come back to it - unless you know off the top of your head a good way to simulate a 2.2 container accurately @cclerget ? I don't know enough without checking one out.

### This fixes or addresses the following GitHub issues:

 - Fixes #5426


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

