### PR TITLE
Unit test: fix TestLoop by closing loop device

### DIFF
--- a/pkg/util/loop/loop_linux_test.go
+++ b/pkg/util/loop/loop_linux_test.go
@@ -22,7 +22,11 @@ func TestLoop(t *testing.T) {
 	info := &Info64{
 		Flags: FlagsAutoClear | FlagsReadOnly,
 	}
-	loopDev := &Device{
+	loopDevOne := &Device{
+		MaxLoopDevices: GetMaxLoopDevices(),
+		Info:           info,
+	}
+	loopDevTwo := &Device{
 		MaxLoopDevices: GetMaxLoopDevices(),
 		Info:           info,
 	}
@@ -31,35 +35,37 @@ func TestLoop(t *testing.T) {
 	loopTwo := -1
 
 	// With wrong path and file pointer
-	if err := loopDev.AttachFromPath("", os.O_RDONLY, &loopOne); err == nil {
+	if err := loopDevOne.AttachFromPath("", os.O_RDONLY, &loopOne); err == nil {
 		t.Errorf("unexpected success with a wrong path")
 	}
-	if err := loopDev.AttachFromFile(nil, os.O_RDONLY, &loopOne); err == nil {
+	if err := loopDevOne.AttachFromFile(nil, os.O_RDONLY, &loopOne); err == nil {
 		t.Errorf("unexpected success with a nil file pointer")
 	}
 
 	// With good file
-	if err := loopDev.AttachFromPath("/etc/passwd", os.O_RDONLY, &loopOne); err != nil {
+	if err := loopDevOne.AttachFromPath("/etc/passwd", os.O_RDONLY, &loopOne); err != nil {
 		t.Error(err)
 	}
+	defer loopDevOne.Close()
 
 	f, err := os.Open("/etc/passwd")
 	if err != nil {
 		t.Error(err)
 	}
+	defer f.Close()
+
 	fi, err := f.Stat()
 	if err != nil {
 		t.Error(err)
 	}
 
 	// With correct file pointer
-	if err := loopDev.AttachFromFile(f, os.O_RDONLY, &loopTwo); err != nil {
+	if err := loopDevTwo.AttachFromFile(f, os.O_RDONLY, &loopTwo); err != nil {
 		t.Error(err)
 	}
 	if loopOne == loopTwo {
 		t.Errorf("attached to the same loop block device /dev/loop%d", loopOne)
 	}
-
 	// Test if loop devices matches associated file
 	_, err = GetStatusFromPath("")
 	if err == nil {
@@ -72,6 +78,8 @@ func TestLoop(t *testing.T) {
 		t.Error(err)
 	}
 
+	loopDevTwo.Close()
+
 	st := fi.Sys().(*syscall.Stat_t)
 	// cast to uint64 as st.Dev is uint32 on MIPS
 	if uint64(st.Dev) != i1.Device || st.Ino != i1.Inode {
@@ -79,26 +87,30 @@ func TestLoop(t *testing.T) {
 	}
 
 	// With shared loop device
-	loopDev.Shared = true
+	loopDevTwo.Shared = true
 	loopTwo = -1
-	if err := loopDev.AttachFromPath("/etc/passwd", os.O_RDONLY, &loopTwo); err != nil {
+	if err := loopDevTwo.AttachFromPath("/etc/passwd", os.O_RDONLY, &loopTwo); err != nil {
 		t.Error(err)
 	}
+	loopDevTwo.Close()
+
 	if loopOne != loopTwo {
 		t.Errorf("not attached to the same loop block device /dev/loop%d", loopOne)
 	}
 
 	loopTwo = -1
-	if err := loopDev.AttachFromPath("/etc/group", os.O_RDONLY, &loopTwo); err != nil {
+	if err := loopDevTwo.AttachFromPath("/etc/group", os.O_RDONLY, &loopTwo); err != nil {
 		t.Error(err)
 	}
+	loopDevTwo.Close()
+
 	if loopOne == loopTwo {
 		t.Errorf("attached to the same loop block device /dev/loop%d", loopOne)
 	}
 
 	// With MaxLoopDevices set to zero
-	loopDev.MaxLoopDevices = 0
-	if err := loopDev.AttachFromPath("/etc/group", os.O_RDONLY, &loopTwo); err == nil {
+	loopDevTwo.MaxLoopDevices = 0
+	if err := loopDevTwo.AttachFromPath("/etc/group", os.O_RDONLY, &loopTwo); err == nil {
 		t.Errorf("unexpected success with MaxLoopDevices = 0")
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix broken tests by always closing the second loop device after each use

### This fixes or addresses the following GitHub issues:

 - Fixes #5835 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

