### PR TITLE
fix: Don't fail if parent of cache dir not accessible

### DIFF
--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -298,5 +298,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"interactive commands":     np(c.testInteractiveCacheCmds),
 		"non-interactive commands": np(c.testNoninteractiveCacheCmds),
 		"issue5097":                np(c.issue5097),
+		"issue5350":                np(c.issue5350),
 	}
 }

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -71,3 +71,36 @@ func (c cacheTests) issue5097(t *testing.T) {
 	}
 
 }
+
+// issue5350 - need to handle the cache being inside a non-accssible directory
+// e.g. home directory without perms to access
+func (c cacheTests) issue5350(t *testing.T) {
+
+	outerDir, cleanupOuter := e2e.MakeTempDir(t, c.env.TestDir, "issue5350-cache-", "")
+	defer e2e.Privileged(cleanupOuter)(t)
+
+	sandboxDir, cleanupSandbox := e2e.MakeTempDir(t, c.env.TestDir, "issue5350-sandbox-", "")
+	defer e2e.Privileged(cleanupSandbox)(t)
+
+	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, outerDir)
+	defer cleanCache(t)
+	c.env.ImgCacheDir = imgCacheDir
+
+	if err := os.Chmod(outerDir, 0o000); err != nil {
+		t.Fatalf("Could not chmod 000 cache outer dir: %v", err)
+	}
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs([]string{"--force", "-s", sandboxDir, "library://alpine:3.11.5"}...),
+		e2e.ExpectExit(0),
+	)
+
+	// Open up permissions or our cleanup will fail
+	if err := os.Chmod(outerDir, 0o755); err != nil {
+		t.Fatalf("Could not chmod 755 cache outer dir: %v", err)
+	}
+
+}

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -256,14 +256,19 @@ func New(cfg Config) (h *Handle, err error) {
 	}
 	h.parentDir = parentDir
 
+	// If we can't access the parent of the cache directory then don't use the
+	// cache.
 	ep, err := fs.FirstExistingParent(parentDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get first existing parent of cache directory: %v", err)
+		sylog.Warningf("Cache disabled - cannot access parent directory of cache: %s.", err)
+		h.disabled = true
+		return h, nil
 	}
 
 	// We check if we can write to the basedir or its first existing parent,
 	// if not we disable the caching mechanism
 	if !fs.IsWritable(ep) {
+		sylog.Warningf("Cache disabled - cache location %s is not writable.", ep)
 		h.disabled = true
 		return h, nil
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Instead of failing if the parent of the cache dir is not accessible,
just don't use caching.

Fixes part of #5350 - but not for docker / OCI sources as
containers/image will still fail on an inaccessible home dir when trying
to look for the docker config.json for auth.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

