### PR TITLE
Allow /etc/localtime & /etc/hosts bind to fail

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2103,6 +2103,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5307":            c.issue5307,           // https://github.com/sylabs/singularity/issues/5307
 		"issue 5399":            c.issue5399,           // https://github.com/sylabs/singularity/issues/5399
 		"issue 5455":            c.issue5455,           // https://github.com/sylabs/singularity/issues/5455
+		"issue 5465":            c.issue5465,           // https://github.com/sylabs/singularity/issues/5465
 		"issue 5631":            c.issue5631,           // https://github.com/sylabs/singularity/issues/5631
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -159,7 +159,7 @@ var authorizedFS = map[string]fsContext{
 	"fuse":    {false},
 }
 
-var internalOptions = []string{"loop", "offset", "sizelimit", "key"}
+var internalOptions = []string{"loop", "offset", "sizelimit", "key", "skip-on-error"}
 
 // Point describes a mount point
 type Point struct {
@@ -316,6 +316,16 @@ func GetKey(options []string) ([]byte, error) {
 		}
 	}
 	return nil, fmt.Errorf("key option not found")
+}
+
+// SkipOnError returns whether the skip-on-error internal option is set for the mount
+func SkipOnError(options []string) bool {
+	for _, opt := range options {
+		if opt == "skip-on-error" {
+			return true
+		}
+	}
+	return false
 }
 
 // HasRemountFlag checks if remount flag is set or not.
@@ -632,17 +642,16 @@ func (p *Points) GetAllImages() []Point {
 }
 
 // AddBind adds a bind mount point
-func (p *Points) AddBind(tag AuthorizedTag, source string, dest string, flags uintptr) error {
+func (p *Points) AddBind(tag AuthorizedTag, source string, dest string, flags uintptr, options ...string) error {
 	bindFlags := flags | syscall.MS_BIND
-	options := ""
-
+	bindOptions := strings.Join(options, ",")
 	if source == "" {
 		return fmt.Errorf("a bind mount point must contain a source")
 	}
 	if !strings.HasPrefix(source, "/") {
 		return fmt.Errorf("source must be an absolute path")
 	}
-	return p.add(tag, source, dest, "", bindFlags, options)
+	return p.add(tag, source, dest, "", bindFlags, bindOptions)
 }
 
 // GetAllBinds returns a list of all registered bind mount points


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow /etc/localtime & /etc/hosts bind to fail
    
In `singularity.conf` and hard-coded under `--contain` we bind `/etc/hosts` and `/etc/localtime` to ensure sensible timezone and hostname resolution in the container.
    
In certain circumstances the container may be such that the bind mount onto `/etc/hosts` or `/etc/localtime` fails. This is a fatal error, but it would be nicer just to warn, as the container is likely still usable.

### This fixes or addresses the following GitHub issues:

 - Fixes #5465


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

