### PR TITLE
e2e: Prepare docker-registry first, to avoid instance/oci errors

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -474,7 +474,7 @@ func (c actionTests) STDPipe(t *testing.T) {
 
 // RunFromURI tests min fuctionality for singularity run/exec URI://
 func (c actionTests) RunFromURI(t *testing.T) {
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 
 	runScript := "testdata/runscript.sh"
 	bind := fmt.Sprintf("%s:/.singularity.d/runscript", runScript)

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -338,7 +338,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 	defer cleanup(t)
 	imagePath := filepath.Join(imageDir, "container")
 
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 
 	tests := []struct {
 		name string

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -49,7 +49,7 @@ func (c imgBuildTests) tempDir(t *testing.T, namespace string) (string, func()) 
 }
 
 func (c imgBuildTests) buildFrom(t *testing.T) {
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 
 	// use a trailing slash in tests for sandbox intentionally to make sure
 	// `singularity build -s /tmp/sand/ docker://alpine` works,

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -308,7 +308,7 @@ func (c *imgBuildTests) issue5166(t *testing.T) {
 }
 
 func (c *imgBuildTests) issue5172(t *testing.T) {
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 
 	u := e2e.UserProfile.HostUser(t)
 

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -253,7 +253,7 @@ func getImageNameFromURI(imgURI string) string {
 
 func (c *ctx) setup(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 
 	// setup file and dir to use as invalid images
 	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -57,7 +57,7 @@ func (c ctx) testInvalidTransport(t *testing.T) {
 func (c ctx) testPushCmd(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 
 	// setup file and dir to use as invalid sources
 	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -458,7 +458,7 @@ func (c ctx) remoteTestFlag(t *testing.T) {
 }
 
 func (c ctx) remoteBasicLogin(t *testing.T) {
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 
 	var (
 		registry    = fmt.Sprintf("oras://%s", c.env.TestRegistry)
@@ -549,7 +549,7 @@ func (c ctx) remoteBasicLogin(t *testing.T) {
 }
 
 func (c ctx) remoteLoginPushPrivate(t *testing.T) {
-	e2e.PrepRegistry(t, c.env)
+	e2e.EnsureRegistry(t)
 	e2e.EnsureImage(t, c.env)
 
 	var (

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -149,10 +149,11 @@ func Run(t *testing.T) {
 	testenv.TestRegistry = "localhost:5000"
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
-	// WARNING(Sylabs-team): Please DO NOT add a call to
-	// e2e.PrepRegistry here. If you need to access the local
-	// registry, add the call at the top of your own test.
-	//
+	// Because tests are parallelized, and PrepRegistry temporarily masks
+	// the Singularity instance directory we *must* now call it before we
+	// start running tests which could use instance and oci functionality.
+	// See: https://github.com/hpcng/singularity/issues/5744
+	e2e.PrepRegistry(t, testenv)
 	// e2e.KillRegistry is called here to ensure that the registry
 	// is stopped after tests run.
 	defer e2e.KillRegistry(t, testenv)


### PR DESCRIPTION
## Description of the Pull Request (PR):

`e2e.PrepRegistry` was designed to be called from tests, using a
one-time mutex to start up the docker-registry instance when needed.

Since 3.6 the e2e-tests have been parallelized. This has resulted in
sporadic test failures in OCI and INSTANCE e2e tests. The failures
are because `e2e.PrepRegistry` sometimes runs concurrently with these
oci/instance tests, and during the prep it masks the instance directory
in the test user $HOME.

We need to run the registry preparation up-front, before any
OCI/INSTANCE tests can occur. This means the shadow instance directory
mount cannot cause any failures.

### This fixes or addresses the following GitHub issues:

 - Fixes #5744


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

