### PR TITLE
Fix unsupported builtins panic from shell interpreter and add umask support

### DIFF
--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -757,6 +758,24 @@ func hashBuiltin(ctx context.Context, argv []string) error {
 	return nil
 }
 
+func umaskBuiltin(ctx context.Context, argv []string) error {
+	hc := interp.HandlerCtx(ctx)
+
+	if len(argv) == 0 {
+		old := unix.Umask(0)
+		unix.Umask(old)
+		fmt.Fprintf(hc.Stdout, "%#.4o\n", old)
+	} else {
+		umask, err := strconv.ParseUint(argv[0], 8, 16)
+		if err != nil {
+			return fmt.Errorf("umask: %s: invalid octal number: %s", argv[0], err)
+		}
+		unix.Umask(int(umask))
+	}
+
+	return nil
+}
+
 // runActionScript interprets and executes the action script within
 // an embedded shell interpreter.
 func runActionScript(engineConfig *singularityConfig.EngineConfig) ([]string, []string, error) {
@@ -794,6 +813,7 @@ func runActionScript(engineConfig *singularityConfig.EngineConfig) ([]string, []
 	shell.RegisterShellBuiltin("fixpath", fixPathBuiltin)
 	shell.RegisterShellBuiltin("hash", hashBuiltin)
 	shell.RegisterShellBuiltin("unescape", unescapeBuiltin)
+	shell.RegisterShellBuiltin("umask_builtin", umaskBuiltin)
 
 	// exec builtin won't execute the command but instead
 	// it returns arguments and environment variables and

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -16,6 +16,16 @@ fi
 
 export PWD
 
+unsupported_builtin() {
+    sylog warning "$1 is not supported by this shell interpreter"
+}
+
+# create alias for unsupported builtin that trigger a panic
+alias umask="umask_builtin"
+alias trap="unsupported_builtin trap"
+alias fg="unsupported_builtin fg"
+alias bg="unsupported_builtin bg"
+
 clear_env() {
     local IFS=$'\n'
 
@@ -69,6 +79,7 @@ restore_env() {
 }
 
 clear_env
+shopt -s expand_aliases
 
 if test -d "/.singularity.d/env"; then
     for __script__ in /.singularity.d/env/*.sh; do
@@ -116,6 +127,7 @@ if ! test -f "/.singularity.d/env/99-runtimevars.sh"; then
     source "/.singularity.d/env/99-runtimevars.sh"
 fi
 
+shopt -u expand_aliases
 restore_env
 
 # See https://github.com/sylabs/singularity/issues/2721,


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix unsupported builtins panic from shell interpreter and add umask support

### This fixes or addresses the following GitHub issues:

 - Fixes #5545 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

