### PR TITLE
Drop the depends on github.com/docker/docker

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,6 +79,7 @@
     - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
     - Satish Chebrolu  <satish@sylabs.io>
     - Shane Loretz <sloretz@openrobotics.org>, <shane.loretz@gmail.com>
+    - Shengjing Zhu <i@zhsj.me>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
     - Tru Huynh <tru@pasteur.fr>

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/containernetworking/plugins v0.8.7
 	github.com/containers/image/v5 v5.6.0
 	github.com/deislabs/oras v0.8.1
-	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/fatih/color v1.9.0
 	github.com/garyburd/redigo v1.6.0 // indirect
 	github.com/go-log/log v0.2.0

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/docker/docker/pkg/system"
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
@@ -324,7 +323,7 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err e
 
 	// run zypper
 	if err = cmd.Run(); err != nil {
-		if ret, _ := system.GetExitCode(err); ret == 107 {
+		if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 107 {
 			sylog.Warningf("Bootstrap succeeded, some RPM scripts failed")
 		} else {
 			return fmt.Errorf("while bootstrapping from zypper: %v", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The exit code of os/exec.Command is easy to get, no need to
import docker's system package.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

