### PR TITLE
Skip host fuse tests if fusermount is not 3.x

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -1723,6 +1724,12 @@ func (c actionTests) fuseMount(t *testing.T) {
 			t,
 			e2e.AsSubtest(tt.name),
 			e2e.WithProfile(tt.profile),
+			e2e.PreRun(func(t *testing.T) {
+				// Host tests require fuse v3 - will fail on host with libfuse v2
+				if strings.Contains(tt.spec, "host") {
+					require.Fusermount3(t)
+				}
+			}),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs([]string{
 				"--fusemount", fmt.Sprintf(optionFmt, tt.spec, sshfsWrapper, sshConfig, tt.key, "/mnt"),

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -69,3 +69,18 @@ func ArchIn(t *testing.T, archs []string) {
 		t.Skipf("test requires architecture %s", strings.Join(archs, "|"))
 	}
 }
+
+// Fusermount3 checks for a version 3 of fusermount, as
+// Singularity requires 3 for fd based mounts.
+func Fusermount3(t *testing.T) {
+	cmd := exec.Command("fusermount", "-V")
+	output, err := cmd.CombinedOutput()
+	msg := string(output)
+	if err != nil {
+		t.Skipf("could not run fusermount: %v", err)
+	}
+	if strings.Contains(msg, "version: 3") {
+		return
+	}
+	t.Skipf("need fusermount 3, found: %s", msg)
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

We need to check that we have libfuse/fusermount3 for host fuse mount
tests, as 2.x is not supported but is present on older Ubuntu and
EL distros.

### This fixes or addresses the following GitHub issues:

 - Fixes #5723

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

