### PR TITLE
Singularity remote command enhancements

### DIFF
--- a/cmd/internal/cli/build_darwin.go
+++ b/cmd/internal/cli/build_darwin.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -30,10 +31,15 @@ func runBuild(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Only remote builds are supported on this platform")
 	}
 
-	handleRemoteBuildFlags(cmd)
+	bc, lc, err := getBuildAndLibraryClientConfig(buildArgs.builderURL, buildArgs.libraryURL)
+	if err != nil {
+		sylog.Fatalf("Unable to get builder and library client configuration: %v", err)
+	}
+	buildArgs.libraryURL = lc.BaseURL
+	buildArgs.builderURL = bc.BaseURL
 
 	// Submiting a remote build requires a valid authToken
-	if authToken == "" {
+	if bc.AuthToken == "" {
 		sylog.Fatalf("Unable to submit build job: %v", remoteWarning)
 	}
 
@@ -42,7 +48,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Unable to build from %s: %v", spec, err)
 	}
 
-	b, err := remotebuilder.New(dest, buildArgs.libraryURL, def, buildArgs.detached, forceOverwrite, buildArgs.builderURL, authToken, buildArgs.arch)
+	b, err := remotebuilder.New(dest, buildArgs.libraryURL, def, buildArgs.detached, forceOverwrite, buildArgs.builderURL, bc.AuthToken, buildArgs.arch)
 	if err != nil {
 		sylog.Fatalf("Failed to create builder: %v", err)
 	}

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2017-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -10,11 +11,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/pkg/cmdline"
 )
 
 const (
-	defaultKeyServer = "https://keys.sylabs.io"
+	defaultKeyServer = endpoint.SCSDefaultKeyserverURI
 )
 
 var (

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -50,7 +51,6 @@ func init() {
 var KeyExportCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                sylabsToken,
 	Run:                   exportRun,
 
 	Use:     docs.KeyExportUse,

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -19,7 +20,6 @@ import (
 var KeyImportCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                sylabsToken,
 	Run:                   importRun,
 
 	Use:     docs.KeyImportUse,

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2017-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -9,12 +10,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
-	scs "github.com/sylabs/singularity/internal/pkg/remote"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -76,7 +76,6 @@ var (
 	KeyNewPairCmd = &cobra.Command{
 		Args:                  cobra.ExactArgs(0),
 		DisableFlagsInUseLine: true,
-		PreRun:                sylabsToken,
 		Run:                   runNewPairCmd,
 		Use:                   docs.KeyNewPairUse,
 		Short:                 docs.KeyNewPairShort,
@@ -116,8 +115,12 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 	}
 
 	// Only connect to the endpoint if we are pushing the key.
-	handleKeyNewPairEndpoint()
-	if err := sypgp.PushPubkey(ctx, http.DefaultClient, key, keyServerURI, authToken); err != nil {
+	keyClient, err := getKeyserverClientConfig(keyServerURI, endpoint.KeyserverPushOp)
+	if err != nil {
+		sylog.Fatalf("Keyserver client failed: %s", err)
+	}
+
+	if err := sypgp.PushPubkey(ctx, keyClient, key); err != nil {
 		fmt.Printf("Failed to push newly created key to keystore: %s\n", err)
 	} else {
 		fmt.Printf("Key successfully pushed to: %s\n", keyServerURI)
@@ -197,23 +200,4 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 	}
 
 	return &genOpts, nil
-}
-
-func handleKeyNewPairEndpoint() {
-	// if we can load config and if default endpoint is set, use that
-	// otherwise fall back on regular authtoken and URI behavior
-	endpoint, err := sylabsRemote(remoteConfig)
-	if err == scs.ErrNoDefault {
-		sylog.Warningf("No default remote in use, falling back to: %v", keyServerURI)
-		return
-	} else if err != nil {
-		sylog.Fatalf("Unable to load remote configuration: %v", err)
-	}
-
-	authToken = endpoint.Token
-	uri, err := endpoint.GetServiceURI("keystore")
-	if err != nil {
-		sylog.Fatalf("Unable to get key service URI: %v", err)
-	}
-	keyServerURI = uri
 }

--- a/cmd/internal/cli/key_search.go
+++ b/cmd/internal/cli/key_search.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2017-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -7,11 +8,12 @@ package cli
 
 import (
 	"context"
-	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/sypgp"
 )
@@ -20,13 +22,15 @@ import (
 var KeySearchCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	PreRun:                sylabsToken,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.TODO()
 
-		handleKeyFlags(cmd)
+		keyClient, err := getKeyserverClientConfig(keyServerURI, endpoint.KeyserverSearchOp)
+		if err != nil {
+			sylog.Fatalf("Keyserver client failed: %s", err)
+		}
 
-		if err := doKeySearchCmd(ctx, args[0], keyServerURI); err != nil {
+		if err := doKeySearchCmd(ctx, args[0], keyClient); err != nil {
 			sylog.Errorf("search failed: %s", err)
 			os.Exit(2)
 		}
@@ -38,7 +42,7 @@ var KeySearchCmd = &cobra.Command{
 	Example: docs.KeySearchExample,
 }
 
-func doKeySearchCmd(ctx context.Context, search string, url string) error {
+func doKeySearchCmd(ctx context.Context, search string, c *client.Config) error {
 	// get keyring with matching search string
-	return sypgp.SearchPubkey(ctx, http.DefaultClient, search, url, authToken, keySearchLongList)
+	return sypgp.SearchPubkey(ctx, c, search, keySearchLongList)
 }

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -128,7 +128,7 @@ var remoteUseExclusiveFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "exclusive",
 	ShortHand:    "e",
-	Usage:        "set the endpoint as exclusive",
+	Usage:        "set the endpoint as exclusive (root user only, imply --global)",
 }
 
 // -o|--order

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -6,33 +7,39 @@
 package cli
 
 import (
+	"io/ioutil"
 	"os"
-	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
-	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
 const (
-	sysDir        = "singularity"
 	remoteWarning = "no authentication token, log in with `singularity remote login`"
 )
 
 var (
-	loginTokenFile string
-	remoteConfig   string
-	remoteNoLogin  bool
-	global         bool
+	loginTokenFile          string
+	loginUsername           string
+	loginPassword           string
+	remoteConfig            string
+	remoteKeyserverOrder    uint32
+	remoteKeyserverInsecure bool
+	loginPasswordStdin      bool
+	loginInsecure           bool
+	remoteNoLogin           bool
+	global                  bool
+	remoteUseExclusive      bool
 )
 
 // assemble values of remoteConfig for user/sys locations
 var remoteConfigUser = syfs.RemoteConf()
-var remoteConfigSys = filepath.Join(buildcfg.SYSCONFDIR, sysDir, syfs.RemoteConfFile)
 
 // -g|--global
 var remoteGlobalFlag = cmdline.Flag{
@@ -72,6 +79,78 @@ var remoteNoLoginFlag = cmdline.Flag{
 	Usage:        "skip automatic login step",
 }
 
+// -u|--username
+var remoteLoginUsernameFlag = cmdline.Flag{
+	ID:           "remoteLoginUsernameFlag",
+	Value:        &loginUsername,
+	DefaultValue: "",
+	Name:         "username",
+	ShortHand:    "u",
+	Usage:        "username to authenticate with (leave it empty for token authentication)",
+	EnvKeys:      []string{"LOGIN_USERNAME"},
+}
+
+// -p|--password
+var remoteLoginPasswordFlag = cmdline.Flag{
+	ID:           "remoteLoginPasswordFlag",
+	Value:        &loginPassword,
+	DefaultValue: "",
+	Name:         "password",
+	ShortHand:    "p",
+	Usage:        "password to authenticate with",
+	EnvKeys:      []string{"LOGIN_PASSWORD"},
+}
+
+// --password-stdin
+var remoteLoginPasswordStdinFlag = cmdline.Flag{
+	ID:           "remoteLoginPasswordStdinFlag",
+	Value:        &loginPasswordStdin,
+	DefaultValue: false,
+	Name:         "password-stdin",
+	Usage:        "take password from standard input",
+}
+
+// -i|--insecure
+var remoteLoginInsecureFlag = cmdline.Flag{
+	ID:           "remoteLoginInsecureFlag",
+	Value:        &loginInsecure,
+	DefaultValue: false,
+	Name:         "insecure",
+	ShortHand:    "i",
+	Usage:        "allow insecure login",
+	EnvKeys:      []string{"LOGIN_INSECURE"},
+}
+
+// -e|--exclusive
+var remoteUseExclusiveFlag = cmdline.Flag{
+	ID:           "remoteUseExclusiveFlag",
+	Value:        &remoteUseExclusive,
+	DefaultValue: false,
+	Name:         "exclusive",
+	ShortHand:    "e",
+	Usage:        "set the endpoint as exclusive",
+}
+
+// -o|--order
+var remoteKeyserverOrderFlag = cmdline.Flag{
+	ID:           "remoteKeyserverOrderFlag",
+	Value:        &remoteKeyserverOrder,
+	DefaultValue: uint32(0),
+	Name:         "order",
+	ShortHand:    "o",
+	Usage:        "define the keyserver order",
+}
+
+// -i|--insecure
+var remoteKeyserverInsecureFlag = cmdline.Flag{
+	ID:           "remoteKeyserverInsecureFlag",
+	Value:        &remoteKeyserverInsecure,
+	DefaultValue: false,
+	Name:         "insecure",
+	ShortHand:    "i",
+	Usage:        "allow insecure connection to keyserver",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(RemoteCmd)
@@ -80,7 +159,10 @@ func init() {
 		cmdManager.RegisterSubCmd(RemoteCmd, RemoteUseCmd)
 		cmdManager.RegisterSubCmd(RemoteCmd, RemoteListCmd)
 		cmdManager.RegisterSubCmd(RemoteCmd, RemoteLoginCmd)
+		cmdManager.RegisterSubCmd(RemoteCmd, RemoteLogoutCmd)
 		cmdManager.RegisterSubCmd(RemoteCmd, RemoteStatusCmd)
+		cmdManager.RegisterSubCmd(RemoteCmd, RemoteAddKeyserverCmd)
+		cmdManager.RegisterSubCmd(RemoteCmd, RemoteRemoveKeyserverCmd)
 
 		// default location of the remote.yaml file is the user directory
 		cmdManager.RegisterFlagForCmd(&remoteConfigFlag, RemoteCmd)
@@ -90,6 +172,16 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&remoteGlobalFlag, RemoteAddCmd, RemoteRemoveCmd, RemoteUseCmd)
 		// add --no-login flag to add command
 		cmdManager.RegisterFlagForCmd(&remoteNoLoginFlag, RemoteAddCmd)
+
+		cmdManager.RegisterFlagForCmd(&remoteLoginUsernameFlag, RemoteLoginCmd)
+		cmdManager.RegisterFlagForCmd(&remoteLoginPasswordFlag, RemoteLoginCmd)
+		cmdManager.RegisterFlagForCmd(&remoteLoginPasswordStdinFlag, RemoteLoginCmd)
+		cmdManager.RegisterFlagForCmd(&remoteLoginInsecureFlag, RemoteLoginCmd)
+
+		cmdManager.RegisterFlagForCmd(&remoteUseExclusiveFlag, RemoteUseCmd)
+
+		cmdManager.RegisterFlagForCmd(&remoteKeyserverOrderFlag, RemoteAddKeyserverCmd)
+		cmdManager.RegisterFlagForCmd(&remoteKeyserverInsecureFlag, RemoteAddKeyserverCmd)
 	})
 }
 
@@ -117,7 +209,13 @@ func setGlobalRemoteConfig(_ *cobra.Command, _ []string) {
 	}
 
 	// set remoteConfig value to the location of the global remote.yaml file
-	remoteConfig = remoteConfigSys
+	remoteConfig = remote.SystemConfigPath
+}
+
+func setKeyserver(_ *cobra.Command, _ []string) {
+	if uint32(os.Getuid()) != 0 {
+		sylog.Fatalf("Unable to modify keyserver configuration: not root user")
+	}
 }
 
 // RemoteAddCmd singularity remote add [remoteName] [remoteURI]
@@ -137,8 +235,11 @@ var RemoteAddCmd = &cobra.Command{
 		if global && !remoteNoLogin {
 			sylog.Infof("Global option detected. Will not automatically log into remote.")
 		} else if !remoteNoLogin {
-			sylog.Infof("Authenticating with remote: %s", name)
-			if err := singularity.RemoteLogin(remoteConfig, remoteConfigSys, name, loginTokenFile); err != nil {
+			loginArgs := &singularity.LoginArgs{
+				Name:      name,
+				Tokenfile: loginTokenFile,
+			}
+			if err := singularity.RemoteLogin(remoteConfig, loginArgs); err != nil {
 				sylog.Fatalf("%s", err)
 			}
 		}
@@ -178,7 +279,7 @@ var RemoteUseCmd = &cobra.Command{
 	PreRun: setGlobalRemoteConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
-		if err := singularity.RemoteUse(remoteConfig, remoteConfigSys, name, global); err != nil {
+		if err := singularity.RemoteUse(remoteConfig, name, global, remoteUseExclusive); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 		sylog.Infof("Remote %q now in use.", name)
@@ -196,7 +297,7 @@ var RemoteUseCmd = &cobra.Command{
 var RemoteListCmd = &cobra.Command{
 	Args: cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := singularity.RemoteList(remoteConfig, remoteConfigSys); err != nil {
+		if err := singularity.RemoteList(remoteConfig); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -213,24 +314,61 @@ var RemoteListCmd = &cobra.Command{
 var RemoteLoginCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
+		loginArgs := new(singularity.LoginArgs)
+
 		// default to empty string to signal to RemoteLogin to use default remote
-		name := ""
 		if len(args) > 0 {
-			name = args[0]
-			sylog.Infof("Authenticating with remote: %s", name)
-		} else {
-			sylog.Infof("Authenticating with default remote.")
+			loginArgs.Name = args[0]
 		}
 
-		if err := singularity.RemoteLogin(remoteConfig, remoteConfigSys, name, loginTokenFile); err != nil {
+		loginArgs.Username = loginUsername
+		loginArgs.Password = loginPassword
+		loginArgs.Tokenfile = loginTokenFile
+		loginArgs.Insecure = loginInsecure
+
+		if loginPasswordStdin {
+			p, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				sylog.Fatalf("Failed to read password from stdin: %s", err)
+			}
+			loginArgs.Password = strings.TrimSuffix(string(p), "\n")
+			loginArgs.Password = strings.TrimSuffix(loginArgs.Password, "\r")
+		}
+
+		if err := singularity.RemoteLogin(remoteConfig, loginArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
+		sylog.Infof("Login succeeded")
 	},
 
 	Use:     docs.RemoteLoginUse,
 	Short:   docs.RemoteLoginShort,
 	Long:    docs.RemoteLoginLong,
 	Example: docs.RemoteLoginExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// RemoteLogoutCmd singularity remote logout [remoteName|serviceURI]
+var RemoteLogoutCmd = &cobra.Command{
+	Args: cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// default to empty string to signal to RemoteLogin to use default remote
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+
+		if err := singularity.RemoteLogout(remoteConfig, name); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+		sylog.Infof("Logout succeeded")
+	},
+
+	Use:     docs.RemoteLogoutUse,
+	Short:   docs.RemoteLogoutShort,
+	Long:    docs.RemoteLogoutLong,
+	Example: docs.RemoteLogoutExample,
 
 	DisableFlagsInUseLine: true,
 }
@@ -243,12 +381,9 @@ var RemoteStatusCmd = &cobra.Command{
 		name := ""
 		if len(args) > 0 {
 			name = args[0]
-			sylog.Infof("Checking status of remote: %s", name)
-		} else {
-			sylog.Infof("Checking status of default remote.")
 		}
 
-		if err := singularity.RemoteStatus(remoteConfig, remoteConfigSys, name); err != nil {
+		if err := singularity.RemoteStatus(remoteConfig, name); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -257,6 +392,60 @@ var RemoteStatusCmd = &cobra.Command{
 	Short:   docs.RemoteStatusShort,
 	Long:    docs.RemoteStatusLong,
 	Example: docs.RemoteStatusExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// RemoteAddKeyserverCmd singularity remote add-keyserver [option] [remoteName] <keyserver_url>
+var RemoteAddKeyserverCmd = &cobra.Command{
+	Args:   cobra.RangeArgs(1, 2),
+	PreRun: setKeyserver,
+	Run: func(cmd *cobra.Command, args []string) {
+		uri := args[0]
+		name := ""
+		if len(args) > 1 {
+			name = args[0]
+			uri = args[1]
+		}
+
+		if cmd.Flag(remoteKeyserverOrderFlag.Name).Changed && remoteKeyserverOrder == 0 {
+			sylog.Fatalf("order must be > 0")
+		}
+
+		if err := singularity.RemoteAddKeyserver(name, uri, remoteKeyserverOrder, remoteKeyserverInsecure); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.RemoteAddKeyserverUse,
+	Short:   docs.RemoteAddKeyserverShort,
+	Long:    docs.RemoteAddKeyserverLong,
+	Example: docs.RemoteAddKeyserverExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// RemoteRemoveKeyserverCmd singularity remote remove-keyserver [remoteName] <keyserver_url>
+var RemoteRemoveKeyserverCmd = &cobra.Command{
+	Args:   cobra.RangeArgs(1, 2),
+	PreRun: setKeyserver,
+	Run: func(cmd *cobra.Command, args []string) {
+		uri := args[0]
+		name := ""
+		if len(args) > 1 {
+			name = args[0]
+			uri = args[1]
+		}
+
+		if err := singularity.RemoteRemoveKeyserver(name, uri); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.RemoteRemoveKeyserverUse,
+	Short:   docs.RemoteRemoveKeyserverShort,
+	Long:    docs.RemoteRemoveKeyserverLong,
+	Example: docs.RemoteRemoveKeyserverExample,
 
 	DisableFlagsInUseLine: true,
 }

--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -38,7 +39,6 @@ func init() {
 // RunHelpCmd singularity run-help <image>
 var RunHelpCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	PreRun:                sylabsToken,
 	Args:                  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Sanity check

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -14,18 +15,20 @@ import (
 	"os/exec"
 	"os/signal"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
 
 	ocitypes "github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
+	scsbuildclient "github.com/sylabs/scs-build-client/client"
+	scskeyclient "github.com/sylabs/scs-key-client/client"
+	scslibclient "github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/plugin"
-	scs "github.com/sylabs/singularity/internal/pkg/remote"
-	"github.com/sylabs/singularity/internal/pkg/util/auth"
+	"github.com/sylabs/singularity/internal/pkg/remote"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	clicallback "github.com/sylabs/singularity/pkg/plugin/callback/cli"
@@ -42,20 +45,10 @@ var cmdInits = make([]func(*cmdline.CommandManager), 0)
 // CurrentUser holds the current user account information
 var CurrentUser = getCurrentUser()
 
-var defaultTokenFile = getDefaultTokenFile()
+// currentRemoteEndpoint holds the current remote endpoint
+var currentRemoteEndpoint *endpoint.Config
 
 var (
-	// TokenFile holds the path to the sylabs auth token file
-	tokenFile string
-	// authToken holds the sylabs auth token
-	authToken, authWarning string
-	// default remote configuration for comparison
-	defaultRemote = scs.EndPoint{
-		URI:    "cloud.sylabs.io",
-		Token:  "",
-		System: true,
-	}
-
 	dockerAuthConfig ocitypes.DockerAuthConfig
 	dockerLogin      bool
 
@@ -128,16 +121,6 @@ var singVerboseFlag = cmdline.Flag{
 	Name:         "verbose",
 	ShortHand:    "v",
 	Usage:        "print additional information",
-}
-
-var singTokenFileFlag = cmdline.Flag{
-	ID:           "singTokenFileFlag",
-	Value:        &tokenFile,
-	DefaultValue: defaultTokenFile,
-	Name:         "tokenfile",
-	ShortHand:    "t",
-	Usage:        "path to the file holding your sylabs authentication token",
-	Deprecated:   "Use 'singularity remote' to manage remote endpoints and tokens.",
 }
 
 // --docker-username
@@ -239,10 +222,6 @@ func getCurrentUser() *user.User {
 		sylog.Fatalf("Couldn't determine user account information: %v", err)
 	}
 	return usr
-}
-
-func getDefaultTokenFile() string {
-	return path.Join(syfs.ConfigDir(), "sylabs-token")
 }
 
 func addCmdInit(cmdInit func(*cmdline.CommandManager)) {
@@ -362,7 +341,6 @@ func Init(loadPlugins bool) {
 	cmdManager.RegisterFlagForCmd(&singSilentFlag, singularityCmd)
 	cmdManager.RegisterFlagForCmd(&singQuietFlag, singularityCmd)
 	cmdManager.RegisterFlagForCmd(&singVerboseFlag, singularityCmd)
-	cmdManager.RegisterFlagForCmd(&singTokenFileFlag, singularityCmd)
 	cmdManager.RegisterFlagForCmd(&singConfigFileFlag, singularityCmd)
 
 	cmdManager.RegisterCmd(VersionCmd)
@@ -503,28 +481,14 @@ var VersionCmd = &cobra.Command{
 	Short: "Show the version for Singularity",
 }
 
-// sylabsToken process the authentication Token
-// priority default_file < env < file_flag
-func sylabsToken(cmd *cobra.Command, args []string) {
-	if val := os.Getenv("SYLABS_TOKEN"); val != "" {
-		authToken = val
-	}
-	if tokenFile != defaultTokenFile {
-		authToken, authWarning = auth.ReadToken(tokenFile)
-	}
-	if authToken == "" {
-		authToken, authWarning = auth.ReadToken(defaultTokenFile)
-	}
-}
-
-func loadRemoteConf(filepath string) (*scs.Config, error) {
+func loadRemoteConf(filepath string) (*remote.Config, error) {
 	f, err := os.OpenFile(filepath, os.O_RDONLY, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("while opening remote config file: %s", err)
 	}
 	defer f.Close()
 
-	c, err := scs.ReadFrom(f)
+	c, err := remote.ReadFrom(f)
 	if err != nil {
 		return nil, fmt.Errorf("while parsing remote config data: %s", err)
 	}
@@ -532,61 +496,16 @@ func loadRemoteConf(filepath string) (*scs.Config, error) {
 	return c, nil
 }
 
-// defaultRemoteLogin attempts to log in the default remote with the specified tokenfile
-// this will update the user remote config if it succeeds, otherwise it will return an error
-func defaultRemoteLogin(filepath string, c *scs.Config) error {
-	endpoint, err := c.GetDefault()
-	if err != nil {
-		return err
-	}
-
-	token, warning := auth.ReadToken(defaultTokenFile)
-	if warning != "" {
-		// token not found, return non logged in endpoint
-		return fmt.Errorf("token not found, cannot log in")
-	}
-
-	endpoint.Token = token
-	if err := endpoint.VerifyToken(); err != nil {
-		return err
-	}
-
-	// opening config file
-	file, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0600)
-	if err != nil {
-		return fmt.Errorf("while opening remote config file: %s", err)
-	}
-	defer file.Close()
-
-	// truncating file before writing new contents and syncing to commit file
-	if err := file.Truncate(0); err != nil {
-		return fmt.Errorf("while truncating remote config file: %s", err)
-	}
-
-	if n, err := file.Seek(0, os.SEEK_SET); err != nil || n != 0 {
-		return fmt.Errorf("failed to reset %s cursor: %s", file.Name(), err)
-	}
-
-	if _, err := c.WriteTo(file); err != nil {
-		return fmt.Errorf("while writing remote config to file: %s", err)
-	}
-
-	if err := file.Sync(); err != nil {
-		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
-	}
-	return nil
-}
-
 // sylabsRemote returns the remote in use or an error
-func sylabsRemote(filepath string) (*scs.EndPoint, error) {
-	var c *scs.Config
+func sylabsRemote() (*endpoint.Config, error) {
+	var c *remote.Config
 
 	// try to load both remotes, check for errors, sync if both exist,
 	// if neither exist return errNoDefault to return to old auth behavior
-	cSys, sysErr := loadRemoteConf(remoteConfigSys)
-	cUsr, usrErr := loadRemoteConf(filepath)
+	cSys, sysErr := loadRemoteConf(remote.SystemConfigPath)
+	cUsr, usrErr := loadRemoteConf(syfs.RemoteConf())
 	if sysErr != nil && usrErr != nil {
-		return nil, scs.ErrNoDefault
+		return endpoint.DefaultEndpointConfig, nil
 	} else if sysErr != nil {
 		c = cUsr
 	} else if usrErr != nil {
@@ -599,24 +518,12 @@ func sylabsRemote(filepath string) (*scs.EndPoint, error) {
 		c = cUsr
 	}
 
-	endpoint, err := c.GetDefault()
+	ep, err := c.GetDefault()
 	if err != nil {
-		return endpoint, err
+		return endpoint.DefaultEndpointConfig, err
 	}
 
-	// default remote without token, look for tokenfile to login with
-	if *endpoint == defaultRemote {
-		origEndpoint := *endpoint
-		err := defaultRemoteLogin(filepath, c)
-		if err != nil {
-			// failed to log in, return unmodified endpoint
-			return &origEndpoint, nil
-		}
-		sylog.Infof("Default remote in use, you are now logged in from existing tokenfile. Use 'singularity remote' commands to further manage remotes")
-		return endpoint, nil
-	}
-
-	return endpoint, nil
+	return ep, nil
 }
 
 func singularityExec(image string, args []string) (string, error) {
@@ -663,4 +570,73 @@ func CheckRootOrUnpriv(cmd *cobra.Command, args []string) {
 	if os.Geteuid() != 0 && buildcfg.SINGULARITY_SUID_INSTALL == 1 {
 		sylog.Fatalf("%q command requires root privileges or an unprivileged installation", cmd.CommandPath())
 	}
+}
+
+func getKeyserverClientConfig(uri string, op endpoint.KeyserverOp) (*scskeyclient.Config, error) {
+	isDefault := uri == endpoint.SCSDefaultKeyserverURI
+
+	if currentRemoteEndpoint == nil {
+		var err error
+
+		// if we can load config and if default endpoint is set, use that
+		// otherwise fall back on regular authtoken and URI behavior
+		currentRemoteEndpoint, err = sylabsRemote()
+		if err != nil {
+			return nil, fmt.Errorf("unable to load remote configuration: %v", err)
+		}
+	}
+	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig && isDefault {
+		sylog.Warningf("No default remote in use, falling back to default keyserver: %s", uri)
+	}
+	if isDefault {
+		uri = ""
+	}
+
+	return currentRemoteEndpoint.KeyserverClientConfig(uri, op)
+}
+
+func getLibraryClientConfig(uri string) (*scslibclient.Config, error) {
+	isDefault := uri == endpoint.SCSDefaultLibraryURI
+
+	if currentRemoteEndpoint == nil {
+		var err error
+
+		// if we can load config and if default endpoint is set, use that
+		// otherwise fall back on regular authtoken and URI behavior
+		currentRemoteEndpoint, err = sylabsRemote()
+		if err != nil {
+			return nil, fmt.Errorf("unable to load remote configuration: %v", err)
+		}
+	}
+	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig && isDefault {
+		sylog.Warningf("No default remote in use, falling back to default library: %s", uri)
+	}
+	if isDefault {
+		uri = ""
+	}
+
+	return currentRemoteEndpoint.LibraryClientConfig(uri)
+}
+
+func getBuilderClientConfig(uri string) (*scsbuildclient.Config, error) {
+	isDefault := uri == endpoint.SCSDefaultBuilderURI
+
+	if currentRemoteEndpoint == nil {
+		var err error
+
+		// if we can load config and if default endpoint is set, use that
+		// otherwise fall back on regular authtoken and URI behavior
+		currentRemoteEndpoint, err = sylabsRemote()
+		if err != nil {
+			return nil, fmt.Errorf("unable to load remote configuration: %v", err)
+		}
+	}
+	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig && isDefault {
+		sylog.Warningf("No default remote in use, falling back to default builder: %s", uri)
+	}
+	if isDefault {
+		uri = ""
+	}
+
+	return currentRemoteEndpoint.BuilderClientConfig(uri)
 }

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2017-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -10,13 +11,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
-	scs "github.com/sylabs/singularity/internal/pkg/remote"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
-	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 var (
@@ -139,7 +138,6 @@ func init() {
 var VerifyCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(1),
-	PreRun:                sylabsToken,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		// args[0] contains image path
@@ -157,14 +155,12 @@ func doVerifyCmd(cmd *cobra.Command, cpath string) {
 
 	// Set keyserver option, if applicable.
 	if !localVerify {
-		handleVerifyFlags(cmd)
-
-		c := client.Config{
-			BaseURL:   keyServerURI,
-			AuthToken: authToken,
-			UserAgent: useragent.Value(),
+		c, err := getKeyserverClientConfig(keyServerURI, endpoint.KeyserverVerifyOp)
+		if err != nil {
+			sylog.Fatalf("Error while getting keyserver client config: %v", err)
 		}
-		opts = append(opts, singularity.OptVerifyUseKeyServer(&c))
+
+		opts = append(opts, singularity.OptVerifyUseKeyServer(c))
 	}
 
 	// Set group option, if applicable.
@@ -213,26 +209,5 @@ func doVerifyCmd(cmd *cobra.Command, cpath string) {
 		}
 
 		fmt.Printf("Container verified: %s\n", cpath)
-	}
-}
-
-func handleVerifyFlags(cmd *cobra.Command) {
-	// if we can load config and if default endpoint is set, use that
-	// otherwise fall back on regular authtoken and URI behavior
-	endpoint, err := sylabsRemote(remoteConfig)
-	if err == scs.ErrNoDefault {
-		sylog.Warningf("No default remote in use, falling back to: %v", keyServerURI)
-		return
-	} else if err != nil {
-		sylog.Fatalf("Unable to load remote configuration: %v", err)
-	}
-
-	authToken = endpoint.Token
-	if !cmd.Flags().Lookup("url").Changed {
-		uri, err := endpoint.GetServiceURI("keystore")
-		if err != nil {
-			sylog.Fatalf("Unable to get library service URI: %v", err)
-		}
-		keyServerURI = uri
 	}
 }

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -11,11 +12,11 @@ const (
 	// remote command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteUse   string = `remote [remote options...]`
-	RemoteShort string = `Manage singularity remote endpoints`
+	RemoteShort string = `Manage singularity remote endpoints, keyservers and OCI/Docker registry credentials`
 	RemoteLong  string = `
-  The 'remote' commands allow you to manage Singularity remote endpoints through 
-  its subcommands. These allow you to add, log in, and use endpoints. The remote
-  configuration is stored in $HOME/.singularity/remotes.yaml by default.`
+  The 'remote' commands allow you to manage Singularity remote endpoints, keyservers
+  and OCI/Docker registry credentials through its subcommands. The remote configuration
+  is stored in $HOME/.singularity/remotes.yaml by default.`
 	RemoteExample string = `
   All group commands have their own help output:
 
@@ -56,7 +57,7 @@ const (
 	// remote list command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteListUse   string = `list`
-	RemoteListShort string = `List all singularity remote endpoints that are configured`
+	RemoteListShort string = `List all singularity remote endpoints and services that are configured`
 	RemoteListLong  string = `
   The 'remote list' command lists all remote endpoints configured for use. If a remote
   is in use, its name will be encompassed by brackets.`
@@ -65,15 +66,34 @@ const (
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote login command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RemoteLoginUse   string = `login [login options...] <remote_name>`
-	RemoteLoginShort string = `Log into a singularity remote endpoint using an authentication token`
+	RemoteLoginUse   string = `login [login options...] <remote_name|registry_uri>`
+	RemoteLoginShort string = `Log into a singularity remote endpoint, an OCI/Docker registry or a keyserver using credentials`
 	RemoteLoginLong  string = `
-  The 'remote login' command allows you to set an authentication token for a
-  specific endpoint. This command will produce a link directing you to the token
-  service you can use to generate a valid token. If no endpoint is specified,
-  it will try the default remote (SylabsCloud).`
+  The 'remote login' command allows you to set credentials for a specific endpoint,
+  an OCI/Docker registry or a keyserver. This command can produce a link directing you to
+  the token service you can use to generate a valid token. If no endpoint or registry is
+  specified, it will try the default remote endpoint (SylabsCloud).`
 	RemoteLoginExample string = `
-  $ singularity remote login SylabsCloud`
+  To log in to an endpoint:
+  $ singularity remote login SylabsCloud
+
+  To login in to a docker/OCI registry:
+  $ singularity remote login --username foo --password bar docker://docker.io`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// remote logout command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RemoteLogoutUse   string = `logout <remote_name|registry_uri>`
+	RemoteLogoutShort string = `Log out from a singularity remote endpoint, an OCI/Docker registry or a keyserver`
+	RemoteLogoutLong  string = `
+  The 'remote logout' command allows you to log out from a singularity specific endpoint,
+  an OCI/Docker registry or a keyserver. If no endpoint or service is specified, it will
+  try the default remote endpoint (SylabsCloud).`
+	RemoteLogoutExample string = `
+  To log out from an endpoint
+  $ singularity remote logout SylabsCloud
+
+  To log out from a docker/OCI registry
+  $ singularity remote logout docker://docker.io`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote status command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -85,4 +105,29 @@ const (
   specified, it will check the status of the default remote (SylabsCloud).`
 	RemoteStatusExample string = `
   $ singularity remote status SylabsCloud`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// remote add-keyserver command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RemoteAddKeyserverUse   string = `add-keyserver [options] [remoteName] <keyserver_url>`
+	RemoteAddKeyserverShort string = `Add a keyserver (root user only)`
+	RemoteAddKeyserverLong  string = `
+  The 'remote add-keyserver' command allows to define additional keyserver. The --order
+  option can define the order of the keyserver for all related key operations, therefore
+  when specifying '--order 1' the keyserver is becoming the primary keyserver. If no endpoint
+  is specified, it will use the default remote endpoint (SylabsCloud).`
+	RemoteAddKeyserverExample string = `
+  $ singularity remote add-keyserver https://keys.example.com
+
+  To add a keyserver to be used as the primary keyserver for the current endpoint
+  $ singularity remote add-keyserver --order 1 https://keys.example.com`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// remote remove-keyserver command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	RemoteRemoveKeyserverUse   string = `remove-keyserver [remoteName] <keyserver_url>`
+	RemoteRemoveKeyserverShort string = `Remove a keyserver (root user only)`
+	RemoteRemoveKeyserverLong  string = `
+  The 'remote remove-keyserver' command allows to remove a defined keyserver from a specific
+  endpoint. If no endpoint is specified, it will use the default remote endpoint (SylabsCloud).`
+	RemoteRemoveKeyserverExample string = `
+  $ singularity remote remove-keyserver https://keys.example.com`
 )

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -7,6 +8,7 @@ package e2e
 
 import (
 	"net"
+	"net/http"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -50,6 +52,16 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 			WithArgs("-s", dockerImage, dockerDefinition),
 			ExpectExit(0),
 		)
+
+		crt := filepath.Join(dockerImage, "certs/root.crt")
+		key := filepath.Join(dockerImage, "certs/root.key")
+
+		go func() {
+			// for simplicity let this be brutally stopped once test finished
+			if err := startAuthServer(crt, key); err != http.ErrServerClosed {
+				t.Errorf("docker auth server error: %s", err)
+			}
+		}()
 
 		var umountFn func(*testing.T)
 

--- a/e2e/internal/e2e/docker_auth_server.go
+++ b/e2e/internal/e2e/docker_auth_server.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	registry "github.com/adigunhammedolalekan/registry-auth"
+)
+
+const (
+	DefaultUsername  = "e2e"
+	DefaultPassword  = "e2e"
+	privateNamespace = "private"
+)
+
+type dockerAuthHandler struct {
+	srv *registry.AuthServer
+}
+
+type authnz struct {
+	username string
+	password string
+	sync.Mutex
+}
+
+const (
+	noAuthUsername = "no-auth"
+)
+
+func (a *authnz) Authenticate(username, password string) error {
+	// deferring unlock in Authorize to be sure username
+	// and password are associated to the same request,
+	// fortunately docker-registry-auth package doesn't
+	// generate error between Authenticate and Authorize
+	// calls, so a deadlock is not possible
+	a.Lock()
+
+	if username == noAuthUsername {
+		a.username = ""
+		a.password = ""
+	} else {
+		a.username = username
+		a.password = password
+	}
+
+	return nil
+}
+
+func (a *authnz) Authorize(req *registry.AuthorizationRequest) ([]string, error) {
+	// release previous lock
+	defer a.Unlock()
+
+	requireAuth := false
+
+	if strings.HasPrefix(req.Name, privateNamespace) || req.Type == "" {
+		requireAuth = true
+	}
+	if requireAuth {
+		if a.username != DefaultUsername || a.password != DefaultPassword {
+			return nil, fmt.Errorf("unauthorized")
+		}
+	}
+
+	return []string{"pull", "push"}, nil
+}
+
+func startAuthServer(crt, key string) error {
+	authnz := new(authnz)
+
+	opt := &registry.Option{
+		Certfile:        crt,
+		Keyfile:         key,
+		TokenExpiration: time.Now().Add(1 * time.Hour).Unix(),
+		TokenIssuer:     "E2E",
+		Authenticator:   authnz,
+		Authorizer:      authnz,
+	}
+
+	srv, err := registry.NewAuthServer(opt)
+	if err != nil {
+		return err
+	}
+
+	http.Handle("/auth", &dockerAuthHandler{srv: srv})
+	return http.ListenAndServe(":5001", nil)
+}
+
+func (d *dockerAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, _, ok := r.BasicAuth()
+	if !ok {
+		// pass a non empty username meaning there is no authentication
+		// credentials, this is required as the docker-registry-auth package
+		// doesn't allow empty credentials, Authorize will reset the username
+		// to an empty value
+		r.SetBasicAuth(noAuthUsername, "")
+	}
+	d.srv.ServeHTTP(w, r)
+}

--- a/e2e/internal/e2e/remote.go
+++ b/e2e/internal/e2e/remote.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"golang.org/x/sys/unix"
+)
+
+func SetupSystemRemoteFile(t *testing.T, testDir string) {
+	Privileged(func(t *testing.T) {
+		orig := filepath.Join(buildcfg.SOURCEDIR, "etc", "remote.yaml")
+		dest := filepath.Join(buildcfg.SINGULARITY_CONFDIR, "remote.yaml")
+		source := filepath.Join(testDir, "remote.yaml")
+
+		data, err := ioutil.ReadFile(orig)
+		if err != nil {
+			t.Fatalf("while reading %s: %s", orig, err)
+		}
+		if err := ioutil.WriteFile(source, data, 0644); err != nil {
+			t.Fatalf("while creating %s: %s", source, err)
+		}
+		if err := unix.Mount(source, dest, "", unix.MS_BIND, ""); err != nil {
+			t.Fatalf("while mounting %s to %s: %s", source, dest, err)
+		}
+	})(t)
+}

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -6,9 +7,12 @@
 package remote
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/sylabs/singularity/e2e/internal/e2e"
@@ -413,12 +417,12 @@ func (c ctx) remoteTestFlag(t *testing.T) {
 		{
 			name:           "list help",
 			cmdArgs:        []string{"list", "--help"},
-			expectedOutput: "List all singularity remote endpoints that are configured",
+			expectedOutput: "List all singularity remote endpoints and services that are configured",
 		},
 		{
 			name:           "login help",
 			cmdArgs:        []string{"login", "--help"},
-			expectedOutput: "Log into a singularity remote endpoint using an authentication token",
+			expectedOutput: "Log into a singularity remote endpoint, an OCI/Docker registry or a keyserver using credentials",
 		},
 		{
 			name:           "remove help",
@@ -453,18 +457,398 @@ func (c ctx) remoteTestFlag(t *testing.T) {
 	}
 }
 
+func (c ctx) remoteBasicLogin(t *testing.T) {
+	e2e.PrepRegistry(t, c.env)
+
+	var (
+		registry    = fmt.Sprintf("oras://%s", c.env.TestRegistry)
+		badRegistry = "oras://bad_registry:5000"
+	)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		stdin      io.Reader
+		expectExit int
+	}{
+		{
+			name:       "login username and empty password",
+			command:    "remote login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", "", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login empty username and empty password",
+			command:    "remote login",
+			args:       []string{"-p", "", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login empty username and bad password",
+			command:    "remote login",
+			args:       []string{"-p", "bad", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login KO",
+			command:    "remote login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", "bad", registry},
+			expectExit: 255,
+		},
+		{
+			name:       "login without scheme KO",
+			command:    "remote login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, c.env.TestRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "login into non-existing keyserver",
+			command:    "remote login",
+			args:       []string{"http://localhost:11371"},
+			expectExit: 255,
+		},
+		{
+			name:       "login OK",
+			command:    "remote login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
+			expectExit: 0,
+		},
+		{
+			name:       "login password-stdin",
+			command:    "remote login",
+			args:       []string{"-u", e2e.DefaultUsername, "--password-stdin", registry},
+			stdin:      strings.NewReader(e2e.DefaultPassword),
+			expectExit: 0,
+		},
+		{
+			name:       "logout KO",
+			command:    "remote logout",
+			args:       []string{badRegistry},
+			expectExit: 255,
+		},
+		{
+			name:       "logout OK",
+			command:    "remote logout",
+			args:       []string{registry},
+			expectExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithStdin(tt.stdin),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+func (c ctx) remoteLoginPushPrivate(t *testing.T) {
+	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureImage(t, c.env)
+
+	var (
+		registry = fmt.Sprintf("oras://%s", c.env.TestRegistry)
+		repo     = fmt.Sprintf("oras://%s/private/e2e:1.0.0", c.env.TestRegistry)
+	)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		expectExit int
+	}{
+		{
+			name:       "push before login",
+			command:    "push",
+			args:       []string{c.env.ImagePath, repo},
+			expectExit: 255,
+		},
+		{
+			name:       "login",
+			command:    "remote login",
+			args:       []string{"-u", e2e.DefaultUsername, "-p", e2e.DefaultPassword, registry},
+			expectExit: 0,
+		},
+		{
+			name:       "push after login",
+			command:    "push",
+			args:       []string{c.env.ImagePath, repo},
+			expectExit: 0,
+		},
+		{
+			name:       "logout",
+			command:    "remote logout",
+			args:       []string{registry},
+			expectExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+func (c ctx) remoteKeyserver(t *testing.T) {
+	var (
+		sylabsKeyserver = "https://keys.sylabs.io"
+		testKeyserver   = "http://localhost:11371"
+		addKeyserver    = "remote add-keyserver"
+		removeKeyserver = "remote remove-keyserver"
+	)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		listLines  []string
+		expectExit int
+		profile    e2e.Profile
+	}{
+		{
+			name:       "add-keyserver non privileged",
+			command:    addKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.UserProfile,
+		},
+		{
+			name:    "add-keyserver without order",
+			command: addKeyserver,
+			args:    []string{"--insecure", testKeyserver},
+			listLines: []string{
+				"URI                     GLOBAL  INSECURE  ORDER",
+				sylabsKeyserver + "  YES     NO        1*",
+				testKeyserver + "  YES     YES       2",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "remove-keyserver previous",
+			command:    removeKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "remove-keyserver non-existent",
+			command:    removeKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "add-keyserver with order 0",
+			command:    addKeyserver,
+			args:       []string{"--order", "0", testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "add-keyserver with order 1",
+			command: addKeyserver,
+			args:    []string{"--order", "1", testKeyserver},
+			listLines: []string{
+				"URI                     GLOBAL  INSECURE  ORDER",
+				testKeyserver + "  YES     NO        1",
+				sylabsKeyserver + "  YES     NO        2*",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "add-keyserver duplicate",
+			command:    addKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "remove-keyserver sylabs",
+			command: removeKeyserver,
+			args:    []string{sylabsKeyserver},
+			listLines: []string{
+				"URI                     GLOBAL  INSECURE  ORDER",
+				testKeyserver + "  YES     NO        1",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "remove-keyserver primary KO",
+			command:    removeKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "add-keyserver restore sylabs",
+			command: addKeyserver,
+			args:    []string{sylabsKeyserver},
+			listLines: []string{
+				"URI                     GLOBAL  INSECURE  ORDER",
+				testKeyserver + "  YES     NO        1",
+				sylabsKeyserver + "  YES     NO        2*",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "remove-keyserver primary OK",
+			command: removeKeyserver,
+			args:    []string{testKeyserver},
+			listLines: []string{
+				"URI                     GLOBAL  INSECURE  ORDER",
+				sylabsKeyserver + "  YES     NO        1*",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "add-keyserver out of order",
+			command:    addKeyserver,
+			args:       []string{"--order", "100", testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.PostRun(func(t *testing.T) {
+				if t.Failed() || len(tt.listLines) == 0 {
+					return
+				}
+				c.env.RunSingularity(
+					t,
+					e2e.WithProfile(e2e.UserProfile),
+					e2e.WithCommand("remote list"),
+					e2e.ExpectExit(
+						0,
+						e2e.ExpectOutput(
+							e2e.ContainMatch,
+							strings.Join(tt.listLines, "\n"),
+						),
+					),
+				)
+			}),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+func (c ctx) remoteUseExclusive(t *testing.T) {
+	var (
+		sylabsRemote = "SylabsCloud"
+		testRemote   = "e2e"
+	)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		expectExit int
+		profile    e2e.Profile
+	}{
+		{
+			name:       "use exclusive without global",
+			command:    "remote use",
+			args:       []string{"--exclusive", testRemote},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "use exclusive as user",
+			command:    "remote use",
+			args:       []string{"--exclusive", "--global", testRemote},
+			expectExit: 255,
+			profile:    e2e.UserProfile,
+		},
+		{
+			name:       "add remote",
+			command:    "remote add",
+			args:       []string{"--global", testRemote, "cloud.test.com"},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "use remote exclusive as root",
+			command:    "remote use",
+			args:       []string{"--exclusive", "--global", testRemote},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "use remote SylabsCloud as user KO",
+			command:    "remote use",
+			args:       []string{sylabsRemote},
+			expectExit: 255,
+			profile:    e2e.UserProfile,
+		},
+		{
+			name:       "remove e2e remote",
+			command:    "remote remove",
+			args:       []string{"--global", testRemote},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "use remote SylabsCloud as user OK",
+			command:    "remote use",
+			args:       []string{sylabsRemote},
+			expectExit: 0,
+			profile:    e2e.UserProfile,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
 		env: env,
 	}
 
+	np := testhelper.NoParallel
+
 	return testhelper.Tests{
-		"add":       c.remoteAdd,
-		"list":      c.remoteList,
-		"remove":    c.remoteRemove,
-		"status":    c.remoteStatus,
-		"test flag": c.remoteTestFlag,
-		"use":       c.remoteUse,
+		"add":                    c.remoteAdd,
+		"list":                   c.remoteList,
+		"remove":                 c.remoteRemove,
+		"status":                 c.remoteStatus,
+		"test flag":              c.remoteTestFlag,
+		"use":                    c.remoteUse,
+		"oci login basic":        np(c.remoteBasicLogin),
+		"oci login push private": np(c.remoteLoginPushPrivate),
+		"keyserver":              np(c.remoteKeyserver),
+		"use exclusive":          np(c.remoteUseExclusive),
 	}
 }

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -769,13 +769,6 @@ func (c ctx) remoteUseExclusive(t *testing.T) {
 		profile    e2e.Profile
 	}{
 		{
-			name:       "use exclusive without global",
-			command:    "remote use",
-			args:       []string{"--exclusive", testRemote},
-			expectExit: 255,
-			profile:    e2e.RootProfile,
-		},
-		{
 			name:       "use exclusive as user",
 			command:    "remote use",
 			args:       []string{"--exclusive", "--global", testRemote},
@@ -790,7 +783,7 @@ func (c ctx) remoteUseExclusive(t *testing.T) {
 			profile:    e2e.RootProfile,
 		},
 		{
-			name:       "use remote exclusive as root",
+			name:       "use remote exclusive with global as root",
 			command:    "remote use",
 			args:       []string{"--exclusive", "--global", testRemote},
 			expectExit: 0,
@@ -816,6 +809,34 @@ func (c ctx) remoteUseExclusive(t *testing.T) {
 			args:       []string{sylabsRemote},
 			expectExit: 0,
 			profile:    e2e.UserProfile,
+		},
+		{
+			name:       "add remote",
+			command:    "remote add",
+			args:       []string{"--global", testRemote, "cloud.test.com"},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "use remote exclusive without global as root",
+			command:    "remote use",
+			args:       []string{"--exclusive", testRemote},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "use remote SylabsCloud as user KO",
+			command:    "remote use",
+			args:       []string{sylabsRemote},
+			expectExit: 255,
+			profile:    e2e.UserProfile,
+		},
+		{
+			name:       "remove e2e remote",
+			command:    "remote remove",
+			args:       []string{"--global", testRemote},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
 		},
 	}
 

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -106,6 +107,9 @@ func Run(t *testing.T) {
 
 	// create an empty plugin directory
 	e2e.SetupPluginDir(t, testenv.TestDir)
+
+	// duplicate system remote.yaml and create a temporary one on top of original
+	e2e.SetupSystemRemoteFile(t, testenv.TestDir)
 
 	// Ensure config files are installed
 	configFiles := []string{

--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -1,15 +1,31 @@
 bootstrap: docker
 from: registry:2.7.1
 
+%environment
+    export REGISTRY_AUTH=token
+    export REGISTRY_AUTH_TOKEN_REALM=http://localhost:5001/auth
+    export REGISTRY_AUTH_TOKEN_SERVICE=Authentication
+    export REGISTRY_AUTH_TOKEN_ISSUER=E2E
+    export REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE=/certs/root.crt
+
 %post
+    apk add openssl
     apk add runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
     # Install v0.5.7 of img (latest will not talk to http registries)
     export IMG_SHA256="41aa98ab28be55ba3d383cb4e8f86dceac6d6e92102ee4410a6b43514f4da1fa"
     # Download and check the sha256sum.
-    wget "https://github.com/genuinetools/img/releases/download/v0.5.7/img-linux-amd64" -O "/usr/local/bin/img" \
+    wget -q "https://github.com/genuinetools/img/releases/download/v0.5.7/img-linux-amd64" -O "/usr/local/bin/img" \
 	  && echo "${IMG_SHA256}  /usr/local/bin/img" | sha256sum -c - \
 	  && chmod a+x "/usr/local/bin/img"
+
+    mkdir /certs
+
+    openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 \
+      -keyout /certs/root.key -out /certs/root.pem -subj "/C=US/CN=localhost"
+    openssl x509 -outform pem -in /certs/root.pem -out /certs/root.crt
+
+    chmod 644 /certs/root.*
 
 %startscript
     /.singularity.d/runscript &

--- a/etc/remote.yaml
+++ b/etc/remote.yaml
@@ -3,3 +3,4 @@ Remotes:
   SylabsCloud:
     URI: cloud.sylabs.io
     System: true
+    Exclusive: false

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667
+	github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60
 	github.com/alexflint/go-filemutex v0.0.0-20171028004239-d358565f3c3f // indirect
 	github.com/apex/log v1.9.0
 	github.com/blang/semver/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60 h1:1IG6ye8dellBRE2uqvG0EzQScRqjsH/n5xOw+n0OGec=
+github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60/go.mod h1:DcXj4IQOoib2b4G2b8JU3VGV3ljXYbIq+PH4CcoAQTI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
@@ -156,6 +158,7 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 h1:FwssHbCDJD025h+BchanCwE1Q8fyMgqDr2mOQAWOLGw=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d h1:jC8tT/S0OGx2cswpeUTn4gOIea8P08lD3VFQT0cOZ50=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=

--- a/internal/app/singularity/remote_add.go
+++ b/internal/app/singularity/remote_add.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/remote"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 )
 
 // RemoteAdd adds remote to configuration
@@ -50,7 +51,7 @@ func RemoteAdd(configFile, name, uri string, global bool) (err error) {
 	if err != nil {
 		return err
 	}
-	e := remote.EndPoint{URI: path.Join(u.Host + u.Path), System: global}
+	e := endpoint.Config{URI: path.Join(u.Host + u.Path), System: global}
 
 	if err := c.Add(name, &e); err != nil {
 		return err

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -310,7 +310,7 @@ func TestRemoteAdd(t *testing.T) {
 			shallPass:  false,
 		},
 		{
-			name:       "26: valid config file; valid remote name; valid URI; local",
+			name:       "26: valid config file; valid remote name; valid URI; global",
 			cfgfile:    validCfgFile,
 			remoteName: validRemoteName,
 			uri:        validURI,
@@ -318,7 +318,7 @@ func TestRemoteAdd(t *testing.T) {
 			shallPass:  true,
 		},
 		{
-			name:       "27: valid config file; empty remote name; valid URI; local",
+			name:       "27: valid config file; empty remote name; valid URI; global",
 			cfgfile:    validCfgFile,
 			remoteName: "",
 			uri:        validURI,
@@ -348,18 +348,39 @@ func TestRemoteAdd(t *testing.T) {
 			test.DropPrivilege(t)
 			defer test.ResetPrivilege(t)
 
+			// remote package detect if the configuration file is
+			// the system configuration to apply some restriction,
+			// therefore we need to replace SystemConfigPath in
+			// the remote package in order to make the test configuration
+			// file as the system configuration file. This shouldn't interfere
+			// with remove tests in remote_remove_test.go (hopefully)
+			oldSysConfig := ""
+			restoreSysConfig := func() {
+				if oldSysConfig != "" {
+					remote.SystemConfigPath = oldSysConfig
+				}
+			}
+
+			if tt.global && tt.shallPass {
+				oldSysConfig = remote.SystemConfigPath
+				remote.SystemConfigPath = tt.cfgfile
+			}
+
 			err := RemoteAdd(tt.cfgfile, tt.remoteName, tt.uri, tt.global)
 			if tt.shallPass == true && err != nil {
+				restoreSysConfig()
 				t.Fatalf("valid case failed: %s\n", err)
 			}
 
 			if tt.shallPass == false && err == nil {
+				restoreSysConfig()
 				RemoteRemove(tt.cfgfile, tt.remoteName)
 				t.Fatal("invalid case passed")
 			}
 
 			if tt.shallPass == true && err == nil {
 				RemoteRemove(tt.cfgfile, tt.remoteName)
+				restoreSysConfig()
 			}
 		})
 	}

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/remote"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	"gopkg.in/yaml.v2"
 )
@@ -62,7 +63,7 @@ func createValidCfgFile(t *testing.T) string {
 	// Set a valid configuration
 	cfg := remote.Config{
 		DefaultRemote: validRemoteName,
-		Remotes: map[string]*remote.EndPoint{
+		Remotes: map[string]*endpoint.Config{
 			"random": {
 				URI:   "validURI",
 				Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -14,11 +15,11 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/remote"
 )
 
-const listLine = "%s\t%s\t%s\n"
-const listLineDefault = "[%s]\t%s\t%s\n"
+const listLine = "%s\t%s\t%s\t%s\n"
+const listLineDefault = "[%s]\t%s\t%s\t%s\n"
 
 // RemoteList prints information about remote configurations
-func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
+func RemoteList(usrConfigFile string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
@@ -37,7 +38,7 @@ func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
 		return fmt.Errorf("while parsing remote config data: %s", err)
 	}
 
-	if err := syncSysConfig(c, sysConfigFile); err != nil {
+	if err := syncSysConfig(c); err != nil {
 		return err
 	}
 
@@ -59,21 +60,83 @@ func RemoteList(usrConfigFile, sysConfigFile string) (err error) {
 	})
 	sort.Strings(names)
 
+	fmt.Println("Cloud Services Endpoints")
+	fmt.Println("========================")
+	fmt.Println()
+
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "NAME", "URI", "GLOBAL")
+	fmt.Fprintf(tw, listLine, "NAME", "URI", "GLOBAL", "EXCLUSIVE")
 	for _, n := range names {
 		sys := "NO"
 		if c.Remotes[n].System {
 			sys = "YES"
 		}
+		excl := "NO"
+		if c.Remotes[n].Exclusive {
+			excl = "YES"
+		}
 
 		uri := c.Remotes[n].URI
 		if c.DefaultRemote != "" && c.DefaultRemote == n {
-			fmt.Fprintf(tw, listLineDefault, n, uri, sys)
+			fmt.Fprintf(tw, listLineDefault, n, uri, sys, excl)
 		} else {
-			fmt.Fprintf(tw, listLine, n, uri, sys)
+			fmt.Fprintf(tw, listLine, n, uri, sys, excl)
 		}
 	}
 	tw.Flush()
+
+	if ep, err := c.GetDefault(); err == nil {
+		if err := ep.UpdateKeyserversConfig(); err != nil {
+			return err
+		}
+
+		fmt.Println()
+		fmt.Println("Keyservers")
+		fmt.Println("==========")
+		fmt.Println()
+
+		tw = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", "URI", "GLOBAL", "INSECURE", "ORDER")
+		order := 1
+		for _, kc := range ep.Keyservers {
+			if kc.Skip {
+				continue
+			}
+			insecure := "NO"
+			if kc.Insecure {
+				insecure = "YES"
+			}
+			fmt.Fprintf(tw, "%s\tYES\t%s\t%d", kc.URI, insecure, order)
+			if !kc.External {
+				fmt.Fprintf(tw, "*\n")
+			} else {
+				fmt.Fprintf(tw, "\n")
+			}
+			order++
+		}
+		tw.Flush()
+
+		fmt.Println()
+		fmt.Println("* Active cloud services keyserver")
+	}
+
+	if len(c.Credentials) > 0 {
+		fmt.Println()
+		fmt.Println("Service's credentials")
+		fmt.Println("=================================")
+		fmt.Println()
+
+		tw = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(tw, "%s\t%s\n", "URI", "INSECURE")
+		for _, r := range c.Credentials {
+			insecure := "NO"
+			if r.Insecure {
+				insecure = "YES"
+			}
+			fmt.Fprintf(tw, "%s\t%s\n", r.URI, insecure)
+		}
+		tw.Flush()
+	}
+
 	return nil
 }

--- a/internal/app/singularity/remote_remove_keyserver.go
+++ b/internal/app/singularity/remote_remove_keyserver.go
@@ -1,5 +1,4 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,67 +8,46 @@ package singularity
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/remote"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 )
 
-func syncSysConfig(cUsr *remote.Config) error {
-	// opening system config file
-	f, err := os.OpenFile(remote.SystemConfigPath, os.O_RDONLY, 0600)
-	if err != nil && os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("while opening remote config file: %s", err)
-	}
-	defer f.Close()
-
-	// read file contents to config struct
-	cSys, err := remote.ReadFrom(f)
-	if err != nil {
-		return fmt.Errorf("while parsing remote config data: %s", err)
-	}
-
-	// sync cUsr with system config cSys
-	if err := cUsr.SyncFrom(cSys); err != nil {
-		return err
-	}
-
-	return nil
-
-}
-
-// RemoteUse sets remote to use
-func RemoteUse(usrConfigFile, name string, global, exclusive bool) (err error) {
-	c := &remote.Config{}
-
-	if exclusive && !global {
-		return fmt.Errorf("-e/--exclusive requires --global/-g")
-	}
-
-	// system config should be world readable
-	perm := os.FileMode(0600)
-	if global {
-		perm = os.FileMode(0644)
+func RemoteRemoveKeyserver(name, uri string) error {
+	// Explicit handling of corner cases: name and uri must be valid strings
+	if strings.TrimSpace(uri) == "" {
+		return fmt.Errorf("invalid URI: cannot have empty URI")
 	}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, perm)
+	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}
 	defer file.Close()
 
 	// read file contents to config struct
-	c, err = remote.ReadFrom(file)
+	c, err := remote.ReadFrom(file)
 	if err != nil {
 		return fmt.Errorf("while parsing remote config data: %s", err)
 	}
 
-	if err := syncSysConfig(c); err != nil {
-		return err
+	var ep *endpoint.Config
+
+	if name == "" {
+		ep, err = c.GetDefault()
+	} else {
+		ep, err = c.GetRemote(name)
 	}
 
-	if err := c.SetDefault(name, exclusive); err != nil {
+	if err != nil {
+		return fmt.Errorf("no endpoint found: %s", err)
+	} else if !ep.System {
+		return fmt.Errorf("current endpoint is not a system defined endpoint")
+	}
+
+	if err := ep.RemoveKeyserver(uri); err != nil {
 		return err
 	}
 

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -7,19 +8,17 @@ package singularity
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
-	"time"
 
-	jsonresp "github.com/sylabs/json-resp"
 	"github.com/sylabs/singularity/internal/pkg/remote"
-	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
+	"github.com/sylabs/singularity/pkg/sylog"
 )
 
-const statusLine = "%s\t%s\t%s\n"
+const statusLine = "%s\t%s\t%s\t%s\n"
 
 type status struct {
 	name    string
@@ -31,8 +30,14 @@ type status struct {
 // RemoteStatus checks status of services related to an endpoint
 // If the supplied remote name is an empty string, it will attempt
 // to use the default remote.
-func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
+func RemoteStatus(usrConfigFile, name string) (err error) {
 	c := &remote.Config{}
+
+	if name != "" {
+		sylog.Infof("Checking status of remote: %s", name)
+	} else {
+		sylog.Infof("Checking status of default remote.")
+	}
 
 	// opening config file
 	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0600)
@@ -50,11 +55,11 @@ func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 		return fmt.Errorf("while parsing remote config data: %s", err)
 	}
 
-	if err := syncSysConfig(c, sysConfigFile); err != nil {
+	if err := syncSysConfig(c); err != nil {
 		return err
 	}
 
-	var e *remote.EndPoint
+	var e *endpoint.Config
 	if name == "" {
 		e, err = c.GetDefault()
 	} else {
@@ -65,21 +70,32 @@ func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 		return err
 	}
 
-	a, err := e.GetAllServiceURIs()
+	sps, err := e.GetAllServices()
 	if err != nil {
-		return fmt.Errorf("while getting asset configuration: %s", err)
+		return fmt.Errorf("while retrieving services: %s", err)
 	}
 
-	ch := make(chan status)
-	for name, uri := range a {
-		go doStatusCheck(name, uri, ch)
+	ch := make(chan *status)
+	for name, sp := range sps {
+		name := name
+		for _, service := range sp {
+			service := service
+			go func() {
+				ch <- doStatusCheck(name, service)
+			}()
+		}
 	}
 
 	// map storing statuses by name
-	smap := make(map[string]status)
-	for range a {
-		s := <-ch
-		smap[s.name] = s
+	smap := make(map[string]*status)
+	for _, sp := range sps {
+		for range sp {
+			s := <-ch
+			if s == nil {
+				continue
+			}
+			smap[s.name] = s
+		}
 	}
 
 	// list in alphanumeric order
@@ -90,56 +106,24 @@ func RemoteStatus(usrConfigFile, sysConfigFile, name string) (err error) {
 	sort.Strings(names)
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, statusLine, "SERVICE", "STATUS", "VERSION")
+	fmt.Fprintf(tw, statusLine, "SERVICE", "STATUS", "VERSION", "URI")
 	for _, n := range names {
 		s := smap[n]
-		fmt.Fprintf(tw, statusLine, strings.Title(s.name+" Service"), s.status, s.version)
+		fmt.Fprintf(tw, statusLine, strings.Title(s.name), s.status, s.version, s.uri)
 	}
 	tw.Flush()
 
 	return nil
 }
 
-// VersionResponse - Response form the API for a version request
-type VersionResponse struct {
-	Version string `json:"version"`
-}
-
-func getStatus(url string) (version string, err error) {
-	client := &http.Client{
-		Timeout: (30 * time.Second),
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url+"/version", nil)
+func doStatusCheck(name string, sp endpoint.Service) *status {
+	uri := sp.URI()
+	version, err := sp.Status()
 	if err != nil {
-		return "", err
+		if err == endpoint.ErrStatusNotSupported {
+			return nil
+		}
+		return &status{name: name, uri: uri, status: "N/A"}
 	}
-
-	req.Header.Set("User-Agent", useragent.Value())
-
-	res, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("error making request to server: %v", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error response from server: %v", res.StatusCode)
-	}
-
-	var vRes VersionResponse
-	if err := jsonresp.ReadResponse(res.Body, &vRes); err != nil {
-		return "", err
-	}
-
-	return vRes.Version, nil
-}
-
-func doStatusCheck(name, uri string, ch chan<- status) {
-	stat, err := getStatus(uri)
-	if err != nil {
-		ch <- status{name: name, uri: uri, status: "N/A"}
-		return
-	}
-	ch <- status{name: name, uri: uri, status: "OK", version: stat}
+	return &status{name: name, uri: uri, status: "OK", version: version}
 }

--- a/internal/app/singularity/remote_use.go
+++ b/internal/app/singularity/remote_use.go
@@ -42,8 +42,12 @@ func syncSysConfig(cUsr *remote.Config) error {
 func RemoteUse(usrConfigFile, name string, global, exclusive bool) (err error) {
 	c := &remote.Config{}
 
-	if exclusive && !global {
-		return fmt.Errorf("-e/--exclusive requires --global/-g")
+	if exclusive {
+		if os.Getuid() != 0 {
+			return fmt.Errorf("unable to set endpoint as exclusive: not root user")
+		}
+		global = true
+		usrConfigFile = remote.SystemConfigPath
 	}
 
 	// system config should be world readable

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -59,7 +60,7 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 		Logger:    (golog.Logger)(sylog.DebugLogger{}),
 	}
 
-	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, libraryConfig, "")
+	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, libraryConfig)
 	if err != nil {
 		return fmt.Errorf("while fetching library image: %v", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -32,7 +33,9 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/util/shell"
 	buildTypes "github.com/sylabs/singularity/pkg/build/types"
 	sytypes "github.com/sylabs/singularity/pkg/build/types"
+	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 // OCIConveyorPacker holds stuff that needs to be packed into the bundle
@@ -65,6 +68,8 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		OCIInsecureSkipTLSVerify: cp.b.Opts.NoHTTPS,
 		DockerAuthConfig:         cp.b.Opts.DockerAuthConfig,
 		OSChoice:                 "linux",
+		AuthFilePath:             syfs.DockerConf(),
+		DockerRegistryUserAgent:  useragent.Value(),
 	}
 	if cp.b.Opts.NoHTTPS {
 		cp.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -12,13 +13,12 @@ import (
 	"io/ioutil"
 
 	keyclient "github.com/sylabs/scs-key-client/client"
-	scs "github.com/sylabs/scs-library-client/client"
+	libclient "github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/internal/app/singularity"
 	"github.com/sylabs/singularity/internal/pkg/cache"
 	"github.com/sylabs/singularity/internal/pkg/client"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/pkg/sylog"
-	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 var (
@@ -27,18 +27,18 @@ var (
 )
 
 // pull will pull a library image into the cache if directTo="", or a specific file if directTo is set.
-func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, arch string, scsConfig *scs.Config, keystoreURI string) (imagePath string, err error) {
+func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, arch string, libraryConfig *libclient.Config) (imagePath string, err error) {
 	imageRef := NormalizeLibraryRef(pullFrom)
 
 	sylog.GetLevel()
 
-	c, err := scs.NewClient(scsConfig)
+	c, err := libclient.NewClient(libraryConfig)
 	if err != nil {
 		return "", fmt.Errorf("unable to initialize client library: %v", err)
 	}
 
 	libraryImage, err := c.GetImage(ctx, arch, imageRef)
-	if err == scs.ErrNotFound {
+	if err == libclient.ErrNotFound {
 		return "", fmt.Errorf("image does not exist in the library: %s (%s)", imageRef, arch)
 	}
 	if err != nil {
@@ -65,7 +65,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 				return "", fmt.Errorf("unable to download image: %v", err)
 			}
 
-			if cacheFileHash, err := scs.ImageHash(cacheEntry.TmpPath); err != nil {
+			if cacheFileHash, err := libclient.ImageHash(cacheEntry.TmpPath); err != nil {
 				return "", fmt.Errorf("error getting image hash: %v", err)
 			} else if cacheFileHash != libraryImage.Hash {
 				return "", fmt.Errorf("cached file hash(%s) and expected hash(%s) does not match", cacheFileHash, libraryImage.Hash)
@@ -85,7 +85,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 }
 
 // Pull will pull a library image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, arch string, tmpDir string, scsConfig *scs.Config, keystoreURI string) (imagePath string, err error) {
+func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, arch string, tmpDir string, libraryConfig *libclient.Config) (imagePath string, err error) {
 
 	directTo := ""
 
@@ -98,11 +98,11 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, arch str
 		sylog.Infof("Downloading library image to tmp cache: %s", directTo)
 	}
 
-	return pull(ctx, imgCache, directTo, pullFrom, arch, scsConfig, keystoreURI)
+	return pull(ctx, imgCache, directTo, pullFrom, arch, libraryConfig)
 }
 
 // PullToFile will pull a library image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, arch string, tmpDir string, scsConfig *scs.Config, keystoreURI string) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, arch string, tmpDir string, libraryConfig *libclient.Config, keyConfig *keyclient.Config) (imagePath string, err error) {
 
 	directTo := ""
 	if imgCache.IsDisabled() {
@@ -110,7 +110,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, a
 		sylog.Debugf("Cache disabled, pulling directly to: %s", directTo)
 	}
 
-	src, err := pull(ctx, imgCache, directTo, pullFrom, arch, scsConfig, keystoreURI)
+	src, err := pull(ctx, imgCache, directTo, pullFrom, arch, libraryConfig)
 	if err != nil {
 		return "", fmt.Errorf("error fetching image: %v", err)
 	}
@@ -123,12 +123,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, a
 		}
 	}
 
-	c := keyclient.Config{
-		BaseURL:   keystoreURI,
-		AuthToken: scsConfig.AuthToken,
-		UserAgent: useragent.Value(),
-	}
-	if err := singularity.Verify(ctx, pullTo, singularity.OptVerifyUseKeyServer(&c)); err != nil {
+	if err := singularity.Verify(ctx, pullTo, singularity.OptVerifyUseKeyServer(keyConfig)); err != nil {
 		sylog.Warningf("%v", err)
 		return pullTo, ErrLibraryPullUnsigned
 	}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -15,7 +16,9 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/build/oci"
 	"github.com/sylabs/singularity/internal/pkg/cache"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
+	"github.com/sylabs/singularity/pkg/syfs"
 	"github.com/sylabs/singularity/pkg/sylog"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
 // pull will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
@@ -28,6 +31,8 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 	sysCtx := &ocitypes.SystemContext{
 		OCIInsecureSkipTLSVerify: noHTTPS,
 		DockerAuthConfig:         ociAuth,
+		AuthFilePath:             syfs.DockerConf(),
+		DockerRegistryUserAgent:  useragent.Value(),
 	}
 	if noHTTPS {
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)

--- a/internal/pkg/remote/credential/config.go
+++ b/internal/pkg/remote/credential/config.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package credential
+
+const (
+	// BasicPrefix is the prefix for the HTTP basic authentication.
+	BasicPrefix = "Basic "
+	// TokenPrefix is the prefix for the HTTP token/bearer authentication.
+	TokenPrefix = "Bearer "
+)
+
+// Config holds credential configuration for a service.
+type Config struct {
+	URI string `yaml:"URI"`
+	// Can take the form of:
+	// - "Basic <base64 encoded username:passwd>"
+	// - "Bearer <token>"
+	// An empty value means there no authentication at all
+	// or that credentials are stored elsewhere
+	Auth     string `yaml:"Auth,omitempty"`
+	Insecure bool   `yaml:"Insecure"`
+}

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -61,6 +61,9 @@ func ensurePassword(password string) (string, error) {
 type ociHandler struct{}
 
 func (h *ociHandler) login(u *url.URL, username, password string, insecure bool) (*Config, error) {
+	if username == "" {
+		return nil, fmt.Errorf("Docker/OCI registry requires a username")
+	}
 	pass, err := ensurePassword(password)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package credential
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	auth "github.com/deislabs/oras/pkg/auth/docker"
+	"github.com/sylabs/singularity/pkg/syfs"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+)
+
+// loginHandlers contains the registered handlers by scheme.
+var loginHandlers = make(map[string]loginHandler)
+
+// loginHandler interface implements login and logout for a specific scheme.
+type loginHandler interface {
+	login(url *url.URL, username, password string, insecure bool) (*Config, error)
+	logout(url *url.URL) error
+}
+
+func init() {
+	oh := &ociHandler{}
+	loginHandlers["oras"] = oh
+	loginHandlers["docker"] = oh
+
+	kh := &keyserverHandler{}
+	loginHandlers["http"] = kh
+	loginHandlers["https"] = kh
+}
+
+// ociHandler handle login/logout for services with docker:// and oras:// scheme.
+type ociHandler struct{}
+
+func (h *ociHandler) login(u *url.URL, username, password string, insecure bool) (*Config, error) {
+	cli, err := auth.NewClient(syfs.DockerConf())
+	if err != nil {
+		return nil, err
+	}
+	if err := cli.Login(context.TODO(), u.Host+u.Path, username, password, insecure); err != nil {
+		return nil, err
+	}
+	return &Config{
+		URI:      u.String(),
+		Insecure: insecure,
+	}, nil
+}
+
+func (h *ociHandler) logout(u *url.URL) error {
+	cli, err := auth.NewClient(syfs.DockerConf())
+	if err != nil {
+		return err
+	}
+	return cli.Logout(context.TODO(), u.Host+u.Path)
+}
+
+// keyserverHandler handle login/logout for keyserver service.
+type keyserverHandler struct{}
+
+func (h *keyserverHandler) login(u *url.URL, username, password string, insecure bool) (*Config, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	if insecure {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if username == "" {
+		req.Header.Set("Authorization", TokenPrefix+password)
+	} else {
+		req.SetBasicAuth(username, password)
+	}
+
+	auth := req.Header.Get("Authorization")
+	req.Header.Set("User-Agent", useragent.Value())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request to server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error response from server: %s", resp.Status)
+	}
+
+	return &Config{
+		URI:      u.String(),
+		Auth:     auth,
+		Insecure: insecure,
+	}, nil
+}
+
+func (h *keyserverHandler) logout(u *url.URL) error {
+	return nil
+}

--- a/internal/pkg/remote/credential/manager.go
+++ b/internal/pkg/remote/credential/manager.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package credential
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/sylabs/singularity/internal/pkg/util/interactive"
+)
+
+// Manager handle login/logout handlers.
+var Manager = new(manager)
+
+type manager struct{}
+
+// Login allows to log into a service like a Docker/OCI registry or a keyserver.
+func (m *manager) Login(uri, username, password string, insecure bool) (*Config, error) {
+	if password == "" {
+		question := "Password (or token when username is empty): "
+		input, err := interactive.AskQuestionNoEcho(question)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read password: %s", err)
+		}
+		password = input
+	}
+	if password == "" {
+		return nil, fmt.Errorf("A password is required")
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	if handler, ok := loginHandlers[u.Scheme]; ok {
+		return handler.login(u, username, password, insecure)
+	}
+
+	return nil, fmt.Errorf("%s transport is not supported", u.Scheme)
+}
+
+// Logout allows to log out from a service like a Docker/OCI registry or a keyserver.
+func (m *manager) Logout(uri string) error {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+
+	if handler, ok := loginHandlers[u.Scheme]; ok {
+		return handler.logout(u)
+	}
+
+	return fmt.Errorf("%s transport is not supported", u.Scheme)
+}

--- a/internal/pkg/remote/credential/manager.go
+++ b/internal/pkg/remote/credential/manager.go
@@ -8,8 +8,6 @@ package credential
 import (
 	"fmt"
 	"net/url"
-
-	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 )
 
 // Manager handle login/logout handlers.
@@ -19,18 +17,6 @@ type manager struct{}
 
 // Login allows to log into a service like a Docker/OCI registry or a keyserver.
 func (m *manager) Login(uri, username, password string, insecure bool) (*Config, error) {
-	if password == "" {
-		question := "Password (or token when username is empty): "
-		input, err := interactive.AskQuestionNoEcho(question)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read password: %s", err)
-		}
-		password = input
-	}
-	if password == "" {
-		return nil, fmt.Errorf("A password is required")
-	}
-
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package endpoint
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	golog "github.com/go-log/log"
+	buildclient "github.com/sylabs/scs-build-client/client"
+	keyclient "github.com/sylabs/scs-key-client/client"
+	libclient "github.com/sylabs/scs-library-client/client"
+	"github.com/sylabs/singularity/pkg/sylog"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+)
+
+func (ep *Config) KeyserverClientConfig(uri string, op KeyserverOp) (*keyclient.Config, error) {
+	// empty uri means to use the default endpoint
+	isDefault := uri == ""
+
+	config := &keyclient.Config{
+		BaseURL:   uri,
+		UserAgent: useragent.Value(),
+	}
+
+	if err := ep.UpdateKeyserversConfig(); err != nil {
+		return nil, err
+	}
+
+	var primaryKeyserver *ServiceConfig
+
+	for _, kc := range ep.Keyservers {
+		if kc.Skip {
+			continue
+		}
+		primaryKeyserver = kc
+		break
+	}
+
+	// shouldn't happen
+	if primaryKeyserver == nil {
+		return nil, fmt.Errorf("no primary keyserver configured")
+	}
+
+	var keyservers []*ServiceConfig
+
+	if isDefault {
+		config.BaseURL = primaryKeyserver.URI
+
+		if op == KeyserverVerifyOp {
+			// verify operation can query multiple keyserver, the token
+			// is automatically set by the custom client
+			keyservers = ep.Keyservers
+		} else {
+			// use the primary keyserver
+			keyservers = []*ServiceConfig{
+				primaryKeyserver,
+			}
+		}
+	} else {
+		keyservers = []*ServiceConfig{
+			&ServiceConfig{
+				URI:      uri,
+				External: true,
+			},
+		}
+	}
+
+	config.HTTPClient = newClient(keyservers, op)
+
+	return config, nil
+}
+
+func (ep *Config) LibraryClientConfig(uri string) (*libclient.Config, error) {
+	// empty uri means to use the default endpoint
+	isDefault := uri == ""
+
+	config := &libclient.Config{
+		BaseURL:   uri,
+		UserAgent: useragent.Value(),
+		Logger:    (golog.Logger)(sylog.DebugLogger{}),
+	}
+
+	if isDefault {
+		libURI, err := ep.GetServiceURI(Library)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get library service URI: %v", err)
+		}
+		config.AuthToken = ep.Token
+		config.BaseURL = libURI
+	}
+
+	return config, nil
+}
+
+func (ep *Config) BuilderClientConfig(uri string) (*buildclient.Config, error) {
+	// empty uri means to use the default endpoint
+	isDefault := uri == ""
+
+	config := &buildclient.Config{
+		BaseURL:   uri,
+		UserAgent: useragent.Value(),
+		Logger:    (golog.Logger)(sylog.DebugLogger{}),
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+
+	if isDefault {
+		buildURI, err := ep.GetServiceURI(Builder)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get builder service URI: %v", err)
+		}
+		config.AuthToken = ep.Token
+		config.BaseURL = buildURI
+	}
+
+	return config, nil
+}

--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -63,7 +63,7 @@ func (ep *Config) KeyserverClientConfig(uri string, op KeyserverOp) (*keyclient.
 		}
 	} else {
 		keyservers = []*ServiceConfig{
-			&ServiceConfig{
+			{
 				URI:      uri,
 				External: true,
 			},

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -39,11 +39,11 @@ func TestKeyserverClientConfig(t *testing.T) {
 			endpoint: &Config{
 				URI: SCSDefaultCloudURI,
 				Keyservers: []*ServiceConfig{
-					&ServiceConfig{
+					{
 						URI:  SCSDefaultKeyserverURI,
 						Skip: true,
 					},
-					&ServiceConfig{
+					{
 						URI:      "http://localhost:11371",
 						External: true,
 					},
@@ -59,10 +59,10 @@ func TestKeyserverClientConfig(t *testing.T) {
 			endpoint: &Config{
 				URI: SCSDefaultCloudURI,
 				Keyservers: []*ServiceConfig{
-					&ServiceConfig{
+					{
 						URI: SCSDefaultKeyserverURI,
 					},
-					&ServiceConfig{
+					{
 						URI:      "http://localhost:11371",
 						External: true,
 					},

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package endpoint
+
+import (
+	"testing"
+
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+)
+
+func init() {
+	useragent.InitValue("singularity", "3.0.0")
+}
+
+func TestKeyserverClientConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		endpoint      *Config
+		uri           string
+		expectedURI   string
+		expectSuccess bool
+		op            KeyserverOp
+	}{
+		{
+			name: "Sylabs cloud",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+			},
+			uri:           SCSDefaultKeyserverURI,
+			expectedURI:   SCSDefaultKeyserverURI,
+			expectSuccess: true,
+			op:            KeyserverSearchOp,
+		},
+		{
+			name: "Sylabs cloud verify",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+				Keyservers: []*ServiceConfig{
+					&ServiceConfig{
+						URI:  SCSDefaultKeyserverURI,
+						Skip: true,
+					},
+					&ServiceConfig{
+						URI:      "http://localhost:11371",
+						External: true,
+					},
+				},
+			},
+			uri:           "",
+			expectedURI:   "http://localhost:11371",
+			expectSuccess: true,
+			op:            KeyserverVerifyOp,
+		},
+		{
+			name: "Sylabs cloud search",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+				Keyservers: []*ServiceConfig{
+					&ServiceConfig{
+						URI: SCSDefaultKeyserverURI,
+					},
+					&ServiceConfig{
+						URI:      "http://localhost:11371",
+						External: true,
+					},
+				},
+			},
+			uri:           "",
+			expectedURI:   SCSDefaultKeyserverURI,
+			expectSuccess: true,
+			op:            KeyserverSearchOp,
+		},
+		{
+			name: "Custom library",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+			},
+			uri:           "https://custom.keys",
+			expectedURI:   "https://custom.keys",
+			expectSuccess: true,
+			op:            KeyserverVerifyOp,
+		},
+		{
+			name: "Fake cloud",
+			endpoint: &Config{
+				URI: "cloud.inexistent-xxxx-domain.io",
+			},
+			expectSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := tt.endpoint.KeyserverClientConfig(tt.uri, tt.op)
+			if err != nil && tt.expectSuccess {
+				t.Errorf("unexpected error: %s", err)
+			} else if err == nil && !tt.expectSuccess {
+				t.Errorf("unexpected success for %s", tt.name)
+			} else if err != nil && !tt.expectSuccess {
+				return
+			}
+			if config.BaseURL != tt.expectedURI {
+				t.Errorf("unexpected uri returned: %s instead of %s", config.BaseURL, tt.expectedURI)
+			} else if config.AuthToken != "" {
+				t.Errorf("unexpected token returned: %s", config.AuthToken)
+			}
+		})
+	}
+}
+
+func TestLibraryClientConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		endpoint      *Config
+		uri           string
+		expectSuccess bool
+	}{
+		{
+			name: "Sylabs cloud",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+			},
+			uri:           SCSDefaultLibraryURI,
+			expectSuccess: true,
+		},
+		{
+			name: "Custom library",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+			},
+			uri:           "https://custom.library",
+			expectSuccess: true,
+		},
+		{
+			name: "Fake cloud",
+			endpoint: &Config{
+				URI: "cloud.inexistent-xxxx-domain.io",
+			},
+			expectSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := tt.endpoint.LibraryClientConfig(tt.uri)
+			if err != nil && tt.expectSuccess {
+				t.Errorf("unexpected error: %s", err)
+			} else if err == nil && !tt.expectSuccess {
+				t.Errorf("unexpected success for %s", tt.name)
+			} else if err != nil && !tt.expectSuccess {
+				return
+			}
+			if config.BaseURL != tt.uri {
+				t.Errorf("unexpected uri returned: %s instead of %s", config.BaseURL, tt.uri)
+			} else if config.AuthToken != "" {
+				t.Errorf("unexpected token returned: %s", config.AuthToken)
+			}
+		})
+	}
+}
+
+func TestBuilderClientConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		endpoint      *Config
+		uri           string
+		expectSuccess bool
+	}{
+		{
+			name: "Sylabs cloud",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+			},
+			uri:           SCSDefaultBuilderURI,
+			expectSuccess: true,
+		},
+		{
+			name: "Custom builder",
+			endpoint: &Config{
+				URI: SCSDefaultCloudURI,
+			},
+			uri:           "https://custom.builder",
+			expectSuccess: true,
+		},
+		{
+			name: "Fake cloud",
+			endpoint: &Config{
+				URI: "https://cloud.fake-domain.io",
+			},
+			expectSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := tt.endpoint.BuilderClientConfig(tt.uri)
+			if err != nil && tt.expectSuccess {
+				t.Errorf("unexpected error: %s", err)
+			} else if err == nil && !tt.expectSuccess {
+				t.Errorf("unexpected success for %s", tt.name)
+			} else if err != nil && !tt.expectSuccess {
+				return
+			}
+			if config.BaseURL != tt.uri {
+				t.Errorf("unexpected uri returned: %s instead of %s", config.BaseURL, tt.uri)
+			} else if config.AuthToken != "" {
+				t.Errorf("unexpected token returned: %s", config.AuthToken)
+			}
+		})
+	}
+}

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -35,6 +35,27 @@ func TestKeyserverClientConfig(t *testing.T) {
 			op:            KeyserverSearchOp,
 		},
 		{
+			name: "Sylabs cloud exclusive KO",
+			endpoint: &Config{
+				URI:       SCSDefaultCloudURI,
+				Exclusive: true,
+			},
+			uri:           "https://custom.keys",
+			expectSuccess: false,
+			op:            KeyserverSearchOp,
+		},
+		{
+			name: "Sylabs cloud exclusive OK",
+			endpoint: &Config{
+				URI:       SCSDefaultCloudURI,
+				Exclusive: true,
+			},
+			uri:           SCSDefaultKeyserverURI,
+			expectedURI:   SCSDefaultKeyserverURI,
+			expectSuccess: true,
+			op:            KeyserverSearchOp,
+		},
+		{
 			name: "Sylabs cloud verify",
 			endpoint: &Config{
 				URI: SCSDefaultCloudURI,
@@ -127,6 +148,24 @@ func TestLibraryClientConfig(t *testing.T) {
 			expectSuccess: true,
 		},
 		{
+			name: "Sylabs cloud exclusive KO",
+			endpoint: &Config{
+				URI:       SCSDefaultCloudURI,
+				Exclusive: true,
+			},
+			uri:           "https://custom.library",
+			expectSuccess: false,
+		},
+		{
+			name: "Sylabs cloud exclusive OK",
+			endpoint: &Config{
+				URI:       SCSDefaultCloudURI,
+				Exclusive: true,
+			},
+			uri:           SCSDefaultLibraryURI,
+			expectSuccess: true,
+		},
+		{
 			name: "Custom library",
 			endpoint: &Config{
 				URI: SCSDefaultCloudURI,
@@ -173,6 +212,24 @@ func TestBuilderClientConfig(t *testing.T) {
 			name: "Sylabs cloud",
 			endpoint: &Config{
 				URI: SCSDefaultCloudURI,
+			},
+			uri:           SCSDefaultBuilderURI,
+			expectSuccess: true,
+		},
+		{
+			name: "Sylabs cloud exclusive KO",
+			endpoint: &Config{
+				URI:       SCSDefaultCloudURI,
+				Exclusive: true,
+			},
+			uri:           "https://custom.builder",
+			expectSuccess: false,
+		},
+		{
+			name: "Sylabs cloud exclusive OK",
+			endpoint: &Config{
+				URI:       SCSDefaultCloudURI,
+				Exclusive: true,
 			},
 			uri:           SCSDefaultBuilderURI,
 			expectSuccess: true,

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package endpoint
+
+import (
+	"github.com/sylabs/singularity/internal/pkg/remote/credential"
+)
+
+var DefaultEndpointConfig = &Config{
+	URI:    SCSDefaultCloudURI,
+	System: true,
+}
+
+// Config describes a single remote endpoint.
+type Config struct {
+	URI        string           `yaml:"URI,omitempty"`
+	Token      string           `yaml:"Token,omitempty"`
+	System     bool             `yaml:"System"`    // Was this EndPoint set from system config file
+	Exclusive  bool             `yaml:"Exclusive"` // true if the endpoint must be used exclusively
+	Keyservers []*ServiceConfig `yaml:"Keyservers,omitempty"`
+
+	// for internal purpose
+	credentials []*credential.Config
+	services    map[string][]Service
+}
+
+func (e *Config) SetCredentials(creds []*credential.Config) {
+	e.credentials = creds
+}
+
+type ServiceConfig struct {
+	// for internal purpose
+	credential *credential.Config
+
+	URI      string `yaml:"URI"`
+	Skip     bool   `yaml:"Skip"`
+	External bool   `yaml:"External"`
+	Insecure bool   `yaml:"Insecure"`
+}

--- a/internal/pkg/remote/endpoint/keyserver.go
+++ b/internal/pkg/remote/endpoint/keyserver.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package endpoint
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sylabs/singularity/internal/pkg/remote/credential"
+	remoteutil "github.com/sylabs/singularity/internal/pkg/remote/util"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+// KeyserverOp represents a keyserver operation type.
+type KeyserverOp uint8
+
+const (
+	// KeyserverPushOp represents a key push operation.
+	KeyserverPushOp KeyserverOp = iota
+	// KeyserverPullOp represents a key pull operation.
+	KeyserverPullOp
+	// KeyserverSearch represents a key search operation.
+	KeyserverSearchOp
+	// KeyserverVerify represents a key verification operation.
+	KeyserverVerifyOp
+)
+
+// AddKeyserver adds a keyserver for the corresponding remote endpoint.
+func (ep *Config) AddKeyserver(uri string, order uint32, insecure bool) error {
+	if err := ep.UpdateKeyserversConfig(); err != nil {
+		return err
+	}
+
+	matchIndex := -1
+	maxOrder := uint32(1)
+
+	for i, kc := range ep.Keyservers {
+		if remoteutil.SameKeyserver(kc.URI, uri) {
+			matchIndex = i
+		}
+		if kc.Skip {
+			continue
+		}
+		maxOrder++
+	}
+
+	if order == 0 {
+		order = maxOrder
+	} else if order > maxOrder {
+		return fmt.Errorf("order is out of range: maximum is %d", maxOrder)
+	}
+
+	var kc *ServiceConfig
+
+	if matchIndex >= 0 {
+		kc = ep.Keyservers[matchIndex]
+		if !kc.External && kc.Skip {
+			kc.Skip = false
+		} else {
+			return fmt.Errorf("%s is already configured", uri)
+		}
+		// remove it first
+		ep.Keyservers = append(ep.Keyservers[:matchIndex], ep.Keyservers[matchIndex+1:]...)
+	} else {
+		kc = &ServiceConfig{
+			External: true,
+			URI:      uri,
+			Insecure: insecure,
+		}
+	}
+
+	// insert it as specified by the order
+	ep.Keyservers = append(ep.Keyservers[:order-1], append([]*ServiceConfig{kc}, ep.Keyservers[order-1:]...)...)
+
+	return nil
+}
+
+// RemoveKeyserver removes a previously added keyserver.
+func (ep *Config) RemoveKeyserver(uri string) error {
+	if err := ep.UpdateKeyserversConfig(); err != nil {
+		return err
+	}
+
+	total := 0
+	for _, kc := range ep.Keyservers {
+		if kc.Skip {
+			continue
+		}
+		total++
+	}
+
+	for i, kc := range ep.Keyservers {
+		if remoteutil.SameKeyserver(kc.URI, uri) && !kc.Skip {
+			if total == 1 {
+				return fmt.Errorf("the primary keyserver %s can't be removed", uri)
+			}
+			if kc.External {
+				ep.Keyservers = append(ep.Keyservers[:i], ep.Keyservers[i+1:]...)
+			} else {
+				// SCS keyserver is just marked as skipped
+				kc.Skip = true
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("keyserver %s is not configured", uri)
+}
+
+// UpdateKeyserversConfig updates the keyserver configuration for the
+// corresponding remote endpoint.
+func (ep *Config) UpdateKeyserversConfig() error {
+	if len(ep.Keyservers) == 0 {
+		// current remote keyserver
+		uri, err := ep.GetServiceURI(Keyserver)
+		if err != nil {
+			return err
+		}
+		ep.Keyservers = append(ep.Keyservers, &ServiceConfig{
+			URI: uri,
+			credential: &credential.Config{
+				URI:  uri,
+				Auth: credential.TokenPrefix + ep.Token,
+			},
+		})
+		return nil
+	}
+	for _, kc := range ep.Keyservers {
+		if kc.credential != nil {
+			continue
+		} else if !kc.External {
+			// associated current endpoint token to the SCS key service
+			kc.credential = &credential.Config{
+				URI:  kc.URI,
+				Auth: credential.TokenPrefix + ep.Token,
+			}
+		} else {
+			// attempt to find credentials in the credential store
+			for _, cred := range ep.credentials {
+				if remoteutil.SameKeyserver(cred.URI, kc.URI) {
+					kc.credential = cred
+					break
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type keyserverTransport struct {
+	keyservers []*ServiceConfig
+	op         KeyserverOp
+	client     *http.Client
+}
+
+func (c *keyserverTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	for i, k := range c.keyservers {
+		if k.Skip {
+			continue
+		}
+
+		cloneReq := req.Clone(ctx)
+
+		if i > 0 {
+			u, err := remoteutil.NormalizeKeyserverURI(k.URI)
+			if err != nil {
+				return nil, err
+			}
+			cloneReq.URL.Scheme = u.Scheme
+			cloneReq.URL.Host = u.Host
+			cloneReq.URL.User = u.User
+		}
+
+		sylog.Debugf("Querying keyserver %s", cloneReq.URL)
+
+		cloneReq.Header.Del("Authorization")
+		if k.credential != nil && k.credential.Auth != "" {
+			cloneReq.Header.Set("Authorization", k.credential.Auth)
+		}
+
+		tr, ok := c.client.Transport.(*http.Transport)
+		if ok {
+			tr.TLSClientConfig.InsecureSkipVerify = k.Insecure
+		}
+
+		resp, err := c.client.Do(cloneReq)
+		if err != nil {
+			if i < len(c.keyservers)-1 {
+				continue
+			}
+			return resp, err
+		}
+
+		if resp.StatusCode/100 == 2 && i < len(c.keyservers)-1 {
+			resp.Body.Close()
+			continue
+		}
+
+		return resp, err
+	}
+
+	return nil, fmt.Errorf("no keyserver configured")
+}
+
+var defaultClient = &http.Client{
+	Timeout: 5 * time.Second,
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+		TLSClientConfig:   &tls.Config{},
+	},
+}
+
+func newClient(keyservers []*ServiceConfig, op KeyserverOp) *http.Client {
+	return &http.Client{
+		Transport: &keyserverTransport{
+			keyservers: keyservers,
+			op:         op,
+			client:     defaultClient,
+		},
+	}
+}

--- a/internal/pkg/remote/endpoint/keyserver.go
+++ b/internal/pkg/remote/endpoint/keyserver.go
@@ -198,7 +198,7 @@ func (c *keyserverTransport) RoundTrip(req *http.Request) (*http.Response, error
 			return resp, err
 		}
 
-		if resp.StatusCode/100 == 2 && i < len(c.keyservers)-1 {
+		if resp.StatusCode/100 != 2 && i < len(c.keyservers)-1 {
 			resp.Body.Close()
 			continue
 		}

--- a/internal/pkg/remote/endpoint/keyserver_test.go
+++ b/internal/pkg/remote/endpoint/keyserver_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package endpoint
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/remote/credential"
+)
+
+func TestAddRemoveKeyserver(t *testing.T) {
+	const (
+		add    = "add"
+		remove = "remove"
+	)
+
+	const (
+		localhostKeyserver = "http://localhost:11371"
+	)
+
+	var testErr error
+	var token = "test"
+
+	scsDefaultCredential := &credential.Config{
+		URI:  SCSDefaultKeyserverURI,
+		Auth: credential.TokenPrefix + token,
+	}
+
+	tests := []struct {
+		name           string
+		operation      string
+		uri            string
+		order          uint32
+		insecure       bool
+		wantErr        bool
+		wantKeyservers []*ServiceConfig
+	}{
+		{
+			name:      "Add " + localhostKeyserver,
+			operation: add,
+			uri:       localhostKeyserver,
+			insecure:  true,
+			wantErr:   false,
+			wantKeyservers: []*ServiceConfig{
+				&ServiceConfig{
+					URI:        SCSDefaultKeyserverURI,
+					credential: scsDefaultCredential,
+				},
+				&ServiceConfig{
+					URI:      localhostKeyserver,
+					External: true,
+					Insecure: true,
+				},
+			},
+		},
+		{
+			name:      "Add hkp://localhost as duplicate",
+			operation: add,
+			uri:       "hkp://localhost",
+			wantErr:   true,
+		},
+		{
+			name:      "Add hkps://localhost with out of order",
+			operation: add,
+			uri:       "hkp://localhost",
+			order:     100,
+			wantErr:   true,
+		},
+		{
+			name:      "Prepend hkps://localhost",
+			operation: add,
+			uri:       "hkps://localhost",
+			order:     1,
+			wantErr:   false,
+			wantKeyservers: []*ServiceConfig{
+				&ServiceConfig{
+					URI:      "hkps://localhost",
+					External: true,
+				},
+				&ServiceConfig{
+					URI:        SCSDefaultKeyserverURI,
+					credential: scsDefaultCredential,
+				},
+				&ServiceConfig{
+					URI:      localhostKeyserver,
+					External: true,
+					Insecure: true,
+				},
+			},
+		},
+		{
+			name:      "Add https://localhost as duplicate",
+			operation: add,
+			uri:       "https://localhost",
+			wantErr:   true,
+		},
+		{
+			name:      "Remove hkps://localhost",
+			operation: remove,
+			uri:       "hkps://localhost",
+			wantErr:   false,
+			wantKeyservers: []*ServiceConfig{
+				&ServiceConfig{
+					URI:        SCSDefaultKeyserverURI,
+					credential: scsDefaultCredential,
+				},
+				&ServiceConfig{
+					URI:      localhostKeyserver,
+					External: true,
+					Insecure: true,
+				},
+			},
+		},
+		{
+			name:      "Remove " + SCSDefaultKeyserverURI,
+			operation: remove,
+			uri:       SCSDefaultKeyserverURI,
+			wantErr:   false,
+			wantKeyservers: []*ServiceConfig{
+				&ServiceConfig{
+					URI:        SCSDefaultKeyserverURI,
+					Skip:       true,
+					credential: scsDefaultCredential,
+				},
+				&ServiceConfig{
+					URI:      localhostKeyserver,
+					External: true,
+					Insecure: true,
+				},
+			},
+		},
+		{
+			name:      "Remove primary " + localhostKeyserver,
+			operation: remove,
+			uri:       localhostKeyserver,
+			wantErr:   true,
+		},
+		{
+			name:      "Add " + SCSDefaultKeyserverURI + " as secondary",
+			operation: add,
+			uri:       SCSDefaultKeyserverURI,
+			order:     2,
+			wantErr:   false,
+			wantKeyservers: []*ServiceConfig{
+				&ServiceConfig{
+					URI:      localhostKeyserver,
+					External: true,
+					Insecure: true,
+				},
+				&ServiceConfig{
+					URI:        SCSDefaultKeyserverURI,
+					credential: scsDefaultCredential,
+				},
+			},
+		},
+	}
+
+	ep := &Config{
+		URI:   SCSDefaultCloudURI,
+		Token: token,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.operation {
+			case add:
+				testErr = ep.AddKeyserver(tt.uri, tt.order, tt.insecure)
+			case remove:
+				testErr = ep.RemoveKeyserver(tt.uri)
+			default:
+				t.Fatalf("unknown test operation")
+			}
+
+			if tt.wantErr && testErr == nil {
+				t.Errorf("unexpected success during %s", tt.operation)
+			} else if !tt.wantErr && testErr != nil {
+				t.Errorf("unexpected error during %s: %s", tt.operation, testErr)
+			} else if tt.wantKeyservers != nil {
+				if !reflect.DeepEqual(tt.wantKeyservers, ep.Keyservers) {
+					t.Errorf("unexpected keyservers list")
+				}
+			}
+		})
+	}
+}

--- a/internal/pkg/remote/endpoint/keyserver_test.go
+++ b/internal/pkg/remote/endpoint/keyserver_test.go
@@ -46,11 +46,11 @@ func TestAddRemoveKeyserver(t *testing.T) {
 			insecure:  true,
 			wantErr:   false,
 			wantKeyservers: []*ServiceConfig{
-				&ServiceConfig{
+				{
 					URI:        SCSDefaultKeyserverURI,
 					credential: scsDefaultCredential,
 				},
-				&ServiceConfig{
+				{
 					URI:      localhostKeyserver,
 					External: true,
 					Insecure: true,
@@ -77,15 +77,15 @@ func TestAddRemoveKeyserver(t *testing.T) {
 			order:     1,
 			wantErr:   false,
 			wantKeyservers: []*ServiceConfig{
-				&ServiceConfig{
+				{
 					URI:      "hkps://localhost",
 					External: true,
 				},
-				&ServiceConfig{
+				{
 					URI:        SCSDefaultKeyserverURI,
 					credential: scsDefaultCredential,
 				},
-				&ServiceConfig{
+				{
 					URI:      localhostKeyserver,
 					External: true,
 					Insecure: true,
@@ -104,11 +104,11 @@ func TestAddRemoveKeyserver(t *testing.T) {
 			uri:       "hkps://localhost",
 			wantErr:   false,
 			wantKeyservers: []*ServiceConfig{
-				&ServiceConfig{
+				{
 					URI:        SCSDefaultKeyserverURI,
 					credential: scsDefaultCredential,
 				},
-				&ServiceConfig{
+				{
 					URI:      localhostKeyserver,
 					External: true,
 					Insecure: true,
@@ -121,12 +121,12 @@ func TestAddRemoveKeyserver(t *testing.T) {
 			uri:       SCSDefaultKeyserverURI,
 			wantErr:   false,
 			wantKeyservers: []*ServiceConfig{
-				&ServiceConfig{
+				{
 					URI:        SCSDefaultKeyserverURI,
 					Skip:       true,
 					credential: scsDefaultCredential,
 				},
-				&ServiceConfig{
+				{
 					URI:      localhostKeyserver,
 					External: true,
 					Insecure: true,
@@ -146,12 +146,12 @@ func TestAddRemoveKeyserver(t *testing.T) {
 			order:     2,
 			wantErr:   false,
 			wantKeyservers: []*ServiceConfig{
-				&ServiceConfig{
+				{
 					URI:      localhostKeyserver,
 					External: true,
 					Insecure: true,
 				},
-				&ServiceConfig{
+				{
 					URI:        SCSDefaultKeyserverURI,
 					credential: scsDefaultCredential,
 				},

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package endpoint
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	jsonresp "github.com/sylabs/json-resp"
+	"github.com/sylabs/singularity/internal/pkg/remote/credential"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+)
+
+const defaultTimeout = 10 * time.Second
+
+const (
+	SCSDefaultCloudURI     = "cloud.sylabs.io"
+	SCSDefaultLibraryURI   = "https://library.sylabs.io"
+	SCSDefaultKeyserverURI = "https://keys.sylabs.io"
+	SCSDefaultBuilderURI   = "https://build.sylabs.io"
+)
+
+// SCS cloud services
+const (
+	Consent   = "consent"
+	Token     = "token"
+	Library   = "library"
+	Keystore  = "keystore" // alias for keyserver
+	Keyserver = "keyserver"
+	Builder   = "builder"
+)
+
+var errorCodeMap = map[int]string{
+	404: "Invalid Credentials",
+	500: "Internal Server Error",
+}
+
+var (
+	// ErrStatusNotSupported represents the error returned by
+	// a service which doesn't support SCS status check.
+	ErrStatusNotSupported = errors.New("status not supported")
+)
+
+// Service defines a simple service interface which can be exposed
+// to retrieve service URI and check the service status.
+type Service interface {
+	URI() string
+	Status() (string, error)
+}
+
+func newService(config *ServiceConfig) Service {
+	return &service{cfg: config}
+}
+
+type service struct {
+	cfg *ServiceConfig
+}
+
+// URI returns the service URI.
+func (s *service) URI() string {
+	return s.cfg.URI
+}
+
+// Status checks the service status and returns the version
+// of the corresponding service. An ErrStatusNotSupported is
+// returned if the service doesn't support this check.
+func (s *service) Status() (version string, err error) {
+	if s.cfg.External {
+		return "", ErrStatusNotSupported
+	}
+
+	client := &http.Client{
+		Timeout: (30 * time.Second),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, s.cfg.URI+"/version", nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", useragent.Value())
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request to server: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("error response from server: %v", res.StatusCode)
+	}
+
+	var vRes struct {
+		Version string `json:"version"`
+	}
+
+	if err := jsonresp.ReadResponse(res.Body, &vRes); err != nil {
+		return "", err
+	}
+
+	return vRes.Version, nil
+}
+
+func (ep *Config) GetAllServices() (map[string][]Service, error) {
+	if ep.services != nil {
+		return ep.services, nil
+	}
+
+	ep.services = make(map[string][]Service)
+
+	client := &http.Client{
+		Timeout: defaultTimeout,
+	}
+
+	url := "https://" + ep.URI + "/assets/config/config.prod.json"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", useragent.Value())
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request to server: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error response from server: %v", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("while reading response body: %v", err)
+	}
+
+	var a map[string]map[string]interface{}
+
+	if err := json.Unmarshal(b, &a); err != nil {
+		return nil, fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
+	}
+
+	for k, v := range a {
+		s := strings.TrimSuffix(k, "API")
+		uri, ok := v["uri"].(string)
+		if !ok {
+			continue
+		}
+
+		serviceConfig := &ServiceConfig{
+			URI: uri,
+			credential: &credential.Config{
+				URI:  uri,
+				Auth: credential.TokenPrefix + ep.Token,
+			},
+		}
+
+		if s == Keystore {
+			s = Keyserver
+		}
+
+		ep.services[s] = []Service{
+			newService(serviceConfig),
+		}
+	}
+
+	return ep.services, nil
+}
+
+// GetServiceURI returns the URI for the service at the specified SCS endpoint
+// Examples of services: consent, build, library, key, token
+func (ep *Config) GetServiceURI(service string) (string, error) {
+	// don't grab remote URI if the endpoint is the
+	// default public Sylabs Cloud Service
+	if ep.URI == SCSDefaultCloudURI {
+		switch service {
+		case Library:
+			return SCSDefaultLibraryURI, nil
+		case Builder:
+			return SCSDefaultBuilderURI, nil
+		case Keyserver:
+			return SCSDefaultKeyserverURI, nil
+		}
+	}
+
+	services, err := ep.GetAllServices()
+	if err != nil {
+		return "", err
+	}
+
+	s, ok := services[service]
+	if !ok || len(s) == 0 {
+		return "", fmt.Errorf("%v is not a service at endpoint", service)
+	} else if s[0].URI() == "" {
+		return "", fmt.Errorf("%v service at endpoint failed to provide URI in response", service)
+	}
+
+	return s[0].URI(), nil
+}

--- a/internal/pkg/remote/endpoint/token.go
+++ b/internal/pkg/remote/endpoint/token.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package endpoint
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/sylabs/singularity/internal/pkg/remote/credential"
+	"github.com/sylabs/singularity/internal/pkg/util/interactive"
+	"github.com/sylabs/singularity/pkg/sylog"
+	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+)
+
+// VerifyToken returns an error if a token is not valid
+func (ep *Config) VerifyToken() (err error) {
+	if ep.URI == "" {
+		return fmt.Errorf("no endpoint URI")
+	}
+
+	defer func() {
+		if err == nil {
+			sylog.Infof("API Key Verified!")
+		}
+	}()
+
+	if ep.Token == "" {
+		fmt.Printf("Generate an API Key at https://%s/auth/tokens, and paste here:\n", ep.URI)
+		ep.Token, err = interactive.AskQuestionNoEcho("API Key: ")
+		if err != nil {
+			return err
+		}
+	}
+
+	sp, err := ep.GetAllServices()
+	if err != nil {
+		return err
+	}
+
+	ts, ok := sp[Token]
+	if !ok || len(ts) == 0 {
+		return fmt.Errorf("no authentication service found")
+	}
+
+	client := &http.Client{
+		Timeout: defaultTimeout,
+	}
+	req, err := http.NewRequest(http.MethodGet, ts[0].URI()+"/v1/token-status", nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", credential.TokenPrefix+ep.Token)
+	req.Header.Set("User-Agent", useragent.Value())
+
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request to server: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		convStatus, ok := errorCodeMap[res.StatusCode]
+		if !ok {
+			convStatus = "Unknown"
+		}
+		return fmt.Errorf("error response from server: %v", convStatus)
+	}
+
+	return nil
+}

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -6,16 +7,19 @@
 package remote
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"strings"
-	"time"
+	"os"
+	"path/filepath"
 
-	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/internal/pkg/remote/credential"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
+	remoteutil "github.com/sylabs/singularity/internal/pkg/remote/util"
+	"github.com/sylabs/singularity/pkg/syfs"
+	"github.com/sylabs/singularity/pkg/sylog"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -24,29 +28,44 @@ var (
 	ErrNoDefault = errors.New("no default remote")
 )
 
-var errorCodeMap = map[int]string{
-	404: "Invalid Token",
-	500: "Internal Server Error",
+const (
+	// DefaultRemoteName is the default remote name
+	DefaultRemoteName = "SylabsCloud"
+)
+
+// DefaultRemoteConfig holds the default remote configuration
+// if there is no remote.yaml present both in user home directory
+// and in system location.
+var DefaultRemoteConfig = &Config{
+	DefaultRemote: DefaultRemoteName,
+	Remotes: map[string]*endpoint.Config{
+		DefaultRemoteName: endpoint.DefaultEndpointConfig,
+	},
 }
+
+// SystemConfigPath holds the path to the remote system configuration.
+var SystemConfigPath = filepath.Join(buildcfg.SYSCONFDIR, "singularity", syfs.RemoteConfFile)
 
 // Config stores the state of remote endpoint configurations
 type Config struct {
-	DefaultRemote string               `yaml:"Active"`
-	Remotes       map[string]*EndPoint `yaml:"Remotes"`
-}
+	DefaultRemote string                      `yaml:"Active"`
+	Remotes       map[string]*endpoint.Config `yaml:"Remotes"`
+	Credentials   []*credential.Config        `yaml:"Credentials,omitempty"`
 
-// EndPoint descriptes a single remote service
-type EndPoint struct {
-	URI    string `yaml:"URI,omitempty"`
-	Token  string `yaml:"Token,omitempty"`
-	System bool   `yaml:"System"` // Was this EndPoint set from system config file
+	// set to true when this is the system configuration
+	system bool
 }
 
 // ReadFrom reads remote configuration from io.Reader
 // returns Config populated with remotes
 func ReadFrom(r io.Reader) (*Config, error) {
 	c := &Config{
-		Remotes: make(map[string]*EndPoint),
+		Remotes: make(map[string]*endpoint.Config),
+	}
+
+	// check if the reader point to the remote system configuration
+	if f, ok := r.(*os.File); ok {
+		c.system = f.Name() == SystemConfigPath
 	}
 
 	// read all data from r into b
@@ -93,12 +112,22 @@ func (c *Config) SyncFrom(sys *Config) error {
 			return fmt.Errorf("name collision while syncing: %s", name)
 		} else if err == nil {
 			eUsr.URI = eSys.URI // update URI just in case
+			eUsr.Exclusive = eSys.Exclusive
+			if eSys.Exclusive {
+				c.DefaultRemote = name
+			}
+			eUsr.Keyservers = eSys.Keyservers
 			continue
 		}
 
-		e := &EndPoint{
-			URI:    eSys.URI,
-			System: true,
+		if eSys.Exclusive {
+			c.DefaultRemote = name
+		}
+		e := &endpoint.Config{
+			URI:        eSys.URI,
+			System:     true,
+			Exclusive:  eSys.Exclusive,
+			Keyservers: eSys.Keyservers,
 		}
 
 		if err := c.Add(name, e); err != nil {
@@ -114,32 +143,44 @@ func (c *Config) SyncFrom(sys *Config) error {
 	return nil
 }
 
-// SetDefault sets default remote endpoint or returns an error if it does not exist
-func (c *Config) SetDefault(name string) error {
-	if _, ok := c.Remotes[name]; !ok {
+// SetDefault sets default remote endpoint or returns an error if it does not exist.
+// A remote endpoint can also be set as exclusive.
+func (c *Config) SetDefault(name string, exclusive bool) error {
+	r, ok := c.Remotes[name]
+	if !ok {
 		return fmt.Errorf("%s is not a remote", name)
 	}
+	if !c.system && exclusive {
+		return fmt.Errorf("exclusive can't be set by user")
+	} else if name != c.DefaultRemote {
+		for n, r := range c.Remotes {
+			if r.Exclusive && !c.system {
+				return fmt.Errorf("could not use %s: remote %s is set to exclusive", name, n)
+			}
+		}
+	}
+
+	dr, ok := c.Remotes[c.DefaultRemote]
+	if ok && c.DefaultRemote != name && exclusive {
+		dr.Exclusive = false
+	}
+	r.Exclusive = exclusive
 
 	c.DefaultRemote = name
 	return nil
 }
 
 // GetDefault returns default remote endpoint or an error
-func (c *Config) GetDefault() (*EndPoint, error) {
+func (c *Config) GetDefault() (*endpoint.Config, error) {
 	if c.DefaultRemote == "" {
 		return nil, ErrNoDefault
 	}
-
-	if _, ok := c.Remotes[c.DefaultRemote]; !ok {
-		return nil, fmt.Errorf("%s is not a remote", c.DefaultRemote)
-	}
-
-	return c.Remotes[c.DefaultRemote], nil
+	return c.GetRemote(c.DefaultRemote)
 }
 
 // Add a new remote endpoint
 // returns an error if it already exists
-func (c *Config) Add(name string, e *EndPoint) error {
+func (c *Config) Add(name string, e *endpoint.Config) error {
 	if _, ok := c.Remotes[name]; ok {
 		return fmt.Errorf("%s is already a remote", name)
 	}
@@ -152,8 +193,10 @@ func (c *Config) Add(name string, e *EndPoint) error {
 // if endpoint is the default, the default is cleared
 // returns an error if it does not exist
 func (c *Config) Remove(name string) error {
-	if _, ok := c.Remotes[name]; !ok {
+	if r, ok := c.Remotes[name]; !ok {
 		return fmt.Errorf("%s is not a remote", name)
+	} else if r.System && !c.system {
+		return fmt.Errorf("%s is global and can't be removed", name)
 	}
 
 	if c.DefaultRemote == name {
@@ -166,12 +209,67 @@ func (c *Config) Remove(name string) error {
 
 // GetRemote returns a reference to an existing endpoint
 // returns error if remote does not exist
-func (c *Config) GetRemote(name string) (*EndPoint, error) {
+func (c *Config) GetRemote(name string) (*endpoint.Config, error) {
 	r, ok := c.Remotes[name]
 	if !ok {
 		return nil, fmt.Errorf("%s is not a remote", name)
 	}
+	r.SetCredentials(c.Credentials)
 	return r, nil
+}
+
+// Login validates and stores credentials for a service like Docker/OCI registries
+// and keyservers.
+func (c *Config) Login(uri, username, password string, insecure bool) error {
+	_, err := remoteutil.NormalizeKeyserverURI(uri)
+	// if there is no error, we consider it as a keyserver
+	if err == nil {
+		var keyserverConfig *endpoint.ServiceConfig
+
+		for _, ep := range c.Remotes {
+			if keyserverConfig != nil {
+				break
+			}
+			for _, kc := range ep.Keyservers {
+				if !kc.External {
+					continue
+				}
+				if remoteutil.SameKeyserver(uri, kc.URI) {
+					keyserverConfig = kc
+					break
+				}
+			}
+		}
+		if keyserverConfig == nil {
+			return fmt.Errorf("no external keyserver configuration found for %s", uri)
+		} else if keyserverConfig.Insecure && !insecure {
+			sylog.Warningf("%s is configured as insecure, forcing insecure flag for login", uri)
+			insecure = true
+		} else if !keyserverConfig.Insecure && insecure {
+			insecure = false
+		}
+	}
+
+	credConfig, err := credential.Manager.Login(uri, username, password, insecure)
+	if err != nil {
+		return err
+	}
+	c.Credentials = append(c.Credentials, credConfig)
+	return nil
+}
+
+// Logout removes previously stored credentials for a service.
+func (c *Config) Logout(uri string) error {
+	if err := credential.Manager.Logout(uri); err != nil {
+		return err
+	}
+	for i, cred := range c.Credentials {
+		if remoteutil.SameURI(cred.URI, uri) {
+			c.Credentials = append(c.Credentials[:i], c.Credentials[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("%s is not configured", uri)
 }
 
 // Rename an existing remote
@@ -192,120 +290,4 @@ func (c *Config) Rename(name, newName string) error {
 	c.Remotes[newName] = c.Remotes[name]
 	delete(c.Remotes, name)
 	return nil
-}
-
-// VerifyToken returns an error if a token is not valid
-func (e *EndPoint) VerifyToken() error {
-	baseURL, err := e.GetServiceURI("token")
-	if err != nil {
-		return fmt.Errorf("while getting token service uri: %v", err)
-	}
-
-	client := &http.Client{
-		Timeout: (30 * time.Second),
-	}
-	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/token-status", nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", e.Token))
-	req.Header.Set("User-Agent", useragent.Value())
-
-	res, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("error making request to server: %v", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		convStatus, ok := errorCodeMap[res.StatusCode]
-		if !ok {
-			convStatus = "Unknown"
-		}
-		return fmt.Errorf("error response from server: %v", convStatus)
-	}
-
-	return nil
-}
-
-func getCloudConfig(uri string) ([]byte, error) {
-	client := &http.Client{
-		Timeout: (30 * time.Second),
-	}
-
-	url := "https://" + uri + "/assets/config/config.prod.json"
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("User-Agent", useragent.Value())
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error making request to server: %v", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error response from server: %v", res.StatusCode)
-	}
-
-	b, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("while reading response body: %v", err)
-	}
-	return b, nil
-}
-
-// GetServiceURI returns the URI for the service at the specified SCS endpoint
-// Examples of services: consent, build, library, key, token
-func (e *EndPoint) GetServiceURI(service string) (string, error) {
-	b, err := getCloudConfig(e.URI)
-	if err != nil {
-		return "", err
-	}
-
-	var a map[string]map[string]interface{}
-	if err := json.Unmarshal(b, &a); err != nil {
-		return "", fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
-	}
-
-	val, ok := a[service+"API"]
-	if !ok {
-		return "", fmt.Errorf("%v is not a service at endpoint", service)
-	}
-
-	uri, ok := val["uri"].(string)
-	if !ok {
-		return "", fmt.Errorf("%v service at endpoint failed to provide URI in response", service)
-	}
-
-	return uri, nil
-}
-
-// GetAllServiceURIs returns all available service urls for a given endpoint in a map
-func (e *EndPoint) GetAllServiceURIs() (map[string]string, error) {
-	b, err := getCloudConfig(e.URI)
-	if err != nil {
-		return nil, err
-	}
-
-	var a map[string]map[string]interface{}
-	if err := json.Unmarshal(b, &a); err != nil {
-		return nil, fmt.Errorf("jsonresp: failed to unmarshal response: %v", err)
-	}
-
-	uris := make(map[string]string)
-	for k := range a {
-		if strings.HasSuffix(k, "API") {
-			if s, ok := a[k]["uri"].(string); ok {
-				uris[strings.TrimSuffix(k, "API")] = s
-			}
-		}
-	}
-
-	return uris, nil
 }

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -155,7 +155,10 @@ func (c *Config) SetDefault(name string, exclusive bool) error {
 	} else if name != c.DefaultRemote {
 		for n, r := range c.Remotes {
 			if r.Exclusive && !c.system {
-				return fmt.Errorf("could not use %s: remote %s is set to exclusive", name, n)
+				return fmt.Errorf(
+					"could not use %s: remote %s has been set exclusive by the system administrator",
+					name, n,
+				)
 			}
 		}
 	}

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -7,18 +8,20 @@ package remote
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 	yaml "gopkg.in/yaml.v2"
 )
 
+const testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
+
 //NOTE: VerifyToken() cannot be fully tested unless we have a dummy token for the token service to authenticate, so we basically only test a few error cases.
 func TestVerifyToken(t *testing.T) {
-	ep := new(EndPoint)
+	ep := new(endpoint.Config)
 
 	err := ep.VerifyToken()
 	if err == nil {
@@ -47,21 +50,21 @@ func TestWriteToReadFrom(t *testing.T) {
 			name: "empty config",
 			c: Config{
 				DefaultRemote: "",
-				Remotes:       map[string]*EndPoint{},
+				Remotes:       map[string]*endpoint.Config{},
 			},
 		},
 		{
 			name: "config with stuff",
 			c: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -140,7 +143,7 @@ func TestSyncFrom(t *testing.T) {
 		{
 			name: "empty sys config",
 			usr: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token",
@@ -148,7 +151,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			res: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token",
@@ -158,7 +161,7 @@ func TestSyncFrom(t *testing.T) {
 		}, {
 			name: "sys config new endpoint",
 			sys: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token", // should be ignored by SyncFrom
@@ -166,7 +169,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			usr: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token",
@@ -174,7 +177,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			res: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.sylabs.io",
 						System: true,
@@ -188,7 +191,7 @@ func TestSyncFrom(t *testing.T) {
 		}, {
 			name: "sys config existing endpoint",
 			sys: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token", // should be ignored by SyncFrom
@@ -196,7 +199,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			usr: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.sylabs.io",
 						System: true,
@@ -208,7 +211,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			res: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.sylabs.io",
 						System: true,
@@ -222,7 +225,7 @@ func TestSyncFrom(t *testing.T) {
 		}, {
 			name: "sys config update existing endpoint",
 			sys: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token", // should be ignored by SyncFrom
@@ -230,7 +233,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			usr: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.old-url.io",
 						System: true,
@@ -242,7 +245,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			res: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.sylabs.io",
 						System: true,
@@ -257,7 +260,7 @@ func TestSyncFrom(t *testing.T) {
 			name: "sys config update default endpoint",
 			sys: Config{
 				DefaultRemote: "sylabs-global",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token", // should be ignored by SyncFrom
@@ -265,7 +268,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			usr: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.old-url.io",
 						System: true,
@@ -278,7 +281,7 @@ func TestSyncFrom(t *testing.T) {
 			},
 			res: Config{
 				DefaultRemote: "sylabs-global",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.sylabs.io",
 						System: true,
@@ -293,7 +296,7 @@ func TestSyncFrom(t *testing.T) {
 			name: "sys config dont update default endpoint",
 			sys: Config{
 				DefaultRemote: "sylabs-global",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token", // should be ignored by SyncFrom
@@ -302,7 +305,7 @@ func TestSyncFrom(t *testing.T) {
 			},
 			usr: Config{
 				DefaultRemote: "sylabs",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.old-url.io",
 						System: true,
@@ -315,7 +318,7 @@ func TestSyncFrom(t *testing.T) {
 			},
 			res: Config{
 				DefaultRemote: "sylabs",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:    "cloud.sylabs.io",
 						System: true,
@@ -335,11 +338,8 @@ func TestSyncFrom(t *testing.T) {
 				t.Error("failed to sync from sys")
 			}
 
-			fmt.Println(test.usr)
-			fmt.Println(test.res)
-
 			if !reflect.DeepEqual(test.usr, test.res) {
-				t.Errorf("incorrect result Config")
+				t.Errorf("bad sync from sys:\n\thave: %v\n\twant: %v", test.usr, test.res)
 			}
 		})
 	}
@@ -348,7 +348,7 @@ func TestSyncFrom(t *testing.T) {
 		{
 			name: "sys endpoint collision",
 			sys: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token",
@@ -356,7 +356,7 @@ func TestSyncFrom(t *testing.T) {
 				},
 			},
 			usr: Config{
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
 						URI:   "cloud.sylabs.io",
 						Token: "fake-token",
@@ -384,7 +384,7 @@ type remoteTest struct {
 	new   Config
 	id    string
 	newID string
-	ep    *EndPoint
+	ep    *endpoint.Config
 }
 
 func TestAddRemote(t *testing.T) {
@@ -392,51 +392,51 @@ func TestAddRemote(t *testing.T) {
 		{
 			name: "add remote to empty config",
 			old: Config{
-				Remotes: map[string]*EndPoint{},
+				Remotes: map[string]*endpoint.Config{},
 			},
 			new: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
-			ep: &EndPoint{
+			ep: &endpoint.Config{
 				URI:   "cloud.sylabs.io",
-				Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+				Token: testToken,
 			},
 		},
 		{
 			name: "add remote to non-empty config",
 			old: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			new: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
-			ep: &EndPoint{
+			ep: &endpoint.Config{
 				URI:   "cloud.sylabs.io",
-				Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+				Token: testToken,
 			},
 		},
 	}
@@ -457,17 +457,17 @@ func TestAddRemote(t *testing.T) {
 		name: "add already existing remote",
 		old: Config{
 			DefaultRemote: "",
-			Remotes: map[string]*EndPoint{
+			Remotes: map[string]*endpoint.Config{
 				"cloud": {
 					URI:   "cloud.sylabs.io",
-					Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+					Token: testToken,
 				},
 			},
 		},
 		id: "cloud",
-		ep: &EndPoint{
+		ep: &endpoint.Config{
 			URI:   "cloud.sylabs.io",
-			Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+			Token: testToken,
 		},
 	}
 
@@ -484,15 +484,15 @@ func TestRemoveRemote(t *testing.T) {
 			name: "remove remote to make empty config",
 			old: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			new: Config{
-				Remotes: map[string]*EndPoint{},
+				Remotes: map[string]*endpoint.Config{},
 			},
 			id: "cloud",
 		},
@@ -500,23 +500,23 @@ func TestRemoveRemote(t *testing.T) {
 			name: "remove remote to make non-empty config",
 			old: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			new: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -526,23 +526,23 @@ func TestRemoveRemote(t *testing.T) {
 			name: "remove default remote to make defaultless config",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			new: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -566,7 +566,7 @@ func TestRemoveRemote(t *testing.T) {
 		name: "remove non-existent remote",
 		old: Config{
 			DefaultRemote: "",
-			Remotes:       map[string]*EndPoint{},
+			Remotes:       map[string]*endpoint.Config{},
 		},
 		id: "cloud",
 	}
@@ -584,19 +584,19 @@ func TestRenameRemote(t *testing.T) {
 			name: "rename remote not default",
 			old: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			new: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"newCloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -607,27 +607,27 @@ func TestRenameRemote(t *testing.T) {
 			name: "rename remote when it's default",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			new: Config{
 				DefaultRemote: "newCloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"newCloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -653,7 +653,7 @@ func TestRenameRemote(t *testing.T) {
 			name: "rename non-existent remote",
 			old: Config{
 				DefaultRemote: "",
-				Remotes:       map[string]*EndPoint{},
+				Remotes:       map[string]*endpoint.Config{},
 			},
 			id:    "cloud",
 			newID: "newCloud",
@@ -663,7 +663,7 @@ func TestRenameRemote(t *testing.T) {
 			name: "rename existing remote to existing remote",
 			old: Config{
 				DefaultRemote: "",
-				Remotes:       map[string]*EndPoint{},
+				Remotes:       map[string]*endpoint.Config{},
 			},
 			id:    "cloud",
 			newID: "newCloud",
@@ -673,14 +673,14 @@ func TestRenameRemote(t *testing.T) {
 			name: "default does not exist",
 			old: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -703,28 +703,28 @@ func TestGetRemote(t *testing.T) {
 			name: "get existing remote",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
-			ep: &EndPoint{
+			ep: &endpoint.Config{
 				URI:   "cloud.sylabs.io",
-				Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+				Token: testToken,
 			},
 		},
 	}
 
 	for _, test := range testsPass {
 		t.Run(test.name, func(t *testing.T) {
-			var ep *EndPoint
+			var ep *endpoint.Config
 			ep, err := test.old.GetRemote(test.id)
 			if err != nil {
 				t.Error("failed to get endpoint from config")
@@ -741,10 +741,10 @@ func TestGetRemote(t *testing.T) {
 			name: "remote does not exist",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -766,27 +766,27 @@ func TestGetDefaultRemote(t *testing.T) {
 			name: "get existing default remote",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
-			ep: &EndPoint{
+			ep: &endpoint.Config{
 				URI:   "cloud.sylabs.io",
-				Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+				Token: testToken,
 			},
 		},
 	}
 
 	for _, test := range testsPass {
 		t.Run(test.name, func(t *testing.T) {
-			var ep *EndPoint
+			var ep *endpoint.Config
 			ep, err := test.old.GetDefault()
 			if err != nil {
 				t.Error("failed to get endpoint from config")
@@ -803,14 +803,14 @@ func TestGetDefaultRemote(t *testing.T) {
 			name: "no default set",
 			old: Config{
 				DefaultRemote: "",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -819,10 +819,10 @@ func TestGetDefaultRemote(t *testing.T) {
 			name: "default does not exist",
 			old: Config{
 				DefaultRemote: "notaremote",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -843,27 +843,27 @@ func TestSetDefaultRemote(t *testing.T) {
 			name: "set existing remote to default",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
 			new: Config{
 				DefaultRemote: "random",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -873,7 +873,7 @@ func TestSetDefaultRemote(t *testing.T) {
 
 	for _, test := range testsPass {
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.old.SetDefault(test.id); err != nil {
+			if err := test.old.SetDefault(test.id, false); err != nil {
 				t.Error("failed to set default endpoint in config")
 			}
 
@@ -888,10 +888,10 @@ func TestSetDefaultRemote(t *testing.T) {
 			name: "default does not exist",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -900,7 +900,109 @@ func TestSetDefaultRemote(t *testing.T) {
 	}
 	for _, test := range testsFail {
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.old.SetDefault(test.id); err == nil {
+			if err := test.old.SetDefault(test.id, false); err == nil {
+				t.Error("unexpected success setting default remote")
+			}
+		})
+	}
+
+	testsExclusivePass := []remoteTest{
+		{
+			name: "set existing remote to default and exclusive",
+			old: Config{
+				DefaultRemote: "cloud",
+				system:        true,
+				Remotes: map[string]*endpoint.Config{
+					"random": {
+						URI:   "cloud.random.io",
+						Token: testToken,
+					},
+					"cloud": {
+						URI:   "cloud.sylabs.io",
+						Token: testToken,
+					},
+				},
+			},
+			new: Config{
+				DefaultRemote: "random",
+				system:        true,
+				Remotes: map[string]*endpoint.Config{
+					"random": {
+						URI:       "cloud.random.io",
+						Exclusive: true,
+						Token:     testToken,
+					},
+					"cloud": {
+						URI:   "cloud.sylabs.io",
+						Token: testToken,
+					},
+				},
+			},
+			id: "random",
+		},
+	}
+	for _, test := range testsExclusivePass {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.old.SetDefault(test.id, true); err != nil {
+				t.Errorf("unexpected error setting default remote as exclusive: %s", err)
+			}
+
+			if !reflect.DeepEqual(test.old, test.new) {
+				t.Errorf("Remove failed to set config:\n\thave: %v\n\twant: %v", test.old, test.new)
+			}
+		})
+	}
+
+	testsUserExclusiveFail := []remoteTest{
+		{
+			name: "set existing remote to default and exclusive as user",
+			old: Config{
+				DefaultRemote: "cloud",
+				Remotes: map[string]*endpoint.Config{
+					"random": {
+						URI:   "cloud.random.io",
+						Token: testToken,
+					},
+					"cloud": {
+						URI:   "cloud.sylabs.io",
+						Token: testToken,
+					},
+				},
+			},
+			id: "random",
+		},
+	}
+	for _, test := range testsUserExclusiveFail {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.old.SetDefault(test.id, true); err == nil {
+				t.Error("unexpected success setting default remote as exclusive as user")
+			}
+		})
+	}
+
+	testsUserDefaultExclusiveFail := []remoteTest{
+		{
+			name: "set existing remote to default with different exclusive endpoint",
+			old: Config{
+				DefaultRemote: "cloud",
+				Remotes: map[string]*endpoint.Config{
+					"random": {
+						URI:   "cloud.random.io",
+						Token: testToken,
+					},
+					"cloud": {
+						URI:       "cloud.sylabs.io",
+						Exclusive: true,
+						Token:     testToken,
+					},
+				},
+			},
+			id: "random",
+		},
+	}
+	for _, test := range testsUserDefaultExclusiveFail {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.old.SetDefault(test.id, false); err == nil {
 				t.Error("unexpected success setting default remote")
 			}
 		})
@@ -913,14 +1015,14 @@ func TestGetServiceURI(t *testing.T) {
 			name: "get uri from real cloud remote",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"random": {
 						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -930,7 +1032,7 @@ func TestGetServiceURI(t *testing.T) {
 
 	for _, test := range testsPass {
 		t.Run(test.name, func(t *testing.T) {
-			var ep *EndPoint
+			var ep *endpoint.Config
 			ep, err := test.old.GetRemote(test.id)
 			if err != nil {
 				t.Fatal("failed to get endpoint from config")
@@ -947,14 +1049,14 @@ func TestGetServiceURI(t *testing.T) {
 			name: "get uri from non-existent remote",
 			old: Config{
 				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
+				Remotes: map[string]*endpoint.Config{
 					"notaremote": {
 						URI:   "not.a.remote",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 					"cloud": {
 						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
+						Token: testToken,
 					},
 				},
 			},
@@ -964,83 +1066,13 @@ func TestGetServiceURI(t *testing.T) {
 	for _, test := range testsFail {
 
 		t.Run(test.name, func(t *testing.T) {
-			var ep *EndPoint
+			var ep *endpoint.Config
 			ep, err := test.old.GetRemote(test.id)
 			if err != nil {
 				t.Fatal("failed to get endpoint from config")
 			}
 
 			if _, err := ep.GetServiceURI("token"); err == nil {
-				t.Error("unexpected success getting uri for non-existent remote")
-			}
-		})
-	}
-}
-
-func TestGetAllServiceURIs(t *testing.T) {
-	testsPass := []remoteTest{
-		{
-			name: "get uris from real cloud remote",
-			old: Config{
-				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
-					"random": {
-						URI:   "cloud.random.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
-					},
-					"cloud": {
-						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
-					},
-				},
-			},
-			id: "cloud",
-		},
-	}
-
-	for _, test := range testsPass {
-		t.Run(test.name, func(t *testing.T) {
-			var ep *EndPoint
-			ep, err := test.old.GetRemote(test.id)
-			if err != nil {
-				t.Fatal("failed to get endpoint from config")
-			}
-
-			if s, err := ep.GetAllServiceURIs(); s == nil || err != nil {
-				t.Errorf("failed to get service uri:\n\tservice uri: %v\n\t err: %v", s, err)
-			}
-		})
-	}
-
-	testsFail := []remoteTest{
-		{
-			name: "get uri from non-existent remote",
-			old: Config{
-				DefaultRemote: "cloud",
-				Remotes: map[string]*EndPoint{
-					"notaremote": {
-						URI:   "not.a.remote",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
-					},
-					"cloud": {
-						URI:   "cloud.sylabs.io",
-						Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM",
-					},
-				},
-			},
-			id: "notaremote",
-		},
-	}
-	for _, test := range testsFail {
-
-		t.Run(test.name, func(t *testing.T) {
-			var ep *EndPoint
-			ep, err := test.old.GetRemote(test.id)
-			if err != nil {
-				t.Fatal("failed to get endpoint from config")
-			}
-
-			if _, err := ep.GetAllServiceURIs(); err == nil {
 				t.Error("unexpected success getting uri for non-existent remote")
 			}
 		})

--- a/internal/pkg/remote/util/util.go
+++ b/internal/pkg/remote/util/util.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	hkpPort  = "11371"
-	hkpsPort = "443"
+	hkpPort = "11371"
 )
 
 const (

--- a/internal/pkg/remote/util/util.go
+++ b/internal/pkg/remote/util/util.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+)
+
+const (
+	hkpPort  = "11371"
+	hkpsPort = "443"
+)
+
+const (
+	httpScheme  = "http"
+	httpsScheme = "https"
+	hkpScheme   = "hkp"
+	hkpsScheme  = "hkps"
+)
+
+// NormalizeKeyserverURI is normalizing a URI string by converting
+// protocol scheme hkp:// and hkps:// to their corresponding http://
+// and https:// protocol scheme and returns the parsed URI with the
+// corresponding scheme.
+func NormalizeKeyserverURI(uri string) (*url.URL, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case httpScheme, httpsScheme:
+	case hkpScheme:
+		u.Scheme = httpScheme
+		if u.Port() == "" {
+			u.Host = net.JoinHostPort(u.Hostname(), hkpPort)
+		}
+	case hkpsScheme:
+		u.Scheme = httpsScheme
+	default:
+		return nil, fmt.Errorf("unsupported keyserver protocol scheme %q", u.Scheme)
+	}
+
+	return u, nil
+}
+
+// SameKeyserver returns if two URIs point to the same keyserver or not, URI are
+// also normalized meaning by example that hkp://localhost is equivalent to
+// http://localhost:11371.
+func SameKeyserver(u1, u2 string) bool {
+	uri1, err := NormalizeKeyserverURI(u1)
+	if err != nil {
+		return false
+	}
+	uri2, err := NormalizeKeyserverURI(u2)
+	if err != nil {
+		return false
+	}
+	return Equal(uri1, uri2)
+}
+
+// SameURI returns if two URIs point to the same service or not.
+func SameURI(u1, u2 string) bool {
+	uri1, err := url.Parse(u1)
+	if err != nil {
+		return false
+	}
+	uri2, err := url.Parse(u2)
+	if err != nil {
+		return false
+	}
+	return Equal(uri1, uri2)
+}
+
+// Equal returns if both URLs have the same hostname, port and scheme or not.
+func Equal(u1, u2 *url.URL) bool {
+	if u1.Host == "" || u2.Host == "" {
+		return false
+	}
+	return u1.Host == u2.Host && u1.Scheme == u2.Scheme
+}

--- a/internal/pkg/remote/util/util_test.go
+++ b/internal/pkg/remote/util/util_test.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package util
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestSameKeyserver(t *testing.T) {
+	tests := []struct {
+		name        string
+		u1          string
+		u2          string
+		mustBeEqual bool
+	}{
+		{
+			name:        "Identical http",
+			u1:          "http://localhost:11371",
+			u2:          "http://localhost:11371",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Identical https",
+			u1:          "https://localhost",
+			u2:          "https://localhost",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Identical https 8443",
+			u1:          "https://localhost:8443",
+			u2:          "https://localhost:8443",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Identical http and hkp",
+			u1:          "http://localhost:11371",
+			u2:          "hkp://localhost",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Identical https and hkps",
+			u1:          "https://localhost",
+			u2:          "hkps://localhost",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Different https and hkps port",
+			u1:          "https://localhost:8443",
+			u2:          "hkps://localhost",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Different http and hkp port",
+			u1:          "http://localhost",
+			u2:          "hkp://localhost",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Identical http with different path",
+			u1:          "http://localhost/path/a",
+			u2:          "http://localhost/path/b",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Not support scheme first URL",
+			u1:          "file://localhost/path/a",
+			u2:          "http://localhost/path/b",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Not support scheme second URL",
+			u1:          "http://localhost/path/a",
+			u2:          "file://localhost/path/b",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Empty URLs",
+			u1:          "",
+			u2:          "",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Control bytes URLs",
+			u1:          "http://localhost\n",
+			u2:          "http://localhost\n",
+			mustBeEqual: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eq := SameKeyserver(tt.u1, tt.u2)
+			if eq && !tt.mustBeEqual {
+				t.Errorf("unexpected match between %s and %s", tt.u1, tt.u2)
+			} else if !eq && tt.mustBeEqual {
+				t.Errorf("unexpected diff between %s and %s", tt.u1, tt.u2)
+			}
+		})
+	}
+}
+
+func TestNormalizeKeyserverURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		uri         string
+		expectedURI string
+		wantErr     bool
+	}{
+		{
+			name:        "Http without port",
+			uri:         "http://localhost",
+			expectedURI: "http://localhost",
+		},
+		{
+			name:        "Http with port",
+			uri:         "http://localhost:11370",
+			expectedURI: "http://localhost:11370",
+		},
+		{
+			name:        "Https without port",
+			uri:         "https://localhost",
+			expectedURI: "https://localhost",
+		},
+		{
+			name:        "Https with port",
+			uri:         "https://localhost:8443",
+			expectedURI: "https://localhost:8443",
+		},
+		{
+			name:        "HKP form",
+			uri:         "hkp://localhost",
+			expectedURI: "http://localhost:11371",
+		},
+		{
+			name:        "HKP form with port",
+			uri:         "hkp://localhost:11370",
+			expectedURI: "http://localhost:11370",
+		},
+		{
+			name:        "HKPS form",
+			uri:         "hkps://localhost",
+			expectedURI: "https://localhost",
+		},
+		{
+			name:        "HKPS form with port",
+			uri:         "hkps://localhost:8443",
+			expectedURI: "https://localhost:8443",
+		},
+		{
+			name:    "Empty URI",
+			uri:     "",
+			wantErr: true,
+		},
+		{
+			name:    "Control bytes URLs",
+			uri:     "http://localhost\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uri, err := NormalizeKeyserverURI(tt.uri)
+			if err == nil && tt.wantErr {
+				t.Errorf("unexpected success for URI %s", tt.uri)
+			} else if err != nil && !tt.wantErr {
+				t.Errorf("unexpected error for URI %s: %s", tt.uri, err)
+			} else if !tt.wantErr && uri.String() != tt.expectedURI {
+				t.Errorf("unexpected URI returned: got %s instead of %s", uri, tt.expectedURI)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name        string
+		u1          *url.URL
+		u2          *url.URL
+		mustBeEqual bool
+	}{
+		{
+			name:        "equal OK (scheme)",
+			u1:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			u2:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			mustBeEqual: true,
+		},
+		{
+			name:        "equal KO (scheme)",
+			u1:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			u2:          &url.URL{Host: "localhost:8000", Scheme: "https"},
+			mustBeEqual: false,
+		},
+		{
+			name:        "equal OK (port)",
+			u1:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			u2:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			mustBeEqual: true,
+		},
+		{
+			name:        "equal KO (port)",
+			u1:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			u2:          &url.URL{Host: "localhost:8001", Scheme: "http"},
+			mustBeEqual: false,
+		},
+		{
+			name:        "equal OK (hostname)",
+			u1:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			u2:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			mustBeEqual: true,
+		},
+		{
+			name:        "equal KO (hostname)",
+			u1:          &url.URL{Host: "localhost:8000", Scheme: "http"},
+			u2:          &url.URL{Host: "localhos:8000", Scheme: "http"},
+			mustBeEqual: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal := Equal(tt.u1, tt.u2)
+			if !equal && tt.mustBeEqual {
+				t.Errorf("%s and %s are not equal for test %s", tt.u1, tt.u2, tt.name)
+			} else if equal && !tt.mustBeEqual {
+				t.Errorf("%s and %s are equal for test %s", tt.u1, tt.u2, tt.name)
+			}
+		})
+	}
+}
+
+func TestSameURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		u1          string
+		u2          string
+		mustBeEqual bool
+	}{
+		{
+			name:        "Http scheme",
+			u1:          "http://localhost:8080",
+			u2:          "http://localhost:8080",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Http scheme with path",
+			u1:          "http://localhost:8080/a/b",
+			u2:          "http://localhost:8080/b/a",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Https scheme",
+			u1:          "https://localhost",
+			u2:          "https://localhost",
+			mustBeEqual: true,
+		},
+		{
+			name:        "Different port",
+			u1:          "http://localhost:80",
+			u2:          "http://localhost:81",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Docker scheme",
+			u1:          "docker://docker.io",
+			u2:          "docker://docker.io",
+			mustBeEqual: true,
+		},
+		{
+			name:        "ORAS scheme",
+			u1:          "oras://localhost:5000",
+			u2:          "oras://localhost:5000",
+			mustBeEqual: true,
+		},
+		{
+			name:        "No scheme",
+			u1:          "localhost",
+			u2:          "localhost",
+			mustBeEqual: false,
+		},
+		{
+			name:        "No scheme with port",
+			u1:          "localhost:8080",
+			u2:          "localhost:8080",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Control bytes in first",
+			u1:          "http://localhost\n",
+			u2:          "",
+			mustBeEqual: false,
+		},
+		{
+			name:        "Control bytes in second",
+			u1:          "",
+			u2:          "http://localhost\n",
+			mustBeEqual: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal := SameURI(tt.u1, tt.u2)
+			if !equal && tt.mustBeEqual {
+				t.Errorf("%s and %s are not equal for test %s", tt.u1, tt.u2, tt.name)
+			} else if equal && !tt.mustBeEqual {
+				t.Errorf("%s and %s are equal for test %s", tt.u1, tt.u2, tt.name)
+			}
+		})
+	}
+}

--- a/internal/pkg/util/uri/uri_test.go
+++ b/internal/pkg/util/uri/uri_test.go
@@ -5,7 +5,9 @@
 
 package uri
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_GetName(t *testing.T) {
 	tests := []struct {

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -18,6 +19,7 @@ import (
 
 const (
 	RemoteConfFile = "remote.yaml"
+	DockerConfFile = "docker-config.json"
 	singularityDir = ".singularity"
 )
 
@@ -58,6 +60,10 @@ func configDir() string {
 
 func RemoteConf() string {
 	return filepath.Join(ConfigDir(), RemoteConfFile)
+}
+
+func DockerConf() string {
+	return filepath.Join(ConfigDir(), DockerConfFile)
 }
 
 // ConfigDirForUsername returns the directory where the singularity

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	RemoteConfFile = "remote.yaml"
+	RemoteCache    = "remote-cache"
 	DockerConfFile = "docker-config.json"
 	singularityDir = ".singularity"
 )
@@ -60,6 +61,10 @@ func configDir() string {
 
 func RemoteConf() string {
 	return filepath.Join(ConfigDir(), RemoteConfFile)
+}
+
+func RemoteCacheDir() string {
+	return filepath.Join(ConfigDir(), RemoteCache)
 }
 
 func DockerConf() string {

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -574,7 +575,7 @@ func formatMROutput(mrString string) (int, []byte, error) {
 }
 
 // SearchPubkey connects to a key server and searches for a specific key
-func SearchPubkey(ctx context.Context, httpClient *http.Client, search, keyserverURI, authToken string, longOutput bool) error {
+func SearchPubkey(ctx context.Context, clientConfig *client.Config, search string, longOutput bool) error {
 	// If the search term is 8+ hex chars then it's a fingerprint, and
 	// we need to prefix with 0x for the search.
 	var IsFingerprint = regexp.MustCompile(`^[0-9A-F]{8,}$`).MatchString
@@ -583,11 +584,7 @@ func SearchPubkey(ctx context.Context, httpClient *http.Client, search, keyserve
 	}
 
 	// Get a Key Service client.
-	c, err := client.NewClient(&client.Config{
-		BaseURL:    keyserverURI,
-		AuthToken:  authToken,
-		HTTPClient: httpClient,
-	})
+	c, err := client.NewClient(clientConfig)
 	if err != nil {
 		return err
 	}
@@ -774,7 +771,7 @@ func formatMROutputLongList(mrString string) (int, []byte, error) {
 }
 
 // FetchPubkey pulls a public key from the Key Service.
-func FetchPubkey(ctx context.Context, httpClient *http.Client, fingerprint, keyserverURI, authToken string, noPrompt bool) (openpgp.EntityList, error) {
+func FetchPubkey(ctx context.Context, clientConfig *client.Config, fingerprint string, noPrompt bool) (openpgp.EntityList, error) {
 
 	// Decode fingerprint and ensure proper length.
 	var fp []byte
@@ -789,11 +786,7 @@ func FetchPubkey(ctx context.Context, httpClient *http.Client, fingerprint, keys
 	}
 
 	// Get a Key Service client.
-	c, err := client.NewClient(&client.Config{
-		BaseURL:    keyserverURI,
-		AuthToken:  authToken,
-		HTTPClient: httpClient,
-	})
+	c, err := client.NewClient(clientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -1092,18 +1085,14 @@ func (keyring *Handle) ImportKey(kpath string, setNewPassword bool) error {
 }
 
 // PushPubkey pushes a public key to the Key Service.
-func PushPubkey(ctx context.Context, httpClient *http.Client, e *openpgp.Entity, keyserverURI, authToken string) error {
+func PushPubkey(ctx context.Context, clientConfig *client.Config, e *openpgp.Entity) error {
 	keyText, err := serializeEntity(e, openpgp.PublicKeyType)
 	if err != nil {
 		return err
 	}
 
 	// Get a Key Service client.
-	c, err := client.NewClient(&client.Config{
-		BaseURL:    keyserverURI,
-		AuthToken:  authToken,
-		HTTPClient: httpClient,
-	})
+	c, err := client.NewClient(clientConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -17,6 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sylabs/scs-key-client/client"
 	"github.com/sylabs/singularity/internal/pkg/test"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 	"golang.org/x/crypto/openpgp"
@@ -84,7 +86,13 @@ func TestSearchPubkey(t *testing.T) {
 			ms.code = tt.code
 			ms.el = tt.el
 
-			if err := SearchPubkey(context.Background(), srv.Client(), tt.search, tt.uri, tt.authToken, false); (err != nil) != tt.wantErr {
+			config := &client.Config{
+				BaseURL:    tt.uri,
+				AuthToken:  tt.authToken,
+				HTTPClient: srv.Client(),
+			}
+
+			if err := SearchPubkey(context.Background(), config, tt.search, false); (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, want error %v", err, tt.wantErr)
 			}
 		})
@@ -121,7 +129,13 @@ func TestFetchPubkey(t *testing.T) {
 			ms.code = tt.code
 			ms.el = tt.el
 
-			el, err := FetchPubkey(context.Background(), srv.Client(), tt.fingerprint, tt.uri, tt.authToken, false)
+			config := &client.Config{
+				BaseURL:    tt.uri,
+				AuthToken:  tt.authToken,
+				HTTPClient: srv.Client(),
+			}
+
+			el, err := FetchPubkey(context.Background(), config, tt.fingerprint, false)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("unexpected error: %v", err)
 				return
@@ -196,7 +210,13 @@ func TestPushPubkey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ms.code = tt.code
 
-			if err := PushPubkey(context.Background(), srv.Client(), testEntity, tt.uri, tt.authToken); (err != nil) != tt.wantErr {
+			config := &client.Config{
+				BaseURL:    tt.uri,
+				AuthToken:  tt.authToken,
+				HTTPClient: srv.Client(),
+			}
+
+			if err := PushPubkey(context.Background(), config, testEntity); (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, want error %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Two subcommands have been added for managing keyservers (globally only):
  - `add-keyserver` with two options:
    - `--order`: to define the order of the keyserver (1 is the primary
keyserver)
    - `--insecure`: to allow to connect to insecure keyserver (like no
valid TLS certificate)
  - `remove-keyserver` to remove a custom keyserver

- Login subcommand now support multiple scheme authentication to allow to
authenticate to Docker/OCI registries and custom keyservers in addition
to the remote endpoint.

- `remote logout` has been added to remove credentials stored by `remote
login`.

- `--exclusive` option has been added to `remote use` in order to allow
administrator to lock remote usage to a specific remote.

CLI remote code has been cleanup in order to centralize the way we get
remote configuration for various endpoints.

### This fixes or addresses the following GitHub issues:

- Fixes #5540 
- Related to #5445 and #5464

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

