### PR TITLE
Bump github.com/hpcng/sif from 1.2.2 to 1.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/gorilla/handlers v1.4.0 // indirect
 	github.com/gorilla/websocket v1.4.2
-	github.com/hpcng/sif v1.2.2
+	github.com/hpcng/sif v1.2.3
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kr/pty v1.1.8
 	github.com/opencontainers/go-digest v1.0.0
@@ -57,7 +57,7 @@ require (
 	github.com/yvasiyarov/gorelic v0.0.6 // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hpcng/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9 h1:t8KUun6NE+Kv500O2sNQ6LIFvUz7QX+RJGOVoJFlyHM=
 github.com/hpcng/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9/go.mod h1:YRpvuFxEV8iMqW8qf0+X+dTRn3labfXfykTzp8hRkSg=
-github.com/hpcng/sif v1.2.2 h1:PeZCiTsg8ePkFlIB+msM9DByESXLNHK4XDgmmcd7YGI=
-github.com/hpcng/sif v1.2.2/go.mod h1:8nGk9UGlTor6OwnLyLeCQ9EzJttTwjTvvUynKBlXeHQ=
+github.com/hpcng/sif v1.2.3 h1:GvH4PNfIyCVPIqaVyf3N63VqHDNQmzuMx2fbIJ6aiCI=
+github.com/hpcng/sif v1.2.3/go.mod h1:ADPdhyu6A7HRhgwjiZhuCKy7ADugDlAjzFO6PJ7MfTc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
## Description of the Pull Request (PR):

Increase sif version to 1.2.3.  Equivalent of Sylabs [pr 22](https://github.com/sylabs/singularity/pull/22).


### This fixes or addresses the following GitHub issues:




#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
