### PR TITLE
Do not show keystore URI in newpair confirmation message

### DIFF
--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -110,7 +110,7 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 	fmt.Printf("done\n")
 
 	if !opts.PushToKeyStore {
-		fmt.Printf("NOT pushing newly created key to: %s\n", keyServerURI)
+		fmt.Println("NOT pushing newly created key to keystore")
 		return
 	}
 
@@ -123,7 +123,7 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 	if err := sypgp.PushPubkey(ctx, key, co...); err != nil {
 		fmt.Printf("Failed to push newly created key to keystore: %s\n", err)
 	} else {
-		fmt.Printf("Key successfully pushed to: %s\n", keyServerURI)
+		fmt.Println("Key successfully pushed to keystore")
 	}
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Remove the URI from the message, until we can address the issue by
having the CLI code able to know the true correct URI in all cases.

The real URI to which we are pushing is computed at a lower level, in
remote endpoint handling, than we have access to in the CLI newpair
code. At present it is only correct for the default keystore.

### This fixes or addresses the following GitHub issues:

 - Fixes #5897 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
