### PR TITLE
Allow RHEL7 cap set in e2e/security tests

### DIFF
--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -157,7 +157,7 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 			name:     "capabilities_keep",
 			argv:     []string{"grep", "^CapEff:", "/proc/self/status"},
 			opts:     []string{"--keep-privs"},
-			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[3f]fffffffff\n`),
+			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[13f]fffffffff\n`),
 		},
 		{
 			// this might break if new capabilities are
@@ -171,7 +171,7 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 			name:     "capabilities_drop",
 			argv:     []string{"grep", "^CapEff:", "/proc/self/status"},
 			opts:     []string{"--drop-caps", "CAP_NET_RAW"},
-			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[3f]fffffdfff\n`),
+			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[13f]fffffdfff\n`),
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In RHEL7.8 our full `CapEff` is now `0000001fffffffff` so we need to
allow that in tests:

- TestE2E/PAR/SECURITY/singularitySecurityPriv/capabilities_keep
- TestE2E/PAR/SECURITY/singularitySecurityPriv/capabilities_drop

Note that we really need to rewrite these tests so that (like the comment from mem says) they pull the full cap set that root has outside of the container, and base the comparison on that not a regex that has to accommodate different capability sets on different distros. I'll transfer this into a tech debt issue.


### This fixes or addresses the following GitHub issues:

 - Fixes #5532


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

