### PR TITLE
Use powers of 1024 in cache list -v sizes

### DIFF
--- a/internal/app/singularity/cache_list_linux.go
+++ b/internal/app/singularity/cache_list_linux.go
@@ -15,25 +15,31 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/cache"
 )
 
+const (
+	KiB = 1024
+	MiB = KiB * 1024
+	GiB = MiB * 1024
+	TiB = GiB * 1024
+)
+
 // findSize takes a size in bytes and converts it to a human-readable string representation
 // expressing kB, MB, GB or TB (whatever is smaller, but still larger than one).
 func findSize(size int64) string {
-
 	var factor float64
 	var unit string
 	switch {
-	case size < 1e6:
-		factor = 1e3
-		unit = "kB"
-	case size < 1e9:
-		factor = 1e6
-		unit = "MB"
-	case size < 1e12:
-		factor = 1e9
-		unit = "GB"
+	case size < MiB:
+		factor = KiB
+		unit = "KiB"
+	case size < GiB:
+		factor = MiB
+		unit = "MiB"
+	case size < TiB:
+		factor = GiB
+		unit = "GiB"
 	default:
-		factor = 1e12
-		unit = "TB"
+		factor = TiB
+		unit = "TiB"
 	}
 	return fmt.Sprintf("%.2f %s", float64(size)/factor, unit)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

 Previously the `cache list -v` was using powers of 1000 for displayed
 sizes. This doesn't match with much else, like the download bar or
 output of `du` which are using powers of 1024.

 Switch to powers of 1024 and display with the accurate `KiB` etc. unit
 for consistency.


Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #3014


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

