### PR TITLE
Force a prompt if `PS1` is empty entering a container.

### DIFF
--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -130,6 +130,14 @@ fi
 shopt -u expand_aliases
 restore_env
 
+# See https://github.com/hpcng/singularity/issues/5340
+# If there is no .singularity.d then a custom PS1 wasn't set.
+# If we were called through a script and PS1 is empty this
+# gives a confusing silent prompt. Force a PS1 if it's empty.
+if test -z "${PS1:-}"; then
+	export PS1="Singularity> "
+fi
+
 # See https://github.com/sylabs/singularity/issues/2721,
 # as bash is often used as the current shell it may confuse
 # users if the provided command is /bin/bash implying to


### PR DESCRIPTION
## Description of the Pull Request (PR):

If a container without a `.singularity.d` is run then there is no
environment file to set a custom `PS1`.

If additionally singularity is called through a script, which will reset
PS1 to empty, then a confusing silent prompt will result.

In our action script force PS1 to a default if it is empty.

This results in the example given in #5340 producing a prompt as expected:

```
02:31 PM $ ./dosing exec centos7-sandbox /bin/bash
Singularity> 
```

### This fixes or addresses the following GitHub issues:

 - Fixes: #5340


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

