### PR TITLE
Record build-arch as a label with build host architecture

### DIFF
--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -323,6 +324,12 @@ func addBuildLabels(labels map[string]string, b *types.Bundle) error {
 			labels["org.label-schema.usage.singularity.deffile."+key] = value
 		}
 	}
+
+	// Architecture of build
+	// Local builds currently always use the host architecture.
+	// In remote builds this label will be applied on the builder... where the
+	// architecture should match the remote build --arch flag.
+	labels["org.label-schema.build-arch"] = runtime.GOARCH
 
 	return nil
 }


### PR DESCRIPTION
# Description of the Pull Request (PR):

Record build-arch as a label with build host architecture

```
dave@ythel~/G/singularity> /usr/local/bin/singularity inspect test.sif 
org.label-schema.build-date: Friday_16_October_2020_15:19:35_CDT
org.label-schema.build-arch: amd64
org.label-schema.schema-version: 1.0
org.label-schema.usage.singularity.deffile.bootstrap: docker
org.label-schema.usage.singularity.deffile.from: alpine
org.label-schema.usage.singularity.version: 3.6.3+72-g0eca74e26-dirt
```


### This fixes or addresses the following GitHub issues:

 - Fixes #4310


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

