### PR TITLE
Overhaul `singularity search` output / flags

### DIFF
--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -8,6 +8,7 @@ package cli
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/scs-library-client/client"
@@ -21,6 +22,10 @@ import (
 var (
 	// SearchLibraryURI holds the base URI to a Sylabs library API instance
 	SearchLibraryURI string
+	// SearchArch holds the architecture for images to display in search results
+	SearchArch string
+	// SearchSigned is set true to only search for signed containers
+	SearchSigned bool
 )
 
 // --library
@@ -33,11 +38,33 @@ var searchLibraryFlag = cmdline.Flag{
 	EnvKeys:      []string{"LIBRARY"},
 }
 
+// --arch
+var searchArchFlag = cmdline.Flag{
+	ID:           "searchArchFlag",
+	Value:        &SearchArch,
+	DefaultValue: runtime.GOARCH,
+	Name:         "arch",
+	Usage:        "architecture to search for",
+	EnvKeys:      []string{"SEARCH_ARCH"},
+}
+
+// --signed
+var searchSignedFlag = cmdline.Flag{
+	ID:           "searchSignedFlag",
+	Value:        &SearchSigned,
+	DefaultValue: false,
+	Name:         "signed",
+	Usage:        "architecture to search for",
+	EnvKeys:      []string{"SEARCH_SIGNED"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(SearchCmd)
 
 		cmdManager.RegisterFlagForCmd(&searchLibraryFlag, SearchCmd)
+		cmdManager.RegisterFlagForCmd(&searchArchFlag, SearchCmd)
+		cmdManager.RegisterFlagForCmd(&searchSignedFlag, SearchCmd)
 	})
 }
 
@@ -58,7 +85,7 @@ var SearchCmd = &cobra.Command{
 			sylog.Fatalf("Error initializing library client: %v", err)
 		}
 
-		if err := library.SearchLibrary(ctx, libraryClient, args[0]); err != nil {
+		if err := library.SearchLibrary(ctx, libraryClient, args[0], SearchArch, SearchSigned); err != nil {
 			sylog.Fatalf("Couldn't search library: %v", err)
 		}
 

--- a/docs/content.go
+++ b/docs/content.go
@@ -644,11 +644,13 @@ Enterprise Performance Computing (EPC)`
 	SearchUse   string = `search [search options...] <search_query>`
 	SearchShort string = `Search a Container Library for images`
 	SearchLong  string = `
-  Search a Container Library for users and containers matching the search query.
-  (default cloud.sylabs.io)`
+  Search a Container Library for container images matching the search query.
+  (default cloud.sylabs.io). You can specify an alternate architecture, and/or limit
+  the results to only signed images.`
 	SearchExample string = `
   $ singularity search lolcow
-  $ singularity search centos`
+  $ singularity search --arch arm64 alpine
+  $ singularity search --signed tensorflow`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// run


### PR DESCRIPTION
## Description of the Pull Request (PR):

The existing `singularity search` includes things that aren't very useful. It is also not architecture aware - a search on an `arm64` system will e.g. include containers that are available on `amd64` only.

Make the following changes:

* Search for the current architecture, or alternate with --arch flag. The library API then only returns matching *images* since these are the only level associated with an architecture. We can't display users or collections like we used to - these aren't really useful anyway.

* Allow user to limit search to signed containers with the --signed flag.

* For matching images show tags, or if no tag the hash that can be used to pull (previously we showed an Image ID which cannot be used to pull).

* Show description for an image if set, and fingerprints if it is signed.

Example output:

```
dave@dev-fedora~/G/singularity> singularity search desc
Found 4 container images for amd64 matching "desc":

	library://dtrudg-sylabs-2/test/description2:bob

	library://dtrudg-sylabs-2/test/description2:sha256.90de783d2001646d1a8e33d5000ffa5b8d0d7b51c3fe992f38362e9be54000db
		This is a container

	library://dtrudg-sylabs-2/test/description3:latest

	library://dtrudg-sylabs-2/test/description:latest,bob
		This is a container


dave@dev-fedora~/G/singularity> singularity search --arch arm64 desc
No container images found for arm64 matching "desc".


dave@dev-fedora~/G/singularity> singularity search --arch arm64 alpine
Found 4 container images for arm64 matching "alpine":

	library://dtrudg-sylabs-2/multiarch/alpine:latest

	library://library/default/alpine:3.11,3.11.5,latest,3

	library://library/default/alpine:3.9,3.9.2

	library://sylabs/tests/passphrase_encrypted_alpine:3.11.5


dave@dev-fedora~/G/singularity> singularity search --arch arm64 alpine
Found 5 container images for arm64 matching "alpine":

	library://dtrudg-sylabs-2/multiarch/alpine:latest

	library://geoffroy.vallee/alpine/alpine:latest
		Signed by: 9D56FA7CAFB4A37729751B8A21749D0D6447B268

	library://library/default/alpine:3.11,3.11.5,latest,3

	library://library/default/alpine:3.9,3.9.2

	library://sylabs/tests/passphrase_encrypted_alpine:3.11.5


dave@dev-fedora~/G/singularity> singularity search --signed tensorflow
Found 9 container images for amd64 matching "tensorflow":

	library://ajgreen/default/tensorflow2-gpu-py3-r-jupyter:latest
		Current software: tensorflow2; py3.7; r; jupyterlab1.2.6
		Signed by: 1B8565093D80FA393BC2BD73EA4711C01D881FCB

	library://jon/default/tensorflow:1.12-gpu
		Signed by: D0E30822F7F4B229B1454388597B8AFA69C8EE9F

	library://mohammad_rafi/default/tensorflow:sha256.336faa55fedcb47a0847ee3dec8cadc545d107b0a4ec923ecbd04d0c133d958c
		Signed by: 10E46E2E3136AC90D124CFDE3FB9DB4D8EF96A8E

	library://speedgo/default/tensorflow:c81-tf210,c81-py382-tf210-haswell-cpu
		Tensorflow 2.1.0 CPU; Python 3.8.2; CentOS 8.1; Haswell CPU;
		Signed by: 136C8E7275869E00B2C2F7E1F56696789DFD1DC0

	library://speedgo/default/tensorflow:c81-tf220,latest,c81-py382-tf220-haswell-cpu
		Tensorflow 2.2.0 CPU; Python 3.8.2; CentOS 8.1; Haswell CPU;
		Signed by: 136C8E7275869E00B2C2F7E1F56696789DFD1DC0

	library://speedgo/default/tensorflow:f30-tf1-0.0.1-rc1,f30-tf1-latest
		Fedora 30; Tensorflow 1.14.0;
		Signed by: 136C8E7275869E00B2C2F7E1F56696789DFD1DC0

	library://speedgo/default/tensorflow:f31-tf210,f31-py382-tf210-haswell-cpu
		Tensorflow 2.1.0 CPU; Python 3.8.2; Fedora 31; Haswell CPU;
		Signed by: 136C8E7275869E00B2C2F7E1F56696789DFD1DC0

	library://sylabs/examples/tensorflow-rocm:latest,1.14.2
		Signed by: 535BFAA2C5FCDBDB7AAD587F4815CE5B17F4F1DB

	library://uvarc/default/tensorflow:2.1.0-py37
		Signed by: 507FDA48B3A4A698685E1B19D8050AD045BAE902

```


### This fixes or addresses the following GitHub issues:

 -  Fixes #4438


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

