### PR TITLE
Update linter to the latest functional version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - maligned
     - misspell
     - nakedret
     # we would like to add these

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,21 +59,18 @@ $ echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
 
 This is an optional (but highly recommended!) step. To ensure
 consistency and to catch certain kinds of issues early, we provide a
-configuration file for golangci-lint. Every pull request must pass the
+configuration file for `golangci-lint`. Every pull request must pass the
 checks specified there, and these will be run automatically before
 attempting to merge the code. If you are modifying Singularity and
 contributing your changes to the repository, it's faster to run these
 checks locally before uploading your pull request.
 
-In order to install golangci-lint, you can run:
+In order to download and install the latest version of `golangci-lint`,
+you can run:
 
+```sh
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 ```
-$ curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh |
-  sh -s -- -b $(go env GOPATH)/bin v1.31.0
-```
-
-This will download and install golangci-lint from its Github releases
-page (using version v1.31.0 at the moment).
 
 ## Clone the repo
 

--- a/scripts/run-linter
+++ b/scripts/run-linter
@@ -2,7 +2,7 @@
 
 set -e
 
-golangci_lint_version=1.31.0
+golangci_lint_version=1.40.1
 golangci_lint_install_url=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
 
 info() {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes latest trials for getting linter to work and get `1.40.1` in place. 


This is part of [Sylabs pr 41](https://github.com/sylabs/singularity/pull/41)

### This fixes or addresses the following GitHub issues:

 - Fixes #6023 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
