### PR TITLE
Wrap e2e.PrepRegistry in a subtest

### DIFF
--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -153,7 +153,9 @@ func Run(t *testing.T) {
 	// the Singularity instance directory we *must* now call it before we
 	// start running tests which could use instance and oci functionality.
 	// See: https://github.com/hpcng/singularity/issues/5744
-	e2e.PrepRegistry(t, testenv)
+	t.Run("PrepRegistry", func(t *testing.T) {
+		e2e.PrepRegistry(t, testenv)
+	})
 	// e2e.KillRegistry is called here to ensure that the registry
 	// is stopped after tests run.
 	defer e2e.KillRegistry(t, testenv)


### PR DESCRIPTION
Closes #5916

When the registry prep fails, e.g. on ppc64le where no docker registry container is available, we should not fail the entire suite. Specific tests requiring the unavailable registry will skip.