### PR TITLE
Prevent gc from closing image file descriptor

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -137,9 +137,9 @@ type Image struct {
 	Usage      Usage     `json:"usage"`
 }
 
-// Init fills in the File object if needed, because it is not passed
-//   between stages
-func (i *Image) Init() {
+// ReInit fills in the File object if needed.  This function should be
+//   called after passing an image object between processes using JSON
+func (i *Image) ReInit() {
 	if i.File == nil && i.Path != "" {
 		i.File = os.NewFile(i.Fd, i.Path)
 	}

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -674,7 +674,13 @@ func (e *EngineConfig) SetImageList(list []image.Image) {
 
 // GetImageList returns image list containing opened images.
 func (e *EngineConfig) GetImageList() []image.Image {
-	return e.JSON.ImageList
+	list := e.JSON.ImageList
+	// The Image object is not fully passed between stages, so Init it
+	for idx := range list {
+		img := &list[idx]
+		img.Init()
+	}
+	return list
 }
 
 // SetCwd sets current working directory.

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -675,10 +675,10 @@ func (e *EngineConfig) SetImageList(list []image.Image) {
 // GetImageList returns image list containing opened images.
 func (e *EngineConfig) GetImageList() []image.Image {
 	list := e.JSON.ImageList
-	// The Image object is not fully passed between stages, so Init it
+	// Image objects are not fully passed between stages, reinitialize them
 	for idx := range list {
 		img := &list[idx]
-		img.Init()
+		img.ReInit()
 	}
 	return list
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

This prevents garbage collection from closing a container image file descriptor, by initializing the Image.File object when it is first referenced rather than just before use.  Previously if a copy of the image file descriptor was made (which is easy to do accidentally in go), the File object would be created in that copy and so when the copy was dereferenced garbage collection would close the corresponding file descriptor.


### This fixes or addresses the following GitHub issues:

 - Fixes #6047
 - Replaces #6052


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
