### PR TITLE
Show correct web URL for detached builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _The old changelog can be found in the `release-2.6` branch_
     when using plugins.
   - Remove spurious warning in parseTokenSection()
   - e2e test fixes for new kernels, new unsquashfs version.
+  - Show correct web URI for detached builds against alternate remotes.
 
 
 # v3.7.0 - [2020-11-24]

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -33,6 +33,7 @@ var buildArgs struct {
 	builderURL   string
 	libraryURL   string
 	keyServerURL string
+	webURL       string
 	detached     bool
 	encrypt      bool
 	fakeroot     bool

--- a/cmd/internal/cli/build_darwin.go
+++ b/cmd/internal/cli/build_darwin.go
@@ -40,6 +40,14 @@ func runBuild(cmd *cobra.Command, args []string) {
 	buildArgs.libraryURL = lc.BaseURL
 	buildArgs.builderURL = bc.BaseURL
 
+	// To provide a web link to detached remote builds we need to know the web frontend URI.
+	// We only know this working forward from a remote config, and not if the user has set custom
+	// service URLs, since there is no straightforward foolproof way to work back from them to a
+	// matching frontend URL.
+	if !cmd.Flag("builder").Changed && !cmd.Flag("library").Changed {
+		buildArgs.webURL = URI()
+	}
+
 	// Submiting a remote build requires a valid authToken
 	if bc.AuthToken == "" {
 		sylog.Fatalf("Unable to submit build job: %v", remoteWarning)
@@ -50,7 +58,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Unable to build from %s: %v", spec, err)
 	}
 
-	b, err := remotebuilder.New(dest, buildArgs.libraryURL, def, buildArgs.detached, forceOverwrite, buildArgs.builderURL, bc.AuthToken, buildArgs.arch)
+	b, err := remotebuilder.New(dest, buildArgs.libraryURL, def, buildArgs.detached, forceOverwrite, buildArgs.builderURL, bc.AuthToken, buildArgs.arch, buildArgs.webURL)
 	if err != nil {
 		sylog.Fatalf("Failed to create builder: %v", err)
 	}

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -133,6 +133,14 @@ func runBuildRemote(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 	buildArgs.libraryURL = lc.BaseURL
 	buildArgs.builderURL = bc.BaseURL
 
+	// To provide a web link to detached remote builds we need to know the web frontend URI.
+	// We only know this working forward from a remote config, and not if the user has set custom
+	// service URLs, since there is no straightforward foolproof way to work back from them to a
+	// matching frontend URL.
+	if !cmd.Flag("builder").Changed && !cmd.Flag("library").Changed {
+		buildArgs.webURL = URI()
+	}
+
 	// submitting a remote build requires a valid authToken
 	if bc.AuthToken == "" {
 		sylog.Fatalf("Unable to submit build job: %v", remoteWarning)
@@ -202,7 +210,7 @@ func runBuildRemote(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 		}()
 	}
 
-	b, err := remotebuilder.New(rbDst, buildArgs.libraryURL, def, buildArgs.detached, forceOverwrite, buildArgs.builderURL, bc.AuthToken, buildArgs.arch)
+	b, err := remotebuilder.New(rbDst, buildArgs.libraryURL, def, buildArgs.detached, forceOverwrite, buildArgs.builderURL, bc.AuthToken, buildArgs.arch, buildArgs.webURL)
 	if err != nil {
 		sylog.Fatalf("Failed to create builder: %v", err)
 	}

--- a/internal/pkg/build/remotebuilder/remotebuilder.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder.go
@@ -31,9 +31,6 @@ import (
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
 )
 
-// CloudURI holds the URI of the Library web front-end.
-const CloudURI = "https://cloud.sylabs.io"
-
 // RemoteBuilder contains the build request and response
 type RemoteBuilder struct {
 	BuildClient         *buildclient.Client
@@ -45,10 +42,11 @@ type RemoteBuilder struct {
 	Force               bool
 	IsDetached          bool
 	BuilderRequirements map[string]string
+	WebURL              string
 }
 
 // New creates a RemoteBuilder with the specified details.
-func New(imagePath, libraryURL string, d types.Definition, isDetached, force bool, builderAddr, authToken, buildArch string) (rb *RemoteBuilder, err error) {
+func New(imagePath, libraryURL string, d types.Definition, isDetached, force bool, builderAddr, authToken, buildArch, webURL string) (rb *RemoteBuilder, err error) {
 	bc, err := buildclient.New(&buildclient.Config{
 		BaseURL:   builderAddr,
 		AuthToken: authToken,
@@ -73,6 +71,7 @@ func New(imagePath, libraryURL string, d types.Definition, isDetached, force boo
 		BuilderRequirements: map[string]string{
 			"arch": buildArch,
 		},
+		WebURL: webURL,
 	}, nil
 }
 
@@ -107,7 +106,9 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 	if rb.IsDetached {
 		fmt.Printf("Build submitted! Once it is complete, the image can be retrieved by running:\n")
 		fmt.Printf("\tsingularity pull --library %s library://%s\n\n", bi.LibraryURL, libraryRefRaw)
-		fmt.Printf("Alternatively, you can access it from a browser at:\n\t%s/library/%s\n", CloudURI, libraryRefRaw)
+		if rb.WebURL != "" {
+			fmt.Printf("Alternatively, you can access it from a browser at:\n\t%s/library/%s\n", rb.WebURL, libraryRefRaw)
+		}
 		return nil
 	}
 

--- a/internal/pkg/build/remotebuilder/remotebuilder_test.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder_test.go
@@ -39,7 +39,7 @@ func TestBuild(t *testing.T) {
 	// Loop over test cases
 	for _, tt := range tests {
 		t.Run(tt.description, test.WithoutPrivilege(func(t *testing.T) {
-			_, err := New("", "", types.Definition{}, false, false, tt.builderAddr, "", runtime.GOARCH)
+			_, err := New("", "", types.Definition{}, false, false, tt.builderAddr, "", runtime.GOARCH, "")
 			if tt.expectSuccess {
 				// Ensure the handler returned no error, and the response is as expected
 				if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Replace the hard coded cloud URI link for detached builds to a URI
derived from the current remote.

If the user specifies custom service URIs (--library/--cloud) there is
no easy and reliable method to get the corresponing web frontend URI, so
do not show the web link.

### This fixes or addresses the following GitHub issues:

 - Fixes: #5782

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

