### PR TITLE
Add mconfig --without-seccomp option

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -57,6 +57,7 @@ fi
 
 with_network=1
 with_suid=1
+with_seccomp_check=1
 
 prefix=
 exec_prefix=
@@ -111,6 +112,7 @@ usage_args () {
 	echo "  Singularity options:"
 	echo "     --without-suid    do not install SUID binary (linux only)"
 	echo "     --without-network do not compile/install network plugins (linux only)"
+	echo "     --without-seccomp do not compile/install seccomp support even if available"
 	echo
 	echo "  Path modification options:"
 	echo "     --prefix         install project in \`prefix'"
@@ -361,6 +363,8 @@ while [ $# -ne 0 ]; do
    with_suid=0; shift;;
   --without-network)
    with_network=0; shift;;
+  --without-seccomp)
+   with_seccomp_check=0; shift;;
   -V)
    if ! echo "$2" | awk '/^-.*/ || /^$/ { exit 2 }'; then
      echo "error: option requires an argument: $1"

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -303,15 +303,17 @@ fi
 ########################
 # libseccomp dev
 ########################
-printf " checking: libseccomp+headers... "
-seccomp_iflags=`pkg-config --cflags-only-I libseccomp 2>/dev/null || true`
-if ! printf "#include <seccomp.h>\nint main() { seccomp_syscall_resolve_name(\"read\"); }" | \
-   $tgtcc $user_cflags $ldflags $seccomp_iflags -x c -o /dev/null - -lseccomp >/dev/null 2>&1; then
-    tgtstatic=0
-    echo "no"
-else
-    echo "yes"
-    appsec=1
+if [ "$with_seccomp_check" = "1" ];then
+    printf " checking: libseccomp+headers... "
+    seccomp_iflags=`pkg-config --cflags-only-I libseccomp 2>/dev/null || true`
+    if ! printf "#include <seccomp.h>\nint main() { seccomp_syscall_resolve_name(\"read\"); }" | \
+       $tgtcc $user_cflags $ldflags $seccomp_iflags -x c -o /dev/null - -lseccomp >/dev/null 2>&1; then
+	tgtstatic=0
+	echo "no"
+    else
+	echo "yes"
+	appsec=1
+    fi
 fi
 
 ########################


### PR DESCRIPTION
## Description of the Pull Request (PR):

This adds a `mconfig --without-seccomp` option in order to compile singularity without the seccomp feature even if libseccomp-devel is available.

It would be great if this could be included in 3.7.1.  I want to use it for my unprivileged build of singularity in cvmfs (/cvmfs/oasis.opensciencegrid.org/mis/singularity).


### This fixes or addresses the following GitHub issues:

None


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

