### PR TITLE
Fix version number typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ _The old changelog can be found in the `release-2.6` branch_
 
   - A change in Linux kernel 5.9 causes `--fakeroot` builds to fail with a
     `/sys/fs/selinux` remount error. This will be addressed in Singularity
-    v3.5.1.
+    v3.7.1.
 
 
 # v3.6.4 - [2020-10-13]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,6 +82,7 @@
     - Shengjing Zhu <i@zhsj.me>
     - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
     - Thomas Hamel <hmlth@t-hamel.fr>
+    - Tim Wright <7im.Wright@protonmail.com>
     - Tru Huynh <tru@pasteur.fr>
     - Vanessa Sochat <vsochat@stanford.edu>
     - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>


### PR DESCRIPTION
## Description of the Pull Request (PR):

The changelog for Singularity 3.7.0 erroneously mentions that an issue will be addressed in a future Singularity version 3.5.1. This statement should say 3.7.1

Attn: @singularity-maintainers

