### PR TITLE
fix: Correct missed alpine:3.8 pulls to alpine:3.11.5

### DIFF
--- a/cmd/singularity/pull_test.go
+++ b/cmd/singularity/pull_test.go
@@ -235,7 +235,7 @@ func TestPull(t *testing.T) {
 			},*/
 		{
 			name:            "PullWithHash",
-			sourceSpec:      "library://sylabs/tests/signed:sha256.5c439fd262095766693dae95fb81334c3a02a7f0e4dc6291e0648ed4ddc61c6c",
+			sourceSpec:      "library://alpine:sha256.03883ca565b32e58fa0a496316d69de35741f2ef34b5b4658a6fec04ed8149a8",
 			force:           true,
 			unauthenticated: true,
 			library:         "",

--- a/cmd/singularity/pull_test.go
+++ b/cmd/singularity/pull_test.go
@@ -245,7 +245,7 @@ func TestPull(t *testing.T) {
 		},
 		{
 			name:            "PullWithoutTransportProtocol",
-			sourceSpec:      "alpine:3.8",
+			sourceSpec:      "alpine:3.11.5",
 			force:           true,
 			unauthenticated: true,
 			library:         "",

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -131,7 +131,7 @@ var tests = []testStruct{
 	// transport tests
 	{
 		desc:             "bare image name",
-		srcURI:           "alpine:3.8",
+		srcURI:           "alpine:3.11.5",
 		force:            true,
 		unauthenticated:  true,
 		expectedExitCode: 0,

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -287,18 +286,6 @@ func (c *ctx) setup(t *testing.T) {
 }
 
 func (c ctx) testPullCmd(t *testing.T) {
-	// XXX(mem): this should come from the environment
-	sylabsAdminFingerprint := "8883491F4268F173C6E5DC49EDECE4F3F38D871E"
-	argv := []string{"key", "pull", sylabsAdminFingerprint}
-	out, err := exec.Command(c.env.CmdPath, argv...).CombinedOutput()
-	if err != nil {
-		t.Fatalf("Cannot pull key %q: %+v\nCommand:\n%s %s\nOutput:\n%s\n",
-			sylabsAdminFingerprint,
-			err,
-			c.env.CmdPath, strings.Join(argv, " "),
-			out)
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			tmpdir, err := ioutil.TempDir(c.env.TestDir, "pull_test.")

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -91,7 +91,7 @@ var tests = []testStruct{
 	// test version specifications
 	{
 		desc:             "image with specific hash",
-		srcURI:           "library://sylabs/tests/signed:sha256.5c439fd262095766693dae95fb81334c3a02a7f0e4dc6291e0648ed4ddc61c6c",
+		srcURI:           "library://alpine:sha256.03883ca565b32e58fa0a496316d69de35741f2ef34b5b4658a6fec04ed8149a8",
 		unauthenticated:  true,
 		expectedExitCode: 0,
 	},


### PR DESCRIPTION
## Description of the Pull Request (PR):

In previous work to replace test image pulls so that they use sources that are compatible with ARM64, PP64LE architectures we switched from `library://alpine:3.8` -> `library://alpine:3.11.5`.

Unfortunately missed 2 pulls of `alpine:3.8` that did not have the library prefix.

Now that these are gone, also remove a vestigial key pull from the tests that doesn't match with the containers in use.

### This fixes or addresses the following GitHub issues:

 - Fixes #1150

