### PR TITLE
fix: respect proxy on keyserver operations

### DIFF
--- a/internal/pkg/remote/endpoint/keyserver.go
+++ b/internal/pkg/remote/endpoint/keyserver.go
@@ -213,7 +213,10 @@ var defaultClient = &http.Client{
 	Timeout: 5 * time.Second,
 	Transport: &http.Transport{
 		DisableKeepAlives: true,
-		TLSClientConfig:   &tls.Config{},
+		// Note - when overriding transport we need to explicitly setup the
+		// proxy parsing from env vars that http.DefaultTransport does.
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{},
 	},
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When creating an http.Client with a custom Transport, we need to
manually setup the env var proxy handling that the http.DefaultTransport
provides normally.

You can test the proxy is now respected by setting an invalid proxy and noting that the error shows it is being used:

```
03:24 PM $ export https_proxy=https://foo

03:24 PM $ singularity key search bob
ERROR:   search failed: failed to get key: Get "https://keys.sylabs.io/pks/lookup?fingerprint=on&op=index&options=mr&search=bob&x-pagesize=256": Get "https://keys.sylabs.io/pks/lookup?fingerprint=on&op=index&options=mr&search=bob&x-pagesize=256": proxyconnect tcp: dial tcp: lookup foo: no such host
```

### This fixes or addresses the following GitHub issues:

 - Fixes #5876 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)
