### PR TITLE
Implement a copy-through ProgressCallback for silent loglevels

### DIFF
--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -26,7 +26,10 @@ type ProgressCallback func(int64, io.Reader, io.Writer) error
 func ProgressBarCallback(ctx context.Context) ProgressCallback {
 
 	if sylog.GetLevel() <= -1 {
-		return nil
+		// If we don't need a bar visible, we just copy data through the callback func
+		return func(totalSize int64, r io.Reader, w io.Writer) error {
+			return CopyWithContext(ctx, w, r)
+		}
 	}
 
 	return func(totalSize int64, r io.Reader, w io.Writer) error {

--- a/internal/pkg/client/progress_test.go
+++ b/internal/pkg/client/progress_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sylabs/singularity/pkg/sylog"
+)
+
+func TestProgressCallback(t *testing.T) {
+	const input = "Hello World!"
+	ctx := context.Background()
+
+	// Check the progress bar, or invisible copy-through, works at all sylog
+	// levels
+
+	levels := []int{
+		int(sylog.DebugLevel),
+		int(sylog.VerboseLevel),
+		int(sylog.InfoLevel),
+		int(sylog.WarnLevel),
+		int(sylog.ErrorLevel),
+		int(sylog.FatalLevel),
+	}
+
+	for _, l := range levels {
+		t.Run(fmt.Sprintf("level%d", l), func(t *testing.T) {
+			sylog.SetLevel(l, true)
+
+			cb := ProgressBarCallback(ctx)
+			src := bytes.NewBufferString(input)
+			dst := bytes.Buffer{}
+
+			err := cb(int64(len(input)), src, &dst)
+			if err != nil {
+				t.Errorf("Unexpected error from ProgressCallBack: %v", err)
+			}
+
+			output := dst.String()
+			if output != input {
+				t.Errorf("Output from callback '%s' != input '%s'", output, input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

A nil ProgressCallback is returned for silent / quiet loglevels which
leads to a panic when this is blindly used by image download clients
(shub / net).

To avoid having to check for a nil callback and behave differently in
the client code, return a callback that does a straight copy-through in
these cases.

### This fixes or addresses the following GitHub issues:

 - Fixes #5924 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
