### PR TITLE
Add --no-mount to override (disable) singularity.conf mount options

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -34,6 +34,7 @@ var (
 	FuseMount          []string
 	SingularityEnv     []string
 	SingularityEnvFile string
+	NoMount            []string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -438,6 +439,17 @@ var actionNoHomeFlag = cmdline.Flag{
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
+// --no-mount
+var actionNoMountFlag = cmdline.Flag{
+	ID:           "actionNoMountFlag",
+	Value:        &NoMount,
+	DefaultValue: []string{},
+	Name:         "no-mount",
+	Usage:        "disable one or more mount xxx options set in singularity.conf",
+	EnvKeys:      []string{"NO_MOUNT"},
+	ExcludedOS:   []string{cmdline.Darwin},
+}
+
 // --no-init
 var actionNoInitFlag = cmdline.Flag{
 	ID:           "actionNoInitFlag",
@@ -690,6 +702,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionNetworkArgsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNetworkFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoHomeFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoMountFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoInitFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNONETFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoNvidiaFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -138,6 +138,31 @@ func hidepidProc() bool {
 	return false
 }
 
+// Set engine flags to disable mounts, to allow overriding them if they are set true
+// in the singularity.conf
+func setNoMountFlags(c *singularityConfig.EngineConfig) {
+	for _, v := range NoMount {
+		switch v {
+		case "proc":
+			c.SetNoProc(true)
+		case "sys":
+			c.SetNoSys(true)
+		case "dev":
+			c.SetNoDev(true)
+		case "devpts":
+			c.SetNoDevPts(true)
+		case "home":
+			c.SetNoHome(true)
+		case "tmp":
+			c.SetNoTmp(true)
+		case "hostfs":
+			c.SetNoHostfs(true)
+		default:
+			sylog.Warningf("Ignoring unknown mount type '%s'", v)
+		}
+	}
+}
+
 // TODO: Let's stick this in another file so that that CLI is just CLI
 func execStarter(cobraCmd *cobra.Command, image string, args []string, name string) {
 	var err error
@@ -401,6 +426,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	engineConfig.SetOverlayImage(OverlayPath)
 	engineConfig.SetWritableImage(IsWritable)
 	engineConfig.SetNoHome(NoHome)
+	setNoMountFlags(engineConfig)
 	engineConfig.SetNv(Nvidia)
 	engineConfig.SetRocm(Rocm)
 	engineConfig.SetAddCaps(AddCaps)

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -157,6 +157,8 @@ func setNoMountFlags(c *singularityConfig.EngineConfig) {
 			c.SetNoTmp(true)
 		case "hostfs":
 			c.SetNoHostfs(true)
+		case "cwd":
+			c.SetNoCwd(true)
 		default:
 			sylog.Warningf("Ignoring unknown mount type '%s'", v)
 		}

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2097,7 +2097,9 @@ func (c actionTests) actionNoMount(t *testing.T) {
 		// ... but in --contained mode disabling devpts stops it being bound in.
 		testDefault   bool
 		testContained bool
-		exit          int
+		// To test --no-mount cwd we need to chdir for the execution
+		cwd  string
+		exit int
 	}{
 		{
 			name:          "proc",
@@ -2147,12 +2149,26 @@ func (c actionTests) actionNoMount(t *testing.T) {
 			testContained: true,
 			exit:          0,
 		},
+		{
+			// /srv is an LSB directory we should be able to rely on for our CWD test
+			name:        "cwd",
+			noMount:     "cwd",
+			noMatch:     "on /srv",
+			testDefault: true,
+			// CWD is never mounted with contain so --no-mount CWD doesn't have an effect,
+			// but let's verify it isn't mounted anyway.
+			testContained: true,
+			cwd:           "/srv",
+			exit:          0,
+		},
 	}
 
 	for _, tt := range tests {
+
 		if tt.testDefault {
 			c.env.RunSingularity(
 				t,
+				e2e.WithDir(tt.cwd),
 				e2e.AsSubtest(tt.name),
 				e2e.WithProfile(e2e.UserProfile),
 				e2e.WithCommand("exec"),
@@ -2164,6 +2180,7 @@ func (c actionTests) actionNoMount(t *testing.T) {
 		if tt.testContained {
 			c.env.RunSingularity(
 				t,
+				e2e.WithDir(tt.cwd),
 				e2e.AsSubtest(tt.name+"Contained"),
 				e2e.WithProfile(e2e.UserProfile),
 				e2e.WithCommand("exec"),

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2076,6 +2076,105 @@ func (c actionTests) actionUmask(t *testing.T) {
 
 }
 
+func (c actionTests) actionNoMount(t *testing.T) {
+	// TODO - this does not test --no-mount hostfs as that is a little tricky
+	// We are in a mount namespace for e2e tests, so we can setup some mounts in there,
+	// create a custom config with `mount hostfs = yes` set, and then look for presence
+	// or absence of the mounts. I'd like to think about this a bit more though - work up
+	// some nice helpers & cleanup for the actions we need.
+	e2e.EnsureImage(t, c.env)
+
+	tests := []struct {
+		name string
+		// Which mount directive to override (disable)
+		noMount string
+		// Output of `mount` command to ensure we should not find
+		// e.g for `--no-mount home` "on /home" as mount command output is of the form:
+		//   tmpfs on /home/dave type tmpfs (rw,seclabel,nosuid,nodev,relatime,size=16384k,uid=1000,gid=1000)
+		noMatch string
+		// Whether to run the test in default and/or contained modes
+		// Needs to be specified as e.g. by default `/dev` mount is a full bind that will always include `/dev/pts`
+		// ... but in --contained mode disabling devpts stops it being bound in.
+		testDefault   bool
+		testContained bool
+		exit          int
+	}{
+		{
+			name:          "proc",
+			noMount:       "proc",
+			noMatch:       "on /proc",
+			testDefault:   true,
+			testContained: true,
+			exit:          1, // mount fails with exit code 1 when there is no `/proc`
+		},
+		{
+			name:          "sys",
+			noMount:       "sys",
+			noMatch:       "on /sys",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "dev",
+			noMount:       "dev",
+			noMatch:       "on /dev",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "devpts",
+			noMount:       "devpts",
+			noMatch:       "on /dev/pts",
+			testDefault:   false,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "tmp",
+			noMount:       "tmp",
+			noMatch:       "on /tmp",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "home",
+			noMount:       "home",
+			noMatch:       "on /home",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.testDefault {
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name),
+				e2e.WithProfile(e2e.UserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs("--no-mount", tt.noMount, c.env.ImagePath, "mount"),
+				e2e.ExpectExit(tt.exit,
+					e2e.ExpectOutput(e2e.UnwantedContainMatch, tt.noMatch)),
+			)
+		}
+		if tt.testContained {
+			c.env.RunSingularity(
+				t,
+				e2e.AsSubtest(tt.name+"Contained"),
+				e2e.WithProfile(e2e.UserProfile),
+				e2e.WithCommand("exec"),
+				e2e.WithArgs("--contain", "--no-mount", tt.noMount, c.env.ImagePath, "mount"),
+				e2e.ExpectExit(tt.exit,
+					e2e.ExpectOutput(e2e.UnwantedContainMatch, tt.noMatch)),
+			)
+		}
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2114,5 +2213,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"fuse mount":            c.fuseMount,           // test fusemount option
 		"bind image":            c.bindImage,           // test bind image
 		"umask":                 c.actionUmask,         // test umask propagation
+		"no-mount":              c.actionNoMount,       // test --no-mount
 	}
 }

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -87,7 +87,7 @@ func (c configTests) configGlobal(t *testing.T) {
 			directive:      "allow pid ns",
 			directiveValue: "no",
 			exit:           0,
-			resultOp:       e2e.ExpectOutput(e2e.UnwantedMatch, "1"),
+			resultOp:       e2e.ExpectOutput(e2e.UnwantedExactMatch, "1"),
 		},
 		{
 			name:           "AllowPidNsYes",

--- a/e2e/internal/e2e/singularitycmd.go
+++ b/e2e/internal/e2e/singularitycmd.go
@@ -45,8 +45,10 @@ const (
 	ContainMatch MatchType = iota
 	// ExactMatch is for exact match
 	ExactMatch
-	// UnwantedMatch is for unwanted match
-	UnwantedMatch
+	// UnwaantedContainMatch checks that output does not contain text
+	UnwantedContainMatch
+	// UnwantedExactMatch checks that output does not exactly match text
+	UnwantedExactMatch
 	// RegexMatch is for regular expression match
 	RegexMatch
 )
@@ -57,8 +59,10 @@ func (m MatchType) String() string {
 		return "ContainMatch"
 	case ExactMatch:
 		return "ExactMatch"
-	case UnwantedMatch:
-		return "UnwantedMatch"
+	case UnwantedContainMatch:
+		return "UnwantedContainMatch"
+	case UnwantedExactMatch:
+		return "UnwantedExactMatch"
 	case RegexMatch:
 		return "RegexMatch"
 	default:
@@ -105,7 +109,14 @@ func (r *SingularityCmdResult) expectMatch(mt MatchType, stream streamType, patt
 				r.FullCmd, streamName, pattern, streamName, output,
 			)
 		}
-	case UnwantedMatch:
+	case UnwantedContainMatch:
+		if strings.Contains(output, pattern) {
+			return errors.Errorf(
+				"Command %q:\nExpect %s stream does not contain:\n%s\nCommand %s stream:\n%s",
+				r.FullCmd, streamName, pattern, streamName, output,
+			)
+		}
+	case UnwantedExactMatch:
 		if strings.TrimSuffix(output, "\n") == pattern {
 			return errors.Errorf(
 				"Command %q:\nExpect %s stream not matching:\n%s\nCommand %s output:\n%s",

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1934,16 +1934,20 @@ func (c *container) isMounted(dest string) bool {
 
 func (c *container) addCwdMount(system *mount.System) error {
 	if c.engine.EngineConfig.GetContain() {
-		sylog.Verbosef("Not mounting current directory: container was requested")
+		sylog.Verbosef("Not mounting current directory: contain was requested")
 		return nil
 	}
 	if !c.engine.EngineConfig.File.UserBindControl {
 		sylog.Warningf("Not mounting current directory: user bind control is disabled by system administrator")
 		return nil
 	}
+	if c.engine.EngineConfig.GetNoCwd() {
+		sylog.Debugf("Skipping current directory mount by user request.")
+		return nil
+	}
 	cwd := c.engine.EngineConfig.GetCwd()
 	if cwd == "" {
-		sylog.Warningf("Not current working directory set: skipping mount")
+		sylog.Warningf("No current working directory set: skipping mount")
 	}
 
 	current, err := filepath.EvalSymlinks(cwd)

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1176,7 +1176,7 @@ func (c *container) addKernelMount(system *mount.System) error {
 	bindFlags := uintptr(syscall.MS_BIND | syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_REC)
 
 	sylog.Debugf("Checking configuration file for 'mount proc'")
-	if c.engine.EngineConfig.File.MountProc {
+	if c.engine.EngineConfig.File.MountProc && !c.engine.EngineConfig.GetNoProc() {
 		sylog.Debugf("Adding proc to mount list\n")
 		if c.pidNS {
 			err = system.Points.AddFS(mount.KernelTag, "/proc", "proc", syscall.MS_NOSUID|syscall.MS_NODEV, "")
@@ -1197,7 +1197,7 @@ func (c *container) addKernelMount(system *mount.System) error {
 	}
 
 	sylog.Debugf("Checking configuration file for 'mount sys'")
-	if c.engine.EngineConfig.File.MountSys {
+	if c.engine.EngineConfig.File.MountSys && !c.engine.EngineConfig.GetNoSys() {
 		sylog.Debugf("Adding sysfs to mount list\n")
 		if !c.userNS {
 			err = system.Points.AddFS(mount.KernelTag, "/sys", "sysfs", syscall.MS_NOSUID|syscall.MS_NODEV, "")
@@ -1278,7 +1278,9 @@ func (c *container) addSessionDevMount(system *mount.System) error {
 func (c *container) addDevMount(system *mount.System) error {
 	sylog.Debugf("Checking configuration file for 'mount dev'")
 
-	if c.engine.EngineConfig.File.MountDev == "minimal" || c.engine.EngineConfig.GetContain() {
+	if c.engine.EngineConfig.File.MountDev == "no" || c.engine.EngineConfig.GetNoDev() {
+		sylog.Verbosef("Not mounting /dev inside the container, disallowed by configuration")
+	} else if c.engine.EngineConfig.File.MountDev == "minimal" || c.engine.EngineConfig.GetContain() {
 		sylog.Debugf("Creating temporary staged /dev")
 		if err := c.session.AddDir("/dev"); err != nil {
 			return fmt.Errorf("failed to add /dev session directory: %s", err)
@@ -1307,7 +1309,7 @@ func (c *container) addDevMount(system *mount.System) error {
 			}
 		}
 
-		if c.engine.EngineConfig.File.MountDevPts {
+		if c.engine.EngineConfig.File.MountDevPts && !c.engine.EngineConfig.GetNoDevPts() {
 			if _, err := os.Stat("/dev/pts/ptmx"); os.IsNotExist(err) {
 				return fmt.Errorf("multiple devpts instances unsupported and /dev/pts configured")
 			}
@@ -1447,14 +1449,12 @@ func (c *container) addDevMount(system *mount.System) error {
 			return fmt.Errorf("unable to add dev to mount list: %s", err)
 		}
 		sylog.Verbosef("Default mount: /dev:/dev")
-	} else if c.engine.EngineConfig.File.MountDev == "no" {
-		sylog.Verbosef("Not mounting /dev inside the container, disallowed by configuration")
 	}
 	return nil
 }
 
 func (c *container) addHostMount(system *mount.System) error {
-	if !c.engine.EngineConfig.File.MountHostfs {
+	if !c.engine.EngineConfig.File.MountHostfs || c.engine.EngineConfig.GetNoHostfs() {
 		sylog.Debugf("Not mounting host file systems per configuration")
 		return nil
 	}
@@ -1730,7 +1730,10 @@ func (c *container) addUserbindsMount(system *mount.System) error {
 				sylog.Warningf("Skipping %s bind mount: source and destination must be identical when binding to %s", src, devPrefix)
 				continue
 			}
-			if c.engine.EngineConfig.File.MountDev == "minimal" || c.engine.EngineConfig.GetContain() {
+			if c.engine.EngineConfig.File.MountDev == "no" || c.engine.EngineConfig.GetNoDev() {
+				sylog.Warningf("Skipping %s bind mount: disallowed by configuration", src)
+				continue
+			} else if c.engine.EngineConfig.File.MountDev == "minimal" || c.engine.EngineConfig.GetContain() {
 				// "--bind /dev" bind case
 				if src == devPrefix {
 					system.Points.RemoveByTag(mount.DevTag)
@@ -1747,9 +1750,6 @@ func (c *container) addUserbindsMount(system *mount.System) error {
 					sylog.Warningf("Skipping %s bind mount: %s", src, err)
 				}
 				sylog.Debugf("Adding device %s to mount list\n", src)
-				continue
-			} else if c.engine.EngineConfig.File.MountDev == "no" {
-				sylog.Warningf("Skipping %s bind mount: disallowed by configuration", src)
 				continue
 			}
 			// proceed with normal binds below if 'mount dev = yes'
@@ -1785,7 +1785,7 @@ func (c *container) addTmpMount(system *mount.System) error {
 	)
 
 	sylog.Debugf("Checking for 'mount tmp' in configuration file")
-	if !c.engine.EngineConfig.File.MountTmp {
+	if !c.engine.EngineConfig.File.MountTmp || c.engine.EngineConfig.GetNoTmp() {
 		sylog.Verbosef("Skipping tmp dir mounting (per config)")
 		return nil
 	}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -146,12 +146,18 @@ type JSONConfig struct {
 	AllowSUID         bool              `json:"allowSUID,omitempty"`
 	KeepPrivs         bool              `json:"keepPrivs,omitempty"`
 	NoPrivs           bool              `json:"noPrivs,omitempty"`
+	NoProc            bool              `json:"noProc,omitempty"`
+	NoSys             bool              `json:"noSys,omitempty"`
+	NoDev             bool              `json:"noDev,omitempty"`
+	NoDevPts          bool              `json:"noDevPts,omitempty"`
 	NoHome            bool              `json:"noHome,omitempty"`
+	NoTmp             bool              `json:"noTmp,omitempty"`
+	NoHostfs          bool              `json:"noHostfs,omitempty"`
 	NoInit            bool              `json:"noInit,omitempty"`
-	DeleteTempDir     string            `json:"deleteTempDir,omitempty"`
 	Fakeroot          bool              `json:"fakeroot,omitempty"`
 	SignalPropagation bool              `json:"signalPropagation,omitempty"`
 	RestoreUmask      bool              `json:"restoreUmask,omitempty"`
+	DeleteTempDir     string            `json:"deleteTempDir,omitempty"`
 	Umask             int               `json:"umask,omitempty"`
 }
 
@@ -540,7 +546,47 @@ func (e *EngineConfig) GetNoPrivs() bool {
 	return e.JSON.NoPrivs
 }
 
-// SetNoHome set no-home flag to not mount home user home directory.
+// SetNoProc set flag to not mount proc directory.
+func (e *EngineConfig) SetNoProc(val bool) {
+	e.JSON.NoProc = val
+}
+
+// GetNoProc returns if no-proc flag is set or not.
+func (e *EngineConfig) GetNoProc() bool {
+	return e.JSON.NoProc
+}
+
+// SetNoSys set flag to not mount sys directory.
+func (e *EngineConfig) SetNoSys(val bool) {
+	e.JSON.NoSys = val
+}
+
+// GetNoSys returns if no-sys flag is set or not.
+func (e *EngineConfig) GetNoSys() bool {
+	return e.JSON.NoSys
+}
+
+// SetNoDev set flag to not mount dev directory.
+func (e *EngineConfig) SetNoDev(val bool) {
+	e.JSON.NoDev = val
+}
+
+// GetNoDev returns if no-dev flag is set or not.
+func (e *EngineConfig) GetNoDev() bool {
+	return e.JSON.NoDev
+}
+
+// SetNoDevPts set flag to not mount dev directory.
+func (e *EngineConfig) SetNoDevPts(val bool) {
+	e.JSON.NoDevPts = val
+}
+
+// GetNoDevPts returns if no-devpts flag is set or not.
+func (e *EngineConfig) GetNoDevPts() bool {
+	return e.JSON.NoDevPts
+}
+
+// SetNoHome set flag to not mount user home directory.
 func (e *EngineConfig) SetNoHome(val bool) {
 	e.JSON.NoHome = val
 }
@@ -548,6 +594,26 @@ func (e *EngineConfig) SetNoHome(val bool) {
 // GetNoHome returns if no-home flag is set or not.
 func (e *EngineConfig) GetNoHome() bool {
 	return e.JSON.NoHome
+}
+
+// SetNoTmp set flag to not mount tmp directories
+func (e *EngineConfig) SetNoTmp(val bool) {
+	e.JSON.NoTmp = val
+}
+
+// GetNoTmp returns if no-tmo flag is set or not.
+func (e *EngineConfig) GetNoTmp() bool {
+	return e.JSON.NoTmp
+}
+
+// SetNoHostFs set flag to not mount all host mounts.
+func (e *EngineConfig) SetNoHostfs(val bool) {
+	e.JSON.NoHostfs = val
+}
+
+// SetNoHostfs returns if no-hostfs flag is set or not.
+func (e *EngineConfig) GetNoHostfs() bool {
+	return e.JSON.NoHostfs
 }
 
 // SetNoInit set noinit flag to not start shim init process.

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -153,6 +153,7 @@ type JSONConfig struct {
 	NoHome            bool              `json:"noHome,omitempty"`
 	NoTmp             bool              `json:"noTmp,omitempty"`
 	NoHostfs          bool              `json:"noHostfs,omitempty"`
+	NoCwd             bool              `json:"noCwd,omitempty"`
 	NoInit            bool              `json:"noInit,omitempty"`
 	Fakeroot          bool              `json:"fakeroot,omitempty"`
 	SignalPropagation bool              `json:"signalPropagation,omitempty"`
@@ -614,6 +615,16 @@ func (e *EngineConfig) SetNoHostfs(val bool) {
 // SetNoHostfs returns if no-hostfs flag is set or not.
 func (e *EngineConfig) GetNoHostfs() bool {
 	return e.JSON.NoHostfs
+}
+
+// SetNoCwd set flag to not mount CWD
+func (e *EngineConfig) SetNoCwd(val bool) {
+	e.JSON.NoCwd = val
+}
+
+// SetNoCwd returns if no-cwd flag is set or not.
+func (e *EngineConfig) GetNoCwd() bool {
+	return e.JSON.NoCwd
 }
 
 // SetNoInit set noinit flag to not start shim init process.


### PR DESCRIPTION
**NOTE**: This is proposed as an alternative to the single `--no-hostfs` in #5086, but I'm very open to any of:

1. Merging this `--no-mount` approach.
2. Adding the single requested `--no-hostfs` by re-opening #5086
3. Adding all of the individual `--no-xxx` flags for each `mount xxx` config option by modifying this PR.

My opinion r.e. the previous discussion in #5086 is that as we have an existing `--no-xxx` pattern for flags, the proposal in `#5086` comments of a `--mount ^xxxx` negation syntax is confusing. Also if we allow positive overrides via a `--mount` we need to worry about precedence / behavior when user binds are disabled etc. For positive overrides (mounting things disabled in `singularity.conf`) `--bind/-B` is already available, with understood semantics.


## Description of the Pull Request (PR):

It has been requested that users can turn off mount options set to `yes`
in `singularity.conf` as they may interfere with some containers -
especially when `mount hostfs = yes` is set.

In #5086 a single `--no-hostfs` flag was introduced but concern was
raised that we should be able to disable all, and this would lead to a
proliferation of flags. Another viewpoint is that we should have all of
the `--no-xxxxx` flags.

This PR proposes a middle ground. Add a `--no-mount` flag that can take
one or more 'mounts' to disable, overriding the `singularity.conf`
value. I feel this is more clear / friendlier than using `--mount ^hostfs`
negation syntax.

Implemented through individual NoXXXX booleans on the EngineConfig so it'd
be trivial to add the `--no-xxxx` CLI flags later if we change our
minds.


### This fixes or addresses the following GitHub issues:

 - Fixes #5081


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

