### PR TITLE
Don't install old golangci-lint in individual CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
-      - run:
           name: Fetch deps
           command: apt-get -q update && apt-get -q install -y build-essential libssl-dev uuid-dev squashfs-tools cryptsetup-bin
       - run:
@@ -108,9 +105,6 @@ jobs:
       - image: golang:1.14-alpine
     steps:
       - checkout
-      - run:
-          name: Install golangci-lint
-          command: wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
       - run:
           name: Fetch deps
           command: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup


### PR DESCRIPTION
## Description of the Pull Request (PR):

In recent PR #5609 scripts/run-linter was updated to use the latest
golangci-lint, and relax the version check for ease of local development
when new versions of the linter come out.

However, it was missed that some of the CI jobs are installing their
own 1.21.0 version explicitly, so some checks are run with 1.21.0 and
some with 1.31.0.

Remove the install of 1.21.0 so everything pulls the right linter via
`scripts/run-linter` in the make check target.

### This fixes or addresses the following GitHub issues:

 - Fixes #5634


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

