### PR TITLE
Provide login/logout command to manage Docker/OCI registry credentials

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -49,7 +49,6 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 	userPath := strings.Join([]string{os.Getenv("PATH"), defaultPath}, ":")
 
 	os.Setenv("USER_PATH", userPath)
-	os.Setenv("PATH", defaultPath)
 
 	// create an handle for the current image cache
 	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
@@ -60,6 +59,10 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 	ctx := context.TODO()
 
 	replaceURIWithImage(ctx, imgCache, cmd, args)
+
+	// set PATH after pulling images to be able to find potential
+	// docker credential helpers outside of standard paths
+	os.Setenv("PATH", defaultPath)
 }
 
 func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, pullFrom string) (string, error) {

--- a/cmd/internal/cli/login.go
+++ b/cmd/internal/cli/login.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2020, Ctrl-Cmd Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	auth "github.com/deislabs/oras/pkg/auth/docker"
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/internal/pkg/util/interactive"
+	"github.com/sylabs/singularity/pkg/cmdline"
+)
+
+var (
+	loginUsername      string
+	loginPassword      string
+	loginPasswordStdin bool
+	loginInsecure      bool
+)
+
+// -u|--username
+var loginUsernameFlag = cmdline.Flag{
+	ID:           "loginUsernameFlag",
+	Value:        &loginUsername,
+	DefaultValue: "",
+	Name:         "username",
+	ShortHand:    "u",
+	Usage:        "username to authenticate with (leave it empty for token authentication)",
+	EnvKeys:      []string{"LOGIN_USERNAME"},
+}
+
+// -p|--password
+var loginPasswordFlag = cmdline.Flag{
+	ID:           "loginPasswordFlag",
+	Value:        &loginPassword,
+	DefaultValue: "",
+	Name:         "password",
+	ShortHand:    "p",
+	Usage:        "password to authenticate with",
+	EnvKeys:      []string{"LOGIN_PASSWORD"},
+}
+
+// --password-stdin
+var loginPasswordStdinFlag = cmdline.Flag{
+	ID:           "loginPasswordStdinFlag",
+	Value:        &loginPasswordStdin,
+	DefaultValue: false,
+	Name:         "password-stdin",
+	Usage:        "take password from standard input",
+}
+
+// -i|--insecure
+var loginInsecureFlag = cmdline.Flag{
+	ID:           "loginInsecureFlag",
+	Value:        &loginInsecure,
+	DefaultValue: false,
+	Name:         "insecure",
+	ShortHand:    "i",
+	Usage:        "allow insecure login",
+	EnvKeys:      []string{"LOGIN_INSECURE"},
+}
+
+func init() {
+	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterCmd(LoginCmd)
+
+		cmdManager.RegisterFlagForCmd(&loginUsernameFlag, LoginCmd)
+		cmdManager.RegisterFlagForCmd(&loginPasswordFlag, LoginCmd)
+		cmdManager.RegisterFlagForCmd(&loginPasswordStdinFlag, LoginCmd)
+		cmdManager.RegisterFlagForCmd(&loginInsecureFlag, LoginCmd)
+	})
+}
+
+// LoginCmd is the 'login' command that allows user to login to service.
+var LoginCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hostname := args[0]
+		username := loginUsername
+		password := loginPassword
+
+		if loginPasswordStdin {
+			p, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+			password = strings.TrimSuffix(string(p), "\n")
+			password = strings.TrimSuffix(password, "\r")
+		} else if password == "" {
+			var err error
+
+			password, err = interactive.AskQuestionNoEcho("Password: ")
+			if err != nil {
+				return err
+			}
+		}
+
+		return Login(username, password, hostname, loginInsecure)
+	},
+	DisableFlagsInUseLine: true,
+
+	Use:           docs.LoginUse,
+	Short:         docs.LoginShort,
+	Long:          docs.LoginLong,
+	Example:       docs.LoginExample,
+	SilenceErrors: true,
+}
+
+func Login(username, password, hostname string, insecure bool) error {
+	cli, err := auth.NewClient()
+	if err != nil {
+		return err
+	}
+	return cli.Login(context.TODO(), hostname, username, password, insecure)
+}

