### PR TITLE
delete command improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
+# Changes since v3.6.1
+
+## Change defaults / behaviours
+
+  - Default to current architecture for `singularity delete`.
+
+## Bug Fixes
+
+  - Respect current remote for `singularity delete` command.
+
 
 # v3.6.1 - [2020-07-21]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ _The old changelog can be found in the `release-2.6` branch_
 
 # Changes since v3.6.1
 
+## New features / functionalities
+
+  - Add --force option to `singularity delete` for non-interactive
+    workflows.
+
 ## Change defaults / behaviours
 
   - Default to current architecture for `singularity delete`.

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -96,7 +96,7 @@ var deleteImageCmd = &cobra.Command{
 		}
 
 		if !deleteForce {
-			y, err := interactive.AskYNQuestion("n", "Are you sure you want to delete %s arch[%s] [N/y] ", imageRef, deleteImageArch)
+			y, err := interactive.AskYNQuestion("n", "Are you sure you want to delete %s (%s) [N/y] ", imageRef, deleteImageArch)
 			if err != nil {
 				sylog.Fatalf(err.Error())
 			}

--- a/e2e/delete/delete.go
+++ b/e2e/delete/delete.go
@@ -49,6 +49,18 @@ func (c ctx) testDeleteCmd(t *testing.T) {
 			expectExit: 0,
 		},
 		{
+			name:       "delete unauthorized force arch",
+			args:       []string{"--force", "--arch=amd64", "library://test/default/test:v0.0.3"},
+			agree:      "",
+			expectExit: 255,
+		},
+		{
+			name:       "delete unauthorized force noarch",
+			args:       []string{"--force", "library://test/default/test:v0.0.3"},
+			agree:      "",
+			expectExit: 255,
+		},
+		{
 			name:       "delete unauthorized custom library",
 			args:       []string{"--library=https://cloud.staging.sylabs.io", "library://test/default/test:v0.0.3"},
 			agree:      "y",

--- a/e2e/delete/delete.go
+++ b/e2e/delete/delete.go
@@ -25,21 +25,34 @@ func (c ctx) testDeleteCmd(t *testing.T) {
 		expectExit int
 	}{
 		{
-			name:       "delete unauthorized",
+			name:       "delete unauthorized arch",
 			args:       []string{"--arch=amd64", "library://test/default/test:v0.0.3"},
 			agree:      "y",
 			expectExit: 255,
 		},
 		{
-			name:       "delete disagree",
+			name:       "delete unauthorized no arch",
+			args:       []string{"library://test/default/test:v0.0.3"},
+			agree:      "y",
+			expectExit: 255,
+		},
+		{
+			name:       "delete disagree arch",
 			args:       []string{"--arch=amd64", "library://test/default/test:v0.0.3"},
 			agree:      "n",
 			expectExit: 0,
 		},
 		{
-			name:       "delete without arch",
+			name:       "delete disagree noarch",
 			args:       []string{"library://test/default/test:v0.0.3"},
-			expectExit: 1,
+			agree:      "n",
+			expectExit: 0,
+		},
+		{
+			name:       "delete unauthorized custom library",
+			args:       []string{"--library=https://cloud.staging.sylabs.io", "library://test/default/test:v0.0.3"},
+			agree:      "y",
+			expectExit: 255,
 		},
 	}
 


### PR DESCRIPTION
When using `singularity delete`, correctly get the library service
for the current remote, and handle any flag override.

Default to the current arch of the machine in use, so that --arch
is not required for every delete operations. The confirmation
message shows the architecture to the user.

Add --force flag for singularity delete

- Fixes: #5417
- Fixes: #5493
- Fixes: #5494
