### PR TITLE
fix: address 'Ctty not valid in child' in e2e-test

### DIFF
--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -595,11 +595,12 @@ func (env TestEnv) RunSingularity(t *testing.T, cmdOps ...SingularityCmdOp) {
 			cmd.Stdin = s.console.Tty()
 			cmd.Stdout = s.console.Tty()
 			cmd.Stderr = s.console.Tty()
+			cmd.ExtraFiles = []*os.File{s.console.Tty()}
 
 			cmd.SysProcAttr = &syscall.SysProcAttr{
 				Setctty: true,
 				Setsid:  true,
-				Ctty:    int(s.console.Tty().Fd()),
+				Ctty:    3,
 			}
 		}
 		if s.postFn != nil {


### PR DESCRIPTION
Explicitly pass console TTY descriptor via `Extrafiles`, and set `Ctty` to child file descriptor, as per https://github.com/golang/go/issues/29458.

Fixes #5508