### PR TITLE
Reworked RPC capability handling to fix regression issue during overlay mount

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2063,6 +2063,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5228":            c.issue5228,           // https://github.com/sylabs/singularity/issues/5228
 		"issue 5271":            c.issue5271,           // https://github.com/sylabs/singularity/issues/5271
 		"issue 5307":            c.issue5307,           // https://github.com/sylabs/singularity/issues/5307
+		"issue 5455":            c.issue5455,           // https://github.com/sylabs/singularity/issues/5455
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -428,7 +428,7 @@ func (c configTests) configFile(t *testing.T) {
 			name:    "UserForbidden",
 			argv:    []string{c.env.ImagePath, "true"},
 			profile: e2e.UserProfile,
-			conf:    "max loop devices = 0\n",
+			conf:    "max loop devices = 128\n",
 			exit:    255,
 		},
 	}

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -154,6 +154,18 @@ func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
+	// Ensure decryption works with an IPC namespace
+	cmdArgs = []string{"--ipc", imgPath}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("env var passphrase with ipc namespace"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("run"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
+		e2e.ExpectExit(0),
+	)
+
 	// Specifying the passphrase on the command line should always fail
 	cmdArgs = []string{"--passphrase", e2e.Passphrase, imgPath}
 	c.env.RunSingularity(


### PR DESCRIPTION
## Description of the Pull Request (PR):

Reworked RPC capability handling to fix regression issue during overlay mount. RPC now modifies its effective capabilities on a per method call basis and will abort execution by reporting the missing capability in a less cryptic error message.

Also fixes a regression issue during container decryption when `--ipc` is specified.

### This fixes or addresses the following GitHub issues:

 - Fixes #5455 
 - Fixes #5461 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

