### PR TITLE
Don't fail on enable fusemount=no when no fuse mounts needed

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2103,6 +2103,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5307":            c.issue5307,           // https://github.com/sylabs/singularity/issues/5307
 		"issue 5399":            c.issue5399,           // https://github.com/sylabs/singularity/issues/5399
 		"issue 5455":            c.issue5455,           // https://github.com/sylabs/singularity/issues/5455
+		"issue 5631":            c.issue5631,           // https://github.com/sylabs/singularity/issues/5631
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -917,15 +917,19 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 // openDevFuse is a helper function that opens /dev/fuse once for each
 // plugin that wants to mount a FUSE filesystem.
 func openDevFuse(e *EngineOperations, starterConfig *starter.Config) (bool, error) {
-	if !e.EngineConfig.File.EnableFusemount {
-		return false, fmt.Errorf("fusemount disabled by configuration 'enable fusemount = no'")
-	}
-
 	// do we require to send file descriptor
 	sendFd := false
 
 	// we won't copy slice while iterating fuse mounts
 	mounts := e.EngineConfig.GetFuseMount()
+
+	if len(mounts) == 0 {
+		return false, nil
+	}
+
+	if !e.EngineConfig.File.EnableFusemount {
+		return false, fmt.Errorf("fusemount disabled by configuration 'enable fusemount = no'")
+	}
 
 	for i := range mounts {
 		sylog.Debugf("Opening /dev/fuse for FUSE mount point %s\n", mounts[i].MountPoint)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Don't fail on enable fusemount=no when no fuse mounts needed

### This fixes or addresses the following GitHub issues:

 - Fixes #5631 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

