### PR TITLE
fix: Allow env vars with literal $ via \\\$ in SINGULARITYENV_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
 
 _The old changelog can be found in the `release-2.6` branch_
 
+### Bug Fixes
+
+  - Allow escaped `\$` in a SINGULARITYENV_ var to set a literal `$` in
+    a container env var.
 
 # v3.8.0 - [2021-06-15]
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -446,5 +446,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"environment file":         c.singularityEnvFile,
 		"issue 5057":               c.issue5057, // https://github.com/sylabs/hpcng/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/sylabs/hpcng/issues/5426
+		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
 	}
 }

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hpcng/singularity/internal/pkg/util/env"
 	"github.com/hpcng/singularity/internal/pkg/util/fs/files"
 	"github.com/hpcng/singularity/internal/pkg/util/machine"
-	"github.com/sylabs/singularity/internal/pkg/util/shell"
+	"github.com/hpcng/singularity/internal/pkg/util/shell"
 	"github.com/hpcng/singularity/internal/pkg/util/shell/interpreter"
 	"github.com/hpcng/singularity/internal/pkg/util/user"
 	singularitycallback "github.com/hpcng/singularity/pkg/plugin/callback/runtime/engine/singularity"

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hpcng/singularity/internal/pkg/util/env"
 	"github.com/hpcng/singularity/internal/pkg/util/fs/files"
 	"github.com/hpcng/singularity/internal/pkg/util/machine"
+	"github.com/sylabs/singularity/internal/pkg/util/shell"
 	"github.com/hpcng/singularity/internal/pkg/util/shell/interpreter"
 	"github.com/hpcng/singularity/internal/pkg/util/user"
 	singularitycallback "github.com/hpcng/singularity/pkg/plugin/callback/runtime/engine/singularity"
@@ -631,18 +632,22 @@ func injectEnvHandler(senv map[string]string) interpreter.OpenHandler {
 			`
 			b.WriteString(fmt.Sprintf(defaultPathSnippet, env.DefaultPath))
 
+			// https://github.com/sylabs/singularity/issues/43
+			// We wrap the value of the export in double quotes manually, and do not use
+			// go's %q format string as it prevents passing an escaped literal $ in
+			// a SINGULARITYENV_ as \$
 			snippet := `
 			if test -v %[1]s; then
 				sylog debug "Overriding %[1]s environment variable"
 			fi
-			export %[1]s=%[2]q
+			export %[1]s="%[2]s"
 			`
 			for key, value := range senv {
 				if key == "LD_LIBRARY_PATH" && value != "" {
 					b.WriteString(fmt.Sprintf(snippet, key, value+":/.singularity.d/libs"))
 					continue
 				}
-				b.WriteString(fmt.Sprintf(snippet, key, value))
+				b.WriteString(fmt.Sprintf(snippet, key, shell.EscapeQuotes(value)))
 			}
 		})
 

--- a/internal/pkg/util/shell/escape.go
+++ b/internal/pkg/util/shell/escape.go
@@ -24,3 +24,8 @@ func Escape(s string) string {
 	escaped = strings.Replace(escaped, `$`, `\$`, -1)
 	return escaped
 }
+
+// EscapeQuotes performs escaping of double quotes only
+func EscapeQuotes(s string) string {
+	return strings.Replace(s, `"`, `\"`, -1)
+}

--- a/internal/pkg/util/shell/escape_test.go
+++ b/internal/pkg/util/shell/escape_test.go
@@ -51,3 +51,24 @@ func TestEscape(t *testing.T) {
 	}
 
 }
+
+func TestEscapeQuotes(t *testing.T) {
+	var escapeQuotesTests = []struct {
+		input    string
+		expected string
+	}{
+		{`Hello`, `Hello`},
+		{`"Hello"`, `\"Hello\"`},
+		{`Hell"o`, `Hell\"o`},
+	}
+
+	for _, test := range escapeQuotesTests {
+		t.Run(test.input, func(t *testing.T) {
+			escaped := EscapeQuotes(test.input)
+			if escaped != test.expected {
+				t.Errorf("got %s, expected %s", escaped, test.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Let me try pushing Sylabs PR [#153](https://github.com/sylabs/singularity/pull/153) and see if my attempt works compared to what Pedro is doing.

Fixes #6079