### PR TITLE
Cherry-pick #5588 to release-3.6 (scs-library-client-update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
+# Changes since v3.6.3
+
+## Bug Fixes
+
+  - Update scs-library-client to support library:// backends using an
+    3rd party S3 object store that does not strictly conform to v4
+    signature spec.
+
+
 # v3.6.3 - [2020-09-15]
 
 ## Security related fixes

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/sylabs/json-resp v0.7.0
 	github.com/sylabs/scs-build-client v0.1.4
 	github.com/sylabs/scs-key-client v0.5.1
-	github.com/sylabs/scs-library-client v0.5.5
+	github.com/sylabs/scs-library-client v0.5.7
 	github.com/sylabs/sif v1.2.1
 	github.com/vbauerster/mpb/v4 v4.12.2
 	github.com/vishvananda/netlink v1.0.1-0.20190618143317-99a56c251ae6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/sylabs/scs-build-client v0.1.4 h1:qSmrjWJBz3/kQfTnfpq3L7aKZyJnUgJajbq
 github.com/sylabs/scs-build-client v0.1.4/go.mod h1:HxxopmlbGhWbHjaLBlTlcnV10NuMJnbf90Lj9yyW+YA=
 github.com/sylabs/scs-key-client v0.5.1 h1:Gig1O0Rs926UJtXyKJLAYn5Kn2Wmi3g5VupOWNizvnE=
 github.com/sylabs/scs-key-client v0.5.1/go.mod h1:iKD05EsmJMGaxKhcjjwh/thEShfaWmky1qo24zHE0pw=
-github.com/sylabs/scs-library-client v0.5.5 h1:sjCtA1VbkZfGjdbbZ0SHbrCVOlqDmFLvjTqz2/m2u7Y=
-github.com/sylabs/scs-library-client v0.5.5/go.mod h1:aGApgDIqM7Seuk0BHztl+vow4cY6NlDFS5jViCDu90U=
+github.com/sylabs/scs-library-client v0.5.7 h1:qJACZ/rJByKle7HyeG/iGZxcc39vAJezVMDLr5YV73E=
+github.com/sylabs/scs-library-client v0.5.7/go.mod h1:DqZKmwqx8B3PbYS0YrETlCVUviOTz+ZQewoLqWjU2AI=
 github.com/sylabs/sif v1.2.1 h1:BvNER55n5ppPzVO8TFxADfM8xMaZKdHur7BR5Yf3leE=
 github.com/sylabs/sif v1.2.1/go.mod h1:gLZA1tQWzKe8lr4Pt+iUP+rJUPcDXZJjs/142yRwmVE=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=


### PR DESCRIPTION
## Description of the Pull Request (PR):

Necessary for anyone accessing a Sylabs library, or an sregistry / other implementation, that uses a 3rd party S3 backend that doesn't strictly conform to the AWS v4 signature spec.

### This fixes or addresses the following GitHub issues:

 - Fixes #5606


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

