### PR TITLE
Allow rw as (noop) bind option

### DIFF
--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -282,6 +282,7 @@ func ParseBindPath(bindpaths string) ([]BindPath, error) {
 
 	var validOptions = map[string]bool{
 		"ro":        true,
+		"rw":        true,
 		"image-src": false,
 		"id":        false,
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Minor bugfix to again allow `rw` as mountoption when specifying binds.

(This was assumedly accidentally lost when introducing image file support.)

### This fixes or addresses the following GitHub issues:

 - Fixes #5416 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

