### PR TITLE
Add configurable default keyserver in singularity.conf

### DIFF
--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -231,6 +231,7 @@ func createCmdsFiles() (string, string, error) {
 	defer textFile.Close()
 
 	// iniatialize singularity CLI by registering all commands without plugins
+	cli.UseDefaultConfig()
 	cli.Init(false)
 	cli.RootCmd().InitDefaultHelpCmd()
 	cli.RootCmd().InitDefaultVersionFlag()

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -66,6 +66,7 @@ func main() {
 			// We must Init() as loading commands etc. is deferred until this is called.
 			// Using true here will result in local docs including any content for installed
 			// plugins.
+			cli.UseDefaultConfig()
 			cli.Init(true)
 			rootCmd := cli.RootCmd()
 			switch args[0] {

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -84,7 +84,7 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom, librar
 		BaseURL:   libraryURL,
 		Logger:    (golog.Logger)(sylog.DebugLogger{}),
 	}
-	return library.Pull(ctx, imgCache, pullFrom, runtime.GOARCH, tmpDir, c, keyServerURL)
+	return library.Pull(ctx, imgCache, pullFrom, runtime.GOARCH, tmpDir, c)
 }
 
 func handleShub(ctx context.Context, imgCache *cache.Handle, pullFrom string) (string, error) {

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
-	scs "github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -116,8 +115,12 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 	}
 
 	// Only connect to the endpoint if we are pushing the key.
-	handleKeyNewPairEndpoint()
+	handleKeyFlags(cmd)
 	if err := sypgp.PushPubkey(ctx, http.DefaultClient, key, keyServerURI, authToken); err != nil {
+		if e, ok := err.(*sypgp.ErrPushAccepted); ok {
+			fmt.Printf("%s\n", e)
+			return
+		}
 		fmt.Printf("Failed to push newly created key to keystore: %s\n", err)
 	} else {
 		fmt.Printf("Key successfully pushed to: %s\n", keyServerURI)
@@ -197,23 +200,4 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 	}
 
 	return &genOpts, nil
-}
-
-func handleKeyNewPairEndpoint() {
-	// if we can load config and if default endpoint is set, use that
-	// otherwise fall back on regular authtoken and URI behavior
-	endpoint, err := sylabsRemote(remoteConfig)
-	if err == scs.ErrNoDefault {
-		sylog.Warningf("No default remote in use, falling back to: %v", keyServerURI)
-		return
-	} else if err != nil {
-		sylog.Fatalf("Unable to load remote configuration: %v", err)
-	}
-
-	authToken = endpoint.Token
-	uri, err := endpoint.GetServiceURI("keystore")
-	if err != nil {
-		sylog.Fatalf("Unable to get key service URI: %v", err)
-	}
-	keyServerURI = uri
 }

--- a/cmd/internal/cli/key_push.go
+++ b/cmd/internal/cli/key_push.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
-	scs "github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/sypgp"
 )
@@ -67,31 +66,14 @@ func doKeyPushCmd(ctx context.Context, fingerprint string, url string) error {
 	entity := keys[0].Entity
 
 	if err = sypgp.PushPubkey(ctx, http.DefaultClient, entity, url, authToken); err != nil {
+		if e, ok := err.(*sypgp.ErrPushAccepted); ok {
+			fmt.Printf("%s\n", e)
+			return nil
+		}
 		return err
 	}
 
 	fmt.Printf("public key `%v' pushed to server successfully\n", fingerprint)
 
 	return nil
-}
-
-func handleKeyFlags(cmd *cobra.Command) {
-	// if we can load config and if default endpoint is set, use that
-	// otherwise fall back on regular authtoken and URI behavior
-	endpoint, err := sylabsRemote(remoteConfig)
-	if err == scs.ErrNoDefault {
-		sylog.Warningf("No default remote in use, falling back to: %v", keyServerURI)
-		return
-	} else if err != nil {
-		sylog.Fatalf("Unable to load remote configuration: %v", err)
-	}
-
-	authToken = endpoint.Token
-	if !cmd.Flags().Lookup("url").Changed {
-		uri, err := endpoint.GetServiceURI("keystore")
-		if err != nil {
-			sylog.Fatalf("Unable to get key service URI: %v", err)
-		}
-		keyServerURI = uri
-	}
 }

