### PR TITLE
Fix decryption issue when using both IPC and PID namespaces

### DIFF
--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -166,6 +166,18 @@ func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
+	// Ensure decryption works with containall (IPC and PID namespaces)
+	cmdArgs = []string{"--containall", imgPath}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("env var passphrase with containall"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("run"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
+		e2e.ExpectExit(0),
+	)
+
 	// Specifying the passphrase on the command line should always fail
 	cmdArgs = []string{"--passphrase", e2e.Passphrase, imgPath}
 	c.env.RunSingularity(


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previously RPC decrypt method used `os.Getpid()` to return the current process ID but when RPC process is in the container PID namespace it returned an ID which can't be used with the `/proc/<pid>/ns/ipc` to enter in the IPC namespace. The fix read the symlink target of `/proc/self` to get the RPC process ID from the host namespace.

### This fixes or addresses the following GitHub issues:

 - Fixes #5547


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

