### PR TITLE
Authenticated CI pulls to avoid DockerHub rate limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,10 @@ x-run:
   buildtest_rpm: &buildtest_rpm
     name: Build and test rpm under docker
     no_output_timeout: 10m
-    command: scripts/ci-docker-run
+    command: |-
+      export E2E_DOCKER_USERNAME=$CIRCLE_CI_DOCKER_USERNAME && \
+      export E2E_DOCKER_PASSWORD=$CIRCLE_CI_DOCKER_PASSWORD && \
+      scripts/ci-docker-run
 
   build_singularity: &build_singularity
     name: Build Singularity
@@ -81,6 +84,9 @@ jobs:
   check_go_mod:
     docker:
       - image: golang:1.14
+        auth:
+          username: $CIRCLE_CI_DOCKER_USERNAME
+          password: $CIRCLE_CI_DOCKER_PASSWORD
     steps:
       - checkout
       - run:
@@ -90,6 +96,9 @@ jobs:
   go114-stretch:
     docker:
       - image: golang:1.14-stretch
+        auth:
+          username: $CIRCLE_CI_DOCKER_USERNAME
+          password: $CIRCLE_CI_DOCKER_PASSWORD
     steps:
       - checkout
       - run:
@@ -103,6 +112,9 @@ jobs:
   go114-alpine:
     docker:
       - image: golang:1.14-alpine
+        auth:
+          username: $CIRCLE_CI_DOCKER_USERNAME
+          password: $CIRCLE_CI_DOCKER_PASSWORD
     steps:
       - checkout
       - run:
@@ -163,7 +175,7 @@ jobs:
       - run:
           <<: *buildtest_rpm
 
-  unit_tests:
+  short_unit_tests:
     <<: *vm_defaults
     steps:
       - checkout
@@ -180,7 +192,7 @@ jobs:
       - run:
           name: Run unit tests
           command: |-
-            make -C ./builddir unit-test
+            make -C ./builddir short-unit-test
 
   short_integration_tests:
     <<: *vm_defaults
@@ -224,7 +236,10 @@ jobs:
           name: Run E2E tests
           no_output_timeout: 35m
           command: |-
-            export E2E_PARALLEL=8 && make -C ./builddir e2e-test
+            export E2E_PARALLEL=8 && \
+            export E2E_DOCKER_USERNAME=$CIRCLE_CI_DOCKER_USERNAME && \
+            export E2E_DOCKER_PASSWORD=$CIRCLE_CI_DOCKER_PASSWORD && \
+            make -C ./builddir e2e-test
       - store_artifacts:
           path: builddir/e2e-cmd-report.txt
 
@@ -238,6 +253,6 @@ workflows:
       - check_go_mod
       - rpmbuild-centos7
       - rpmbuild-centos8
-      - unit_tests
+      - short_unit_tests
       - short_integration_tests
       - e2e_tests

