### PR TITLE
Move rpmbuild jobs into a separate CI workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,8 +251,10 @@ workflows:
       - go114-alpine
       - go114-macos
       - check_go_mod
-      - rpmbuild-centos7
-      - rpmbuild-centos8
       - short_unit_tests
       - short_integration_tests
       - e2e_tests
+  rpmbuild:
+    jobs:
+      - rpmbuild-centos7
+      - rpmbuild-centos8


### PR DESCRIPTION
## Description of the Pull Request (PR):

Periodically, rpmbuild jobs fail as they track the latest CentOS
release. There is a delay for source packages to make it into the vault
repos after a CentOS release, so this can cause test failures.

### This fixes or addresses the following GitHub issues:

 - Fixes #

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

