### PR TITLE
use SINGULARITY_TMPDIR for large temp files created by docker-daemon

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -70,6 +70,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		OSChoice:                 "linux",
 		AuthFilePath:             syfs.DockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
+		BigFilesTemporaryDir:     b.TmpDir,
 	}
 	if cp.b.Opts.NoHTTPS {
 		cp.sysCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -33,6 +33,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 		DockerAuthConfig:         ociAuth,
 		AuthFilePath:             syfs.DockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
+		BigFilesTemporaryDir:     tmpDir,
 	}
 	if noHTTPS {
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)


### PR DESCRIPTION
## Description of the Pull Request (PR):

We use CI to create singularity images for releases. These are pretty minimal and we don't have too much control over the specs, but they do have large storage attached. When creating singularity images, we set `SINGULARITY_CACHEDIR`, `SINGULARITY_TMPDIR`, `SINGULARITY_LOCALCACHEDIR` to make sure the small partitions on `/` and `/var` aren't filled up.

We also often build/pull docker images locally on the CI machine and then use `docker-daemon` when building singularity images from them. This has recently caused problems: large files were being created on the primary filesystem, filling it up and halting image creation or causing OS instability.

The fix is a simple one, setting `BigFilesTemporaryDir: TmpDir` on the SystemContext objects used by `oci.ImageSHA` and `OCIConveyorPacker.fetch`.

### This fixes or addresses the following GitHub issues:

 - Fixes #5604 


#### Before submitting a PR, make sure you have done the following:

[x] Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
[x] Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