--- a/internal/app/singularity/verify.go
+++ b/internal/app/singularity/verify.go
@@ -7,6 +7,7 @@ package singularity
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/sif/pkg/integrity"
@@ -18,7 +19,7 @@ import (
 type VerifyCallback func(*sif.FileImage, integrity.VerifyResult) bool
 
 type verifier struct {
-	c         *client.Config
+	c         []*client.Config
 	groupIDs  []uint32
 	objectIDs []uint32
 	all       bool
@@ -29,10 +30,13 @@ type verifier struct {
 // VerifyOpt are used to configure v.
 type VerifyOpt func(v *verifier) error
 
-// OptVerifyUseKeyServer specifies that the keyserver specified by c be used as a source of key
+// OptVerifyUseKeyServers specifies that the keyservers specified by c be used as a source of key
 // material, in addition to the local public keyring.
-func OptVerifyUseKeyServer(c *client.Config) VerifyOpt {
+func OptVerifyUseKeyServers(c []*client.Config) VerifyOpt {
 	return func(v *verifier) error {
+		if len(c) == 0 {
+			return fmt.Errorf("no keyserver specified")
+		}
 		v.c = c
 		return nil
 	}

--- a/internal/app/singularity/verify_test.go
+++ b/internal/app/singularity/verify_test.go
@@ -63,7 +63,9 @@ func (m mockHKP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func Test_newVerifier(t *testing.T) {
-	cfg := client.Config{AuthToken: "token"}
+	cfg := []*client.Config{
+		{AuthToken: "token"},
+	}
 
 	tests := []struct {
 		name         string
@@ -77,8 +79,8 @@ func Test_newVerifier(t *testing.T) {
 		},
 		{
 			name:         "OptVerifyUseKeyServer",
-			opts:         []VerifyOpt{OptVerifyUseKeyServer(&cfg)},
-			wantVerifier: verifier{c: &cfg},
+			opts:         []VerifyOpt{OptVerifyUseKeyServers(cfg)},
+			wantVerifier: verifier{c: cfg},
 		},
 		{
 			name:         "OptVerifyGroup",
@@ -119,7 +121,9 @@ func Test_newVerifier(t *testing.T) {
 }
 
 func Test_verifier_getOpts(t *testing.T) {
-	cfg := client.Config{AuthToken: "token"}
+	cfg := []*client.Config{
+		{AuthToken: "token"},
+	}
 
 	emptyImage, err := sif.LoadContainer(filepath.Join("testdata", "images", "empty.sif"), true)
 	if err != nil {
@@ -146,9 +150,11 @@ func Test_verifier_getOpts(t *testing.T) {
 			name: "TLSRequired",
 			f:    &emptyImage,
 			v: verifier{
-				c: &client.Config{
-					BaseURL:   "hkp://pool.sks-keyservers.net",
-					AuthToken: "blah",
+				c: []*client.Config{
+					{
+						BaseURL:   "hkp://pool.sks-keyservers.net",
+						AuthToken: "blah",
+					},
 				},
 			},
 			wantErr: client.ErrTLSRequired,
@@ -166,7 +172,7 @@ func Test_verifier_getOpts(t *testing.T) {
 		},
 		{
 			name:     "ClientConfig",
-			v:        verifier{c: &cfg},
+			v:        verifier{c: cfg},
 			f:        &oneGroupImage,
 			wantOpts: 1,
 		},
@@ -243,7 +249,11 @@ func TestVerify(t *testing.T) {
 	defer s.Close()
 
 	// Create an option that points to the mock HKP server.
-	keyServerOpt := OptVerifyUseKeyServer(&client.Config{BaseURL: s.URL})
+	keyServerOpt := OptVerifyUseKeyServers(
+		[]*client.Config{
+			{BaseURL: s.URL},
+		},
+	)
 
 	tests := []struct {
 		name         string

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -59,7 +59,7 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 		Logger:    (golog.Logger)(sylog.DebugLogger{}),
 	}
 
-	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, libraryConfig, "")
+	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, libraryConfig)
 	if err != nil {
 		return fmt.Errorf("while fetching library image: %v", err)
 	}

--- a/pkg/sypgp/keyring.go
+++ b/pkg/sypgp/keyring.go
@@ -26,30 +26,35 @@ func PublicKeyRing() (openpgp.KeyRing, error) {
 // hybridKeyRing is keyring made up of a local keyring as well as a keyserver. The type satisfies
 // the openpgp.KeyRing interface.
 type hybridKeyRing struct {
-	local openpgp.KeyRing // Local keyring.
-	ctx   context.Context // Context, for use when retrieving keys remotely.
-	c     *client.Client  // Keyserver client.
+	local   openpgp.KeyRing  // Local keyring.
+	ctx     context.Context  // Context, for use when retrieving keys remotely.
+	clients []*client.Client // Keyserver client.
 }
 
 // NewHybridKeyRing returns a keyring backed by both the local public keyring and the configured
 // keyserver.
-func NewHybridKeyRing(ctx context.Context, cfg *client.Config) (openpgp.KeyRing, error) {
+func NewHybridKeyRing(ctx context.Context, cfg []*client.Config) (openpgp.KeyRing, error) {
 	// Get local keyring.
 	kr, err := PublicKeyRing()
 	if err != nil {
 		return nil, err
 	}
 
-	// Set up client to retrieve keys from keyserver.
-	c, err := client.NewClient(cfg)
-	if err != nil {
-		return nil, err
+	var clients []*client.Client
+
+	// Set up clients to retrieve keys from keyserver.
+	for _, clientConfig := range cfg {
+		c, err := client.NewClient(clientConfig)
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, c)
 	}
 
 	return &hybridKeyRing{
-		local: kr,
-		ctx:   ctx,
-		c:     c,
+		local:   kr,
+		ctx:     ctx,
+		clients: clients,
 	}, nil
 }
 
@@ -60,13 +65,20 @@ func (kr *hybridKeyRing) KeysById(id uint64) []openpgp.Key {
 		return keys
 	}
 
-	// No keys found in local keyring, check with keyserver.
-	el, err := kr.remoteEntitiesByID(id)
-	if err != nil {
-		sylog.Warningf("failed to get key material: %v", err)
-		return nil
+	// No keys found in local keyring, check with keyservers.
+	for _, c := range kr.clients {
+		el, err := kr.remoteEntitiesByID(c, id)
+		if err != nil {
+			sylog.Warningf("failed to get key material from %s: %v", c.BaseURL.String(), err)
+			continue
+		}
+		keys := el.KeysById(id)
+		if len(keys) > 0 {
+			return keys
+		}
 	}
-	return el.KeysById(id)
+
+	return nil
 }
 
 // KeysByIdUsage returns the set of keys with the given id that also meet the key usage given by
@@ -77,13 +89,20 @@ func (kr *hybridKeyRing) KeysByIdUsage(id uint64, requiredUsage byte) []openpgp.
 		return keys
 	}
 
-	// No keys found in local keyring, check with keyserver.
-	el, err := kr.remoteEntitiesByID(id)
-	if err != nil {
-		sylog.Warningf("failed to get key material: %v", err)
-		return nil
+	// No keys found in local keyring, check with keyservers.
+	for _, c := range kr.clients {
+		el, err := kr.remoteEntitiesByID(c, id)
+		if err != nil {
+			sylog.Warningf("failed to get key material from %s: %v", c.BaseURL.String(), err)
+			continue
+		}
+		keys := el.KeysByIdUsage(id, requiredUsage)
+		if len(keys) > 0 {
+			return keys
+		}
 	}
-	return el.KeysByIdUsage(id, requiredUsage)
+
+	return nil
 }
 
 // DecryptionKeys returns all private keys that are valid for decryption.
@@ -92,8 +111,8 @@ func (kr *hybridKeyRing) DecryptionKeys() []openpgp.Key {
 }
 
 // remoteEntitiesByID returns the set of entities from the keyserver that have the given key id.
-func (kr *hybridKeyRing) remoteEntitiesByID(id uint64) (openpgp.EntityList, error) {
-	kt, err := kr.c.PKSLookup(kr.ctx, nil, fmt.Sprintf("%#x", id), client.OperationGet, false, true, nil)
+func (kr *hybridKeyRing) remoteEntitiesByID(c *client.Client, id uint64) (openpgp.EntityList, error) {
+	kt, err := c.PKSLookup(kr.ctx, nil, fmt.Sprintf("%#x", id), client.OperationGet, false, true, nil)
 	if err != nil {
 		// If the request failed with HTTP status code unauthorized, guide the user to fix that.
 		var jerr *jsonresp.Error

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -190,6 +190,7 @@ func TestPushPubkey(t *testing.T) {
 		{"BadURL", ":", "", http.StatusOK, true},
 		{"TerribleURL", "terrible:", "", http.StatusOK, true},
 		{"Unauthorized", srv.URL, "", http.StatusUnauthorized, true},
+		{"Accepted", srv.URL, "", http.StatusAccepted, true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -22,45 +22,47 @@ func GetCurrentConfig() *File {
 
 // File describes the singularity.conf file options
 type File struct {
-	AllowSetuid             bool     `default:"yes" authorized:"yes,no" directive:"allow setuid"`
-	AllowPidNs              bool     `default:"yes" authorized:"yes,no" directive:"allow pid ns"`
-	ConfigPasswd            bool     `default:"yes" authorized:"yes,no" directive:"config passwd"`
-	ConfigGroup             bool     `default:"yes" authorized:"yes,no" directive:"config group"`
-	ConfigResolvConf        bool     `default:"yes" authorized:"yes,no" directive:"config resolv_conf"`
-	MountProc               bool     `default:"yes" authorized:"yes,no" directive:"mount proc"`
-	MountSys                bool     `default:"yes" authorized:"yes,no" directive:"mount sys"`
-	MountDevPts             bool     `default:"yes" authorized:"yes,no" directive:"mount devpts"`
-	MountHome               bool     `default:"yes" authorized:"yes,no" directive:"mount home"`
-	MountTmp                bool     `default:"yes" authorized:"yes,no" directive:"mount tmp"`
-	MountHostfs             bool     `default:"no" authorized:"yes,no" directive:"mount hostfs"`
-	UserBindControl         bool     `default:"yes" authorized:"yes,no" directive:"user bind control"`
-	EnableFusemount         bool     `default:"yes" authorized:"yes,no" directive:"enable fusemount"`
-	EnableUnderlay          bool     `default:"yes" authorized:"yes,no" directive:"enable underlay"`
-	MountSlave              bool     `default:"yes" authorized:"yes,no" directive:"mount slave"`
-	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
-	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
-	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
-	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
-	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
-	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
-	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
-	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
-	SessiondirMaxSize       uint     `default:"16" directive:"sessiondir max size"`
-	MountDev                string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
-	EnableOverlay           string   `default:"try" authorized:"yes,no,try,driver" directive:"enable overlay"`
-	BindPath                []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
-	LimitContainerOwners    []string `directive:"limit container owners"`
-	LimitContainerGroups    []string `directive:"limit container groups"`
-	LimitContainerPaths     []string `directive:"limit container paths"`
-	RootDefaultCapabilities string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
-	MemoryFSType            string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
-	CniConfPath             string   `directive:"cni configuration path"`
-	CniPluginPath           string   `directive:"cni plugin path"`
-	MksquashfsPath          string   `directive:"mksquashfs path"`
-	MksquashfsProcs         uint     `default:"0" directive:"mksquashfs procs"`
-	MksquashfsMem           string   `directive:"mksquashfs mem"`
-	CryptsetupPath          string   `directive:"cryptsetup path"`
-	ImageDriver             string   `directive:"image driver"`
+	BindPath                   []string `default:"/etc/localtime,/etc/hosts" directive:"bind path"`
+	LimitContainerOwners       []string `directive:"limit container owners"`
+	LimitContainerGroups       []string `directive:"limit container groups"`
+	LimitContainerPaths        []string `directive:"limit container paths"`
+	MountDev                   string   `default:"yes" authorized:"yes,no,minimal" directive:"mount dev"`
+	EnableOverlay              string   `default:"try" authorized:"yes,no,try,driver" directive:"enable overlay"`
+	RootDefaultCapabilities    string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
+	MemoryFSType               string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
+	CniConfPath                string   `directive:"cni configuration path"`
+	CniPluginPath              string   `directive:"cni plugin path"`
+	MksquashfsPath             string   `directive:"mksquashfs path"`
+	MksquashfsMem              string   `directive:"mksquashfs mem"`
+	CryptsetupPath             string   `directive:"cryptsetup path"`
+	ImageDriver                string   `directive:"image driver"`
+	DefaultKeyserver           string   `directive:"default keyserver"`
+	MaxLoopDevices             uint     `default:"256" directive:"max loop devices"`
+	SessiondirMaxSize          uint     `default:"16" directive:"sessiondir max size"`
+	MksquashfsProcs            uint     `default:"0" directive:"mksquashfs procs"`
+	AllowSetuid                bool     `default:"yes" authorized:"yes,no" directive:"allow setuid"`
+	AllowPidNs                 bool     `default:"yes" authorized:"yes,no" directive:"allow pid ns"`
+	ConfigPasswd               bool     `default:"yes" authorized:"yes,no" directive:"config passwd"`
+	ConfigGroup                bool     `default:"yes" authorized:"yes,no" directive:"config group"`
+	ConfigResolvConf           bool     `default:"yes" authorized:"yes,no" directive:"config resolv_conf"`
+	MountProc                  bool     `default:"yes" authorized:"yes,no" directive:"mount proc"`
+	MountSys                   bool     `default:"yes" authorized:"yes,no" directive:"mount sys"`
+	MountDevPts                bool     `default:"yes" authorized:"yes,no" directive:"mount devpts"`
+	MountHome                  bool     `default:"yes" authorized:"yes,no" directive:"mount home"`
+	MountTmp                   bool     `default:"yes" authorized:"yes,no" directive:"mount tmp"`
+	MountHostfs                bool     `default:"no" authorized:"yes,no" directive:"mount hostfs"`
+	UserBindControl            bool     `default:"yes" authorized:"yes,no" directive:"user bind control"`
+	EnableFusemount            bool     `default:"yes" authorized:"yes,no" directive:"enable fusemount"`
+	EnableUnderlay             bool     `default:"yes" authorized:"yes,no" directive:"enable underlay"`
+	MountSlave                 bool     `default:"yes" authorized:"yes,no" directive:"mount slave"`
+	AllowContainerSquashfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
+	AllowContainerExtfs        bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
+	AllowContainerDir          bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
+	AllowContainerEncrypted    bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
+	AlwaysUseNv                bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
+	AlwaysUseRocm              bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
+	SharedLoopDevices          bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
+	KeyserverVerifyDefaultOnly bool     `default:"yes" authorized:"yes,no" directive:"keyserver verify default only"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF
@@ -350,4 +352,25 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 # If the driver name specified has not been registered via a plugin installation
 # the run-time will abort.
 image driver = {{ .ImageDriver }}
+
+# DEFAULT KEYSERVER: [STRING]
+# DEFAULT: Undefined
+# This allows the administrator to set the keyserver used by default to pull, push
+# and search public keys, it's also used as the default keyserver to query during
+# signature verification. When this value is empty the default keyserver used is
+# https://keys.sylabs.io.
+# This option may be useful for environments with their own public key server.
+# NOTE: this value is ignored when user specify --url with the relevant commands.
+# default keyserver = https://keys.example.com
+{{ if ne .DefaultKeyserver "" }}default keyserver = {{ .DefaultKeyserver }}{{ end }}
+
+# KEYSERVER VERIFY DEFAULT ONLY: [BOOL]
+# DEFAULT: yes
+# This allows the administrator to control during the image verification whether the
+# 'default keyserver' is the only keyserver to used or not. When set to 'no' the verify
+# command will also reach the keyserver associated with the active remote endpoint of users
+# as the secondary keyserver to use if no key is found for the 'default keyserver'.
+# NOTE: this directive has no effect if the 'default keyserver' is empty or if --url
+# is specified by user.
+keyserver verify default only = {{ if eq .KeyserverVerifyDefaultOnly true }}yes{{ else }}no{{ end }}
 `


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds two configuration directives :
- `default keyserver` allowing an administrator to set the default keyserver used to pull, push and search for public keys, this server is also used during signature verification.
- `keyserver verify default only` allow the administrator to control during the image verification whether the 'default keyserver' is the only one to be used or not. When set to 'no' the verify command will also reach the keyserver associated with the active remote endpoint of users as the secondary keyserver to use if no key is found on the 'default keyserver'.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

