### PR TITLE
Implement support for host in library reference

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -75,11 +75,23 @@ func handleOras(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command,
 }
 
 func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string) (string, error) {
-	c, err := getLibraryClientConfig(endpoint.SCSDefaultLibraryURI)
+	r, err := library.NormalizeLibraryRef(pullFrom)
 	if err != nil {
 		return "", err
 	}
-	return library.Pull(ctx, imgCache, pullFrom, runtime.GOARCH, tmpDir, c)
+
+	var libraryURI string
+	if r.Host != "" {
+		libraryURI = "https://" + r.Host
+	} else {
+		libraryURI = endpoint.SCSDefaultLibraryURI
+	}
+
+	c, err := getLibraryClientConfig(libraryURI)
+	if err != nil {
+		return "", err
+	}
+	return library.Pull(ctx, imgCache, r, runtime.GOARCH, tmpDir, c)
 }
 
 func handleShub(ctx context.Context, imgCache *cache.Handle, pullFrom string) (string, error) {

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,13 +17,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
-
 	"github.com/spf13/cobra"
 	"github.com/sylabs/singularity/internal/pkg/build"
 	"github.com/sylabs/singularity/internal/pkg/build/remotebuilder"
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
 	"github.com/sylabs/singularity/internal/pkg/cache"
+	"github.com/sylabs/singularity/internal/pkg/remote/endpoint"
 	fakerootConfig "github.com/sylabs/singularity/internal/pkg/runtime/engine/fakeroot/config"
 	"github.com/sylabs/singularity/internal/pkg/util/fs"
 	"github.com/sylabs/singularity/internal/pkg/util/interactive"

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -197,6 +197,21 @@ var tests = []testStruct{
 		force:            true,
 		expectedExitCode: 0,
 	},
+
+	// pulling with library URI containing host name
+	{
+		desc:             "library URI containing bad host name",
+		srcURI:           "library://notlibrary.sylabs.io/library/default/busybox:1.31.1",
+		library:          "https://notlibrary.sylabs.io",
+		expectedExitCode: 255,
+	},
+	{
+		desc:             "library URI containing host name",
+		srcURI:           "library://library.sylabs.io/library/default/busybox:1.31.1",
+		library:          "https://library.sylabs.io",
+		force:            true,
+		expectedExitCode: 0,
+	},
 }
 
 func (c *ctx) imagePull(t *testing.T, tt testStruct) {

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -198,17 +198,23 @@ var tests = []testStruct{
 		expectedExitCode: 0,
 	},
 
+	// pulling with library URI containing host name and library argument
+	{
+		desc:             "library URI containing host name and library argument",
+		srcURI:           "library://notlibrary.sylabs.io/library/default/busybox:1.31.1",
+		library:          "https://notlibrary.sylabs.io",
+		expectedExitCode: 255,
+	},
+
 	// pulling with library URI containing host name
 	{
 		desc:             "library URI containing bad host name",
 		srcURI:           "library://notlibrary.sylabs.io/library/default/busybox:1.31.1",
-		library:          "https://notlibrary.sylabs.io",
 		expectedExitCode: 255,
 	},
 	{
 		desc:             "library URI containing host name",
 		srcURI:           "library://library.sylabs.io/library/default/busybox:1.31.1",
-		library:          "https://library.sylabs.io",
 		force:            true,
 		expectedExitCode: 0,
 	},

--- a/internal/pkg/build/remotebuilder/remotebuilder.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -150,7 +150,10 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 			return errors.Wrap(err, fmt.Sprintf("error initializing library client: %v", err))
 		}
 
