### PR TITLE
e2e - pass docker hub credentials through sudo call

### DIFF
--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -32,5 +32,5 @@ fi
 
 proxy_vars="HTTP_PROXY=$HTTP_PROXY HTTPS_PROXY=$HTTPS_PROXY ALL_PROXY=$ALL_PROXY NO_PROXY=$NO_PROXY"
 cred_vars="E2E_DOCKER_USERNAME=$E2E_DOCKER_USERNAME E2E_DOCKER_PASSWORD=$E2E_DOCKER_PASSWORD"
-export sudo_args="env -i PATH=$PATH HOME=$HOME $proxy_vars SINGULARITY_E2E_COVERAGE=$SINGULARITY_E2E_COVERAGE"
+export sudo_args="env -i PATH=$PATH HOME=$HOME $proxy_vars $cred_vars SINGULARITY_E2E_COVERAGE=$SINGULARITY_E2E_COVERAGE"
 exec scripts/go-test -sudo -parallel $procs -tags "e2e_test" "$@" ./e2e


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ensure the constructed docker hub credentials in `$cred_vars` pass through the sudo call that starts the e2e tests.

Did not impact us between the original PR and now, as it seems the rate limits were delayed, and phased in. 


### This fixes or addresses the following GitHub issues:

 - Fixes #5717


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

