### PR TITLE
Make push/pull verification warning messages consistent

### DIFF
--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -86,7 +86,7 @@ func LibraryPush(ctx context.Context, pushSpec LibraryPushSpec, libraryConfig *c
 			return ErrLibraryUnsigned
 		}
 	} else {
-		sylog.Warningf("Skipping container verifying")
+		sylog.Warningf("Skipping container verification")
 	}
 
 	libraryClient, err := client.NewClient(libraryConfig)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make push/pull verification warning messages consistent

The current pull warning message is "Skipping container verification"