--- a/cmd/internal/cli/login.go
+++ b/cmd/internal/cli/login.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/pkg/cmdline"
+	"github.com/sylabs/singularity/pkg/syfs"
 )
 
 var (
@@ -114,7 +115,7 @@ var LoginCmd = &cobra.Command{
 }
 
 func Login(username, password, hostname string, insecure bool) error {
-	cli, err := auth.NewClient()
+	cli, err := auth.NewClient(syfs.DockerConf())
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/cli/login.go
+++ b/cmd/internal/cli/login.go
@@ -98,10 +98,15 @@ var LoginCmd = &cobra.Command{
 		} else if password == "" {
 			var err error
 
-			password, err = interactive.AskQuestionNoEcho("Password: ")
+			question := "Password (or token if username is empty): "
+			password, err = interactive.AskQuestionNoEcho(question)
 			if err != nil {
 				sylog.Fatalf("Failed to read password: %s", err)
 			}
+		}
+
+		if password == "" {
+			sylog.Fatalf("Password required")
 		}
 
 		if err := Login(username, password, hostname, loginInsecure); err != nil {

--- a/cmd/internal/cli/logout.go
+++ b/cmd/internal/cli/logout.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/pkg/cmdline"
+	"github.com/sylabs/singularity/pkg/syfs"
 )
 
 func init() {
@@ -41,7 +42,7 @@ var LogoutCmd = &cobra.Command{
 }
 
 func Logout(hostname string) error {
-	cli, err := auth.NewClient()
+	cli, err := auth.NewClient(syfs.DockerConf())
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/cli/logout.go
+++ b/cmd/internal/cli/logout.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020, Ctrl-Cmd Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"context"
+	"errors"
+
+	auth "github.com/deislabs/oras/pkg/auth/docker"
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/pkg/cmdline"
+)
+
+func init() {
+	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterCmd(LogoutCmd)
+	})
+}
+
+// LogoutCmd is the 'logout' command that allows user to remove credential for a registry.
+var LogoutCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hostname := args[0]
+		if hostname == "" {
+			return errors.New("a hostname must be specified")
+		}
+		return Logout(hostname)
+	},
+	DisableFlagsInUseLine: true,
+
+	Use:           docs.LogoutUse,
+	Short:         docs.LogoutShort,
+	Long:          docs.LogoutLong,
+	Example:       docs.LogoutExample,
+	SilenceErrors: true,
+}
+
+func Logout(hostname string) error {
+	cli, err := auth.NewClient()
+	if err != nil {
+		return err
+	}
+	return cli.Logout(context.TODO(), hostname)
+}

