### PR TITLE
DRAFT - Proof of concept nvidia-container-cli work

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -374,6 +374,19 @@ static void set_rpc_privileges(void) {
     priv->capabilities.bounding = capflag(CAP_SYS_ADMIN);
     priv->capabilities.bounding |= capflag(CAP_IPC_LOCK);
     priv->capabilities.bounding |= capflag(CAP_MKNOD);
+    /* required by nvidia-container-cli */
+    priv->capabilities.bounding |= capflag(CAP_CHOWN);
+    priv->capabilities.bounding |= capflag(CAP_DAC_OVERRIDE);
+    priv->capabilities.bounding |= capflag(CAP_DAC_READ_SEARCH);
+    priv->capabilities.bounding |= capflag(CAP_FOWNER);
+    priv->capabilities.bounding |= capflag(CAP_KILL);
+    priv->capabilities.bounding |= capflag(CAP_MKNOD);
+    priv->capabilities.bounding |= capflag(CAP_SETGID);
+    priv->capabilities.bounding |= capflag(CAP_SETPCAP);
+    priv->capabilities.bounding |= capflag(CAP_SETUID);
+    priv->capabilities.bounding |= capflag(CAP_SYS_CHROOT);
+    priv->capabilities.bounding |= capflag(CAP_SYS_PTRACE);
+    
 
     debugf("Set RPC privileges\n");
     apply_privileges(priv, current);

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -130,6 +130,14 @@ type WriteFileArgs struct {
 	Perm     os.FileMode
 }
 
+// NVContainer defines the arguments to NVContainer.
+type NVContainerArgs struct {
+	PathEnv    string
+	Flags      []string
+	RootFsPath string
+	RunAsRoot  bool
+}
+
 // FileInfo returns FileInfo interface to be passed as RPC argument.
 func FileInfo(fi os.FileInfo) os.FileInfo {
 	return &fileInfo{

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -235,3 +235,14 @@ func (t *RPC) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	}
 	return t.Client.Call(t.Name+".WriteFile", arguments, nil)
 }
+
+// NVContainer calls 'nvidia-container-cli configure' to setup GPU devs/libs
+func (t *RPC) NVContainer(pathEnv string, flags []string, rootFsPath string, runAsRoot bool) error {
+	arguments := &args.NVContainerArgs{
+		PathEnv:    pathEnv,
+		Flags:      flags,
+		RootFsPath: rootFsPath,
+		RunAsRoot:  runAsRoot,
+	}
+	return t.Client.Call(t.Name+".NVContainer", arguments, nil)
+}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -137,6 +137,7 @@ type JSONConfig struct {
 	WritableTmpfs     bool              `json:"writableTmpfs,omitempty"`
 	Contain           bool              `json:"container,omitempty"`
 	Nv                bool              `json:"nv,omitempty"`
+	NvContainer       bool              `json:"nvContainer,omitempty"`
 	Rocm              bool              `json:"rocm,omitempty"`
 	CustomHome        bool              `json:"customHome,omitempty"`
 	Instance          bool              `json:"instance,omitempty"`
@@ -220,6 +221,16 @@ func (e *EngineConfig) SetNv(nv bool) {
 // GetNv returns if nv flag is set or not.
 func (e *EngineConfig) GetNv() bool {
 	return e.JSON.Nv
+}
+
+// SetNvContainer sets nvcontainer flag to use nvidia-container-cli for CUDA setup
+func (e *EngineConfig) SetNvContainer(nvContainer bool) {
+	e.JSON.NvContainer = nvContainer
+}
+
+// GetNvContainer returns if nv flag is set or not.
+func (e *EngineConfig) GetNvContainer() bool {
+	return e.JSON.NvContainer
 }
 
 // SetRocm sets rocm flag to bind rocm libraries into containee.JSON.

--- a/pkg/util/gpu/nvidia.go
+++ b/pkg/util/gpu/nvidia.go
@@ -71,6 +71,12 @@ func NvidiaIpcsPath(envPath string) []string {
 	return nvidiaFiles
 }
 
+// HasNvidiaContainerCli returns true if `nvidia-container-cli` is available.
+func HasNvidiaContainerCli() bool {
+	_, err := exec.LookPath("nvidia-container-cli")
+	return err == nil
+}
+
 // nvidiaContainerCli runs `nvidia-container-cli list` and returns list of
 // libraries, ipcs and binaries for proper NVIDIA work. This may return duplicates!
 func nvidiaContainerCli(args ...string) ([]string, error) {


### PR DESCRIPTION
This is a draft proof of concept for directly using `nvidia-container-cli` to setup device and library binding for NVIDIA GPUs.

Intention is to be able to match the functionality available with the docker nvidia-runtime by using the upstream tooling, and respecting its env vars etc.

This is currently a very very rough hacky proof of concept... but you can currently do this:

```
ubuntu@ip-172-31-46-249:~$ singularity run --nv sandbox
INFO:    using nvidia-container-cli POC. Skipping direct binds
INFO:    Using nvidia-container-cli for GPU setup
INFO:    Setting --writable-tmpfs (required by nvidia-container-cli)

Singularity> mount | grep nvidia
tmpfs on /proc/driver/nvidia type tmpfs (rw,nosuid,nodev,noexec,relatime,mode=555,uid=1000,gid=1000)
/dev/nvme0n1p1 on /usr/bin/nvidia-smi type ext4 (ro,nosuid,nodev,relatime,discard)
/dev/nvme0n1p1 on /usr/bin/nvidia-debugdump type ext4 (ro,nosuid,nodev,relatime,discard)
/dev/nvme0n1p1 on /usr/bin/nvidia-persistenced type ext4 (ro,nosuid,nodev,relatime,discard)
/dev/nvme0n1p1 on /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.450.80.02 type ext4 (ro,nosuid,nodev,relatime,discard)
/dev/nvme0n1p1 on /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.450.80.02 type ext4 (ro,nosuid,nodev,relatime,discard)
udev on /dev/nvidiactl type devtmpfs (ro,nosuid,noexec,relatime,size=8033176k,nr_inodes=2008294,mode=755)

Singularity> nvidia-smi
Tue Apr 13 21:45:23 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 450.80.02    Driver Version: 450.80.02    CUDA Version: N/A      |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla T4            On   | 00000000:00:1E.0 Off |                    0 |
| N/A   27C    P8     9W /  70W |      0MiB / 15109MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```

**2020-04-14**

Now the basics here are working with SIFs or writable sandboxes (explicit or implicit) in userns mode:

```
ubuntu@ip-172-31-46-249:~$ singularity run --nv cuda_11.2.2-base-centos7.sif nvidia-smi | grep Tesla
INFO:    using nvidia-container-cli POC. Skipping direct binds
INFO:    Using nvidia-container-cli for GPU setup
INFO:    Setting --writable-tmpfs (required by nvidia-container-cli)
|   0  Tesla T4            On   | 00000000:00:1E.0 Off |                    0 |

ubuntu@ip-172-31-46-249:~$ singularity run -u --writable --nv cuda_11.2.2-base-centos7.sif nvidia-smi | grep Tesla
INFO:    using nvidia-container-cli POC. Skipping direct binds
INFO:    Using nvidia-container-cli for GPU setup
INFO:    Converting SIF file to temporary sandbox...
|   0  Tesla T4            On   | 00000000:00:1E.0 Off |                    0 |
INFO:    Cleaning up image...
```



