### PR TITLE
Fix sshfs FUSE e2e tests to use ssh_config from the sshfs alpine image

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1714,7 +1714,8 @@ func (c actionTests) fuseMount(t *testing.T) {
 		},
 	}
 
-	optionFmt := "%s:%s root@127.0.0.1:/ -p 2022 -o IdentityFile=%s -o StrictHostKeyChecking=no %s"
+	optionFmt := "%s:%s root@127.0.0.1:/ -p 2022 -F %s -o IdentityFile=%s -o StrictHostKeyChecking=no %s"
+	sshConfig := filepath.Join(imageDir, "etc", "ssh", "ssh_config")
 
 	for _, tt := range basicTests {
 		c.env.RunSingularity(
@@ -1723,7 +1724,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs([]string{
-				"--fusemount", fmt.Sprintf(optionFmt, tt.spec, sshfsWrapper, tt.key, "/mnt"),
+				"--fusemount", fmt.Sprintf(optionFmt, tt.spec, sshfsWrapper, sshConfig, tt.key, "/mnt"),
 				imageDir,
 				"test", "-d", "/mnt/etc",
 			}...),


### PR DESCRIPTION
## Description of the Pull Request (PR):

Passing `-F` with `ssh_config` from the sshfs image fix the issue by overriding the system-wide `/etc/ssh/ssh_config` from host system

### This fixes or addresses the following GitHub issues:

 - Fixes #5372 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

