### PR TITLE
e2e/security - compare to root CapEff, not regex

### DIFF
--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -6,6 +6,7 @@
 package security
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/sylabs/singularity/e2e/internal/testhelper"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
+	"github.com/sylabs/singularity/pkg/util/capabilities"
 )
 
 type ctx struct {
@@ -108,6 +110,21 @@ func (c ctx) testSecurityUnpriv(t *testing.T) {
 
 // testSecurityPriv tests security flag fuctionality for singularity exec with elevated privileges
 func (c ctx) testSecurityPriv(t *testing.T) {
+	var caps uint64
+	var err error
+	// Get the capability set for root on this system
+	// e.g. "CapEff:	000001ffffffffff"
+	e2e.Privileged(func(t *testing.T) {
+		caps, err = capabilities.GetProcessEffective()
+	})(t)
+	if err != nil {
+		t.Fatalf("Could not get CapEff: %v", err)
+	}
+	fullCap := fmt.Sprintf("CapEff:\t%0.16x", caps)
+	// We are going to drop CAP_NET_RAW which should result in the CapEff
+	// string ending dfff
+	dropCap := fmt.Sprintf("CapEff:\t%0.16x", caps-uint64(1<<capabilities.Map["CAP_NET_RAW"].Value))
+
 	tests := []struct {
 		name       string
 		argv       []string
@@ -148,30 +165,16 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 		},
 		// capabilities
 		{
-			// this might break if new capabilities are
-			// added
-			//
-			// TODO(mem): what we really want to test is
-			// that the set outside the container is the
-			// same set inside the container.
 			name:     "capabilities_keep",
 			argv:     []string{"grep", "^CapEff:", "/proc/self/status"},
 			opts:     []string{"--keep-privs"},
-			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[13f]fffffffff\n`),
+			expectOp: e2e.ExpectOutput(e2e.ContainMatch, fullCap),
 		},
 		{
-			// this might break if new capabilities are
-			// added; cap_net_raw corresponds to the missing
-			// bit in CapEff.
-			//
-			// TODO(mem): what we really want to test is
-			// that the set outside the container is the
-			// same set inside the container, modulo
-			// cap_net_raw.
 			name:     "capabilities_drop",
 			argv:     []string{"grep", "^CapEff:", "/proc/self/status"},
 			opts:     []string{"--drop-caps", "CAP_NET_RAW"},
-			expectOp: e2e.ExpectOutput(e2e.RegexMatch, `CapEff:\s+[0f]{6}[13f]fffffdfff\n`),
+			expectOp: e2e.ExpectOutput(e2e.ContainMatch, dropCap),
 		},
 	}
 

--- a/pkg/util/capabilities/process_unsupported.go
+++ b/pkg/util/capabilities/process_unsupported.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// +build !linux
+
+package capabilities
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var ErrCapNotSupported = fmt.Errorf("capabilities not supported on this OS: %s", runtime.GOOS)
+
+// GetProcessEffective returns effective capabilities for
+// the current process.
+func GetProcessEffective() (uint64, error) {
+	return 0, ErrCapNotSupported
+}
+
+// GetProcessPermitted returns permitted capabilities for
+// the current process.
+func GetProcessPermitted() (uint64, error) {
+	return 0, ErrCapNotSupported
+}
+
+// GetProcessInheritable returns inheritable capabilities for
+// the current process.
+func GetProcessInheritable() (uint64, error) {
+	return 0, ErrCapNotSupported
+}
+
+// SetProcessEffective set effective capabilities for the
+// the current process and returns previous effective set.
+func SetProcessEffective(caps uint64) (uint64, error) {
+	return 0, ErrCapNotSupported
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Kernel 5.9 introduced another capability, breaking our regex for testing
keep/drop works correctly. Take the time now to test against the
specific CapEff as root outside of a container, instead of a regex. This
should prevent future breakage.

### This fixes or addresses the following GitHub issues:

 - Fixes #5721


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

