### PR TITLE
For actions, defer cache init until we know we need it

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -49,15 +49,9 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 
 	os.Setenv("USER_PATH", userPath)
 
-	// create an handle for the current image cache
-	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
-	if imgCache == nil {
-		sylog.Fatalf("failed to create a new image cache handle")
-	}
-
 	ctx := context.TODO()
 
-	replaceURIWithImage(ctx, imgCache, cmd, args)
+	replaceURIWithImage(ctx, cmd, args)
 
 	// set PATH after pulling images to be able to find potential
 	// docker credential helpers outside of standard paths
@@ -96,7 +90,7 @@ func handleNet(ctx context.Context, imgCache *cache.Handle, pullFrom string) (st
 	return net.Pull(ctx, imgCache, pullFrom, tmpDir)
 }
 
-func replaceURIWithImage(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, args []string) {
+func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string) {
 	// If args[0] is not transport:ref (ex. instance://...) formatted return, not a URI
 	t, _ := uri.Split(args[0])
 	if t == "instance" || t == "" {
@@ -105,6 +99,12 @@ func replaceURIWithImage(ctx context.Context, imgCache *cache.Handle, cmd *cobra
 
 	var image string
 	var err error
+
+	// Create a cache handle only when we know we are are using a URI
+	imgCache := getCacheHandle(cache.Config{Disable: disableCache})
+	if imgCache == nil {
+		sylog.Fatalf("failed to create a new image cache handle")
+	}
 
 	switch t {
 	case uri.Library:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cache was being initialized even if we didn't need it, due to running an
image or sandbox. Spurious warnings could result as in #5587. Only init
the cache when we know we are handling a URI.


### This fixes or addresses the following GitHub issues:

 - Fixes #5587 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

