### PR TITLE
Release 3.7.0 markdown doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
-# v3.7.0-rc.1 Release Candidate - [2020-11-10]
+# v3.7.0 - [2020-11-24]
 
 ## New features / functionalities
 
@@ -107,7 +107,12 @@ _The old changelog can be found in the `release-2.6` branch_
     is used with `--contain`.
   - Tolerate comments on `%files` sections in build definition files.
   - Fix a loop device file descriptor leak.
-  
+
+## Known Issues
+
+  - A change in Linux kernel 5.9 causes `--fakeroot` builds to fail with a
+    `/sys/fs/selinux` remount error. This will be addressed in Singularity
+    v3.5.1.
 
 
 # v3.6.4 - [2020-10-13]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove `/u
 reinstalling it._
 
 ```
-$ export VERSION=1.14.9 OS=linux ARCH=amd64  # change this as you need
+$ export VERSION=1.14.12 OS=linux ARCH=amd64  # change this as you need
 
 $ wget -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz https://dl.google.com/go/go${VERSION}.${OS}-${ARCH}.tar.gz && \
   sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Community contributions are always greatly appreciated. To start developing
 Singularity, check out the [guidelines for contributing](CONTRIBUTING.md).
 
 We also welcome contributions to our [user
-guide](https://github.com/sylabs/singularity-userdocs) and [admin
-guide](https://github.com/sylabs/singularity-admindocs).
+guide](https://github.com/hpcng/singularity-userdocs) and [admin
+guide](https://github.com/hpcng/singularity-admindocs).
 
 ## Support
 


### PR DESCRIPTION
Markdown doc changes for the 3.7.0 release scheduled for 2020-11-24

Merging these to `master` and will then merge `master` -> `release-3.7` so that we include the small e2e docker credentials change #5717 in the release.

At release tomorrow, `master` & `release-3.7` will be level. 