### PR TITLE
e2e: fix registry instance for Skopeo 1.4.0

### DIFF
--- a/e2e/testdata/Docker_registry.def
+++ b/e2e/testdata/Docker_registry.def
@@ -26,7 +26,7 @@ from: registry:2.7.1
     # wait until docker registry is up
     while ! wget -q -O /dev/null 127.0.0.1:5000 ; do sleep 0.5; done
 
-    skopeo --dest-tls-verify=false --insecure-policy copy docker://busybox docker://localhost:5000/my-busybox
+    skopeo --insecure-policy copy --dest-tls-verify=false docker://busybox docker://localhost:5000/my-busybox
 
     # e2e PrepRegistry will repeatedly trying to connect to this port
     # giving indication that it can start


### PR DESCRIPTION
The `--dest-tls-verify` must now be specified as a flag to `copy` and not as a global flag for Skopeo 1.4.0.

This is imported from [sylabs pr #220](https://github.com/sylabs/singularity/pull/220) and fixes e2e failures we saw in #6096 with message
```
FATAL:   While performing build: conveyor failed to get: reading manifest latest in localhost:5000/my-busybox: manifest unknown: manifest unknown
```

