### PR TITLE
Fix high memory usage during build when destination image is present and is big

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sylabs/singularity/pkg/build/types"
 	"github.com/sylabs/singularity/pkg/build/types/parser"
 	"github.com/sylabs/singularity/pkg/cmdline"
+	"github.com/sylabs/singularity/pkg/image"
 	"github.com/sylabs/singularity/pkg/sylog"
 )
 
@@ -299,8 +300,15 @@ func checkBuildTarget(path string) error {
 
 			question := fmt.Sprintf("Build target '%s' already exists and will be deleted during the build process. Do you want to continue? [N/y]", f.Name())
 
-			if isDefFile, _ := parser.IsValidDefinition(abspath); isDefFile {
-				question = fmt.Sprintf("Build target '%s' is a definition file that will be overwritten. Do you still want to overwrite? [N/y]", f.Name())
+			img, err := image.Init(abspath, false)
+			if err != nil {
+				if err != image.ErrUnknownFormat {
+					return fmt.Errorf("while determining '%s' format: %s", f.Name(), err)
+				}
+				// unknown image file format
+				question = fmt.Sprintf("Build target '%s' may be a definition file or a text/binary file that will be overwritten. Do you still want to overwrite it? [N/y]", f.Name())
+			} else {
+				img.File.Close()
 			}
 
 			input, err := interactive.AskYNQuestion("n", question)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix high memory usage during build when destination image is present and is big by inverting logic and check for known image format instead of checking for a definition file which is reading the file entirely in memory and causing high memory usage.

### This fixes or addresses the following GitHub issues:

 - Fixes #5824 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

