### PR TITLE
Change shell interpreter command timeout from 5 seconds to 1 minute

### DIFF
--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -40,8 +40,8 @@ type Shell struct {
 }
 
 // execTimeout defines the execution timeout for commands executed by the
-// shell interpreter.
-var execTimeout = 5 * time.Second
+// shell interpreter (default: 1 minute).
+var execTimeout = time.Minute
 
 // defaultExecHandler is the default command execution handler if there is
 // no registered shell builtin.


### PR DESCRIPTION
## Description of the Pull Request (PR):

The current timeout of 5 seconds is too short for environment running commands potentially taking longer than 5 seconds.

### This fixes or addresses the following GitHub issues:

- Fixes #5653
- Fixes #5589


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

