### PR TITLE
Some updates to make the debian packageing work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ build/*
 runtime/cli
 
 pkg/library/client/test[0-9]*
+
+debian

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,3 +161,7 @@ $ make -C builddir rpm RPMPREFIX=/usr/local
 
 For more information on installing/updating/uninstalling the RPM, check out our 
 [admin docs](https://singularity.hpcng.org/admin-docs/master/admin_quickstart.html).
+
+## Debian Package
+
+Additional information on how to build a Debian package can be found in [dist/debian/DEBIAN_PACKAGE.md](dist/debian/DEBIAN_PACKAGE.md).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,6 +162,8 @@ $ make -C builddir rpm RPMPREFIX=/usr/local
 For more information on installing/updating/uninstalling the RPM, check out our 
 [admin docs](https://singularity.hpcng.org/admin-docs/master/admin_quickstart.html).
 
+## Debian Package
+
 Additional information on [how to build a Debian package](dist/debian/DEBIAN_PACKAGE.md) can be 
 found in `dist/debian`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,7 +161,3 @@ $ make -C builddir rpm RPMPREFIX=/usr/local
 
 For more information on installing/updating/uninstalling the RPM, check out our 
 [admin docs](https://singularity.hpcng.org/admin-docs/master/admin_quickstart.html).
-
-## Debian Package
-
-Additional information on how to build a Debian package can be found in [dist/debian/DEBIAN_PACKAGE.md](dist/debian/DEBIAN_PACKAGE.md).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,3 +161,7 @@ $ make -C builddir rpm RPMPREFIX=/usr/local
 
 For more information on installing/updating/uninstalling the RPM, check out our 
 [admin docs](https://singularity.hpcng.org/admin-docs/master/admin_quickstart.html).
+
+Additional information on [how to build a Debian package](dist/debian/DEBIAN_PACKAGE.md) can be 
+found in `dist/debian`.
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,6 +164,4 @@ For more information on installing/updating/uninstalling the RPM, check out our
 
 ## Debian Package
 
-Additional information on [how to build a Debian package](dist/debian/DEBIAN_PACKAGE.md) can be 
-found in `dist/debian`.
-
+Additional information on how to build a Debian package can be found in [dist/debian/DEBIAN_PACKAGE.md](dist/debian/DEBIAN_PACKAGE.md).

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -1,7 +1,7 @@
-# creating the Debian package
+# Creating the Debian package
 
 ## Preparation
-As long as the debian directory is in the subdirectroy you need to link
+As long as the debian directory is in the sub-directory you need to link
 or copy it in the top directory.
 
 In the top directory do this:
@@ -23,8 +23,11 @@ configuration variables need to be prefixed by `DEB_`
 See `mconfig --help` for details about the configuration options.
 
 `export DEB_NOSUID=1`    adds --without-suid
+
 `export DEB_NONETWORK=1` adds --without-network
+
 `export DEB_NOSECCOMP=1` adds --without-seccomp
+
 `export DEB_NOALL=1`     adds all of the above
 
 To select a specific profile for `mconfig`.
@@ -33,7 +36,7 @@ For real production environment us this configuration:
 ```
 export DEB_SC_PROFILE=release-stripped
 ```
-or if debuging is needed use this.
+or if debugging is needed use this.
 ```
 export DEB_SC_PROFILE=debug
 ```
@@ -59,8 +62,8 @@ Usually `debchange` is configured by the environment variables `DEBFULLNAME` and
 `EMAIL`. As `debuild` creates a clean environment it filters out most of the 
 environment variables. To set `DEBFULLNAME` for the `debchange` command in the 
 makefile, you have to set `DEB_FULLNAME`. If these variables are not set, `debchange`
-will try to find appropriate values from the system config. Usually by using the
-login name and the domainname. 
+will try to find appropriate values from the system configuration. Usually by using the
+login name and the domain-name. 
 ```
 export DEB_FULLNAME="Your Name"
 export EMAIL="you@example.org"
@@ -80,5 +83,5 @@ or all in one
 debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
 ```
 
-For details see the manpage of `debuild` and `dpkg-buildpackage` and `lintian`
+For details see the man-page of `debuild` and `dpkg-buildpackage` and `lintian`
 

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -83,5 +83,7 @@ or all in one
 debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
 ```
 
+After successful build the debian package can be found in the parent directory. 
+
 For details see the man-page of `debuild` and `dpkg-buildpackage` and `lintian`
 

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -6,7 +6,8 @@ or copy it in the top directory.
 
 In the top directory do this:
 ```
-ln -s dist/debian .
+rm -rf debian
+cp -r dist/debian .
 ```
 
 Make sure all the dependencies are met. See the `INSTALL.md` for this. 

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -1,0 +1,84 @@
+# creating the Debian package
+
+## Preparation
+As long as the debian directory is in the subdirectroy you need to link
+or copy it in the top directory.
+
+In the top directory do this:
+```
+ln -s dist/debian .
+```
+
+Make sure all the dependencies are met. See the `INSTALL.md` for this. 
+Otherwise `debuild` will complain and quit. 
+
+## Configuration
+To do some configuration for the build, some environment variables can
+be used.
+
+Due to the fact, that `debuild` filters out some variables, all the
+configuration variables need to be prefixed by `DEB_`
+
+### mconfig
+See `mconfig --help` for details about the configuration options.
+
+`export DEB_NOSUID=1`    adds --without-suid
+`export DEB_NONETWORK=1` adds --without-network
+`export DEB_NOSECCOMP=1` adds --without-seccomp
+`export DEB_NOALL=1`     adds all of the above
+
+To select a specific profile for `mconfig`.
+
+For real production environment us this configuration:
+```
+export DEB_SC_PROFILE=release-stripped
+```
+or if debuging is needed use this.
+```
+export DEB_SC_PROFILE=debug
+```
+
+In case a different build directory is needed:
+```
+export DEB_SC_BUILDDIR=builddir
+```
+
+### debchange
+One way to update the changelog would be that the developer of singularity 
+update the Debian changelog on every commit. As this is double work, because
+of the CHANGELOG.md in the top directory, the changelog is automatically 
+updated with the version of the source which is currently checked out.
+Which means you can easily build debian packages for all the different tagged
+versions of the software. See `INSTALL.md` on how to checkout a specific 
+version. 
+
+Be aware, that `debchange` will complain about a lower version as the top in
+the current changelog. Which means you have to cleanup the changelog if needed.
+
+Usually `debchange` is configured by the environment variables `DEBFULLNAME` and 
+`EMAIL`. As `debuild` creates a clean environment it filters out most of the 
+environment variables. To set `DEBFULLNAME` for the `debchange` command in the 
+makefile, you have to set `DEB_FULLNAME`. If these variables are not set, `debchange`
+will try to find appropriate values from the system config. Usually by using the
+login name and the domainname. 
+```
+export DEB_FULLNAME="Your Name"
+export EMAIL="you@example.org"
+```
+
+## Building
+As usual for creating a debian package you can use `dpkg-buildpackage` 
+or `debuild` which is a kind of wrapper for the first and includes the start
+of `lintian`, too. 
+
+```
+dpkg-buildpackage --build=binary --no-sign
+lintian --verbose --display-info --show-overrides
+```
+or all in one
+```
+debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
+```
+
+For details see the manpage of `debuild` and `dpkg-buildpackage` and `lintian`
+

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -52,12 +52,17 @@ One way to update the changelog would be that the developer of singularity
 update the Debian changelog on every commit. As this is double work, because
 of the CHANGELOG.md in the top directory, the changelog is automatically 
 updated with the version of the source which is currently checked out.
-Which means you can easily build debian packages for all the different tagged
+Which means you can easily build Debian packages for all the different tagged
 versions of the software. See `INSTALL.md` on how to checkout a specific 
 version. 
 
 Be aware, that `debchange` will complain about a lower version as the top in
 the current changelog. Which means you have to cleanup the changelog if needed.
+If you did not change anything in the debian directory manually, it might be easiest
+to [start from scratch](#Preparation).
+Be aware, that the Debian install directory as you see it now, might not be available
+in older versions (branches, tags). Make sure you have a clean copy of the debian
+directory before you switch to (checkout) an older version.
 
 Usually `debchange` is configured by the environment variables `DEBFULLNAME` and 
 `EMAIL`. As `debuild` creates a clean environment it filters out most of the 
@@ -71,7 +76,7 @@ export EMAIL="you@example.org"
 ```
 
 ## Building
-As usual for creating a debian package you can use `dpkg-buildpackage` 
+As usual for creating a Debian package you can use `dpkg-buildpackage`
 or `debuild` which is a kind of wrapper for the first and includes the start
 of `lintian`, too. 
 
@@ -84,12 +89,25 @@ or all in one
 debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
 ```
 
-After successful build the debian package can be found in the parent directory. 
+After successful build the Debian package can be found in the parent directory.
 
 To clean up the temporary files created by `debuild` use the command:
 ```
 dh clean
 ```
+To cleanup the copy of the debian directory, make sure you saved your changes (if any) and remove it.
+```
+rm -rf debian
+```
 
-For details see the man-page of `debuild` and `dpkg-buildpackage` and `lintian`
+For details on Debian package building see the man-page of `debuild` and `dpkg-buildpackage` and `lintian`
+
+# Debian Repository
+In the current version this is by far not ready for using it in official Debian Repositories.
+
+This might change in future. I updated the old debian directory to make it just work, for people
+needing it.
+
+Any help is welcome to provide a Debian installer which can be used for building a Debian package,
+that can be used in official Debian Repositories.
 

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -85,5 +85,10 @@ debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
 
 After successful build the debian package can be found in the parent directory. 
 
+To clean up the temporary files created by `debuild` use the command:
+```
+dh clean
+```
+
 For details see the man-page of `debuild` and `dpkg-buildpackage` and `lintian`
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -23,7 +23,7 @@ Vcs-Browser: https://github.com/hpcng/singularity
 
 # "singularity" is a packaged game (but the contents don't clash)
 Package: singularity-container
-Architecture: amd64
+Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, python, squashfs-tools
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -15,6 +15,7 @@ Build-Depends:
  libssl-dev,
  python,
  uuid-dev,
+ golang-go (>= 2:1.13)
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity
 Vcs-Git: https://github.com/hpcng/singularity.git
@@ -22,7 +23,7 @@ Vcs-Browser: https://github.com/hpcng/singularity
 
 # "singularity" is a packaged game (but the contents don't clash)
 Package: singularity-container
-Architecture: any
+Architecture: amd64
 Depends: ${misc:Depends}, ${shlibs:Depends}, python, squashfs-tools
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -1,37 +1,88 @@
 #!/usr/bin/make -f
 
-srcpkg = $(shell LC_ALL=C dpkg-parsechangelog | grep '^Source:' | cut -d ' ' -f 2,2)
-debver = $(shell LC_ALL=C dpkg-parsechangelog | grep '^Version:' | cut -d ' ' -f 2,2 )
-uver = $(shell echo $(debver) | cut -d '-' -f 1,1 )
+pkgsrc = $(shell LC_ALL=C dpkg-parsechangelog --show-field Source )
+pkgver = $(shell LC_ALL=C dpkg-parsechangelog --show-field Version )
 
+# Needed by debchange to set Name and EMAIL in changelog
+# DEBFULLNAME is filtered out by debuild
+# use DEB_FULLNAME instead, which will set DEBFULLNAME
+ifdef DEB_FULLNAME
+export DEBFULLNAME=$(DEB_FULLNAME)
+endif
+# DEBEMAIL is not filtered out by debuild 
+
+# request verbose debhelper here or from environment
 #DH_VERBOSE=1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-PKGDIR=debian/singularity-container
-export SINGULARITY_CACHEDIR=$(PKGDIR)/var/lib/singularity/cache
+# if verbose is requested do mconfig in verbose mode, too.
+ifdef DH_VERBOSE
+SC_VERBOSE = -v
+endif
+
+# get version via script
+SC_VERSION = $(shell scripts/get-version )
+NEW_VERSION = $(shell dpkg --compare-versions $(SC_VERSION) gt $(pkgver) && echo $(SC_VERSION) )
+
+# these can be overwritten by environment variables
+DEB_SC_PROFILE ?= release
+DEB_SC_BUILDDIR ?= builddir
+
+# see mconfig for options
+# set environemnt variables to disable options
+# NOALL, NOSUID, NONETWORK, NOSECCOMP
+SC_OPTIONS =
+ifdef DEB_NOALL
+SC_OPTIONS = --without-suid --without-network --without-seccomp
+else
+ifdef DEB_NOSUID
+SC_OPTIONS += --without-suid
+endif
+ifdef DEB_NONETWORK
+SC_OPTIONS += --without-network
+endif
+ifdef DEB_NOSECCOMP
+SC_OPTIONS += --without-seccomp
+endif
+endif
+
+MAKEPARALLEL = $(shell nproc --ignore=2 || echo 1 )
+override pkgdir = debian/$(pkgsrc)
+
+export SINGULARITY_CACHEDIR=$(pkgdir)/var/lib/singularity/cache
 
 %:
-	dh $@  --with autoreconf
+	dh $@  --with=autoreconf
 
 override_dh_auto_configure:
-	dh_auto_configure -- --localstatedir=/var/lib
+ifneq ($(NEW_VERSION),)
+	$(warning "Setting new version in debian changelog: $(NEW_VERSION)")
+	@debchange -v $(NEW_VERSION)$(VERSION_POSTFIX) "Version $(NEW_VERSION)" && debchange -m -r ""
+endif
+	@./mconfig $(SC_VERBOSE) -b $(DEB_SC_BUILDDIR) -P $(DEB_SC_PROFILE) $(SC_OPTIONS) \
+                --prefix=/usr --sysconfdir=/etc --localstatedir=/var/lib
+
+override_dh_auto_build:
+	@dh_auto_build -Smakefile --parallel --max-parallel=$(MAKEPARALLEL) -D$(DEB_SC_BUILDDIR)
 
 override_dh_auto_install:
-	dh_auto_install
-	: # move bash completions into now new standard location
-	mv $(PKGDIR)/etc/bash_completion.d $(PKGDIR)/usr/share/bash-completion/completions
+	@dh_auto_install -Smakefile -D$(DEB_SC_BUILDDIR)
+	@mv $(pkgdir)/etc/bash_completion.d $(pkgdir)/usr/share/bash-completion/completions
 
 override_dh_installman:
 	: # Very sloppy man pages for now
-	debian/generate_manpages $(PKGDIR) $(debver)
-	dh_installman
-
-override_dh_installdocs:
-	dh_installdocs README.md CONTRIBUTORS.md
+	@chmod 755 $(pkgdir)/usr/bin/run-singularity
+	@debian/generate_manpages $(pkgdir) $(pkgver)
+	@dh_installman
 
 override_dh_auto_test:
 
 override_dh_fixperms:
-	dh_fixperms
-	chown root.root $(PKGDIR)/usr/lib/*/singularity/bin/*
-	chmod 4755 $(PKGDIR)/usr/lib/*/singularity/bin/*-suid
+	@dh_fixperms
+	@chmod 4755 $(pkgdir)/usr/libexec/singularity/bin/*-suid
+
+override_dh_clean:
+	@rm -rf -- $(DEB_SC_BUILDDIR)
+	@dh_clean
+
+# vim:ft=make:noet:sts=0

--- a/dist/debian/singularity-container.lintian-overrides
+++ b/dist/debian/singularity-container.lintian-overrides
@@ -1,2 +1,3 @@
 # Singularity requires root suid for operation
-singularity-container: setuid-binary usr/lib/*/singularity/sexec-suid 4755 root/root
+singularity-container: setuid-binary usr/libexec/singularity/bin/starter-suid 4755 root/root
+


