### PR TITLE
fix: wait for cryptsetup /dev/mapper device to appear

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@
     - Thomas Hamel <hmlth@t-hamel.fr>
     - Tim Wright <7im.Wright@protonmail.com>
     - Tru Huynh <tru@pasteur.fr>
+    - Tyson Whitehead <twhitehead@gmail.com>
     - Vanessa Sochat <vsochat@stanford.edu>
     - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>
     - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -306,6 +306,9 @@ func (crypt *Device) Open(key []byte, path string) (string, error) {
 			if err == nil {
 				break
 			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return "", err
+			}
 			delay := 100 * (1 << attempt) * time.Millisecond
 			if delay > 12800*time.Millisecond {
 				return "", fmt.Errorf("device /dev/mapper/%s did not show up within %d seconds", nextCrypt, (delay-1)/time.Second)

--- a/pkg/util/crypt/crypt_dev.go
+++ b/pkg/util/crypt/crypt_dev.go
@@ -309,11 +309,12 @@ func (crypt *Device) Open(key []byte, path string) (string, error) {
 			if !errors.Is(err, os.ErrNotExist) {
 				return "", err
 			}
-			delay := 100 * (1 << attempt) * time.Millisecond
-			if delay > 12800*time.Millisecond {
-				return "", fmt.Errorf("device /dev/mapper/%s did not show up within %d seconds", nextCrypt, (delay-1)/time.Second)
+			delayNext := 100 * (1 << attempt) * time.Millisecond // power of two exponential back off means
+			delaySoFar := delayNext - 1                          // total delay so far is next delay - 1
+			if delaySoFar >= 25500*time.Millisecond {
+				return "", fmt.Errorf("device /dev/mapper/%s did not show up within %d seconds", nextCrypt, delaySoFar/time.Second)
 			}
-			time.Sleep(delay)
+			time.Sleep(delayNext)
 		}
 
 		sylog.Debugf("Successfully opened encrypted device %s", path)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The device `/dev/mapper/...` does not show up before `cryptsetup` returns. This creates a race condition as, if singularity attempts to mount `/dev/mapper/...`, before it shows up, it fails.

This pull request causes singularity to wait up to 25.5s for `/dev/mapper/...` to show up, through a series of exponential back off sleeps, before continuing. If it doesn't show up in that time it will abort with an error.

### This fixes or addresses the following GitHub issues:

 - Fixes #5950

#### Before submitting a PR, make sure you have done the following:

- [X] Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- [X] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- [X] Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- [X] Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
