### PR TITLE
Add overlay command to ease the creation of ext3 writable overlay

### DIFF
--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/pkg/cmdline"
+)
+
+func init() {
+	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterCmd(OverlayCmd)
+		cmdManager.RegisterSubCmd(OverlayCmd, OverlayCreateCmd)
+
+		cmdManager.RegisterFlagForCmd(&overlaySizeFlag, OverlayCreateCmd)
+		cmdManager.RegisterFlagForCmd(&overlayCreateDirFlag, OverlayCreateCmd)
+	})
+}
+
+// OverlayCmd is the 'overlay' command that allows to manage writable overlay.
+var OverlayCmd = &cobra.Command{
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("Invalid command")
+	},
+	DisableFlagsInUseLine: true,
+
+	Use:     docs.OverlayUse,
+	Short:   docs.OverlayShort,
+	Long:    docs.OverlayLong,
+	Example: docs.OverlayExample,
+}

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/sylabs/singularity/docs"
+	"github.com/sylabs/singularity/internal/app/singularity"
+	"github.com/sylabs/singularity/pkg/cmdline"
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+var (
+	overlaySize int
+	overlayDirs []string
+)
+
+// -s|--size
+var overlaySizeFlag = cmdline.Flag{
+	ID:           "overlaySizeFlag",
+	Value:        &overlaySize,
+	DefaultValue: 64,
+	Name:         "size",
+	ShortHand:    "s",
+	Usage:        "size of the EXT3 writable overlay in MiB",
+}
+
+// --create-dir
+var overlayCreateDirFlag = cmdline.Flag{
+	ID:           "overlayCreateDirFlag",
+	Value:        &overlayDirs,
+	DefaultValue: []string{},
+	Name:         "create-dir",
+	Usage:        "directory to create as part of the overlay layout",
+}
+
+func setPath(cmd *cobra.Command, args []string) {
+	userPath := os.Getenv("PATH")
+	path := []string{defaultPath}
+	if userPath != "" {
+		path = append(path, userPath)
+	}
+	os.Setenv("PATH", strings.Join(path, string(filepath.ListSeparator)))
+}
+
+// OverlayCreateCmd is the 'overlay create' command that allows to create writable overlay.
+var OverlayCreateCmd = &cobra.Command{
+	Args:   cobra.ExactArgs(1),
+	PreRun: setPath,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := singularity.OverlayCreate(overlaySize, args[0], overlayDirs...); err != nil {
+			sylog.Fatalf(err.Error())
+		}
+		return nil
+	},
+	DisableFlagsInUseLine: true,
+
+	Use:     docs.OverlayCreateUse,
+	Short:   docs.OverlayCreateShort,
+	Long:    docs.OverlayCreateLong,
+	Example: docs.OverlayCreateExample,
+}

--- a/docs/content.go
+++ b/docs/content.go
@@ -1039,4 +1039,26 @@ Enterprise Performance Computing (EPC)`
 
   To display the resulting configuration instead of writing it to file:
   $ singularity config global --dry-run --set "bind path" /etc/resolv.conf`
