### PR TITLE
Clarify CLI help for docker / oras URIs

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -59,9 +59,9 @@ Enterprise Performance Computing (EPC)`
   Targets can also be remote and defined by a URI of the following formats:
 
       library://  an image library (default https://cloud.sylabs.io/library)
-      docker://   a Docker registry (default Docker Hub)
+      docker://   a Docker/OCI registry (default Docker Hub)
       shub://     a Singularity registry (default Singularity Hub)
-      oras://     a supporting OCI registry`
+      oras://     an OCI registry that holds SIF files using ORAS`
 
 	BuildExample string = `
 
@@ -454,14 +454,16 @@ Enterprise Performance Computing (EPC)`
   instance://*        A local running instance of a container. (See the instance
                       command group.)
 
-  library://*         A container hosted on a Library (default 
-                      https://cloud.sylabs.io/library)
+  library://*         A SIF container hosted on a Library
+                      (default https://cloud.sylabs.io/library)
 
-  docker://*          A container hosted on Docker Hub
+  docker://*          A Docker/OCI container hosted on Docker Hub or another
+                      OCI registry.
 
-  shub://*            A container hosted on Singularity Hub
+  shub://*            A container hosted on Singularity Hub.
 
-  oras://*            A container hosted on a supporting OCI registry`
+  oras://*            A SIF container hosted on an OCI registry that supports
+                      the OCI Registry As Storage (ORAS) specification.`
 	ExecUse   string = `exec [exec options...] <container> <command>`
 	ExecShort string = `Run a command within a container`
 	ExecLong  string = `
@@ -579,13 +581,13 @@ Enterprise Performance Computing (EPC)`
   library: Pull an image from the currently configured library
       library://user/collection/container[:tag]
 
-  docker: Pull an image from Docker Hub
+  docker: Pull a Docker/OCI image from Docker Hub, or another OCI registry.
       docker://user/image:tag
     
   shub: Pull an image from Singularity Hub
       shub://user/image:tag
 
-  oras: Pull a SIF image from a supporting OCI registry
+  oras: Pull a SIF image from an OCI registry that supports ORAS.
       oras://registry/namespace/image:tag
 
   http, https: Pull an image using the http(s?) protocol


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add reference to generic OCI registries rather than just Docker Hub
sources. Explictly state for oras:// that it's a SIF image on an OCI
registry that must support ORAS.

### This fixes or addresses the following GitHub issues:

 - Fixes #2983


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

