### PR TITLE
Spelling mistake in api.go

### DIFF
--- a/internal/pkg/client/shub/api.go
+++ b/internal/pkg/client/shub/api.go
@@ -22,7 +22,7 @@ const (
 	defaultRegistry string = `https://singularity-hub.org`
 	shubAPIRoute    string = "/api/container/"
 	// URINotSupported if we are using a non default registry error out for now
-	URINotSupported string = "Only the default Singularity Hub registry is suported for now"
+	URINotSupported string = "Only the default Singularity Hub registry is supported for now"
 )
 
 // URI stores the various components of a singularityhub URI


### PR DESCRIPTION
Just noticed a tiny spelling mistake and it bothered me enough to open a PR :P