+
+	OverlayUse   string = `overlay`
+	OverlayShort string = `Manage an EXT3 writable overlay image`
+	OverlayLong  string = `
+  The overlay command allows management of EXT3 writable overlay images.`
+	OverlayExample string = `
+  All overlay commands have their own help output:
+
+  $ singularity help overlay create
+  $ singularity overlay create --help`
+
+	OverlayCreateUse   string = `create <options> image`
+	OverlayCreateShort string = `Create EXT3 writable overlay image`
+	OverlayCreateLong  string = `
+  The overlay create command allows to create EXT3 writable overlay image either
+  as a single EXT3 image or by adding it automatically to an existing SIF image.`
+	OverlayCreateExample string = `
+  To create and add a writable overlay to an existing SIF image:
+  $ singularity overlay create --size 1024 /tmp/image.sif
+
+  To create a single EXT3 writable overlay image:
+  $ singularity overlay create --size 1024 /tmp/my_overlay.img`
 )

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -1,0 +1,190 @@
+package overlay
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sylabs/singularity/internal/pkg/test/tool/require"
+
+	"github.com/sylabs/singularity/e2e/internal/e2e"
+	"github.com/sylabs/singularity/e2e/internal/testhelper"
+)
+
+type ctx struct {
+	env e2e.TestEnv
+}
+
+func (c ctx) testOverlayCreate(t *testing.T) {
+	require.Filesystem(t, "overlay")
+	require.MkfsExt3(t)
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "overlay", "")
+	defer cleanup(t)
+
+	pgpDir, _ := e2e.MakeSyPGPDir(t, tmpDir)
+	c.env.KeyringDir = pgpDir
+
+	sifSignedImage := filepath.Join(tmpDir, "signed.sif")
+	sifImage := filepath.Join(tmpDir, "unsigned.sif")
+	ext3Image := filepath.Join(tmpDir, "image.ext3")
+	ext3DirImage := filepath.Join(tmpDir, "imagedir.ext3")
+
+	// signed SIF image
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(sifSignedImage, "library://busybox:1.31.1"),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("key import"),
+		e2e.WithArgs("testdata/ecl-pgpkeys/key1.asc"),
+		e2e.ConsoleRun(e2e.ConsoleSendLine("e2e")),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("sign"),
+		e2e.WithArgs("-k", "0", sifSignedImage),
+		e2e.ConsoleRun(e2e.ConsoleSendLine("e2e")),
+		e2e.ExpectExit(0),
+	)
+
+	// unsigned SIF image
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(sifImage, "library://busybox:1.31.1"),
+		e2e.ExpectExit(0),
+	)
+
+	type test struct {
+		name    string
+		profile e2e.Profile
+		command string
+		args    []string
+		exit    int
+	}
+
+	tests := []test{
+		{
+			name:    "create ext3 overlay with small size",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", "--size", "1", ext3Image},
+			exit:    255,
+		},
+		{
+			name:    "create ext3 overlay image",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", "--size", "128", ext3Image},
+			exit:    0,
+		},
+		{
+			name:    "check ext3 overlay size",
+			profile: e2e.UserProfile,
+			command: "exec",
+			args:    []string{"-B", ext3Image + ":/mnt/image", c.env.ImagePath, "/bin/sh", "-c", "[ $(stat -c %s /mnt/image) = 134217728 ] || false"},
+			exit:    0,
+		},
+		{
+			name:    "create ext3 overlay with an existing image",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", ext3Image},
+			exit:    255,
+		},
+		{
+			name:    "create ext3 overlay with dir",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", "--create-dir", "/usr/local/testing", ext3DirImage},
+			exit:    0,
+		},
+		{
+			name:    "check overlay dir permissions",
+			profile: e2e.UserProfile,
+			command: "exec",
+			args:    []string{"-o", ext3DirImage, c.env.ImagePath, "mkdir", "/usr/local/testing/perms"},
+			exit:    0,
+		},
+		{
+			name:    "create ext3 overlay image in unsigned SIF",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", sifImage},
+			exit:    0,
+		},
+		{
+			name:    "create ext3 overlay image in SIF with an existing overlay",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", sifImage},
+			exit:    255,
+		},
+		{
+			name:    "create ext3 overlay image in signed SIF",
+			profile: e2e.UserProfile,
+			command: "overlay",
+			args:    []string{"create", sifSignedImage},
+			exit:    255,
+		},
+	}
+
+	err := e2e.CheckCryptsetupVersion()
+	if err == nil {
+		// encrypted SIF image
+		passphraseEnvVar := fmt.Sprintf("%s=%s", "SINGULARITY_ENCRYPTION_PASSPHRASE", e2e.Passphrase)
+
+		sifEncryptedImage := filepath.Join(tmpDir, "encrypted.sif")
+
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("build"),
+			e2e.WithArgs("--encrypt", sifEncryptedImage, "library://busybox:1.31.1"),
+			e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
+			e2e.ExpectExit(0),
+		)
+
+		tests = append(tests, test{
+			name:    "create ext3 overlay image in encrypted SIF",
+			profile: e2e.RootProfile,
+			command: "overlay",
+			args:    []string{"create", sifEncryptedImage},
+			exit:    255,
+		})
+	}
+
+	for _, tt := range tests {
+		c.env.RunSingularity(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.ExpectExit(tt.exit),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+	c := ctx{
+		env: env,
+	}
+
+	return testhelper.Tests{
+		"create": c.testOverlayCreate,
+	}
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sylabs/singularity/e2e/instance"
 	"github.com/sylabs/singularity/e2e/key"
 	"github.com/sylabs/singularity/e2e/oci"
+	"github.com/sylabs/singularity/e2e/overlay"
 	"github.com/sylabs/singularity/e2e/plugin"
 	"github.com/sylabs/singularity/e2e/pull"
 	"github.com/sylabs/singularity/e2e/push"
@@ -179,6 +180,7 @@ func Run(t *testing.T) {
 	suite.AddGroup("INSTANCE", instance.E2ETests)
 	suite.AddGroup("KEY", key.E2ETests)
 	suite.AddGroup("OCI", oci.E2ETests)
+	suite.AddGroup("OVERLAY", overlay.E2ETests)
 	suite.AddGroup("PLUGIN", plugin.E2ETests)
 	suite.AddGroup("PULL", pull.E2ETests)
 	suite.AddGroup("PUSH", push.E2ETests)

--- a/internal/app/singularity/overlay_create.go
+++ b/internal/app/singularity/overlay_create.go
@@ -1,0 +1,205 @@
+package singularity
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/singularity/pkg/image"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	mkfsBinary = "mkfs.ext3"
+	ddBinary   = "dd"
+)
+
+func sifInfo(img *os.File) (string, bool, error) {
+	fimg, err := sif.LoadContainerFp(img, true)
+	if err != nil {
+		return "", false, err
+	}
+
+	arch := string(fimg.Header.Arch[:sif.HdrArchLen-1])
+	if arch == sif.HdrArchUnknown {
+		arch = sif.GetSIFArch(runtime.GOARCH)
+	}
+
+	signed := false
+	for _, desc := range fimg.DescrArr {
+		if desc.Datatype == sif.DataSignature && desc.Link == sif.DescrDefaultGroup {
+			signed = true
+			break
+		}
+	}
+
+	return arch, signed, fimg.UnloadContainer()
+}
+
+func OverlayCreate(size int, imgPath string, overlayDirs ...string) error {
+	if size < 64 {
+		return fmt.Errorf("image size must be equal or greater than 64 MiB")
+	}
+
+	mkfs, err := exec.LookPath(mkfsBinary)
+	if err != nil {
+		return fmt.Errorf("%s not found in $PATH", mkfsBinary)
+	}
+	dd, err := exec.LookPath(ddBinary)
+	if err != nil {
+		return fmt.Errorf("%s not found in $PATH", ddBinary)
+	}
+
+	buf := new(bytes.Buffer)
+
+	// check if -d option is available
+	cmd := exec.Command(mkfs, "--help")
+	cmd.Stderr = buf
+	// ignore error because the command always returns with exit code 1
+	_ = cmd.Run()
+
+	if !strings.Contains(buf.String(), "[-d ") {
+		return fmt.Errorf("%s seems too old as it doesn't support -d, this is required to create the overlay layout", mkfsBinary)
+	}
+
+	sifImage := false
+	sifArch := ""
+
+	if err := unix.Access(imgPath, unix.W_OK); err == nil {
+		img, err := image.Init(imgPath, false)
+		if err != nil {
+			return fmt.Errorf("while opening image file %s: %s", imgPath, err)
+		}
+		switch img.Type {
+		case image.SIF:
+			sysPart, err := img.GetRootFsPartition()
+			if err != nil {
+				return fmt.Errorf("while getting root FS partition: %s", err)
+			} else if sysPart.Type == image.ENCRYPTSQUASHFS {
+				return fmt.Errorf("encrypted root FS partition in %s: could not add writable overlay", imgPath)
+			}
+
+			overlays, err := img.GetOverlayPartitions()
+			if err != nil {
+				return fmt.Errorf("while getting SIF overlay partitions: %s", err)
+			}
+			arch, signed, err := sifInfo(img.File)
+			if err != nil {
+				return fmt.Errorf("while getting SIF info: %s", err)
+			} else if signed {
+				return fmt.Errorf("SIF image %s is signed: could not add writable overlay", imgPath)
+			}
+			sifArch = arch
+
+			img.File.Close()
+
+			for _, overlay := range overlays {
+				if overlay.Type != image.EXT3 {
+					continue
+				}
+				delCmd := fmt.Sprintf("singularity sif del %d %s", overlay.ID, imgPath)
+				return fmt.Errorf("a writable overlay partition already exists in %s (ID: %d), delete it first with %q", imgPath, overlay.ID, delCmd)
+			}
+
+			sifImage = true
+		case image.EXT3:
+			return fmt.Errorf("EXT3 overlay image %s already exists", imgPath)
+		default:
+			return fmt.Errorf("destination image must be SIF image")
+		}
+	}
+
+	tmpFile := imgPath + ".ext3"
+	defer func() {
+		_ = os.Remove(tmpFile)
+	}()
+
+	errBuf := new(bytes.Buffer)
+
+	cmd = exec.Command(dd, "if=/dev/zero", "of="+tmpFile, "bs=1M", fmt.Sprintf("count=%d", size))
+	cmd.Stderr = errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("while zero'ing overlay image %s: %s\nCommand error: %s", tmpFile, err, errBuf)
+	}
+	errBuf.Reset()
+
+	if err := os.Chmod(tmpFile, 0600); err != nil {
+		return fmt.Errorf("while setting 0600 permission on %s: %s", tmpFile, err)
+	}
+
+	tmpDir, err := ioutil.TempDir("", "overlay-")
+	if err != nil {
+		return fmt.Errorf("while creating temporary overlay directory: %s", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	perm := os.FileMode(0755)
+
+	if os.Getuid() > 65535 || os.Getgid() > 65535 {
+		perm = 0777
+	}
+
+	upperDir := filepath.Join(tmpDir, "upper")
+	workDir := filepath.Join(tmpDir, "work")
+
+	oldumask := unix.Umask(0)
+	defer unix.Umask(oldumask)
+
+	if err := os.Mkdir(upperDir, perm); err != nil {
+		return fmt.Errorf("while creating %s: %s", upperDir, err)
+	}
+	if err := os.Mkdir(workDir, perm); err != nil {
+		return fmt.Errorf("while creating %s: %s", workDir, err)
+	}
+
+	for _, dir := range overlayDirs {
+		od := filepath.Join(upperDir, dir)
+		if !strings.HasPrefix(od, upperDir) {
+			return fmt.Errorf("overlay directory created outside of overlay layout %s", upperDir)
+		}
+		if err := os.MkdirAll(od, perm); err != nil {
+			return fmt.Errorf("while creating %s: %s", od, err)
+		}
+	}
+
+	cmd = exec.Command(mkfs, "-d", tmpDir, tmpFile)
+	cmd.Stderr = errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("while creating ext3 partition in %s: %s\nCommand error: %s", tmpFile, err, errBuf)
+	}
+	errBuf.Reset()
+
+	if sifImage {
+		self, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("while determining current executable path: %s", err)
+		}
+
+		args := []string{
+			"sif", "add",
+			"--datatype", "4", "--partfs", "2",
+			"--parttype", "4", "--partarch", sifArch,
+			"--groupid", "1",
+			imgPath, tmpFile,
+		}
+		cmd = exec.Command(self, args...)
+		cmd.Stderr = errBuf
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("while adding ext3 overlay partition to %s: %s\nCommand error: %s", imgPath, err, errBuf)
+		}
+	} else {
+		if err := os.Rename(tmpFile, imgPath); err != nil {
+			return fmt.Errorf("while renaming %s to %s: %s", tmpFile, imgPath, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -6,6 +6,7 @@
 package require
 
 import (
+	"bytes"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -67,5 +68,23 @@ func ArchIn(t *testing.T, archs []string) {
 			}
 		}
 		t.Skipf("test requires architecture %s", strings.Join(archs, "|"))
+	}
+}
+
+// MkfsExt3 checks that mkfs.ext3 is available and
+// support -d option to create writable overlay layout.
+func MkfsExt3(t *testing.T) {
+	mkfs, err := exec.LookPath("mkfs.ext3")
+	if err != nil {
+		t.Skipf("mkfs.ext3 not found in $PATH")
+	}
+
+	buf := new(bytes.Buffer)
+	cmd := exec.Command(mkfs, "--help")
+	cmd.Stderr = buf
+	_ = cmd.Run()
+
+	if !strings.Contains(buf.String(), "[-d ") {
+		t.Skipf("mkfs.ext3 is too old and doesn't support -d")
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add overlay command to ease the creation of ext3 writable overlay
- allow to create an overlay as a single ext3 image file.
- allow to create and add an ext3 writable overlay to an existing SIF image.

SIF restrictions:
- SIF image must not contain a writable overlay
- SIF image must not be signed
- SIF image must not be encrypted

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

