### PR TITLE
Update debian in ci from stretch to buster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,11 @@ jobs:
   debian:
     name: debian
     runs-on: ubuntu-20.04
-    container: golang:1.16-stretch
+    container: golang:1.16-buster
     steps:
       - name: Fetch deps
         run: |
           apt-get -q update && apt-get -q install -y build-essential libssl-dev uuid-dev squashfs-tools cryptsetup-bin
-          echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
-          apt-get -q update
-          apt-get -q remove -y --purge git
-          apt-get -q install -y -t stretch-backports git
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update the debian CI build to use buster instead of stretch, analogous to what Sylabs did in their [pr 51](https://github.com/sylabs/singularity/pull/51).


### This fixes or addresses the following GitHub issues:

 - Fixes #6025


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