--- a/cmd/internal/cli/logout.go
+++ b/cmd/internal/cli/logout.go
@@ -7,13 +7,13 @@ package cli
 
 import (
 	"context"
-	"errors"
 
 	auth "github.com/deislabs/oras/pkg/auth/docker"
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/syfs"
+	"github.com/sylabs/singularity/pkg/sylog"
 )
 
 func init() {
@@ -25,12 +25,15 @@ func init() {
 // LogoutCmd is the 'logout' command that allows user to remove credential for a registry.
 var LogoutCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		hostname := args[0]
 		if hostname == "" {
-			return errors.New("a hostname must be specified")
+			sylog.Fatalf("A hostname must be specified")
 		}
-		return Logout(hostname)
+		if err := Logout(hostname); err != nil {
+			sylog.Fatalf("Logout failed: %s", err)
+		}
+		sylog.Infof("Logout succeeded")
 	},
 	DisableFlagsInUseLine: true,
 

--- a/docs/login.go
+++ b/docs/login.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020, Ctrl-Cmd Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package docs
+
+// Global content for help and man pages
+const (
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// login command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	LoginUse   string = `login [login options...] <hostname>`
+	LoginShort string = `Login to Docker/OCI registries`
+	LoginLong  string = `
+  The 'login' command allow you to manage Docker/OCI registry login credentials,
+  the configuration is stored in $HOME/.docker/config.json.`
+	LoginExample string = `$ singularity login -u john -p secret docker.io`
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// logout command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	LogoutUse     string = `logout <hostname>`
+	LogoutShort   string = `Logout from Docker/OCI registries`
+	LogoutLong    string = `The 'logout' command allow you to remove Docker/OCI registry login credentials`
+	LogoutExample string = `$ singularity logout docker.io`
+)

--- a/docs/login.go
+++ b/docs/login.go
@@ -14,7 +14,7 @@ const (
 	LoginShort string = `Login to Docker/OCI registries`
 	LoginLong  string = `
   The 'login' command allow you to manage Docker/OCI registry login credentials,
-  the configuration is stored in $HOME/.docker/config.json.`
+  the configuration is stored in $HOME/.singularity/docker-config.json.`
 	LoginExample string = `$ singularity login -u john -p secret docker.io`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/internal/e2e/docker_auth_server.go
+++ b/e2e/internal/e2e/docker_auth_server.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2020, Ctrl-Cmd Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	registry "github.com/adigunhammedolalekan/registry-auth"
+)
+
+const (
+	DefaultUsername  = "e2e"
+	DefaultPassword  = "e2e"
+	privateNamespace = "private"
+)
+
+type dockerAuthHandler struct {
+	srv *registry.AuthServer
+}
+
+type authnz struct {
+	username string
+	password string
+	sync.Mutex
+}
+
+const (
+	noAuthUsername = "no-auth"
+)
+
+func (a *authnz) Authenticate(username, password string) error {
+	// deferring unlock in Authorize to be sure username
+	// and password are associated to the same request,
+	// fortunately docker-registry-auth package doesn't
+	// generate error between Authenticate and Authorize
+	// calls, so a deadlock is not possible
+	a.Lock()
+
+	if username == noAuthUsername {
+		a.username = ""
+		a.password = ""
+	} else {
+		a.username = username
+		a.password = password
+	}
+
+	return nil
+}
+
+func (a *authnz) Authorize(req *registry.AuthorizationRequest) ([]string, error) {
+	// release previous lock
+	defer a.Unlock()
+
+	requireAuth := false
+
+	if strings.HasPrefix(req.Name, privateNamespace) || req.Type == "" {
+		requireAuth = true
+	}
+	if requireAuth {
+		if a.username != DefaultUsername || a.password != DefaultPassword {
+			return nil, fmt.Errorf("unauthorized")
+		}
+	}
+
+	return []string{"pull", "push"}, nil
+}
+
+func startAuthServer(crt, key string) error {
+	authnz := new(authnz)
+
+	opt := &registry.Option{
+		Certfile:        crt,
+		Keyfile:         key,
+		TokenExpiration: time.Now().Add(1 * time.Hour).Unix(),
+		TokenIssuer:     "E2E",
+		Authenticator:   authnz,
+		Authorizer:      authnz,
+	}
+
+	srv, err := registry.NewAuthServer(opt)
+	if err != nil {
+		return err
+	}
+
+	http.Handle("/auth", &dockerAuthHandler{srv: srv})
+	return http.ListenAndServe(":5001", nil)
+}
+
+func (d *dockerAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, _, ok := r.BasicAuth()
+	if !ok {
+		// pass a non empty username meaning there is no authentication
+		// credentials, this is required as the docker-registry-auth package
+		// doesn't allow empty credentials, Authorize will reset the username
+		// to an empty value
+		r.SetBasicAuth(noAuthUsername, "")
+	}
+	d.srv.ServeHTTP(w, r)
+}

--- a/e2e/login/login.go
+++ b/e2e/login/login.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package login
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/e2e/internal/testhelper"
+)
+
+type ctx struct {
+	env e2e.TestEnv
+}
+
+func (c ctx) testBasicLogin(t *testing.T) {
+	e2e.PrepRegistry(t, c.env)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		stdin      io.Reader
+		expectExit int
+	}{
+		{
+			name:       "login username and empty password",
+			command:    "login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", "", c.env.TestRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "login empty username and empty password",
+			command:    "login",
+			args:       []string{"-p", "", c.env.TestRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "login empty username and bad password",
+			command:    "login",
+			args:       []string{"-p", "bad", c.env.TestRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "login KO",
+			command:    "login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", "bad", c.env.TestRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "login OK",
+			command:    "login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, c.env.TestRegistry},
+			expectExit: 0,
+		},
+		{
+			name:       "login password-stdin",
+			command:    "login",
+			args:       []string{"-u", e2e.DefaultUsername, "--password-stdin", c.env.TestRegistry},
+			stdin:      strings.NewReader(e2e.DefaultPassword),
+			expectExit: 0,
+		},
+		{
+			name:       "logout KO",
+			command:    "logout",
+			args:       []string{"bad_registry:5000"},
+			expectExit: 255,
+		},
+		{
+			name:       "logout OK",
+			command:    "logout",
+			args:       []string{c.env.TestRegistry},
+			expectExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithStdin(tt.stdin),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+func (c ctx) testPrivateWithLogin(t *testing.T) {
+	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureImage(t, c.env)
+
+	repo := fmt.Sprintf("oras://%s/private/e2e:1.0.0", c.env.TestRegistry)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		expectExit int
+	}{
+		{
+			name:       "push before login",
+			command:    "push",
+			args:       []string{c.env.ImagePath, repo},
+			expectExit: 255,
+		},
+		{
+			name:       "login",
+			command:    "login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, c.env.TestRegistry},
+			expectExit: 0,
+		},
+		{
+			name:       "push after login",
+			command:    "push",
+			args:       []string{c.env.ImagePath, repo},
+			expectExit: 0,
+		},
+		{
+			name:       "logout",
+			command:    "logout",
+			args:       []string{c.env.TestRegistry},
+			expectExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+	c := ctx{
+		env: env,
+	}
+
+	np := testhelper.NoParallel
+
+	return testhelper.Tests{
+		"basic":   np(c.testBasicLogin),
+		"private": np(c.testPrivateWithLogin),
+	}
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sylabs/singularity/e2e/inspect"
 	"github.com/sylabs/singularity/e2e/instance"
 	"github.com/sylabs/singularity/e2e/key"
+	"github.com/sylabs/singularity/e2e/login"
 	"github.com/sylabs/singularity/e2e/oci"
 	"github.com/sylabs/singularity/e2e/plugin"
 	"github.com/sylabs/singularity/e2e/pull"
@@ -164,6 +165,7 @@ func Run(t *testing.T) {
 	suite.AddGroup("INSPECT", inspect.E2ETests)
 	suite.AddGroup("INSTANCE", instance.E2ETests)
 	suite.AddGroup("KEY", key.E2ETests)
+	suite.AddGroup("LOGIN", login.E2ETests)
 	suite.AddGroup("OCI", oci.E2ETests)
 	suite.AddGroup("PLUGIN", plugin.E2ETests)
 	suite.AddGroup("PULL", pull.E2ETests)

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -1,15 +1,31 @@
 bootstrap: docker
 from: registry:2.7.1
 
+%environment
+    export REGISTRY_AUTH=token
+    export REGISTRY_AUTH_TOKEN_REALM=http://localhost:5001/auth
+    export REGISTRY_AUTH_TOKEN_SERVICE=Authentication
+    export REGISTRY_AUTH_TOKEN_ISSUER=E2E
+    export REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE=/certs/root.crt
+
 %post
+    apk add openssl
     apk add runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
     # Install v0.5.7 of img (latest will not talk to http registries)
     export IMG_SHA256="41aa98ab28be55ba3d383cb4e8f86dceac6d6e92102ee4410a6b43514f4da1fa"
     # Download and check the sha256sum.
-    wget "https://github.com/genuinetools/img/releases/download/v0.5.7/img-linux-amd64" -O "/usr/local/bin/img" \
+    wget -q "https://github.com/genuinetools/img/releases/download/v0.5.7/img-linux-amd64" -O "/usr/local/bin/img" \
 	  && echo "${IMG_SHA256}  /usr/local/bin/img" | sha256sum -c - \
 	  && chmod a+x "/usr/local/bin/img"
+
+    mkdir /certs
+
+    openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 \
+      -keyout /certs/root.key -out /certs/root.pem -subj "/C=US/CN=localhost"
+    openssl x509 -outform pem -in /certs/root.pem -out /certs/root.crt
+
+    chmod 644 /certs/root.*
 
 %startscript
     /.singularity.d/runscript &

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667
+	github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60
 	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f // indirect
 	github.com/apex/log v1.6.0
 	github.com/blang/semver/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60 h1:1IG6ye8dellBRE2uqvG0EzQScRqjsH/n5xOw+n0OGec=
+github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60/go.mod h1:DcXj4IQOoib2b4G2b8JU3VGV3ljXYbIq+PH4CcoAQTI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,7 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 h1:FwssHbCDJD025h+BchanCwE1Q8fyMgqDr2mOQAWOLGw=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d h1:jC8tT/S0OGx2cswpeUTn4gOIea8P08lD3VFQT0cOZ50=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -32,7 +32,9 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/shell"
 	buildTypes "github.com/sylabs/singularity/pkg/build/types"
 	sytypes "github.com/sylabs/singularity/pkg/build/types"
+	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 // OCIConveyorPacker holds stuff that needs to be packed into the bundle
@@ -65,6 +67,8 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		OCIInsecureSkipTLSVerify: cp.b.Opts.NoHTTPS,
 		DockerAuthConfig:         cp.b.Opts.DockerAuthConfig,
 		OSChoice:                 "linux",
+		AuthFilePath:             syfs.DockerConf(),
+		DockerRegistryUserAgent:  useragent.Value(),
 	}
 	if cp.b.Opts.NoHTTPS {
 		cp.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -15,7 +15,9 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/build/oci"
 	"github.com/sylabs/singularity/internal/pkg/cache"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 // pull will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
@@ -28,6 +30,8 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 	sysCtx := &ocitypes.SystemContext{
 		OCIInsecureSkipTLSVerify: noHTTPS,
 		DockerAuthConfig:         ociAuth,
+		AuthFilePath:             syfs.DockerConf(),
+		DockerRegistryUserAgent:  useragent.Value(),
 	}
 	if noHTTPS {
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -13,14 +13,17 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	ocitypes "github.com/containers/image/v5/types"
+	auth "github.com/deislabs/oras/pkg/auth/docker"
 	"github.com/deislabs/oras/pkg/content"
 	orasctx "github.com/deislabs/oras/pkg/context"
 	"github.com/deislabs/oras/pkg/oras"
@@ -41,6 +44,21 @@ const (
 	SifLayerMediaType = "appliciation/vnd.sylabs.sif.layer.tar"
 )
 
+func getResolver(ociAuth *ocitypes.DockerAuthConfig) (remotes.Resolver, error) {
+	opts := docker.ResolverOptions{Credentials: genCredfn(ociAuth)}
+	if ociAuth != nil && (ociAuth.Username != "" || ociAuth.Password != "") {
+		return docker.NewResolver(opts), nil
+	}
+
+	cli, err := auth.NewClient()
+	if err != nil {
+		sylog.Warningf("Couldn't load auth credential file: %s", err)
+		return docker.NewResolver(opts), nil
+	}
+
+	return cli.Resolver(context.Background(), &http.Client{}, false)
+}
+
 // DownloadImage downloads a SIF image specified by an oci reference to a file using the included credentials
 func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	ref = strings.TrimPrefix(ref, "oras://")
@@ -57,7 +75,10 @@ func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) er
 		sylog.Infof("No tag or digest found, using default: %s", SifDefaultTag)
 	}
 
-	resolver := docker.NewResolver(docker.ResolverOptions{Credentials: genCredfn(ociAuth)})
+	resolver, err := getResolver(ociAuth)
+	if err != nil {
+		return fmt.Errorf("while getting resolver: %s", err)
+	}
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -137,7 +158,10 @@ func UploadImage(path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 		sylog.Infof("No tag or digest found, using default: %s", SifDefaultTag)
 	}
 
-	resolver := docker.NewResolver(docker.ResolverOptions{Credentials: genCredfn(ociAuth)})
+	resolver, err := getResolver(ociAuth)
+	if err != nil {
+		return fmt.Errorf("while getting resolver: %s", err)
+	}
 
 	store := content.NewFileStore("")
 	defer store.Close()
@@ -189,7 +213,10 @@ func ImageSHA(ctx context.Context, uri string, ociAuth *ocitypes.DockerAuthConfi
 	ref := strings.TrimPrefix(uri, "oras://")
 	ref = strings.TrimPrefix(ref, "//")
 
-	resolver := docker.NewResolver(docker.ResolverOptions{Credentials: genCredfn(ociAuth)})
+	resolver, err := getResolver(ociAuth)
+	if err != nil {
+		return "", fmt.Errorf("while getting resolver: %s", err)
+	}
 
 	_, desc, err := resolver.Resolve(ctx, ref)
 	if err != nil {

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -30,6 +30,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sylabs/singularity/pkg/image"
+	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
@@ -50,7 +51,7 @@ func getResolver(ociAuth *ocitypes.DockerAuthConfig) (remotes.Resolver, error) {
 		return docker.NewResolver(opts), nil
 	}
 
-	cli, err := auth.NewClient()
+	cli, err := auth.NewClient(syfs.DockerConf())
 	if err != nil {
 		sylog.Warningf("Couldn't load auth credential file: %s", err)
 		return docker.NewResolver(opts), nil

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	RemoteConfFile = "remote.yaml"
+	DockerConfFile = "docker-config.json"
 	singularityDir = ".singularity"
 )
 
@@ -58,6 +59,10 @@ func configDir() string {
 
 func RemoteConf() string {
 	return filepath.Join(ConfigDir(), RemoteConfFile)
+}
+
+func DockerConf() string {
+	return filepath.Join(ConfigDir(), DockerConfFile)
 }
 
 // ConfigDirForUsername returns the directory where the singularity


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds:
- `singularity login` command to login to a registry:
  - `singularity login -u test -p test localhost:5000`
- `singularity logout` command to logout from a logged registry
  - `singularity logout localhost:5000`

Credentials are stored in `~/.singularity/docker-config.json` and are used automatically when pulling/pushing with OCI/Docker/ORAS registries.
It would also be possible to configure docker credential helpers in this file for registries like GCR, ECR ...

Follow-up about licensing of docker auth server code : https://github.com/adigunhammedolalekan/registry-auth/issues/1

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

