### PR TITLE
unsquashfs - don't extract xattrs where not supported by fs

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1089,5 +1089,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5250":                      c.issue5250,                 // https://github.com/sylabs/singularity/issues/5250
 		"issue 5315":                      c.issue5315,                 // https://github.com/sylabs/singularity/issues/5315
 		"issue 5435":                      c.issue5435,                 // https://github.com/hpcng/singularity/issues/5435
+		"issue 5668":                      c.issue5668,                 // https://github.com/hpcng/singularity/issues/5435
 	}
 }

--- a/pkg/image/unpacker/squashfs_singularity.go
+++ b/pkg/image/unpacker/squashfs_singularity.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
+	"github.com/sylabs/singularity/pkg/sylog"
 )
 
 func init() {
@@ -108,7 +109,7 @@ func getLibraries(binary string) ([]string, error) {
 
 // unsquashfsSandboxCmd is the command instance for executing unsquashfs command
 // in a sandboxed environment with singularity.
-func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, rootless bool) (*exec.Cmd, error) {
+func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, opts ...string) (*exec.Cmd, error) {
 	const (
 		// will contain both dest and filename inside the sandbox
 		rootfsImageDir = "/image"
@@ -216,14 +217,14 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, rootl
 
 	// unsquashfs execution arguments
 	args = append(args, unsquashfs)
-	if rootless {
-		args = append(args, "-user-xattrs")
-	}
+	args = append(args, opts...)
+
 	if overwrite {
 		args = append(args, "-f")
 	}
 	args = append(args, "-d", rootfsDest, filename)
 
+	sylog.Debugf("Calling wrapped unsquashfs: singularity %v", args)
 	cmd := exec.Command(filepath.Join(buildcfg.BINDIR, "singularity"), args...)
 	cmd.Dir = "/"
 	cmd.Env = []string{

--- a/pkg/image/unpacker/squashfs_test.go
+++ b/pkg/image/unpacker/squashfs_test.go
@@ -37,13 +37,27 @@ func isExist(path string) bool {
 }
 
 func TestSquashfs(t *testing.T) {
+	// Run on default TMPDIR which is unlikely to be a tmpfs but may be.
+	t.Run("default", func(t *testing.T) {
+		testSquashfs(t, "")
+	})
+	// Run on /dev/shm which should be a tmpfs - catches #5668
+	t.Run("dev_shm", func(t *testing.T) {
+		if _, err := os.Stat("/dev/shm"); err != nil {
+			t.Skipf("Could not access /dev/shm")
+		}
+		testSquashfs(t, "/dev/shm")
+	})
+}
+
+func testSquashfs(t *testing.T, tmpParent string) {
 	s := NewSquashfs()
 
 	if !s.HasUnsquashfs() {
-		t.SkipNow()
+		t.Skip("unsquashfs not found")
 	}
 
-	dir, err := ioutil.TempDir("", "unpacker-")
+	dir, err := ioutil.TempDir(tmpParent, "unpacker-")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Corrects an issue that mainly occurs on Fedora 33 / Ubuntu 20.04 to a
tmpfs, as they use unsquashfs 4.4 which returns error codes for
non-fatal errors.

First we try unsquashfs with appropriate xattr options.

If we are in rootless mode we need "-user-xattrs" so we don't try to
set system xattrs that require root.

However...

 1. This isn't supported on unsquashfs 4.0 in RHEL6 so we have to fall
    back to not using that option on failure.

 2. Must check (user) xattrs are supported on the FS as unsquashfs >=4.4
    will give a non-zero error code if it cannot set them, e.g. on tmpfs
    (#5668).


### This fixes or addresses the following GitHub issues:

 - Fixes #5668


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

