### PR TITLE
Fix loop devices file descriptor leak when shared loop devices is enabled

### DIFF
--- a/pkg/util/loop/loop_linux.go
+++ b/pkg/util/loop/loop_linux.go
@@ -94,6 +94,8 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 				// be sure that the loop device won't be released between this
 				// check and the mount of the filesystem
 				sylog.Debugf("Sharing loop device %d", device)
+				loop.fd = new(int)
+				*loop.fd = loopFd
 				return nil
 			}
 			syscall.Close(loopFd)


### PR DESCRIPTION
### This fixes or addresses the following GitHub issues:

 - Fixes #5760


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

