### PR TITLE
fix: Support double quoted filenames in %files sections

### DIFF
--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -114,6 +114,10 @@ func TestCopyFile(t *testing.T) {
 	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
+	srcSpaceFile := filepath.Join(dir, "source File")
+	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name      string
@@ -125,6 +129,8 @@ func TestCopyFile(t *testing.T) {
 		{"ToDirSlash", srcFile, "destDir/", "destDir/sourceFile"},
 		{"ToFile", srcFile, "destDir/destFile", "destDir/destFile"},
 		{"LongPathToFile", srcFile, "destDir/long/path/to/destFile", "destDir/long/path/to/destFile"},
+		{"FromSpace", srcSpaceFile, "", "source File"},
+		{"ToSpace", srcFile, "dest File", "dest File"},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/build/files/files.go
+++ b/internal/pkg/build/files/files.go
@@ -20,6 +20,9 @@ done
 
 func expandPath(path string) ([]string, error) {
 	var output, stderr bytes.Buffer
+
+	// Escape spaces for glob pattern
+	path = strings.Replace(path, " ", "\\ ", -1)
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf(filenameExpansionScript, path))
 	cmd.Stdout = &output
 	cmd.Stderr = &stderr

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -185,7 +185,8 @@ func TestParseDefinitionFile(t *testing.T) {
 		{"NoHeaderWhiteSpace", "testdata_good/noheaderwhitespace/noheaderwhitespace", "testdata_good/noheaderwhitespace/noheaderwhitespace.json"},
 		{"MultipleScripts", "testdata_good/multiplescripts/multiplescripts", "testdata_good/multiplescripts/multiplescripts.json"},
 		{"SectionArgs", "testdata_good/sectionargs/sectionargs", "testdata_good/sectionargs/sectionargs.json"},
-		{"MultipleFiless", "testdata_good/multiplefiles/multiplefiles", "testdata_good/multiplefiles/multiplefiles.json"},
+		{"MultipleFiles", "testdata_good/multiplefiles/multiplefiles", "testdata_good/multiplefiles/multiplefiles.json"},
+		{"QuotedFiles", "testdata_good/quotedfiles/quotedfiles", "testdata_good/quotedfiles/quotedfiles.json"},
 		{"Shebang", "testdata_good/shebang/shebang", "testdata_good/shebang/shebang.json"},
 	}
 

--- a/pkg/build/types/parser/testdata_good/quotedfiles/quotedfiles
+++ b/pkg/build/types/parser/testdata_good/quotedfiles/quotedfiles
@@ -1,0 +1,15 @@
+Bootstrap: docker
+From: alpine:latest
+
+%files
+    "file 1"
+    "file 1" "nospace1"
+    "file 1" "with space 1"
+    file2
+    file2 "nospace2"
+    file2 "with space 2"
+    "file3" "nospace3"
+    "file3" "with space 3"
+
+%post
+    echo "Hello"

--- a/pkg/build/types/parser/testdata_good/quotedfiles/quotedfiles.json
+++ b/pkg/build/types/parser/testdata_good/quotedfiles/quotedfiles.json
@@ -1,0 +1,94 @@
+{
+  "header": {
+    "bootstrap": "docker",
+    "from": "alpine:latest"
+  },
+  "imageData": {
+    "metadata": null,
+    "labels": {},
+    "imageScripts": {
+      "help": {
+        "args": "",
+        "script": ""
+      },
+      "environment": {
+        "args": "",
+        "script": ""
+      },
+      "runScript": {
+        "args": "",
+        "script": ""
+      },
+      "test": {
+        "args": "",
+        "script": ""
+      },
+      "startScript": {
+        "args": "",
+        "script": ""
+      }
+    }
+  },
+  "buildData": {
+    "files": [
+      {
+        "args": "",
+        "files": [
+          {
+            "source": "file 1",
+            "destination": ""
+          },
+          {
+            "source": "file 1",
+            "destination": "nospace1"
+          },
+          {
+            "source": "file 1",
+            "destination": "with space 1"
+          },
+          {
+            "source": "file2",
+            "destination": ""
+          },
+          {
+            "source": "file2",
+            "destination": "nospace2"
+          },
+          {
+            "source": "file2",
+            "destination": "with space 2"
+          },
+          {
+            "source": "file3",
+            "destination": "nospace3"
+          },
+          {
+            "source": "file3",
+            "destination": "with space 3"
+          }
+        ]
+      }
+    ],
+    "buildScripts": {
+      "pre": {
+        "args": "",
+        "script": ""
+      },
+      "setup": {
+        "args": "",
+        "script": ""
+      },
+      "post": {
+        "args": "",
+        "script": "    echo \"Hello\"\n"
+      },
+      "test": {
+        "args": "",
+        "script": ""
+      }
+    }
+  },
+  "customData": null,
+  "raw": "Qm9vdHN0cmFwOiBkb2NrZXIKRnJvbTogYWxwaW5lOmxhdGVzdAoKJWZpbGVzCiAgICAiZmlsZSAxIgogICAgImZpbGUgMSIgIm5vc3BhY2UxIgogICAgImZpbGUgMSIgIndpdGggc3BhY2UgMSIKICAgIGZpbGUyCiAgICBmaWxlMiAibm9zcGFjZTIiCiAgICBmaWxlMiAid2l0aCBzcGFjZSAyIgogICAgImZpbGUzIiAibm9zcGFjZTMiCiAgICAiZmlsZTMiICJ3aXRoIHNwYWNlIDMiCgolcG9zdAogICAgZWNobyAiSGVsbG8iCg==",
+  "appOrder": []
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Change the line splitting rules in the %files section parser so it
doesn't split on spaces within double quotes.

When a filename with a space is passed down to the copy code, make sure
we escape the spaces in the shell globbing attempt.

### This fixes or addresses the following GitHub issues:

 - Fixes #5437

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