-		imageRef := library.NormalizeLibraryRef(bi.LibraryRef)
+		imageRef, err := library.NormalizeLibraryRef(bi.LibraryRef)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("error parsing library reference: %v", err))
+		}
 
 		if err = library.DownloadImageNoProgress(ctx, c, rb.ImagePath, rb.BuilderRequirements["arch"], imageRef); err != nil {
 			return errors.Wrap(err, "failed to pull image file")

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -53,7 +53,10 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 	sylog.Debugf("LibraryURL: %v", libraryURL)
 	sylog.Debugf("LibraryRef: %v", b.Recipe.Header["from"])
 
-	imageRef := library.NormalizeLibraryRef(b.Recipe.Header["from"])
+	imageRef, err := library.NormalizeLibraryRef(b.Recipe.Header["from"])
+	if err != nil {
+		return fmt.Errorf("error parsing libraryRef: %v", err)
+	}
 	libraryConfig := &client.Config{
 		BaseURL:   libraryURL,
 		AuthToken: authToken,

--- a/internal/pkg/client/library/library.go
+++ b/internal/pkg/client/library/library.go
@@ -24,26 +24,26 @@ const defaultTag = "latest"
 // Comparison will be lower case as the GUI / code has used different capitalisation through time.
 const noDescription = "no description"
 
-// NormalizeLibraryRef parses library ref and sets default tag, if necessary.
-func NormalizeLibraryRef(ref string) (*scslibrary.Ref, error) {
+func splitHostNameAndPath(ref string) (string, string) {
 	ref = strings.TrimPrefix(ref, "library://")
 
-	slashes := strings.Count(ref, "/")
-
-	var elem, tags []string
-	var host, pathref string
-
-	if slashes == 0 || slashes == 2 {
-		// handle "library://image:tag" or "library://collection/container/image[:tag]"
-		pathref = ref
-	} else {
-		// handle "library://hostname/collection/container/image[:tag]"
-		c := strings.SplitN(ref, "/", 2)
-		host = c[0]
-		pathref = c[1]
+	if strings.Count(ref, "/") <= 2 {
+		// handle "library://container[:tag]", "library://collection/container[:tag]", or "library://entity/collection/container[:tag]"
+		return "", ref
 	}
 
-	elem = strings.SplitN(pathref, ":", 2)
+	// handle "library://hostname/entity/collection/container[:tag]"
+	c := strings.SplitN(ref, "/", 2)
+	return c[0], c[1]
+}
+
+// NormalizeLibraryRef parses library ref and sets default tag, if necessary.
+func NormalizeLibraryRef(ref string) (*scslibrary.Ref, error) {
+	host, pathref := splitHostNameAndPath(ref)
+
+	elem := strings.SplitN(pathref, ":", 2)
+
+	var tags []string
 	if len(elem) == 2 {
 		tags = strings.Split(elem[1], ",")
 	} else {

--- a/internal/pkg/client/library/library.go
+++ b/internal/pkg/client/library/library.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -24,27 +24,37 @@ const defaultTag = "latest"
 // Comparison will be lower case as the GUI / code has used different capitalisation through time.
 const noDescription = "no description"
 
-// NormalizeLibraryRef strips off leading "library://" prefix, if any, and
-// appends the default tag (latest) if none specified.
-func NormalizeLibraryRef(libraryRef string) string {
-	ir := strings.TrimPrefix(libraryRef, "library://")
-	if !strings.Contains(ir, ":") {
-		return ir + ":" + defaultTag
+// NormalizeLibraryRef parses library ref and sets default tag, if necessary.
+func NormalizeLibraryRef(ref string) (*scslibrary.Ref, error) {
+	ref = strings.TrimPrefix(ref, "library://")
+
+	slashes := strings.Count(ref, "/")
+
+	var elem, tags []string
+	var host, pathref string
+
+	if slashes == 0 || slashes == 2 {
+		// handle "library://image:tag" or "library://collection/container/image[:tag]"
+		pathref = ref
+	} else {
+		// handle "library://hostname/collection/container/image[:tag]"
+		c := strings.SplitN(ref, "/", 2)
+		host = c[0]
+		pathref = c[1]
 	}
-	return ir
+
+	elem = strings.SplitN(pathref, ":", 2)
+	if len(elem) == 2 {
+		tags = strings.Split(elem[1], ",")
+	} else {
+		tags = []string{defaultTag}
+	}
+
+	return &scslibrary.Ref{Host: host, Path: elem[0], Tags: tags}, nil
 }
 
 // DownloadImage is a helper function to wrap library image download operation
-func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch, libraryRef string, callback client.ProgressCallback) error {
-	// reassemble "stripped" library ref for scs-library-client
-	validLibraryRef := "library:///" + libraryRef
-
-	// parse library ref
-	r, err := scslibrary.Parse(validLibraryRef)
-	if err != nil {
-		return fmt.Errorf("error parsing library ref: %v", err)
-	}
-
+func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch string, libraryRef *scslibrary.Ref, callback client.ProgressCallback) error {
 	// open destination file for writing
 	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0777)
 	if err != nil {
@@ -53,12 +63,12 @@ func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch, l
 	defer f.Close()
 
 	var tag string
-	if len(r.Tags) > 0 {
-		tag = r.Tags[0]
+	if len(libraryRef.Tags) > 0 {
+		tag = libraryRef.Tags[0]
 	}
 
 	// call library client to download image
-	err = c.DownloadImage(ctx, f, arch, r.Path, tag, callback)
+	err = c.DownloadImage(ctx, f, arch, libraryRef.Path, tag, callback)
 	if err != nil {
 		// Delete incomplete image file in the event of failure
 		// we get here e.g. if the context is canceled by Ctrl-C
@@ -75,7 +85,7 @@ func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch, l
 
 // DownloadImageNoProgress downloads an image from the library without
 // displaying a progress bar while doing so
-func DownloadImageNoProgress(ctx context.Context, c *scslibrary.Client, imagePath, arch, libraryRef string) error {
+func DownloadImageNoProgress(ctx context.Context, c *scslibrary.Client, imagePath, arch string, libraryRef *scslibrary.Ref) error {
 	return DownloadImage(ctx, c, imagePath, arch, libraryRef, nil)
 }
 

--- a/internal/pkg/client/library/library_test.go
+++ b/internal/pkg/client/library/library_test.go
@@ -6,41 +6,46 @@
 package library
 
 import (
+	"reflect"
 	"testing"
-
-	"github.com/sylabs/scs-library-client/client"
 )
 
 func TestNormalizeLibraryRef(t *testing.T) {
 	tests := []struct {
-		name        string
-		libraryRef  string
-		expected    string
-		expectedTag string
+		name         string
+		libraryRef   string
+		expected     string
+		expectedTags []string
+		expectedHost string
 	}{
-		{"with tag", "library://alpine:latest", "alpine:latest", "latest"},
-		{"fully qualified with tag", "library://user/collection/container:2.0.0", "user/collection/container:2.0.0", "2.0.0"},
-		{"without tag", "library://alpine", "alpine:latest", "latest"},
-		{"with tag variation", "library://alpine:1.0.1", "alpine:1.0.1", "1.0.1"},
+		{"with tag", "library://alpine:latest", "alpine", []string{"latest"}, ""},
+		{"with multiple tags", "library://alpine:tag1,tag2", "alpine", []string{"tag1", "tag2"}, ""},
+		{"fully qualified with tag", "library://user/collection/container:2.0.0", "user/collection/container", []string{"2.0.0"}, ""},
+		{"fully qualified with multiple tags", "library://user/collection/container:2.0.0,3.0.0", "user/collection/container", []string{"2.0.0", "3.0.0"}, ""},
+		{"without tag", "library://alpine", "alpine", []string{"latest"}, ""},
+		{"with tag variation", "library://alpine:1.0.1", "alpine", []string{"1.0.1"}, ""},
+		{"with hostname", "library://hostname/collection/container/image:tag1", "collection/container/image", []string{"tag1"}, "hostname"},
+		{"with hostname with multiple tags", "library://hostname/collection/container/image:tag1,tag2", "collection/container/image", []string{"tag1", "tag2"}, "hostname"},
+		{"with hostname without tag", "library://hostname/collection/container/image", "collection/container/image", []string{"latest"}, "hostname"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := NormalizeLibraryRef(tt.libraryRef)
+			result, err := NormalizeLibraryRef(tt.libraryRef)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 
-			if result != tt.expected {
+			if result.Path != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, result)
 			}
 
-			// pass (potentially) reformatted library ref to scs-library-client
-			// parser for further validation
-			r, err := client.Parse("library:///" + result)
-			if err != nil {
-				t.Errorf("Error parsing reformatted library ref (%s): %v", result, err)
+			if !reflect.DeepEqual(result.Tags, tt.expectedTags) {
+				t.Errorf("Expected tag %v, got %v", tt.expectedTags, result.Tags)
 			}
 
-			if r.Tags[0] != tt.expectedTag {
-				t.Errorf("Expected tag %s, got %s", tt.expectedTag, r.Tags[0])
+			if result.Host != tt.expectedHost {
+				t.Errorf("Expected host %s, got %s", tt.expectedHost, result.Host)
 			}
 		})
 	}


### PR DESCRIPTION
Implement support for using library ref "library://&lt;hostname&gt;/&lt;entity&gt;/&lt;collection&gt;/&lt;container&gt;[:tag]" while maintaining legacy support for "library://&lt;entity&gt;/&lt;collection&gt;/&lt;container&gt;[:tag]".

This allows the end-user to override the currently selected remote (similar to the `--library <hostname>` argument on `singularity pull`), for example.

Exclusive setting is honoured to disable host name override if system-wide exclusive flag is set.