### PR TITLE
Use -buildmode=default on ppc64le

### DIFF
--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -3,7 +3,14 @@ GO111MODULE := on
 GO_TAGS := containers_image_openpgp sylog oci_engine singularity_engine fakeroot_engine
 GO_TAGS_SUID := containers_image_openpgp sylog singularity_engine fakeroot_engine
 GO_LDFLAGS :=
+# Need to use non-pie build on ppc64le
+# https://github.com/hpcng/singularity/issues/5762
+uname_m := $(shell uname -m)
+ifeq ($(uname_m),ppc64le)
+GO_BUILDMODE := -buildmode=default
+else
 GO_BUILDMODE := -buildmode=pie
+endif
 GO_GCFLAGS := -gcflags=github.com/sylabs/singularity/...="-trimpath $(SOURCEDIR)=>github.com/sylabs/singularity@v0.0.0"
 GO_ASMFLAGS := -asmflags=github.com/sylabs/singularity/...="-trimpath $(SOURCEDIR)=>github.com/sylabs/singularity@v0.0.0"
 GO_MODFLAGS := $(if $(wildcard $(SOURCEDIR)/vendor/modules.txt),-mod=vendor,-mod=readonly)


### PR DESCRIPTION
-buildmode=pie can cause SIGSEGV or unknown caller pc errors with
plugins on ppc64le. Use the default non-pie build mode which avoids
these errors.

Fixes #5762