### PR TITLE
Add package-version as top level directory in dist tarball

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -21,11 +21,13 @@
 # 
 # 
 
-%define singgopath src/github.com/hpcng/singularity
-
 # Disable debugsource packages; otherwise it ends up with an empty %files
 #   file in debugsourcefiles.list on Fedora
 %undefine _debugsource_packages
+
+# This can be slightly different than %{version}.
+# For example, it has dash instead of tilde for release candidates.
+%define package_version @PACKAGE_VERSION@
 
 Summary: Application and environment virtualization
 Name: singularity
@@ -34,7 +36,7 @@ Release: @PACKAGE_RELEASE@%{?dist}
 # https://spdx.org/licenses/BSD-3-Clause-LBNL.html
 License: BSD-3-Clause-LBNL
 URL: https://singularity.hpcng.org
-Source: %{name}-@PACKAGE_VERSION@.tar.gz
+Source: %{name}-%{package_version}.tar.gz
 ExclusiveOS: linux
 # RPM_BUILD_ROOT wasn't being set ... for some reason
 %if "%{sles_version}" == "11"
@@ -93,12 +95,15 @@ mkdir %{name}-%{version}
 %build
 cd %{name}-%{version}
 
-mkdir -p gopath/%{singgopath}
-tar -C "gopath/src/github.com/hpcng/" -xf "%SOURCE0"
+# Setup an empty GOPATH for the build
+mkdir -p gopath
 
 export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
-cd $GOPATH/%{singgopath}
+
+# Perform the build outside of GOPATH as we are using go modules
+tar -xf "%SOURCE0"
+cd %{name}-%{package_version}
 
 # Not all of these parameters currently have an effect, but they might be
 #  used someday.  They are the same parameters as in the configure macro.
@@ -123,9 +128,12 @@ make old_config=
 %install
 cd %{name}-%{version}
 
+# Setup an empty GOPATH for the build
 export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
-cd $GOPATH/%{singgopath}/builddir
+
+# Enter the source builddir for the install
+cd %{name}-%{package_version}/builddir
 
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 make DESTDIR=$RPM_BUILD_ROOT install man

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -31,6 +31,5 @@ su testuser -c '
   export GOPATH=$BLD/gopath
   PATH=$GOPATH/bin:$PATH
 
-  cd $GOPATH/src/github.com/hpcng/singularity
   singularity exec library://alpine:3.11.5 /bin/true
 '

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -28,7 +28,7 @@ rmfiles="VERSION"
 tarball="${package_name}-${version}.tar.gz"
 echo " DIST create tarball: $tarball"
 rm -f $tarball
-pathtop="$package_name"
+pathtop="${package_name}-${version}"
 ln -sf .. builddir/$pathtop
 rmfiles="$rmfiles builddir/$pathtop"
 trap "rm -f $rmfiles" 0


### PR DESCRIPTION
## Description of the Pull Request (PR):

This changes the top level directory in the distribution tarballs from "singularity" to "singularity-version", to make it consistent with most open source pages.  Sylabs did this in their [pr 25](https://github.com/sylabs/singularity/pull/25) after applying preliminary updates in their [pr 21](https://github.com/sylabs/singularity/pull/21).

### This fixes or addresses the following GitHub issues:

 - Fixes #2215


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
