### PR TITLE
fix: Use -user-xattrs in rootless unsquashfs when possible

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2064,6 +2064,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5228":            c.issue5228,           // https://github.com/sylabs/singularity/issues/5228
 		"issue 5271":            c.issue5271,           // https://github.com/sylabs/singularity/issues/5271
 		"issue 5307":            c.issue5307,           // https://github.com/sylabs/singularity/issues/5307
+		"issue 5399":            c.issue5399,           // https://github.com/sylabs/singularity/issues/5399
 		"issue 5455":            c.issue5455,           // https://github.com/sylabs/singularity/issues/5455
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds

--- a/e2e/testdata/regressions/issue_5399.def
+++ b/e2e/testdata/regressions/issue_5399.def
@@ -1,0 +1,8 @@
+Bootstrap: library
+From: alpine:3.11.5
+
+%post
+apk add attr
+touch /sys-xattr
+setfattr -n "security.selinux" -v "system_u:object_r:tmp_t:s0" /sys-xattr
+

--- a/pkg/image/unpacker/squashfs.go
+++ b/pkg/image/unpacker/squashfs.go
@@ -6,12 +6,15 @@
 package unpacker
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/sylabs/singularity/pkg/sylog"
 )
 
 // Squashfs represents a squashfs unpacker.
@@ -60,6 +63,33 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) error 
 		}
 		if err := tmp.Close(); err != nil {
 			return fmt.Errorf("failed to close staging file: %s", err)
+		}
+	}
+
+	// If we are running as non-root, first try with `-user-xattrs` so we won't fail trying
+	// to set system xatts. This isn't supported on unsquashfs 4.0 in RHEL6 so we
+	//  have to fall back to not using that option on failure.
+	if os.Geteuid() != 0 {
+		sylog.Debugf("Rootless extraction. Trying -user-xattrs for unsquashfs")
+		args := []string{"-user-xattrs", "-f", "-d", dest, filename}
+		args = append(args, files...)
+		cmd := exec.Command(s.UnsquashfsPath, args...)
+		if stdin {
+			cmd.Stdin = reader
+		}
+
+		o, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+
+		// Invalid options give output...
+		// SYNTAX: unsquashfs [options] filesystem [directories or files to extract]
+		if bytes.HasPrefix(o, []byte("SYNTAX")) {
+			sylog.Warningf("unsquashfs does not support -user-xattrs. Images with system xattrs my fail to extract")
+		} else {
+			// A different error is fatal
+			return fmt.Errorf("extract command failed: %s: %s", string(o), err)
 		}
 	}
 

--- a/pkg/image/unpacker/squashfs.go
+++ b/pkg/image/unpacker/squashfs.go
@@ -86,7 +86,7 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) error 
 		// Invalid options give output...
 		// SYNTAX: unsquashfs [options] filesystem [directories or files to extract]
 		if bytes.HasPrefix(o, []byte("SYNTAX")) {
-			sylog.Warningf("unsquashfs does not support -user-xattrs. Images with system xattrs my fail to extract")
+			sylog.Warningf("unsquashfs does not support -user-xattrs. Images with system xattrs may fail to extract")
 		} else {
 			// A different error is fatal
 			return fmt.Errorf("extract command failed: %s: %s", string(o), err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

In `unsquashfs` 4.4 which is present in Ubuntu 20.04, a return code of `1` is given when it was not possible to extract system xattrs due to running as a non-root user. In 4.2, 4.3 warnings were printed but the return code was `0` still, so Singularity continued without error. In #5399 is a documented way of producing a fatal error on Ubuntu 20.04 due to the 4.4 version of `unsquashfs`. Any `security.selinux` attrs within a SIF file extracted as non-root on a Debian based (non-selinux) system using `unsquashfs` 4.4 will cause this:

```
write_xattr: could not write xattr security.selinux for file bob/sys-xattr because you're not superuser!
write_xattr: to avoid this error message, either specify -user-xattrs, -no-xattrs, or run as superuser
```
    
When we can, use the `-user-xattrs` option if `unsquashfs` is invoked as a non-root user. This is required to avoid a failure when there are system xattrs set on a file that will be extracted.

We have to check to see if we can use it, because `unsquashfs` is 4.0 in RHEL6 and does not include this flag. The usage output that results from the call with the missing flag starts with `SYNTAX`.

Also, provide a file with a security xattr in an e2e test image.. build.. and verify we can run it with `--fakeroot`. This test would fail on Ubuntu 20.04 without the fix.

Note that skipping over system xattrs is already done when extracting docker layer. Umoci will not attempt to set xattrs that are system ones when it is running rootless. Here we ensure SIF -> sandbox doesn't hit issues.

### This fixes or addresses the following GitHub issues:

 - Fixes #5399 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

