### PR TITLE
Fix get-version

### DIFF
--- a/scripts/get-version
+++ b/scripts/get-version
@@ -28,7 +28,7 @@ fi
 # gitdesc extracts the closest version tag, removing the leading "v" and
 # returning the rest
 gitdesc() {
-	git describe --match='v[0-9]*' --always "$@" 2>/dev/null |
+	git describe --match='v[0-9]*' --always --candidates=1 "$@" 2>/dev/null |
 	sed -e 's,^v,,'
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This fixes scripts/get-version so it correctly locates the most recent tag, by using the `git describe --contains=1` option.  Currently on the master branch it is showing 3.8.0-rc.2, and this makes it use 3.8.0.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
