### PR TITLE
e2e: walk until gid!=0 when finding unpriv uid/gid

### DIFF
--- a/e2e/internal/e2e/init/init_linux.go
+++ b/e2e/internal/e2e/init/init_linux.go
@@ -68,7 +68,7 @@ static int getUnprivIDs(pid_t pid, uid_t *uid, gid_t *gid) {
 		return -1;
 	}
 	pid_t ppid = getProcInfo(pid, uid, gid);
-	if ( *uid == 0 ) {
+	if ( *uid == 0 || *gid == 0 ) {
 		return getUnprivIDs(ppid, uid, gid);
 	}
 	return 0;


### PR DESCRIPTION
## Description of the Pull Request (PR):

On Fedora 33 with sudo `sudo-1.9.5p2-1.fc33.x86_64` we need to walk up the process chain until both `uid !=0` and `gid !=0` when finding our unpriv account for the e2e tests. Changes in sudo mean that at present we can land on a process that doesn't satisfy this if we are walking only until `uid !=0`.


### This fixes or addresses the following GitHub issues:

 - Fixes #5869


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

