### PR TITLE
fix: allow pull with --library https://library.sylabs.io

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -135,7 +135,7 @@ var buildDetachedFlag = cmdline.Flag{
 var buildBuilderFlag = cmdline.Flag{
 	ID:           "buildBuilderFlag",
 	Value:        &buildArgs.builderURL,
-	DefaultValue: endpoint.SCSDefaultBuilderURI,
+	DefaultValue: "",
 	Name:         "builder",
 	Usage:        "remote Build Service URL, setting this implies --remote",
 	EnvKeys:      []string{"BUILDER"},

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -145,7 +145,7 @@ var buildBuilderFlag = cmdline.Flag{
 var buildLibraryFlag = cmdline.Flag{
 	ID:           "buildLibraryFlag",
 	Value:        &buildArgs.libraryURL,
-	DefaultValue: endpoint.SCSDefaultLibraryURI,
+	DefaultValue: "",
 	Name:         "library",
 	Usage:        "container Library URL",
 	EnvKeys:      []string{"LIBRARY"},

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/app/singularity"
-	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
@@ -69,7 +68,7 @@ var deleteLibraryURI string
 var deleteLibraryURIFlag = cmdline.Flag{
 	ID:           "deleteLibraryURIFlag",
 	Value:        &deleteLibraryURI,
-	DefaultValue: endpoint.SCSDefaultLibraryURI,
+	DefaultValue: "",
 	Name:         "library",
 	Usage:        "delete images from the provided library",
 	EnvKeys:      []string{"LIBRARY"},

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -14,13 +14,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
-	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
-)
-
-const (
-	defaultKeyServer = endpoint.SCSDefaultKeyserverURI
 )
 
 var (
@@ -34,7 +29,7 @@ var (
 var keyServerURIFlag = cmdline.Flag{
 	ID:           "keyServerURIFlag",
 	Value:        &keyServerURI,
-	DefaultValue: defaultKeyServer,
+	DefaultValue: "",
 	Name:         "url",
 	ShortHand:    "u",
 	Usage:        "specify the key server URL",

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -68,7 +68,7 @@ var pullArchFlag = cmdline.Flag{
 var pullLibraryURIFlag = cmdline.Flag{
 	ID:           "pullLibraryURIFlag",
 	Value:        &pullLibraryURI,
-	DefaultValue: endpoint.SCSDefaultLibraryURI,
+	DefaultValue: "",
 	Name:         "library",
 	Usage:        "download images from the provided library",
 	EnvKeys:      []string{"LIBRARY"},

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -207,7 +207,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 		if err != nil {
 			sylog.Fatalf("Unable to get library client configuration: %v", err)
 		}
-		co, err := getKeyserverClientOpts(endpoint.SCSDefaultKeyserverURI, endpoint.KeyserverVerifyOp)
+		co, err := getKeyserverClientOpts("", endpoint.KeyserverVerifyOp)
 		if err != nil {
 			sylog.Fatalf("Unable to get keyserver client configuration: %v", err)
 		}

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -36,7 +36,7 @@ var (
 var pushLibraryURIFlag = cmdline.Flag{
 	ID:           "pushLibraryURIFlag",
 	Value:        &PushLibraryURI,
-	DefaultValue: endpoint.SCSDefaultLibraryURI,
+	DefaultValue: "",
 	Name:         "library",
 	Usage:        "the library to push to",
 	EnvKeys:      []string{"LIBRARY"},

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -102,7 +102,7 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Cannot push image to library: %v", remoteWarning)
 			}
 
-			co, err := getKeyserverClientOpts(endpoint.SCSDefaultKeyserverURI, endpoint.KeyserverVerifyOp)
+			co, err := getKeyserverClientOpts("", endpoint.KeyserverVerifyOp)
 			if err != nil {
 				sylog.Fatalf("Unable to get keyserver client configuration: %v", err)
 			}

--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/sylabs/singularity/docs"
 	"github.com/sylabs/singularity/internal/pkg/client/library"
-	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	"github.com/sylabs/singularity/pkg/cmdline"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
@@ -32,7 +31,7 @@ var (
 var searchLibraryFlag = cmdline.Flag{
 	ID:           "searchLibraryFlag",
 	Value:        &SearchLibraryURI,
-	DefaultValue: endpoint.SCSDefaultLibraryURI,
+	DefaultValue: "",
 	Name:         "library",
 	Usage:        "URI for library to search",
 	EnvKeys:      []string{"LIBRARY"},

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -621,7 +621,7 @@ func getLibraryClientConfig(uri string) (*scslibclient.Config, error) {
 		}
 	}
 	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig {
-		sylog.Warningf("No default remote in use, falling back to default library: %s", uri)
+		sylog.Warningf("No default remote in use, falling back to default library: %s", endpoint.SCSDefaultLibraryURI)
 	}
 
 	return currentRemoteEndpoint.LibraryClientConfig(uri)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -610,8 +610,6 @@ func getKeyserverClientOpts(uri string, op endpoint.KeyserverOp) ([]scskeyclient
 }
 
 func getLibraryClientConfig(uri string) (*scslibclient.Config, error) {
-	isDefault := uri == endpoint.SCSDefaultLibraryURI
-
 	if currentRemoteEndpoint == nil {
 		var err error
 
@@ -622,11 +620,8 @@ func getLibraryClientConfig(uri string) (*scslibclient.Config, error) {
 			return nil, fmt.Errorf("unable to load remote configuration: %v", err)
 		}
 	}
-	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig && isDefault {
+	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig {
 		sylog.Warningf("No default remote in use, falling back to default library: %s", uri)
-	}
-	if isDefault {
-		uri = ""
 	}
 
 	return currentRemoteEndpoint.LibraryClientConfig(uri)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -586,9 +586,10 @@ func CheckRootOrUnpriv(cmd *cobra.Command, args []string) {
 	}
 }
 
+// getKeyServerClientOpts returns client options for keyserver access.
+// A "" value for uri will return client options for the current endpoint.
+// A specified uri will return client options for that keyserver.
 func getKeyserverClientOpts(uri string, op endpoint.KeyserverOp) ([]scskeyclient.Option, error) {
-	isDefault := uri == endpoint.SCSDefaultKeyserverURI
-
 	if currentRemoteEndpoint == nil {
 		var err error
 
@@ -599,16 +600,16 @@ func getKeyserverClientOpts(uri string, op endpoint.KeyserverOp) ([]scskeyclient
 			return nil, fmt.Errorf("unable to load remote configuration: %v", err)
 		}
 	}
-	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig && isDefault {
-		sylog.Warningf("No default remote in use, falling back to default keyserver: %s", uri)
-	}
-	if isDefault {
-		uri = ""
+	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig {
+		sylog.Warningf("No default remote in use, falling back to default keyserver: %s", endpoint.SCSDefaultKeyserverURI)
 	}
 
 	return currentRemoteEndpoint.KeyserverClientOpts(uri, op)
 }
 
+// getLibraryClientConfig returns client config for library server access.
+// A "" value for uri will return client config for the current endpoint.
+// A specified uri will return client options for that library server.
 func getLibraryClientConfig(uri string) (*scslibclient.Config, error) {
 	if currentRemoteEndpoint == nil {
 		var err error
@@ -627,9 +628,10 @@ func getLibraryClientConfig(uri string) (*scslibclient.Config, error) {
 	return currentRemoteEndpoint.LibraryClientConfig(uri)
 }
 
+// getBuilderClientConfig returns client config for build server access.
+// A "" value for uri will return client config for the current endpoint.
+// A specified uri will return client options for that build server.
 func getBuilderClientConfig(uri string) (*scsbuildclient.Config, error) {
-	isDefault := uri == endpoint.SCSDefaultBuilderURI
-
 	if currentRemoteEndpoint == nil {
 		var err error
 
@@ -640,11 +642,8 @@ func getBuilderClientConfig(uri string) (*scsbuildclient.Config, error) {
 			return nil, fmt.Errorf("unable to load remote configuration: %v", err)
 		}
 	}
-	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig && isDefault {
-		sylog.Warningf("No default remote in use, falling back to default builder: %s", uri)
-	}
-	if isDefault {
-		uri = ""
+	if currentRemoteEndpoint == endpoint.DefaultEndpointConfig {
+		sylog.Warningf("No default remote in use, falling back to default builder: %s", endpoint.SCSDefaultBuilderURI)
 	}
 
 	return currentRemoteEndpoint.BuilderClientConfig(uri)

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -31,7 +31,7 @@ var (
 var verifyServerURIFlag = cmdline.Flag{
 	ID:           "verifyServerURIFlag",
 	Value:        &keyServerURI,
-	DefaultValue: defaultKeyServer,
+	DefaultValue: "",
 	Name:         "url",
 	ShortHand:    "u",
 	Usage:        "specify a URL for a key server",

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -629,6 +629,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 
 			t.Run("pull", c.testPullCmd)
 			t.Run("pullDisableCache", c.testPullDisableCacheCmd)
+
+			// Regressions
+			t.Run("issue5808", c.issue5808)
 		}),
 	}
 }

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -35,7 +35,7 @@ func (c ctx) issue5808(t *testing.T) {
 	)
 	// Remove test remote when we are done here
 	defer func(t *testing.T) {
-		argv := []string{"use", testEndpoint}
+		argv := []string{"remove", testEndpoint}
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest("remote remove"),

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package pull
+
+import (
+	"path"
+	"testing"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+)
+
+// If a remote is set to a different endpoint we should be able to pull
+// with `--library https://library.sylabs.io` from the default Sylabs cloud library.
+func (c ctx) issue5808(t *testing.T) {
+	testEndpoint := "issue5808"
+	testEndpointURI := "https://cloud.staging.sylabs.io"
+	defaultLibraryURI := "https://library.sylabs.io"
+	testImage := "library://sylabs/tests/signed:1.0.0"
+
+	pullDir, cleanup := e2e.MakeTempDir(t, "", "issue5808", "")
+	defer cleanup(t)
+
+	// Add another endpoint
+	argv := []string{"add", "--no-login", testEndpoint, testEndpointURI}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("remote add"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs(argv...),
+		e2e.ExpectExit(0),
+	)
+	// Remove test remote when we are done here
+	defer func(t *testing.T) {
+		argv := []string{"use", testEndpoint}
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest("remote remove"),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("remote"),
+			e2e.WithArgs(argv...),
+			e2e.ExpectExit(0),
+		)
+	}(t)
+
+	// Set as default
+	argv = []string{"use", testEndpoint}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("remote use"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("remote"),
+		e2e.WithArgs(argv...),
+		e2e.ExpectExit(0),
+	)
+
+	// Pull a library image
+	dest := path.Join(pullDir, "alpine.sif")
+	argv = []string{"--arch", "amd64", "--library", defaultLibraryURI, dest, testImage}
+	c.env.RunSingularity(
+		t,
+		e2e.AsSubtest("pull"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs(argv...),
+		e2e.ExpectExit(0),
+	)
+
+}


### PR DESCRIPTION
If the current remote is not the default Sylabs cloud endpoint we should be able to use `--library https://library.sylabs.io` to pull from the default library. This worked prior to remote changes in 3.7.

Refactored the flag handling for the `--library` `--builder` and keyserver `--url` flags to accomplish this goal, and improve clarity of the code.

Previously these flags defaulted to the URI of the relevant service at the sylabs cloud endpoint, making it superficially look like those URIs would be used for subsequent operations. Within `getXXXClientConfig`, however, we reset `uri` to `""` if the uri had not been modified from the default. The `""` which is then passed lower down means that the URLs for the _configured endpoint_ are used for operations.

Refactoring so that `""` is the default value for the flags makes it clearer that they are for overriding the current endpoint, and by default we are not overriding the current remote endpoint. It also allows us to override with `--library https://library.sylabs.io` if we are *not* using the default endpoint. This was impossible with the previous logic, as we always cleared the URL if it matched the production service, e.g.

```
isDefault := uri == endpoint.SCSDefaultLibraryURI
...
if isDefault {
	uri = ""
}
```

With the above code in place, the uri could never be overridden to the default URI for Sylabs cloud.

    
Fixes #5808