### PR DESCRIPTION
## Updates to make debuild work again.

Because the directory was moved to the subdir dist, it is needed
to copy the directory to the top directory or set a link
before running debuild.

As usual the command for building the debian package is:
```
debuild -b -us -uc
```
To make it configurable some environment variables can be set.
Due to the fact, that debuild filters out some variables, all the
configuration variables need to be prefixed by DEB_

First the changelog file is updated with the current version. 
To configure the fullname and email available in the changelog
message set the environment variables:
```
export DEBFULLNAME="Your Name"
export DEB_FULLNAME=${DEBFULLNAME}
export EMAIL=<your email>
```
options for mconfig, by setting the environment variables:
`DEB_NOSUID=1 `   adds --without-suid
`DEB_NONETWORK=1` adds --without-network
`DEB_NOSECCOMP=1` adds --without-seccomp
`DEB_NOALL=1`     adds all of the above

To select a specific profile for mconfig:
```
export DEB_SC_PROFILE=release-stripped
```
or
```
export DEB_SC_PROFILE=debug
```
The builddir can be specified with this:
```
export DEB_SC_BUILDDIR=builddir
```
Currently no other config options can be set via environment,
but it would be easy to add them if needed.

I used as much as possible from the existing rules file for this
first step.

In the control file I added a build dependency to golang and changed
the architecture to amd64.

I do not expect that it is already perfect, but I hope this helps others in need 
for a debian package of singularity-container.