### PR TITLE
Ensure files staged into build do not match distro package content

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1086,6 +1086,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4969":                      c.issue4969,                 // https://github.com/sylabs/singularity/issues/4969
 		"issue 5166":                      c.issue5166,                 // https://github.com/sylabs/singularity/issues/5166
 		"issue 5172":                      c.issue5172,                 // https://github.com/sylabs/singularity/issues/5172
+		"issue 5250":                      c.issue5250,                 // https://github.com/sylabs/singularity/issues/5250
 		"issue 5315":                      c.issue5315,                 // https://github.com/sylabs/singularity/issues/5315
 		"issue 5435":                      c.issue5435,                 // https://github.com/hpcng/singularity/issues/5435
 	}

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -429,3 +429,24 @@ func (c *imgBuildTests) issue5435(t *testing.T) {
 		e2e.ExpectExit(255),
 	)
 }
+
+// This test will yum reinstall the 'setup' package in a centos 7 container during %post.
+// On a CentOS/RHEL/Fedora host this yum reinstall errors unless the bound in /etc/hosts in the build is modified from
+// the package default, so that yum does not attempt to remove->replace it (which is not possible as it is bound in).
+// See the workaround in build.createStageFile
+func (c *imgBuildTests) issue5250(t *testing.T) {
+	image := filepath.Join(c.env.TestDir, "issue_5250.sif")
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(image, "testdata/regressions/issue_5250.def"),
+		e2e.PostRun(func(t *testing.T) {
+			os.Remove(image)
+		}),
+		e2e.ExpectExit(
+			0,
+		),
+	)
+}

--- a/e2e/testdata/regressions/issue_5250.def
+++ b/e2e/testdata/regressions/issue_5250.def
@@ -1,0 +1,5 @@
+BootStrap: docker
+From: centos:centos7
+
+%post
+    yum -y reinstall setup


### PR DESCRIPTION
## Description of the Pull Request (PR):

During builds we stage copies of `/etc/hosts` and other files on the
host system, and bind these copies into the container for `%post`.

On RHEL/CentOS/Fedora, when `/etc/hosts` on the host system is
unmodified from the default content provided by the distro's 'setup'
package, yum will try to rename & replace it if the 'setup' package
is reinstalled / upgraded. This will fail as it is bind mounted, and
cannot be renamed.

To work around this we just add a newline to the end of files we are
copying and binding in build.createStageFile. Adding a newline means
the staged file is now different than the one in the 'setup' package
and yum will leave the file alone, as it considers it modified by the
user.

### This fixes or addresses the following GitHub issues:

 - Fixes #5250


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

