### PR TITLE
Disable -race for tests on ppc64le only

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -45,7 +45,7 @@ unit-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-junit $(B
 unit-test:
 	@echo " TEST sudo go test [unit]"
 	$(V)cd $(SOURCEDIR) && \
-		scripts/go-test -sudo -v $(EXTRA_FLAGS) \
+		scripts/go-test -sudo -v $(GO_RACE) $(EXTRA_FLAGS) \
 		./...
 	@echo "       PASS"
 
@@ -54,7 +54,7 @@ short-unit-test: EXTRA_FLAGS := $(if $(filter yes,$(strip $(JUNIT_OUTPUT))),-jun
 short-unit-test:
 	@echo " TEST sudo go test [unit]"
 	$(V)cd $(SOURCEDIR) && \
-		scripts/go-test -sudo -v -short $(EXTRA_FLAGS) \
+		scripts/go-test -sudo -v -short $(GO_RACE) $(EXTRA_FLAGS) \
 		./...
 	@echo "       PASS"
 
@@ -66,7 +66,7 @@ e2e-test:
 	$(V)rm -f $(BUILDDIR_ABSPATH)/e2e-cmd-coverage
 	$(V)cd $(SOURCEDIR) && \
 		SINGULARITY_E2E_COVERAGE=$(BUILDDIR_ABSPATH)/e2e-cmd-coverage \
-		scripts/e2e-test -v $(EXTRA_FLAGS)
+		scripts/e2e-test -v $(GO_RACE) $(EXTRA_FLAGS)
 	@echo "       PASS"
 	@echo " TEST e2e-coverage"
 	$(V)cd $(SOURCEDIR) && \
@@ -79,7 +79,7 @@ e2e-test:
 integration-test:
 	@echo " TEST sudo go test [integration]"
 	$(V)cd $(SOURCEDIR) && \
-		scripts/go-test -sudo -v -tags 'integration_test' \
+		scripts/go-test -sudo -v -tags 'integration_test' $(GO_RACE) \
 		./cmd/singularity ./pkg/network
 	@echo "       PASS"
 
@@ -87,7 +87,7 @@ integration-test:
 short-integration-test:
 	@echo " TEST sudo go test [short-integration]"
 	$(V)cd $(SOURCEDIR) && \
-		scripts/go-test -sudo -v -tags 'integration_test' \
+		scripts/go-test -sudo -v -tags 'integration_test' $(GO_RACE) \
 		./pkg/network
 	@echo "       PASS"
 
@@ -95,7 +95,7 @@ short-integration-test:
 action-test:
 	@echo " TEST sudo go test [action]"
 	$(V)cd $(SOURCEDIR) && \
-		scripts/go-test -sudo -v -tags 'integration_test' \
+		scripts/go-test -sudo -v -tags 'integration_test' $(GO_RACE) \
 		-run TestSingularityActions ./cmd/singularity \
 		-args -skip-overlay
 	@echo "       PASS"
@@ -106,7 +106,7 @@ test:
 	$(V)M=0; eval 'while [ $$M -le 20 ]; do sleep 60; M=`expr $$M + 1`; echo "Still testing ($$M) ..."; done &' ; \
     	trap "kill $$! || true" 0; \
 		cd $(SOURCEDIR) && \
-		scripts/go-test -sudo -v -tags 'integration_test' \
+		scripts/go-test -sudo -v -tags 'integration_test' $(GO_RACE) \
 		./...
 	@echo "       PASS"
 

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -5,11 +5,15 @@ GO_TAGS_SUID := containers_image_openpgp sylog singularity_engine fakeroot_engin
 GO_LDFLAGS :=
 # Need to use non-pie build on ppc64le
 # https://github.com/hpcng/singularity/issues/5762
+# Need to disable race detector on ppc64le
+# https://github.com/hpcng/singularity/issues/5914
 uname_m := $(shell uname -m)
 ifeq ($(uname_m),ppc64le)
 GO_BUILDMODE := -buildmode=default
+GO_RACE :=
 else
 GO_BUILDMODE := -buildmode=pie
+GO_RACE := -race
 endif
 GO_GCFLAGS := -gcflags=github.com/sylabs/singularity/...="-trimpath $(SOURCEDIR)=>github.com/sylabs/singularity@v0.0.0"
 GO_ASMFLAGS := -asmflags=github.com/sylabs/singularity/...="-trimpath $(SOURCEDIR)=>github.com/sylabs/singularity@v0.0.0"

--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -129,7 +129,6 @@ rc=0
 	-timeout=30m \
 	-tags "${GO_TAGS}" \
 	-cover \
-	-race \
 	${sudo_exec} \
 	"$@" ||
 rc=$?


### PR DESCRIPTION
Closes #5914

On ppc64le the e2e tests will fail if run with -race under Go 1.14 or
1.15.

They worked correctly with Go 1.13, but newer versions cause the CGO
init() method to be called twice if -race is used, the latter time unprivileged... so
it fails. Not clear why this happens. Only on ppc64le, not amd64 or
arm64.