### PR TITLE
Reset environment while retrieving library dependencies for unsquashfs sandbox

### DIFF
--- a/pkg/image/unpacker/squashfs_singularity.go
+++ b/pkg/image/unpacker/squashfs_singularity.go
@@ -72,6 +72,12 @@ func getLibraries(binary string) ([]string, error) {
 	cmd.Stdout = buf
 	cmd.Stderr = errBuf
 
+	// set an empty environment as LD_LIBRARY_PATH
+	// may mix dependencies, just rely only on the library
+	// cache or its own lookup mechanism, see issue:
+	// https://github.com/hpcng/singularity/issues/5666
+	cmd.Env = []string{}
+
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("while getting library dependencies: %s\n%s", err, errBuf.String())
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Set an empty environment as LD_LIBRARY_PATH may mix dependencies, just rely only on the library cache or its own lookup mechanism.

### This fixes or addresses the following GitHub issues:

 - Fixes #5666 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

