### PR TITLE
add `SINGULARITY_MKSQUASHFS_PROCS` and `SINGULARITY_MKSQUASHFS_MEM` env vars

### DIFF
--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -7,8 +7,10 @@ package squashfs
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
@@ -53,10 +55,17 @@ func GetPath() (string, error) {
 }
 
 func GetProcs() (uint, error) {
+	// prioritize the environment variable over config
+	procstr, exists := os.LookupEnv("SINGULARITY_MKSQUASHFS_PROCS")
+	if exists {
+		proc, err := strconv.ParseUint(procstr, 10, 32)
+		return uint(proc), err
+	}
 	c, err := getConfig()
 	if err != nil {
 		return 0, err
 	}
+
 	// proc is either "" or the string value in the conf file
 	proc := c.MksquashfsProcs
 
@@ -64,12 +73,17 @@ func GetProcs() (uint, error) {
 }
 
 func GetMem() (string, error) {
+	// prioritize the environment variable over config
+	mem, exists := os.LookupEnv("SINGULARITY_MKSQUASHFS_MEM")
+	if exists {
+		return mem, nil
+	}
 	c, err := getConfig()
 	if err != nil {
 		return "", err
 	}
 	// mem is either "" or the string value in the conf file
-	mem := c.MksquashfsMem
+	mem = c.MksquashfsMem
 
 	return mem, err
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

These environment variables can be used to set the -processors and -mem options to `mksquashfs`. These environment variables take precedence over the configuration file.

### This fixes or addresses the following GitHub issues:

 - related to the conversation in https://github.com/hpcng/singularity/pull/5003#issuecomment-764937035

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

