### PR TITLE
Be more explicit in `remote login` prompts / info

### DIFF
--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -338,7 +338,6 @@ var RemoteLoginCmd = &cobra.Command{
 		if err := singularity.RemoteLogin(remoteConfig, loginArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
-		sylog.Infof("Login succeeded")
 	},
 
 	Use:     docs.RemoteLoginUse,

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sylabs/singularity/internal/pkg/remote"
 	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/util/auth"
+	"github.com/sylabs/singularity/pkg/sylog"
 )
 
 type LoginArgs struct {
@@ -89,5 +90,6 @@ func RemoteLogin(usrConfigFile string, args *LoginArgs) (err error) {
 		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
 	}
 
+	sylog.Infof("Token stored in %s", file.Name())
 	return nil
 }

--- a/internal/pkg/remote/endpoint/token.go
+++ b/internal/pkg/remote/endpoint/token.go
@@ -24,13 +24,14 @@ func (ep *Config) VerifyToken() (err error) {
 
 	defer func() {
 		if err == nil {
-			sylog.Infof("API Key Verified!")
+			sylog.Infof("Access Token Verified!")
 		}
 	}()
 
 	if ep.Token == "" {
-		fmt.Printf("Generate an API Key at https://%s/auth/tokens, and paste here:\n", ep.URI)
-		ep.Token, err = interactive.AskQuestionNoEcho("API Key: ")
+		fmt.Printf("Generate an access token at https://%s/auth/tokens, and paste it here.\n", ep.URI)
+		fmt.Println("Token entered will be hidden for security.")
+		ep.Token, err = interactive.AskQuestionNoEcho("Access Token: ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description of the Pull Request (PR):

Address things that @GodloveD noted catch people out with `remote login` in #4019 

Change `API Key` -> `access token` as that's what we talk about elsewhere on the cloud site etc, and we use `token` in the code too.

```
11:00 AM $ singularity remote login
Generate an access token at https://cloud.sylabs.io/auth/tokens, and paste it here.
Token entered will be hidden for security.
Access Token: 
INFO:    Access Token Verified!
INFO:    Token stored in /home/dave/.singularity/remote.yaml
```

### This fixes or addresses the following GitHub issues:

 - Fixes #4019

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

