### PR TITLE
Typo fix for v3.7.0 CHANGELOG 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ _The old changelog can be found in the `release-2.6` branch_
   - Increase embedded shell interpreter timeout, to allow slow-running
     environment scripts to complete.
   - Correct buffer handling for key import to allow import from STDIN. 
-  - Reset environment to avoid `LD_LIBRARYPATH` issues when resolving
+  - Reset environment to avoid `LD_LIBRARY_PATH` issues when resolving
     dependencies for the `unsquashfs` sandbox.
   - Fall back to `/sbin/ldconfig` if `ldconfig` on `PATH` fails while
     resolving GPU libraries. Fixes problems on systems using Nix /

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,7 +41,7 @@
     - Hakon Enger <hakonenger@github.com>
     - Hugo Meiland <hugo.meiland@microsoft.com>
     - Ian Kaneshiro <ian@sylabs.io>, <iankane@umich.edu>
-    - Jack Morrison <morrisonjc@ornl.gov>
+    - Jack Morrison <morrisonjc@ornl.gov>, <jack@rescale.com>
     - Jacob Chappell <chappellind@gmail.com>, <jacob.chappell@uky.edu>
     - Jarrod Johnson <jjohnson2@lenovo.com>
     - Jason Stover <jms@sylabs.io>, <jason.stover@gmail.com>


### PR DESCRIPTION
## Description of the Pull Request (PR):

Typo fix for the v3.7.0 changelog. It had mentioned `LD_LIBRARYPATH`, and this PR changes it to `LD_LIBRARY_PATH`.


Attn: @singularity-maintainers