--- a/e2e/internal/e2e/dockerhub_auth.go
+++ b/e2e/internal/e2e/dockerhub_auth.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	auth "github.com/deislabs/oras/pkg/auth/docker"
+	"github.com/sylabs/singularity/internal/pkg/util/user"
+	"github.com/sylabs/singularity/pkg/syfs"
+)
+
+const dockerHub = "docker.io"
+
+func SetupDockerHubCredentials(t *testing.T) {
+	var unprivUser, privUser *user.User
+
+	username := os.Getenv("E2E_DOCKER_USERNAME")
+	pass := os.Getenv("E2E_DOCKER_PASSWORD")
+
+	if username == "" && pass == "" {
+		t.Log("No DockerHub credentials supplied, DockerHub rate limits could be hit")
+		return
+	}
+
+	unprivUser = CurrentUser(t)
+	writeDockerHubCredentials(t, unprivUser.Dir, username, pass)
+	Privileged(func(t *testing.T) {
+		privUser = CurrentUser(t)
+		writeDockerHubCredentials(t, privUser.Dir, username, pass)
+	})(t)
+}
+
+func writeDockerHubCredentials(t *testing.T, dir, username, pass string) {
+	configPath := filepath.Join(dir, ".singularity", syfs.DockerConfFile)
+	cli, err := auth.NewClient(configPath)
+	if err != nil {
+		t.Fatalf("failed to get docker auth client: %v", err)
+	}
+	if err := cli.Login(context.Background(), dockerHub, username, pass, false); err != nil {
+		t.Fatalf("failed to login to dockerhub: %v", err)
+	}
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -115,6 +115,8 @@ func Run(t *testing.T) {
 	// create an empty ECL configuration and empty global keyring
 	e2e.SetupSystemECLAndGlobalKeyRing(t, testenv.TestDir)
 
+	e2e.SetupDockerHubCredentials(t)
+
 	// Ensure config files are installed
 	configFiles := []string{
 		sysconfdir("singularity.conf"),

--- a/internal/pkg/build/assemblers/sandbox_test.go
+++ b/internal/pkg/build/assemblers/sandbox_test.go
@@ -25,6 +25,10 @@ const (
 
 // TestSandboxAssemblerDocker sees if we can build a sandbox from an image from a Docker registry
 func TestSandboxAssemblerDocker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-sandboxAssembler"), os.TempDir())
 	if err != nil {
 		t.Fatalf("unable to make bundle: %v", err)
@@ -68,6 +72,10 @@ func TestSandboxAssemblerDocker(t *testing.T) {
 
 // TestSandboxAssemblerShub sees if we can build a sandbox from an image from a Singularity registry
 func TestSandboxAssemblerShub(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// TODO(mem): reenable this; disabled while shub is down
 	t.Skip("Skipping tests that access singularity hub")
 

--- a/internal/pkg/build/assemblers/sif_test.go
+++ b/internal/pkg/build/assemblers/sif_test.go
@@ -35,6 +35,10 @@ func TestMain(m *testing.M) {
 
 // TestSIFAssemblerDocker sees if we can build a SIF image from an image from a Docker registry
 func TestSIFAssemblerDocker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	mksquashfsPath, err := exec.LookPath("mksquashfs")
 	if err != nil {
 		t.Fatalf("could not find mksquashfs: %v", err)
@@ -85,6 +89,10 @@ func TestSIFAssemblerDocker(t *testing.T) {
 
 // TestSIFAssemblerShub sees if we can build a SIF image from an image from a Singularity registry
 func TestSIFAssemblerShub(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// TODO(mem): reenable this; disabled while shub is down
 	t.Skip("Skipping tests that access singularity hub")
 

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -120,6 +120,10 @@ func TestOCIConveyorDockerArchive(t *testing.T) {
 // TestOCIConveyerDockerDaemon tests if we can use an oci laytout dir
 // as a source
 func TestOCIConveyorDockerDaemon(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	cmd := exec.Command("docker", "ps")
 	err := cmd.Run()
 	if err != nil {
@@ -245,6 +249,10 @@ func TestOCIConveyorOCILayout(t *testing.T) {
 
 // TestOCIPacker checks if we can create a Kitchen
 func TestOCIPacker(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-oci"), os.TempDir())
 	if err != nil {
 		return

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -49,6 +49,15 @@ unit-test:
 		./...
 	@echo "       PASS"
 
+.PHONY: short-unit-test
+short-unit-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(BUILDDIR_ABSPATH)/unit-test.xml)
+short-unit-test:
+	@echo " TEST sudo go test [unit]"
+	$(V)cd $(SOURCEDIR) && \
+		scripts/go-test -sudo -v -short $(EXTRA_FLAGS) \
+		./...
+	@echo "       PASS"
+
 
 .PHONY: e2e-test
 e2e-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(BUILDDIR_ABSPATH)/e2e-test.xml)

--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -1,4 +1,12 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+if [[ ! -z "$E2E_DOCKER_USERNAME" && ! -z "$E2E_DOCKER_PASSWORD" ]]; then
+    docker login --username $E2E_DOCKER_USERNAME --password $E2E_DOCKER_PASSWORD
+    function logout {
+        docker logout
+    }
+    trap logout EXIT
+fi
 
 # Run docker as shown at
 #  https://djw8605.github.io/2016/05/03/building-centos-packages-on-travisci/
@@ -13,7 +21,8 @@ if [[ "$OS_TYPE" = "opensuse" ]]; then
 else
     DOCKER_HUB_URI="${OS_TYPE}:$OS_VERSION"
 fi
-sudo docker pull "$DOCKER_HUB_URI"
+
+docker pull "$DOCKER_HUB_URI"
 
 # Mount /var/run/docker.sock and set --network=host so we can call docker from inside
 # cause some tests need it. Cannot mount to /var/run/docker.sock inside cause CentOS
@@ -26,7 +35,10 @@ else
 fi
 DOCKER_CONTAINER_NAME="test_${OS_TYPE}_${OS_VERSION}"
 
-docker run --privileged -ti --network=host -v "$(pwd):/build:rw"  \
+docker run --privileged -ti --network=host \
+  -e E2E_DOCKER_USERNAME=$E2E_DOCKER_USERNAME \
+  -e E2E_DOCKER_PASSWORD=$E2E_DOCKER_PASSWORD \
+  -v "$(pwd):/build:rw"  \
   --name "$DOCKER_CONTAINER_NAME" "$DOCKER_HUB_URI" /bin/bash -exc \
 	"cd /build && scripts/ci-rpm-build-test $OS_TYPE $OS_VERSION"
 

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -20,6 +20,8 @@ echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 chown -R testuser .
 
+SINGULARITY_DOCKER_USERNAME=$E2E_DOCKER_USERNAME \
+SINGULARITY_DOCKER_PASSWORD=$E2E_DOCKER_PASSWORD \
 su testuser -c '
   set -x
   set -e

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -31,5 +31,6 @@ if [ -n "$ALL_PROXY" -o -n "$HTTP_PROXY" -o -n "$HTTPS_PROXY" ]; then
 fi
 
 proxy_vars="HTTP_PROXY=$HTTP_PROXY HTTPS_PROXY=$HTTPS_PROXY ALL_PROXY=$ALL_PROXY NO_PROXY=$NO_PROXY"
+cred_vars="E2E_DOCKER_USERNAME=$E2E_DOCKER_USERNAME E2E_DOCKER_PASSWORD=$E2E_DOCKER_PASSWORD"
 export sudo_args="env -i PATH=$PATH HOME=$HOME $proxy_vars SINGULARITY_E2E_COVERAGE=$SINGULARITY_E2E_COVERAGE"
 exec scripts/go-test -sudo -parallel $procs -tags "e2e_test" "$@" ./e2e


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR does several things to enable this.

1. The CircleCI environment variables `CIRCLE_CI_DOCKER_[USERNAME|PASSWORD]` have been configured for an HPCng owned DockerHub account. These environment variables are now being leveraged in our `.circleci/config.yml` for jobs that require the pulling of images from DockerHub.
2. The e2e test harness has been extended to configure DockerHub credentials in the temporary home directory for use by the singularity CLI when `E2E_DOCKER_[USERNAME|PASSWORD]` are present.
3. The scripts to launch RPM builds within docker containers and `Action` integration tests after successful installation have been extended to leverage `E2E_DOCKER_[USERNAME|PASSWORD]` if present.
4. The unit tests which require a pull from DockerHub have been added to the group of tests to be skipped when running "short" unit tests. A new `Makefile` target has been included to leverage `short-unit-tests` instead `unit-tests` while retaining that make target. As far as I can tell, all test conditions skipped under `short` have equivalent test cases within the e2e tests.

It is important to note that the CircleCI environment variables leveraged for credentials will not be passed to builds on forks. Users with commit access to this repository are considered trusted by CircleCI's trust model and exposing these variables within forks would allow anyone to expose or abuse these credentials.

With that being said, the situation with CircleCI rate limiting of DockerHub pulls appears to be changing to prevent extreme CI disruption come the start of November(https://discuss.circleci.com/t/updated-authenticate-with-docker-to-avoid-impact-of-nov-1st-rate-limits/37567). So, I have decided to not include logic to fail/skip jobs that require credentials on forks until we know when rate limiting will become a blocker for fork based CI jobs.

Once/if rate limiting does become a blocker, users without commit access submitting PRs from forks will only be able to run a subset of tests that do not rely on DockerHub, like the short unit tests, and someone with commit access will need to bring shepherd their work into a branch within the repo, after an initial review, in order to be able to test against DockerHub.

Related to #5602

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers