### PR TITLE
Support unsquashfs 4.4 in inspect e2e test

### DIFF
--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -70,9 +70,16 @@ func (c ctx) singularityInspect(t *testing.T) {
 
 	require.Command(t, "unsquashfs")
 
-	cmd := exec.Command("unsquashfs", "-d", sandboxImage, squashImage)
+	// First try with -user-xattrs since unsquashfs 4.4 gives an error code if
+	// it can't set system xattrs while rootless.
+	cmd := exec.Command("unsquashfs", "-user-xattrs", "-d", sandboxImage, squashImage)
 	if res := cmd.Run(t); res.Error != nil {
-		t.Fatalf("Unexpected error while running command.\n%s", res)
+		// If we failed, then try without -user-xattrs for older unsquashfs
+		// versions that don't have that flag.
+		cmd := exec.Command("unsquashfs", "-d", sandboxImage, squashImage)
+		if res := cmd.Run(t); res.Error != nil {
+			t.Fatalf("Unexpected error while running command.\n%s", res)
+		}
 	}
 
 	compareLabel := func(label, out string, appName string) func(*testing.T, *inspect.Metadata) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Support unsquashfs 4.4 in inspect e2e test


### This fixes or addresses the following GitHub issues:

 - Fixes #5720


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

