### PR TITLE
Remove master socket file descriptor from Go netpoll in stage 2 (#5946)

### DIFF
--- a/internal/pkg/runtime/engine/engine_linux.go
+++ b/internal/pkg/runtime/engine/engine_linux.go
@@ -63,7 +63,7 @@ type Operations interface {
 	// No additional privileges can be gained during this call (unless container
 	// is executed as root intentionally) as starter will set uid/euid/suid
 	// to the targetUID (PrepareConfig will set it by calling starter.Config.SetTargetUID).
-	StartProcess(net.Conn) error
+	StartProcess(int) error
 	// PostStartProcess is called from master after successful
 	// execution of the container process.
 	//

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -177,7 +177,7 @@ func fakerootSeccompProfile() *specs.LinuxSeccomp {
 //
 // This will be executed as a fake root user in a new user
 // namespace (PrepareConfig will set both).
-func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
+func (e *EngineOperations) StartProcess(masterConnFd int) error {
 	const (
 		mountInfo    = "/proc/self/mountinfo"
 		selinuxMount = "/sys/fs/selinux"

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -55,7 +54,7 @@ const defaultShell = "/bin/sh"
 // No additional privileges can be gained during this call (unless container
 // is executed as root intentionally) as starter will set uid/euid/suid
 // to the targetUID (PrepareConfig will set it by calling starter.Config.SetTargetUID).
-func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
+func (e *EngineOperations) StartProcess(masterConnFd int) error {
 	// Manage all signals.
 	// Queue them until they're ready to be handled below.
 	// Use a channel size of two here, since we may receive SIGURG, which is
@@ -233,7 +232,7 @@ func (e *EngineOperations) StartProcess(masterConn net.Conn) error {
 		return syscall.Errno(err)
 	}
 
-	masterConn.Close()
+	syscall.Close(masterConnFd)
 
 	for {
 		select {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Based on report from #5946 the issue seems related to the masterConn socket here https://github.com/hpcng/singularity/blob/eb85a9a928a2368a610004d4ad382be9061a452b/internal/pkg/runtime/engine/singularity/process_linux.go#L58
staying open until the container process is executed or closed explicitly, this is a requirement to communicate with the parent process and can only be closed after the execution of the container process.

What happen here is that the stage2 common code create a `net.FileConn` from the master socket descriptor here https://github.com/hpcng/singularity/blob/eb85a9a928a2368a610004d4ad382be9061a452b/internal/app/starter/stage_linux.go#L46
therefore the file descriptor become part of the netpoll fds.

This PR removes master socket file descriptor from Go runtime netpoll by not using `net.FileConn`.

### This fixes or addresses the following GitHub issues:

 - Fixes #5946


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
