### PR TITLE
Use squashfs mem and processors limits in enzureGzipComp

### DIFF
--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -195,7 +195,7 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		}
 		mksquashfsProcs, err := squashfs.GetProcs()
 		if err != nil {
-			return nil, fmt.Errorf("while searching for mksquashfs processr limits: %v", err)
+			return nil, fmt.Errorf("while searching for mksquashfs processor limits: %v", err)
 		}
 		mksquashfsMem, err := squashfs.GetMem()
 		if err != nil {
@@ -260,6 +260,22 @@ func ensureGzipComp(tmpdir, mksquashfsPath string) (bool, error) {
 	}
 
 	flags = []string{"-noappend", "-comp", "gzip"}
+
+	mksquashfsProcs, err := squashfs.GetProcs()
+	if err != nil {
+		return false, fmt.Errorf("while searching for mksquashfs processor limits: %v", err)
+	}
+	mksquashfsMem, err := squashfs.GetMem()
+	if err != nil {
+		return false, fmt.Errorf("while searching for mksquashfs mem limits: %v", err)
+	}
+	if mksquashfsMem != "" {
+		flags = append(flags, "-mem", mksquashfsMem)
+	}
+	if mksquashfsProcs != 0 {
+		flags = append(flags, "-processors", fmt.Sprint(mksquashfsProcs))
+	}
+
 	if err := s.Create([]string{srcf.Name()}, f.Name(), flags); err != nil {
 		return false, fmt.Errorf("could not build squashfs with required gzip compression")
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The ensureGzipComp function was calling mksquashfs without passing
cpu and processor limit flags, so it may cause a failure in memory
limited environments even when those options have been set.

Pass the options to the mksquashfs call in ensureGzipComp too.

### This fixes or addresses the following GitHub issues:

Fixes: #5434

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

