### PR TITLE
Try /sbin/ldconfig for gpu libs if $PATH ldconfig fails

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2097,6 +2097,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4797":            c.issue4797,           // https://github.com/sylabs/singularity/issues/4797
 		"issue 4823":            c.issue4823,           // https://github.com/sylabs/singularity/issues/4823
 		"issue 4836":            c.issue4836,           // https://github.com/sylabs/singularity/issues/4836
+		"issue 5002":            c.issue5002,           // https://github.com/sylabs/singularity/issues/5002
 		"issue 5211":            c.issue5211,           // https://github.com/sylabs/singularity/issues/5211
 		"issue 5228":            c.issue5228,           // https://github.com/sylabs/singularity/issues/5228
 		"issue 5271":            c.issue5271,           // https://github.com/sylabs/singularity/issues/5271

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -570,8 +570,38 @@ func (c actionTests) issue5465(t *testing.T) {
 	)
 }
 
+// Check that we fall back to system ldconfig if a non-working one is on PATH
+func (c actionTests) issue5002(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	// Create a dummy ldconfig that doesn't work
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-5631-", "")
+	defer e2e.Privileged(cleanup)(t)
+	fakeLdconfig := filepath.Join(tmpDir, "ldconfig")
+	err := fs.EnsureFileWithPermission(fakeLdconfig, 0755)
+	if err != nil {
+		t.Fatalf("Could not create fake ldconfig: %s", err)
+	}
+
+	pathEnv := os.Getenv("PATH")
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("PATH=%s:%s", tmpDir, pathEnv))
+
+	// Make sure we fall back to system ldconfig okay
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithEnv(env),
+		e2e.WithArgs("--nv", c.env.ImagePath, "/bin/true"),
+		e2e.ExpectExit(0,
+			e2e.ExpectError(e2e.ContainMatch, "trying /sbin/ldconfig"),
+		),
+	)
+}
+
 // Check that flag / env var binds are passed in $SINGULARITY_BIND in the
-// conainer. Sometimes used by containers that require data to be bound in to a
+// container. Sometimes used by containers that require data to be bound in to a
 // location etc., and was present in older versions of Singularity.
 func (c actionTests) issue5599(t *testing.T) {
 	e2e.EnsureImage(t, c.env)

--- a/pkg/util/gpu/paths.go
+++ b/pkg/util/gpu/paths.go
@@ -162,10 +162,6 @@ func paths(gpuFileList []string) ([]string, []string, error) {
 	// walk through the ldconfig output and add entries which contain the filenames
 	// returned by nvidia-container-cli OR the nvliblist.conf file contents
 	ldConfig, err := exec.LookPath("ldconfig")
-	if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
-		sylog.Debugf("Could not find ldconfig in PATH")
-		ldConfig = "ldconfig"
-	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not lookup ldconfig: %v", err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

On systems with Nix/Guix type userland on top of a 'standard'
distribution there may be a non-working userland `ldconfig` on `$PATH`
that will fail to find the system installed CUDA libs. If we fail to
execute `ldconfig` on `$PATH` then fall back to trying the default
`/sbin/ldconfig` in case that works.


### This fixes or addresses the following GitHub issues:

 - Fixes #5002


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

