### PR TITLE
Fix failure with unsquashfs >= 4.4 when extracting pseudo devices as a non root user

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2107,6 +2107,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5465":            c.issue5465,           // https://github.com/sylabs/singularity/issues/5465
 		"issue 5599":            c.issue5599,           // https://github.com/sylabs/singularity/issues/5599
 		"issue 5631":            c.issue5631,           // https://github.com/sylabs/singularity/issues/5631
+		"issue 5690":            c.issue5690,           // https://github.com/sylabs/singularity/issues/5690
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -624,3 +624,25 @@ func (c actionTests) issue5599(t *testing.T) {
 		),
 	)
 }
+
+// Check that unsquashfs (for version >= 4.4) works for non root users when image contains
+// pseudo devices in /dev.
+func (c actionTests) issue5690(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(c.env.ImagePath, "/bin/true"),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(c.env.ImagePath, "/bin/true"),
+		e2e.ExpectExit(0),
+	)
+}

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1090,5 +1090,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5315":                      c.issue5315,                 // https://github.com/sylabs/singularity/issues/5315
 		"issue 5435":                      c.issue5435,                 // https://github.com/hpcng/singularity/issues/5435
 		"issue 5668":                      c.issue5668,                 // https://github.com/hpcng/singularity/issues/5435
+		"issue 5690":                      c.issue5690,                 // https://github.com/hpcng/singularity/issues/5690
 	}
 }

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -470,3 +470,28 @@ func (c *imgBuildTests) issue5668(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 }
+
+// Check that unsquashfs (for version >= 4.4) works for non root users when image contains
+// pseudo devices in /dev.
+func (c *imgBuildTests) issue5690(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	sandbox, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-5690-", "")
+	defer e2e.Privileged(cleanup)(t)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--force", "--sandbox", sandbox, c.env.ImagePath),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--force", "--sandbox", sandbox, c.env.ImagePath),
+		e2e.ExpectExit(0),
+	)
+}

--- a/e2e/testdata/Singularity
+++ b/e2e/testdata/Singularity
@@ -17,6 +17,8 @@ from: alpine:3.11.5
 
 %setup
     echo "SETUP"
+    # to test extraction to a sandbox for non root users
+    mknod $SINGULARITY_ROOTFS/dev/null c 1 3
 
 %appenv testapp
     TESTAPP=testapp

--- a/pkg/image/unpacker/squashfs_singularity.go
+++ b/pkg/image/unpacker/squashfs_singularity.go
@@ -109,7 +109,7 @@ func getLibraries(binary string) ([]string, error) {
 
 // unsquashfsSandboxCmd is the command instance for executing unsquashfs command
 // in a sandboxed environment with singularity.
-func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, opts ...string) (*exec.Cmd, error) {
+func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filter string, opts ...string) (*exec.Cmd, error) {
 	const (
 		// will contain both dest and filename inside the sandbox
 		rootfsImageDir = "/image"
@@ -222,7 +222,12 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, opts 
 	if overwrite {
 		args = append(args, "-f")
 	}
+
 	args = append(args, "-d", rootfsDest, filename)
+
+	if filter != "" {
+		args = append(args, filter)
+	}
 
 	sylog.Debugf("Calling wrapped unsquashfs: singularity %v", args)
 	cmd := exec.Command(filepath.Join(buildcfg.BINDIR, "singularity"), args...)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Similar issue to #5668. The idea is to filter `dev/` directory for non root user

### This fixes or addresses the following GitHub issues:

 - Fixes #5690 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

