### PR TITLE
Add CAP_MKNOD in capability bounding set of RPC

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -373,6 +373,7 @@ static void set_rpc_privileges(void) {
     /* required by cryptsetup */
     priv->capabilities.bounding = capflag(CAP_SYS_ADMIN);
     priv->capabilities.bounding |= capflag(CAP_IPC_LOCK);
+    priv->capabilities.bounding |= capflag(CAP_MKNOD);
 
     debugf("Set RPC privileges\n");
     apply_privileges(priv, current);


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix regression introduced by capability handling rework and add missing CAP_MKNOD in capability bounding set of RPC to fix issue with cryptsetup when decrypting image.
May not necessary related to docker but may be related to cryptsetup version, looks like old version creates device while new maybe rely on linux kernel to do the job, not sure about that, didn't dig into ...

### This fixes or addresses the following GitHub issues:

 - Fixes #5546 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

