### PR TITLE
Use -mem and -processors on all ensureGzipComp mksquashfs calls

### DIFF
--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -241,6 +241,22 @@ func ensureGzipComp(tmpdir, mksquashfsPath string) (bool, error) {
 	f.Close()
 
 	flags := []string{"-noappend"}
+
+	mksquashfsProcs, err := squashfs.GetProcs()
+	if err != nil {
+		return false, fmt.Errorf("while searching for mksquashfs processor limits: %v", err)
+	}
+	mksquashfsMem, err := squashfs.GetMem()
+	if err != nil {
+		return false, fmt.Errorf("while searching for mksquashfs mem limits: %v", err)
+	}
+	if mksquashfsMem != "" {
+		flags = append(flags, "-mem", mksquashfsMem)
+	}
+	if mksquashfsProcs != 0 {
+		flags = append(flags, "-processors", fmt.Sprint(mksquashfsProcs))
+	}
+
 	if err := s.Create([]string{srcf.Name()}, f.Name(), flags); err != nil {
 		return false, fmt.Errorf("while creating squashfs: %v", err)
 	}
@@ -260,22 +276,8 @@ func ensureGzipComp(tmpdir, mksquashfsPath string) (bool, error) {
 		return false, nil
 	}
 
-	flags = []string{"-noappend", "-comp", "gzip"}
-
-	mksquashfsProcs, err := squashfs.GetProcs()
-	if err != nil {
-		return false, fmt.Errorf("while searching for mksquashfs processor limits: %v", err)
-	}
-	mksquashfsMem, err := squashfs.GetMem()
-	if err != nil {
-		return false, fmt.Errorf("while searching for mksquashfs mem limits: %v", err)
-	}
-	if mksquashfsMem != "" {
-		flags = append(flags, "-mem", mksquashfsMem)
-	}
-	if mksquashfsProcs != 0 {
-		flags = append(flags, "-processors", fmt.Sprint(mksquashfsProcs))
-	}
+	// Now force add `-comp gzip` in addition to -noappend -mem -processors
+	flags = append(flags, "-comp", "gzip")
 
 	if err := s.Create([]string{srcf.Name()}, f.Name(), flags); err != nil {
 		return false, fmt.Errorf("could not build squashfs with required gzip compression")


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use -mem and -processors on all ensureGzipComp mksquashfs calls

Previous attempt did not take into account there are *two* calls
to mksquashfs in the ensureGzipComp function.

Now this definitely works with processor and mem limit set....

```
$ ulimit -v 4000000
$ strace -o log -f singularity build $HOME/test.sif docker://alpine

$ grep mksquashfs log | grep execve
38794 execve("/sbin/mksquashfs", ["/sbin/mksquashfs", "/tmp/bundle-temp-313358976/squas"..., "/tmp/bundle-temp-313358976/squas"..., "-noappend", "-mem", "64M", "-processors", "1"], 0xc00018a000 /* 29 vars */ <unfinished ...>
38808 execve("/sbin/mksquashfs", ["/sbin/mksquashfs", "/tmp/rootfs-fd56db44-cb70-11ea-9"..., "/tmp/bundle-temp-313358976/squas"..., "-noappend", "-all-root", "-mem", "64M", "-processors", "1"], 0xc0002d4000 /* 29 vars */ <unfinished ...>
```

### This fixes or addresses the following GitHub issues:

 - Fixes: #5434


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

