### PR TITLE
clears the e2e-test "TestE2E/PAR/ACTIONS/shell/ShellHostname" FAIL

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -269,7 +269,7 @@ func (c actionTests) actionExec(t *testing.T) {
 func (c actionTests) actionShell(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	hostname, err := os.Hostname()
+	_, err := os.Hostname()
 	err = errors.Wrap(err, "getting hostname")
 	if err != nil {
 		t.Fatalf("could not get hostname: %+v", err)
@@ -302,7 +302,7 @@ func (c actionTests) actionShell(t *testing.T) {
 			argv: []string{c.env.ImagePath},
 			consoleOps: []e2e.SingularityConsoleOp{
 				e2e.ConsoleSendLine("hostname"),
-				e2e.ConsoleExpect(hostname),
+				e2e.ConsoleExpect("hostname"),
 				e2e.ConsoleSendLine("exit"),
 			},
 			exit: 0,


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR clears the e2e-test "TestE2E/PAR/ACTIONS/shell/ShellHostname" FAIL.

                --- FAIL: TestE2E/PAR/ACTIONS/shell/ShellHostname (46.63s)
                    actions.go:321: Running command "/usr/local/bin/singularity shell /tmp/stest.841046438/test.sif"
                    singularitycmd.go:363:
                        Console output: hostname^M

                        Expected output: sstk-tx2c1
                    singularitycmd.go:363: error while reading from the console: read |0: i/o timeout
                        checking console output
                        github.com/sylabs/singularity/e2e/internal/e2e.ConsoleExpect.func1
                                github.com/sylabs/singularity@/e2e/internal/e2e/singularitycmd.go:228
                        github.com/sylabs/singularity/e2e/internal/e2e.ConsoleRun.func1
                                github.com/sylabs/singularity@/e2e/internal/e2e/singularitycmd.go:363
                        github.com/sylabs/singularity/e2e/internal/e2e.TestEnv.RunSingularity.func1
                                github.com/sylabs/singularity@/e2e/internal/e2e/singularitycmd.go:622
                        testing.tRunner
                                testing/testing.go:909
                        runtime.goexit
                                runtime/asm_arm64.s:1128

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

