### PR TITLE
Filter `mkdirat` for seccomp tests on ARM64

### DIFF
--- a/cmd/singularity/testdata/seccomp-profile.json
+++ b/cmd/singularity/testdata/seccomp-profile.json
@@ -12,7 +12,8 @@
     "syscalls": [
         {
             "names": [
-                "mkdir"
+                "mkdir",
+                "mkdirat"
             ],
             "action": "SCMP_ACT_KILL",
             "args": [],

--- a/e2e/security/testdata/seccomp-profile.json
+++ b/e2e/security/testdata/seccomp-profile.json
@@ -12,7 +12,8 @@
     "syscalls": [
         {
             "names": [
-                "mkdir"
+                "mkdir",
+                "mkdirat"
             ],
             "action": "SCMP_ACT_KILL",
             "args": [],

--- a/e2e/testdata/seccomp-profile.json
+++ b/e2e/testdata/seccomp-profile.json
@@ -18,7 +18,8 @@
     "syscalls": [
         {
             "names": [
-                "mkdir"
+                "mkdir",
+                "mkdirat"
             ],
             "action": "SCMP_ACT_KILL",
             "args": [],


### PR DESCRIPTION
## Description of the Pull Request (PR):

There is no mkdir syscall on ARM64 so the mkdir command will make a
mkdirat syscall. Filter this in our tests so that we correctly prove
seccomp filtering works on ARM64.

### This fixes or addresses the following GitHub issues:

 - Fixes: #5490


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

