### PR TITLE
Restore umask in container, actions, not fakeroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
+# Changes since v3.6.4
+
+## Changed defaults / behaviours
+
+  - When actions (run/shell/exec...) are used without --fakeroot the
+    umask from the calling environment will be propagated into the
+    container, so that files are created with expected permissions.
+    Use the `--no-umask` flag to return to the previous behaviour of
+    setting a default 0022 umask.
+
+
 # v3.6.3 - [2020-09-15]
 
 ## Security related fixes

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -48,6 +48,7 @@ var (
 	NoInit          bool
 	NoNvidia        bool
 	NoRocm          bool
+	NoUmask         bool
 	VM              bool
 	VMErr           bool
 	NoNet           bool
@@ -636,6 +637,17 @@ var actionEnvFileFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
+// --no-umask
+var actionNoUmaskFlag = cmdline.Flag{
+	ID:           " actionNoUmask",
+	Value:        &NoUmask,
+	DefaultValue: false,
+	Name:         "no-umask",
+	Usage:        "do not propagate umask to the container, set default 0022 umask",
+	EnvKeys:      []string{"NO_UMASK"},
+	ExcludedOS:   []string{cmdline.Darwin},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -711,5 +723,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&dockerUsernameFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionEnvFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionEnvFileFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoUmaskFlag, actionsInstanceCmd...)
 	})
 }

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -154,6 +154,13 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 		return fmt.Errorf("failed to apply security configuration: %s", err)
 	}
 
+	// If necessary, set the umask that was saved from the calling environment
+	// https://github.com/hpcng/singularity/issues/5214
+	if e.EngineConfig.GetRestoreUmask() {
+		sylog.Debugf("Setting umask in container to %04o", e.EngineConfig.GetUmask())
+		_ = syscall.Umask(e.EngineConfig.GetUmask())
+	}
+
 	if (!isInstance && !shimProcess) || bootInstance || e.EngineConfig.GetInstanceJoin() {
 		args := e.EngineConfig.OciConfig.Process.Args
 		env := e.EngineConfig.OciConfig.Process.Env

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -151,6 +151,8 @@ type JSONConfig struct {
 	DeleteTempDir     string            `json:"deleteTempDir,omitempty"`
 	Fakeroot          bool              `json:"fakeroot,omitempty"`
 	SignalPropagation bool              `json:"signalPropagation,omitempty"`
+	RestoreUmask      bool              `json:"restoreUmask,omitempty"`
+	Umask             int               `json:"umask,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -830,4 +832,24 @@ func (e *EngineConfig) SetConfigurationFile(filename string) {
 // GetConfigurationFile returns the singularity configuration file to use.
 func (e *EngineConfig) GetConfigurationFile() string {
 	return e.JSON.ConfigurationFile
+}
+
+// SetRestoreUmask returns whether to restore Umask for the container launched process.
+func (e *EngineConfig) SetRestoreUmask(restoreUmask bool) {
+	e.JSON.RestoreUmask = restoreUmask
+}
+
+// GetRestoreUmask returns the umask to be used in the container launched process.
+func (e *EngineConfig) GetRestoreUmask() bool {
+	return e.JSON.RestoreUmask
+}
+
+// SetUmask sets the umask to be used in the container launched process.
+func (e *EngineConfig) SetUmask(umask int) {
+	e.JSON.Umask = umask
+}
+
+// SetUmask returns the umask to be used in the container launched process.
+func (e *EngineConfig) GetUmask() int {
+	return e.JSON.Umask
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Restore umask in container, actions, not fakeroot
    
When we are running through an actions flow, and are *not* using
fakeroot then by default save the umask from the calling environment and
set it within the container.
    
This ensures that when a user works inside a container then files they
create on host filesystems have the permissions that they expect, given
their umask.
    
Add a flag `--no-umask` to disable this propagation.

### This fixes or addresses the following GitHub issues:

 - Fixes #5214


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

