### PR TITLE
Provide advisory error message for missing overlay image upper/work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
+# Changes since v3.6.0
+
+## Bug Fixes
+
+  - Provide advisory message r.e. need for `upper` and `work` to
+    exist in overlay images.
+
+
+
 # v3.6.0 - [2020-07-14]
 
 ## Security related fixes

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -878,9 +878,15 @@ func (c *container) overlayUpperWork(system *mount.System) error {
 	}
 
 	if err := createUpperWork(ov.GetUpperDir(), "upper"); err != nil {
+		sylog.Errorf("Could not create overlay upper dir. If using an overlay image ensure it contains 'upper' and 'work' directories")
 		return err
 	}
-	return createUpperWork(ov.GetWorkDir(), "workdir")
+	if err := createUpperWork(ov.GetWorkDir(), "workdir"); err != nil {
+		sylog.Errorf("Could not create overlay work dir. If using an overlay image ensure it contains 'upper' and 'work' directories")
+		return err
+	}
+
+	return nil
 }
 
 func (c *container) addOverlayMount(system *mount.System) error {


### PR DESCRIPTION
## Description of the Pull Request (PR):

With the move of RPC operations to a context with less privilege /
fewer capabilities, both `upper` and `work` should be present in
an overlay ext3 image file before Singularity is run.

Add an advisory message that explains this, and is less cryptic
than the heavily nested FATAL error messages.

```
singularity shell --overlay overlay.img alpine_latest.sif
ERROR:   Could not create overlay work dir. If using an overlay image ensure it contains 'upper' and 'work' directories
FATAL:   container creation failed: hook function for tag prelayer returns error: failed to create /usr/local/var/singularity/mnt/session/overlay-images/0/work directory: mkdir /usr/local/var/singularity/mnt/session/overlay-images/0/work: permission denied
```

### This fixes or addresses the following GitHub issues:

Fixes: #5430

(docs change also needed)

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

