### PR TITLE
Update the help url from sylabs to hpcng

### DIFF
--- a/e2e/testdata/help/help-oci-attach.txt
+++ b/e2e/testdata/help/help-oci-attach.txt
@@ -15,4 +15,4 @@ Examples:
   $ singularity oci attach mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-create.txt
+++ b/e2e/testdata/help/help-oci-create.txt
@@ -25,4 +25,4 @@ Examples:
   $ singularity oci create -b ~/bundle mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-delete.txt
+++ b/e2e/testdata/help/help-oci-delete.txt
@@ -15,4 +15,4 @@ Examples:
   $ singularity oci delete mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-exec.txt
+++ b/e2e/testdata/help/help-oci-exec.txt
@@ -15,4 +15,4 @@ Examples:
   $ singularity oci exec mycontainer id
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-kill.txt
+++ b/e2e/testdata/help/help-oci-kill.txt
@@ -19,4 +19,4 @@ Examples:
   $ singularity oci kill mycontainer -s INT
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-mount.txt
+++ b/e2e/testdata/help/help-oci-mount.txt
@@ -14,4 +14,4 @@ Examples:
   $ singularity oci mount /tmp/example.sif /var/lib/singularity/bundles/example
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-pause.txt
+++ b/e2e/testdata/help/help-oci-pause.txt
@@ -14,4 +14,4 @@ Examples:
   $ singularity oci pause mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-resume.txt
+++ b/e2e/testdata/help/help-oci-resume.txt
@@ -15,4 +15,4 @@ Examples:
   $ singularity oci resume mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-run.txt
+++ b/e2e/testdata/help/help-oci-run.txt
@@ -29,4 +29,4 @@ Examples:
   $ singularity oci delete mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-start.txt
+++ b/e2e/testdata/help/help-oci-start.txt
@@ -15,4 +15,4 @@ Examples:
   $ singularity oci start mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-state.txt
+++ b/e2e/testdata/help/help-oci-state.txt
@@ -17,4 +17,4 @@ Examples:
   $ singularity oci state mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-umount.txt
+++ b/e2e/testdata/help/help-oci-umount.txt
@@ -15,4 +15,4 @@ Examples:
   $ singularity oci umount /var/lib/singularity/bundles/example
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci-update.txt
+++ b/e2e/testdata/help/help-oci-update.txt
@@ -21,4 +21,4 @@ Examples:
   $ cat /tmp/cgroups-update.json | singularity oci update --from-file - mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/

--- a/e2e/testdata/help/help-oci.txt
+++ b/e2e/testdata/help/help-oci.txt
@@ -33,4 +33,4 @@ Examples:
   $ singularity oci start mycontainer
 
 
-For additional help or support, please visit https://www.sylabs.io/docs/
+For additional help or support, please visit https://singularity.hpcng.org/help/


### PR DESCRIPTION
## Description of the Pull Request (PR):

This changes the e2e help url text to match the change in URL from #6058


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
