### PR TITLE
Switch from img to skopeo for e2e registry prep

### DIFF
--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -10,14 +10,7 @@ from: registry:2.7.1
 
 %post
     apk add openssl
-    apk add runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
-
-    # Install v0.5.7 of img (latest will not talk to http registries)
-    export IMG_SHA256="41aa98ab28be55ba3d383cb4e8f86dceac6d6e92102ee4410a6b43514f4da1fa"
-    # Download and check the sha256sum.
-    wget -q "https://github.com/genuinetools/img/releases/download/v0.5.7/img-linux-amd64" -O "/usr/local/bin/img" \
-	  && echo "${IMG_SHA256}  /usr/local/bin/img" | sha256sum -c - \
-	  && chmod a+x "/usr/local/bin/img"
+    apk add skopeo runc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
     mkdir /certs
 
@@ -33,9 +26,7 @@ from: registry:2.7.1
     # wait until docker registry is up
     while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.5; done
 
-    img pull busybox || kill -TERM 1
-    img tag busybox localhost:5000/my-busybox || kill -TERM 1
-    img push localhost:5000/my-busybox || kill -TERM 1
+    skopeo --dest-tls-verify=false copy docker://busybox docker://localhost:5000/my-busybox
 
     # e2e PrepRegistry will repeatedly trying to connect to this port
     # giving indication that it can start


### PR DESCRIPTION
Using an up-to-date tool that is provided in apk form for various
architectures.

 - Fixes #5750