### PR TITLE
Pass engine configuration through environment variables instead of a unix socket pair

### DIFF
--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -19,7 +19,6 @@
 #define warningf(b...)   singularity_message(WARNING, b)
 #define errorf(b...)     singularity_message(ERROR, b)
 
-#define MAX_JSON_SIZE       128*1024
 #define MAX_MAP_SIZE        4096
 #define MAX_PATH_SIZE       PATH_MAX
 #define MAX_GID             32
@@ -159,8 +158,9 @@ struct starter {
 
 /* engine configuration */
 struct engine {
-    char config[MAX_JSON_SIZE];
     size_t size;
+    size_t map_size;
+    char *config;
 };
 
 /* starter configuration */

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -444,7 +444,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"environment manipulation": c.singularityEnv,
 		"environment option":       c.singularityEnvOption,
 		"environment file":         c.singularityEnvFile,
+		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
-
 	}
 }

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -132,13 +132,13 @@ func (c *Command) init(config *config.Common, ops ...CommandOp) error {
 		return fmt.Errorf("while marshaling config: %s", err)
 	}
 
-	pipeFd, err := sendData(data)
+	envConfig, err := copyConfigToEnv(data)
 	if err != nil {
-		return fmt.Errorf("while sending configuration data: %s", err)
+		return fmt.Errorf("while copying engine configuration: %s", err)
 	}
 
-	env := []string{sylog.GetEnvVar(), fmt.Sprintf("PIPE_EXEC_FD=%d", pipeFd)}
-	c.env = append(c.env, env...)
+	c.env = append(c.env, sylog.GetEnvVar())
+	c.env = append(c.env, envConfig...)
 
 	return nil
 }

--- a/internal/pkg/util/starter/starter_unsupported.go
+++ b/internal/pkg/util/starter/starter_unsupported.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 )
 
-// sendData sets a socket communication channel between caller and starter
-// binary in order to pass engine JSON configuration data to starter.
-func sendData(data []byte) (int, error) {
-	return -1, fmt.Errorf("not supported on this platform")
+// copyConfigToEnv checks that the current stack size is big enough
+// to pass runtime configuration through environment variables.
+// On linux RLIMIT_STACK determines the amount of space used for the
+// process's command-line arguments and environment variables.
+func copyConfigToEnv(data []byte) ([]string, error) {
+	return nil, fmt.Errorf("not supported on this platform")
 }

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -46,6 +46,19 @@ config_add_def SESSIONDIR LOCALSTATEDIR \"/singularity/mnt/session\"
 config_add_def SINGULARITY_SUID_INSTALL $with_suid
 config_add_def PLUGIN_ROOTDIR LIBEXECDIR \"/singularity/plugin\"
 
+# engine configuration constants
+engine_config_env="ENGINE_CONFIG"
+engine_config_chunks_env="ENGINE_CONFIG_CHUNKS"
+max_engine_config_chunk="8"
+
+config_add_def ENGINE_CONFIG_ENV \"$engine_config_env\"
+config_add_def ENGINE_CONFIG_CHUNK_ENV \"$engine_config_chunks_env\"
+# add two bytes for '=' and the null character
+config_add_def ENGINE_CONFIG_ENV_PADDING ${#engine_config_env}+${#max_engine_config_chunk}+2
+config_add_def MAX_CHUNK_SIZE 131072-ENGINE_CONFIG_ENV_PADDING
+config_add_def MAX_ENGINE_CONFIG_CHUNK $max_engine_config_chunk
+config_add_def MAX_ENGINE_CONFIG_SIZE MAX_ENGINE_CONFIG_CHUNK*MAX_CHUNK_SIZE
+
 build_runtime=0
 if [ "$host" = "unix" ]; then
 	build_runtime=1


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Pass engine configuration through environment variables instead of a unix socket pair to allow bigger configuration to be passed between CLI and runtime. This implementation depends of RLIMIT_STACK current limit and also has a maximum hardcoded size of 1Mb for the engine configuration.

- Fixes missing memory release when joining container.

### This fixes or addresses the following GitHub issues:

 - Fixes #5057 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

