### PR TITLE
Support go 1.16, update CI to use go 1.16.4, and add test for go 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-20.04
-    container: golang:1.14
+    container: golang:1.16
     steps:
       - uses: actions/checkout@v2
 
       - name: Check go.mod
         run: ./scripts/check-go.mod
 
-  go114-stretch:
-    name: go114-stretch
+  go116-stretch:
+    name: go116-stretch
     runs-on: ubuntu-20.04
-    container: golang:1.14-stretch
+    container: golang:1.16-stretch
     steps:
       - name: Fetch deps
         run: |
@@ -41,10 +41,10 @@ jobs:
       - name: Check Singularity
         run: make -C ./builddir check
 
-  go114-alpine:
-    name: go114-alpine
+  go116-alpine:
+    name: go116-alpine
     runs-on: ubuntu-20.04
-    container: golang:1.14-alpine
+    container: golang:1.16-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -59,8 +59,8 @@ jobs:
       - name: Check Singularity
         run: make -C ./builddir check
 
-  go114-macos:
-    name: go114-macos
+  go116-macos:
+    name: go116-macos
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.16.4
 
       - name: Build Singularity
         run: |
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.16.4
 
       - name: Fetch deps
         run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.16.4
 
       - name: Fetch deps
         run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -177,7 +177,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.15
+          go-version: 1.16.4
 
       - name: Fetch deps
         if: env.run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Check go.mod
         run: ./scripts/check-go.mod
 
-  go116-stretch:
-    name: go116-stretch
+  debian:
+    name: debian
     runs-on: ubuntu-20.04
     container: golang:1.16-stretch
     steps:
@@ -41,8 +41,8 @@ jobs:
       - name: Check Singularity
         run: make -C ./builddir check
 
-  go116-alpine:
-    name: go116-alpine
+  alpine:
+    name: alpine
     runs-on: ubuntu-20.04
     container: golang:1.16-alpine
     steps:
@@ -59,8 +59,27 @@ jobs:
       - name: Check Singularity
         run: make -C ./builddir check
 
-  go116-macos:
-    name: go116-macos
+  oldgo:
+    name: oldgo
+    runs-on: ubuntu-20.04
+    # match the minimum version required by mconfig
+    container: golang:1.13-alpine
+    steps:
+      - name: Fetch deps
+        run: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
+
+      - uses: actions/checkout@v2
+
+      - name: Build Singularity
+        run: |
+          ./mconfig -v -p /usr/local
+          make -C ./builddir all
+
+      - name: Check Singularity
+        run: make -C ./builddir check
+
+  macos:
+    name: macos
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2

--- a/e2e/internal/e2e/priv_linux.go
+++ b/e2e/internal/e2e/priv_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019,2020 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,10 +7,10 @@ package e2e
 
 import (
 	"runtime"
-	"syscall"
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 // Privileged wraps the supplied test function with calls to ensure
@@ -21,21 +21,21 @@ func Privileged(f func(*testing.T)) func(*testing.T) {
 
 		runtime.LockOSThread()
 
-		if err := syscall.Setresuid(0, 0, origUID); err != nil {
+		if err := unix.Setresuid(0, 0, origUID); err != nil {
 			err = errors.Wrap(err, "changing user ID to 0")
 			t.Fatalf("privileges escalation failed: %+v", err)
 		}
-		if err := syscall.Setresgid(0, 0, origGID); err != nil {
+		if err := unix.Setresgid(0, 0, origGID); err != nil {
 			err = errors.Wrap(err, "changing group ID to 0")
 			t.Fatalf("privileges escalation failed: %+v", err)
 		}
 
 		defer func() {
-			if err := syscall.Setresgid(origGID, origGID, 0); err != nil {
+			if err := unix.Setresgid(origGID, origGID, 0); err != nil {
 				err = errors.Wrapf(err, "changing group ID to %d", origUID)
 				t.Fatalf("privileges drop failed: %+v", err)
 			}
-			if err := syscall.Setresuid(origUID, origUID, 0); err != nil {
+			if err := unix.Setresuid(origUID, origUID, 0); err != nil {
 				err = errors.Wrapf(err, "changing group ID to %d", origGID)
 				t.Fatalf("privileges drop failed: %+v", err)
 			}

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -13,8 +13,9 @@ import (
 	"os/user"
 	"runtime"
 	"strconv"
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 var origUID, origGID, unprivUID, unprivGID int
@@ -38,12 +39,12 @@ func DropPrivilege(t *testing.T) {
 	runtime.LockOSThread()
 
 	if os.Getgid() == 0 {
-		if err := syscall.Setresgid(unprivGID, unprivGID, origGID); err != nil {
+		if err := unix.Setresgid(unprivGID, unprivGID, origGID); err != nil {
 			t.Fatalf("failed to set group identity: %v", err)
 		}
 	}
 	if os.Getuid() == 0 {
-		if err := syscall.Setresuid(unprivUID, unprivUID, origUID); err != nil {
+		if err := unix.Setresuid(unprivUID, unprivUID, origUID); err != nil {
 			t.Fatalf("failed to set user identity: %v", err)
 		}
 
@@ -55,10 +56,10 @@ func DropPrivilege(t *testing.T) {
 
 // ResetPrivilege returns effective privilege to the original user.
 func ResetPrivilege(t *testing.T) {
-	if err := syscall.Setresuid(origUID, origUID, unprivUID); err != nil {
+	if err := unix.Setresuid(origUID, origUID, unprivUID); err != nil {
 		t.Fatalf("failed to reset user identity: %v", err)
 	}
-	if err := syscall.Setresgid(origGID, origGID, unprivGID); err != nil {
+	if err := unix.Setresgid(origGID, origGID, unprivGID); err != nil {
 		t.Fatalf("failed to reset group identity: %v", err)
 	}
 	if err := os.Setenv("HOME", origHome); err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

This adds support for go 1.16 and updates the CI workflow to use golang 1.16.4.  Based on [Sylabs pr 45](https://github.com/sylabs/singularity/pull/45).


### This fixes or addresses the following GitHub issues:

 - Fixes #6024


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
