### PR TITLE
Remove TestSelfTest integration test

### DIFF
--- a/cmd/singularity/cli_test.go
+++ b/cmd/singularity/cli_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/sylabs/singularity/internal/pkg/buildcfg"
-	"github.com/sylabs/singularity/internal/pkg/test"
 )
 
 var (
@@ -26,23 +25,6 @@ var (
 )
 
 var runDisabled = flag.Bool("run_disabled", false, "run tests that have been temporarily disabled")
-
-func TestSelfTest(t *testing.T) {
-	test.DropPrivilege(t)
-	defer test.ResetPrivilege(t)
-
-	// We always prefer to run tests with a clean temporary image cache rather
-	// than using the cache of the user running the test.
-	// In order to unit test using the singularity cli that is thread-safe,
-	// we prepare a temporary cache that the process running the command will
-	// use.
-	cmd := exec.Command(cmdPath, "selftest")
-	setupCmdCache(t, cmd, "image-cache")
-	if b, err := cmd.CombinedOutput(); err == nil {
-		t.Log(string(b))
-		t.Fatal("unexpected success running selftest")
-	}
-}
 
 func run(m *testing.M) int {
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

`singularity selftest` was a command in previous versions of
Singularity. A test for it was ported over 3 years ago, but the
command never was. The test that is being removed here expects
`singularity selftest` to fail. It doesn't need to go across to the
e2e suite, as I don't believe there are any plans to implement
`singularity selftest` in 3.x.

### This fixes or addresses the following GitHub issues:

 - Part of #5830 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

