### PR TITLE
Add trust info to key pull help. key store->keyring

### DIFF
--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -82,7 +82,7 @@ func init() {
 	})
 }
 
-// KeyCmd is the 'key' command that allows management of key stores
+// KeyCmd is the 'key' command that allows management of keyrings
 var KeyCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return errors.New("Invalid command")

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sylabs/singularity/pkg/sypgp"
 )
 
-// KeyImportCmd is `singularity key (or keys) import` and imports a local key into the singularity key store.
+// KeyImportCmd is `singularity key (or keys) import` and imports a local key into the singularity keyring.
 var KeyImportCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -70,7 +70,7 @@ func doKeyPullCmd(ctx context.Context, fingerprint string, c *client.Config) err
 		storeKey := true
 		for _, estore := range elstore {
 			if e.PrimaryKey.KeyId == estore.PrimaryKey.KeyId {
-				storeKey = false // Entity is already in key store
+				storeKey = false // Entity is already in keyring
 				break
 			}
 		}

--- a/docs/content.go
+++ b/docs/content.go
@@ -255,7 +255,7 @@ Enterprise Performance Computing (EPC)`
 	KeyNewPairShort string = `Create a new key pair`
 	KeyNewPairLong  string = `
   The 'key newpair' command allows you to create a new key or public/private
-  keys to be stored in the default user local key store location (e.g., 
+  keys to be stored in the default user local keyring location (e.g., 
   $HOME/.singularity/sypgp).`
 	KeyNewPairExample string = `
   $ singularity key newpair
@@ -297,9 +297,12 @@ Enterprise Performance Computing (EPC)`
 	KeyPullUse   string = `pull [pull options...] <fingerprint>`
 	KeyPullShort string = `Download a public key from a key server`
 	KeyPullLong  string = `
-  The 'key pull' command allows you to connect to a key server look for and 
-  download a public key. Key rings are stored into (e.g., 
-  $HOME/.singularity/sypgp).`
+  The 'key pull' command allows you to retrieve public key material from a
+  remote key server, and add it to your keyring. Note that Singularity consults
+  your keyring when running commands such as 'singularity verify', and thus
+  adding a key to your keyring implies a level of trust. Because of this, it is
+  recommended that you verify the fingerprint of the key with its owner prior
+  to running this command.`
 	KeyPullExample string = `
   $ singularity key pull 8883491F4268F173C6E5DC49EDECE4F3F38D871E`
 
@@ -310,7 +313,7 @@ Enterprise Performance Computing (EPC)`
 	KeyPushShort string = `Upload a public key to a key server`
 	KeyPushLong  string = `
   The 'key push' command allows you to connect to a key server and upload public
-  keys from the local key store.`
+  keys from the local keyring.`
 	KeyPushExample string = `
   $ singularity key push 8883491F4268F173C6E5DC49EDECE4F3F38D871E`
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adopt the wording proposed by @tri-adam in #3116 to give some guidance
about trust wrt key pull.

Move to consistent use of `keyring` where we sometimes had `key store`
left over after prior changes.

### This fixes or addresses the following GitHub issues:

 - Fixes #2977
 - Fixes #3116


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

