### PR TITLE
Fix LD_LIBRARY_PATH environment override regression with --nv/--rocm

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -23,7 +23,8 @@ type ctx struct {
 }
 
 const (
-	defaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	defaultPath     = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	singularityLibs = "/.singularity.d/libs"
 )
 
 func (c ctx) singularityEnv(t *testing.T) {
@@ -282,6 +283,19 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 			matchEnv: "BASH_FUNC_ml%%",
 			matchVal: "",
 		},
+		{
+			name:     "TestDefaultLdLibraryPath",
+			image:    c.env.ImagePath,
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: singularityLibs,
+		},
+		{
+			name:     "TestCustomLdLibraryPath",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo:" + singularityLibs,
+		},
 	}
 
 	for _, tt := range tests {
@@ -378,6 +392,19 @@ func (c ctx) singularityEnvFile(t *testing.T) {
 			envFile:  "PREPEND_PATH=/",
 			matchEnv: "PATH",
 			matchVal: "/:" + imageDefaultPath,
+		},
+		{
+			name:     "DefaultLdLibraryPath",
+			image:    c.env.ImagePath,
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: singularityLibs,
+		},
+		{
+			name:     "CustomLdLibraryPath",
+			image:    c.env.ImagePath,
+			envFile:  "LD_LIBRARY_PATH=/foo",
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo:" + singularityLibs,
 		},
 	}
 

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -607,8 +607,7 @@ func (b *bufferCloser) Close() error {
 }
 
 // Register a virtual file /.singularity.d/env/inject-singularity-env.sh sourced
-// either after sourcing /.singularity.d/env/10-docker2singularity.sh or before
-// sourcing /.singularity.d/env/90-environment.sh.
+// after /.singularity.d/env/99-base.sh or /environment.
 // This handler turns all SINGUALRITYENV_KEY=VAL defined variables into their form:
 // export KEY=VAL. It can be sourced only once otherwise it returns an empty content.
 func injectEnvHandler(senv map[string]string) interpreter.OpenHandler {
@@ -632,6 +631,10 @@ func injectEnvHandler(senv map[string]string) interpreter.OpenHandler {
 			export %[1]s=%[2]q
 			`
 			for key, value := range senv {
+				if key == "LD_LIBRARY_PATH" && value != "" {
+					b.WriteString(fmt.Sprintf(snippet, key, value+":/.singularity.d/libs"))
+					continue
+				}
 				b.WriteString(fmt.Sprintf(snippet, key, value))
 			}
 		})


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix a regression introduced by #5028 with `LD_LIBRARY_PATH` not injecting `/.singularity.d/libs` path when already set via `SINGULARITYENV_` or via `--env`/`--env-file`, making `--nv`/`--rocm` ineffective


### This fixes or addresses the following GitHub issues:

 - Fixes #5499 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

