### PR TITLE
Allow escaping commas and colons in source bind path with the followi…

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -84,7 +84,7 @@ var actionAppFlag = cmdline.Flag{
 var actionBindFlag = cmdline.Flag{
 	ID:           "actionBindFlag",
 	Value:        &BindPaths,
-	DefaultValue: []string{},
+	DefaultValue: cmdline.StringArray{}, // to allow commas in bind path
 	Name:         "bind",
 	ShortHand:    "B",
 	Usage:        "a user-bind path specification.  spec has the format src[:dest[:opts]], where src and dest are outside and inside paths.  If dest is not given, it is set equal to src.  Mount options ('opts') may be specified as 'ro' (read-only) or 'rw' (read/write, which is the default). Multiple bind paths can be given by a comma separated list.",

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -408,7 +408,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		img.File.Close()
 	}
 
-	binds, err := singularityConfig.ParseBindPath(strings.Join(BindPaths, ","))
+	binds, err := singularityConfig.ParseBindPath(BindPaths)
 	if err != nil {
 		sylog.Fatalf("while parsing bind path: %s", err)
 	}

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -22,6 +22,8 @@ const (
 	Linux = "linux"
 )
 
+type StringArray []string
+
 // Flag holds information about a command flag
 type Flag struct {
 	ID           string
@@ -92,6 +94,8 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 		m.registerStringVar(flag, cmds)
 	case []string:
 		m.registerStringSliceVar(flag, cmds)
+	case StringArray:
+		m.registerStringArrayVar(flag, cmds)
 	case bool:
 		m.registerBoolVar(flag, cmds)
 	case int:
@@ -123,6 +127,18 @@ func (m *flagManager) registerStringSliceVar(flag *Flag, cmds []*cobra.Command) 
 			c.Flags().StringSliceVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, flag.DefaultValue.([]string), flag.Usage)
 		} else {
 			c.Flags().StringSliceVar(flag.Value.(*[]string), flag.Name, flag.DefaultValue.([]string), flag.Usage)
+		}
+		m.setFlagOptions(flag, c)
+	}
+	return nil
+}
+
+func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) error {
+	for _, c := range cmds {
+		if flag.ShortHand != "" {
+			c.Flags().StringArrayVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, ([]string)(flag.DefaultValue.(StringArray)), flag.Usage)
+		} else {
+			c.Flags().StringArrayVar(flag.Value.(*[]string), flag.Name, ([]string)(flag.DefaultValue.(StringArray)), flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow escaping commas and colons in source bind path with the following syntax:

- `singularity shell -B /tmp/comma\\,separated_dir:/data image`
- `singularity shell -B "/tmp/comma\,separated_dir":/data image`
- `singularity shell -B /tmp/colon\\:sep_dir:/data image`
- `singularity shell -B "/tmp/colon\:sep_dir":/data image`

### This fixes or addresses the following GitHub issues:

- Fixes #5923
- Fixes #5959


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
