### PR TITLE
Set labels dynamically from build post section through SINGULARITY_LABELS

### DIFF
--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -82,7 +82,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 				v = meta.Attributes.Apps[appName].Labels[label]
 			}
 			if v != out {
-				t.Errorf("unpexected %s label value, got %s instead of %s", label, out, v)
+				t.Errorf("unexpected %s label value, got %s instead of %s", label, out, v)
 			}
 		}
 	}
@@ -117,6 +117,16 @@ func (c ctx) singularityInspect(t *testing.T) {
 			name:      "label_hi",
 			insType:   "--labels",
 			compareFn: compareLabel("hi", "\"hello world\"", ""),
+		},
+		{
+			name:      "build_label_first",
+			insType:   "--labels",
+			compareFn: compareLabel("first.build.labels", "first", ""),
+		},
+		{
+			name:      "build_label_second",
+			insType:   "--labels",
+			compareFn: compareLabel("second.build.labels", "second", ""),
 		},
 		{
 			name:      "label_org.label-schema.usage",

--- a/e2e/testdata/inspecter_container.def
+++ b/e2e/testdata/inspecter_container.def
@@ -15,6 +15,9 @@ HI "HELLO WORLD"
 
 %post
 echo "export hello=\"world\"" >> $SINGULARITY_ENVIRONMENT
+# add labels from post section
+k=first; echo "$k.build.labels  $k" >> $SINGULARITY_LABELS
+k=second; echo "$k.build.labels $k" >> $SINGULARITY_LABELS
 
 %test
 ls /

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -31,7 +31,11 @@ type stage struct {
 	b *types.Bundle
 }
 
-const sEnvironment = "SINGULARITY_ENVIRONMENT=/.singularity.d/env/91-environment.sh"
+const (
+	sLabelsPath  = "/.build.labels"
+	sEnvironment = "SINGULARITY_ENVIRONMENT=/.singularity.d/env/91-environment.sh"
+	sLabels      = "SINGULARITY_LABELS=" + sLabelsPath
+)
 
 // Assemble assembles the bundle to the specified path.
 func (s *stage) Assemble(path string) error {
@@ -76,7 +80,7 @@ func (s *stage) runSectionScript(name string, script types.Script) error {
 func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) error {
 	if s.b.Recipe.BuildData.Post.Script != "" {
 		cmdArgs := []string{"-s", "-c", configFile, "exec", "--pwd", "/", "--writable"}
-		cmdArgs = append(cmdArgs, "--cleanenv", "--env", sEnvironment)
+		cmdArgs = append(cmdArgs, "--cleanenv", "--env", sEnvironment, "--env", sLabels)
 
 		if sessionResolv != "" {
 			cmdArgs = append(cmdArgs, "-B", sessionResolv+":/etc/resolv.conf")

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -272,17 +272,9 @@ func doSections(s *bufio.Scanner, d *types.Definition) error {
 	return populateDefinition(sectionsMap, &files, &appOrder, d)
 }
 
-func populateDefinition(sections map[string]*types.Script, files *[]types.Files, appOrder *[]string, d *types.Definition) (err error) {
-	// initialize standard sections if not already created
-	// this function relies on standard sections being initialized in the map
-	for section := range validSections {
-		if _, ok := sections[section]; !ok {
-			sections[section] = &types.Script{}
-		}
-	}
-
+func GetLabels(content string) map[string]string {
 	// labels are parsed as a map[string]string
-	labelsSections := strings.TrimSpace(sections["labels"].Script)
+	labelsSections := strings.TrimSpace(content)
 	subs := strings.Split(labelsSections, "\n")
 	labels := make(map[string]string)
 
@@ -303,6 +295,18 @@ func populateDefinition(sections map[string]*types.Script, files *[]types.Files,
 		labels[key] = val
 	}
 
+	return labels
+}
+
+func populateDefinition(sections map[string]*types.Script, files *[]types.Files, appOrder *[]string, d *types.Definition) (err error) {
+	// initialize standard sections if not already created
+	// this function relies on standard sections being initialized in the map
+	for section := range validSections {
+		if _, ok := sections[section]; !ok {
+			sections[section] = &types.Script{}
+		}
+	}
+
 	d.ImageData = types.ImageData{
 		ImageScripts: types.ImageScripts{
 			Help:        *sections["help"],
@@ -311,7 +315,7 @@ func populateDefinition(sections map[string]*types.Script, files *[]types.Files,
 			Test:        *sections["test"],
 			Startscript: *sections["startscript"],
 		},
-		Labels: labels,
+		Labels: GetLabels(sections["labels"].Script),
 	}
 	d.BuildData.Files = *files
 	d.BuildData.Scripts = types.Scripts{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Support labels additions from `post` section with the new `SINGULARITY_LABELS` environment variable:

```
%post
    VAL="some_value"
    echo "my.label $VAL" >> $SINGULARITY_LABELS
```

### This fixes or addresses the following GitHub issues:

 - Fixes #5120


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

