### PR TITLE
Move CI to Ubuntu 20.04 and Go 1.14.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 vm_defaults: &vm_defaults
   working_directory: ~/go/singularity
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202008-01
 
 x-run:
   setup_environment: &setup_environment
@@ -18,12 +18,12 @@ x-run:
       test -e $BASH_ENV && sed -e 's,^,BASH_ENV: ,' < $BASH_ENV
 
   update_go: &update_go
-    name: Update Go to 1.13.1
+    name: Update Go to 1.14.9
     working_directory: /tmp
     command: |-
-      wget https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz
+      wget https://dl.google.com/go/go1.14.9.linux-amd64.tar.gz
       sudo rm -rf $GOROOT
-      sudo tar -C /usr/local -xzf go1.13.1.linux-amd64.tar.gz
+      sudo tar -C /usr/local -xzf go1.14.9.linux-amd64.tar.gz
       sudo ln -s $GOROOT/bin/go /usr/local/bin/go
 
   fetch_deb_deps: &fetch_deb_deps
@@ -80,16 +80,16 @@ x-run:
 jobs:
   check_go_mod:
     docker:
-      - image: golang:1.13
+      - image: golang:1.14
     steps:
       - checkout
       - run:
           name: Check go.mod
           command: scripts/check-go.mod
 
-  go113-stretch:
+  go114-stretch:
     docker:
-      - image: golang:1.13-stretch
+      - image: golang:1.14-stretch
     steps:
       - checkout
       - run:
@@ -103,9 +103,9 @@ jobs:
       - run:
           <<: *check_singularity
 
-  go113-alpine:
+  go114-alpine:
     docker:
-      - image: golang:1.13-alpine
+      - image: golang:1.14-alpine
     steps:
       - checkout
       - run:
@@ -119,7 +119,7 @@ jobs:
       - run:
           <<: *check_singularity
 
-  go113-macos:
+  go114-macos:
     macos:
       xcode: "10.2.0"
     working_directory: /Users/distiller/go/src/github.com/sylabs/singularity
@@ -132,12 +132,12 @@ jobs:
             echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
             echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> $BASH_ENV
       - run:
-          name: Update Go to 1.13.1
+          name: Update Go to 1.14.9
           working_directory: /tmp
           command: |-
-            curl -LO https://dl.google.com/go/go1.13.1.darwin-amd64.tar.gz
+            curl -LO https://dl.google.com/go/go1.14.9.darwin-amd64.tar.gz
             sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go1.13.1.darwin-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.14.9.darwin-amd64.tar.gz
             sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
       - run:
           name: Build Singularity
@@ -238,9 +238,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - go113-stretch
-      - go113-alpine
-      - go113-macos
+      - go114-stretch
+      - go114-alpine
+      - go114-macos
       - check_go_mod
       - rpmbuild-centos7
       - rpmbuild-centos8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove `/u
 reinstalling it._
 
 ```
-$ export VERSION=1.13.15 OS=linux ARCH=amd64  # change this as you need
+$ export VERSION=1.14.9 OS=linux ARCH=amd64  # change this as you need
 
 $ wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz && \
   sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Switch to new Ubuntu 20.04 machine image in Circle CI that will allow things like LUKS2 tests to run, that are not supported by the previous Ubuntu 16.04 machine.
- Migrate to go 1.14.9 in main CI so we are on a supported version.

Note - the requirement to ensure we can still build on the older go found in RHEL8 (currently 1.13) is fulfilled through @DrDaveD 's recent work to bring rpmbuild into the CircleCI stuff, which is using `yum install -y golang` to get Go.

### This fixes or addresses the following GitHub issues:

 - Fixes #5595 
 - Fixes #5528 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

