### PR TITLE
Show token status in `singularity remote status`

### DIFF
--- a/docs/remote.go
+++ b/docs/remote.go
@@ -98,11 +98,13 @@ const (
 	// remote status command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteStatusUse   string = `status [remote_name]`
-	RemoteStatusShort string = `Check the status of the singularity services at an endpoint`
+	RemoteStatusShort string = `Check the status of the singularity services at an endpoint, and your authentication token`
 	RemoteStatusLong  string = `
   The 'remote status' command checks the status of the specified remote endpoint
-  and reports the availibility of services and their versions. If no endpoint is
-  specified, it will check the status of the default remote (SylabsCloud).`
+  and reports the availability of services and their versions. If no endpoint is
+  specified, it will check the status of the default remote (SylabsCloud). If you
+  have logged in with an authentication token the validity of that token will be
+  checked.`
 	RemoteStatusExample string = `
   $ singularity remote status SylabsCloud`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -113,7 +113,7 @@ func RemoteStatus(usrConfigFile, name string) (err error) {
 	}
 	tw.Flush()
 
-	return nil
+	return doTokenCheck(e)
 }
 
 func doStatusCheck(name string, sp endpoint.Service) *status {
@@ -126,4 +126,18 @@ func doStatusCheck(name string, sp endpoint.Service) *status {
 		return &status{name: name, uri: uri, status: "N/A"}
 	}
 	return &status{name: name, uri: uri, status: "OK", version: version}
+}
+
+func doTokenCheck(e *endpoint.Config) error {
+	if e.Token == "" {
+		fmt.Println("\nNo authentication token set (logged out).")
+		return nil
+	}
+	if err := e.VerifyToken(""); err != nil {
+		fmt.Println("\nAuthentication token is invalid (please login again).")
+		return err
+
+	}
+	fmt.Println("\nValid authentication token set (logged in).")
+	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

I think this is as good a place as any to put the token check - under `status`.


```
dave@dev-fedora~> singularity remote status
INFO:    Checking status of default remote.
SERVICE    STATUS  VERSION             URI
Builder    OK      v1.1.14-0-gc7a68c1  https://build.sylabs.io
Consent    OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/consent
Keyserver  OK      v1.12.0-0-gd4746cb  https://keys.sylabs.io
Library    OK      v1.0.16-0-gb7eeae4  https://library.sylabs.io
Token      OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/token

No authentication token set (logged out).


dave@dev-fedora~> singularity remote status
INFO:    Checking status of default remote.
SERVICE    STATUS  VERSION             URI
Builder    OK      v1.1.14-0-gc7a68c1  https://build.sylabs.io
Consent    OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/consent
Keyserver  OK      v1.12.0-0-gd4746cb  https://keys.sylabs.io
Library    OK      v1.0.16-0-gb7eeae4  https://library.sylabs.io
Token      OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/token
INFO:    Access Token Verified!

Valid authentication token set (logged in).


dave@dev-fedora~> singularity remote status
INFO:    Checking status of default remote.
SERVICE    STATUS  VERSION             URI
Builder    OK      v1.1.14-0-gc7a68c1  https://build.sylabs.io
Consent    OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/consent
Keyserver  OK      v1.12.0-0-gd4746cb  https://keys.sylabs.io
Library    OK      v1.0.16-0-gb7eeae4  https://library.sylabs.io
Token      OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/token

Authentication token is invalid (please login again).
FATAL:   error response from server: Invalid Credentials
```


### This fixes or addresses the following GitHub issues:

 - Fixes #4447


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

