### PR TITLE
Pass user env/flag binds into container as SINGULARITY_BIND

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -386,6 +386,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		sylog.Fatalf("while parsing bind path: %s", err)
 	}
 	engineConfig.SetBindPath(binds)
+	generator.AddProcessEnv("SINGULARITY_BIND", strings.Join(BindPaths, ","))
 
 	if len(FuseMount) > 0 {
 		/* If --fusemount is given, imply --pid */

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2104,6 +2104,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5399":            c.issue5399,           // https://github.com/sylabs/singularity/issues/5399
 		"issue 5455":            c.issue5455,           // https://github.com/sylabs/singularity/issues/5455
 		"issue 5465":            c.issue5465,           // https://github.com/sylabs/singularity/issues/5465
+		"issue 5599":            c.issue5599,           // https://github.com/sylabs/singularity/issues/5599
 		"issue 5631":            c.issue5631,           // https://github.com/sylabs/singularity/issues/5631
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds


### PR DESCRIPTION
## Description of the Pull Request (PR):

In prior versions of singularity the `SINGULARITY_BIND` env var would
pass into the container. I've seen `SINGULARITY_BIND` examined in
containers to e.g. check that a user specifically bound in a data
directory where that's necessary.

Restore so that `SINGULARITY_BIND` in the container reflects user
defined env var, and also now flag binds.

Checking `SINGULARITY_BIND` in a container like this is admittedly fragile - but this PR is concerned with allowing it, as it has been requested in #5599 

### This fixes or addresses the following GitHub issues:

 - Fixes: #5599 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

