### PR TITLE
fix: Correct --no-home message for 3.6 CWD behavior

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -432,7 +432,7 @@ var actionNoHomeFlag = cmdline.Flag{
 	Value:        &NoHome,
 	DefaultValue: false,
 	Name:         "no-home",
-	Usage:        "do NOT mount users home directory if home is not the current working directory",
+	Usage:        "do NOT mount users home directory if /home is not the current working directory",
 	EnvKeys:      []string{"NO_HOME"},
 	ExcludedOS:   []string{cmdline.Darwin},
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

With `--no-home`, in 3.6 `/home/<user>` will only be present if cwd is `/home`, as
mounting that will generally mean all user home directories are mounted.
If cwd is `/home/<user>` then it won't be mounted.

### This fixes or addresses the following GitHub issues:

 - Fixes #5478


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

