### PR TITLE
build-singularity example - changed base image from CentOS to RockyLinux

### DIFF
--- a/examples/build-singularity/README.md
+++ b/examples/build-singularity/README.md
@@ -19,4 +19,4 @@
 
     ./build-singularity.sif {version}
 
-    ./build-singularity.sif 3.6.2
+    ./build-singularity.sif 3.8.0

--- a/examples/build-singularity/build-singularity.def
+++ b/examples/build-singularity/build-singularity.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: rockylinux/rockylinux
+From: rockylinux/rockylinux:8.4
 
 %post
     # Set build time env variable

--- a/examples/build-singularity/build-singularity.def
+++ b/examples/build-singularity/build-singularity.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: centos:8
+From: rockylinux/rockylinux
 
 %post
     # Set build time env variable
@@ -48,9 +48,12 @@ From: centos:8
 
         ./build-singularity.sif {version}
 
-    	./build-singularity.sif 3.7.2
+    	./build-singularity.sif 3.8.0
 
     CHANGELOG
+
+    v1.0.2
+    changed CentOS to RockyLinux
     
     v1.0.1
     changed PowerTools -> powertools
@@ -61,4 +64,4 @@ From: centos:8
 
 %labels
     Author chrismmaggio
-    Version 1.0.1
+    Version 1.0.2


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update the build-singularity example to pull the base image from Docker/RockyLinux instead of Docker/CentOS 

### This fixes or addresses the following GitHub issues:

N/A

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
