### PR TITLE
Undo application of sylabs pr 152

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@ _With the release of `v3.0.0`, we're introducing a new changelog format in an at
   - _Migration guidance_
   - _New features / functionalities_
 
-### Changed defaults / behaviours
-
-  - LABELs from Docker/OCI images are now inherited. This fixes a longstanding
-    regression from Singularity 2.x. Note that you will now need to use
-    `--force` in a build to override a label that already exists in the source
-    Docker/OCI container.
-
 ### New features / functionalities
 
 _The old changelog can be found in the `release-2.6` branch_

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/hpcng/singularity/e2e/internal/e2e"
@@ -398,46 +397,6 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 	}
 }
 
-func (c ctx) testDockerLabels(t *testing.T) {
-	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "labels-", "")
-	defer cleanup(t)
-	imagePath := filepath.Join(imageDir, "container")
-
-	// Test container & set labels
-	// See: https://github.com/sylabs/singularity-test-containers/pull/1
-	imgSrc := "docker://sylabsio/labels"
-	label1 := "LABEL1: 1"
-	label2 := "LABEL2: TWO"
-
-	c.env.RunSingularity(
-		t,
-		e2e.AsSubtest("build"),
-		e2e.WithProfile(e2e.RootProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs(imagePath, imgSrc),
-		e2e.ExpectExit(0),
-	)
-
-	verifyOutput := func(t *testing.T, r *e2e.SingularityCmdResult) {
-		output := string(r.Stdout)
-		for _, l := range []string{label1, label2} {
-			if !strings.Contains(output, l) {
-				t.Errorf("Did not find expected label %s in inspect output", l)
-			}
-		}
-	}
-
-	c.env.RunSingularity(
-		t,
-		e2e.AsSubtest("inspect"),
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("inspect"),
-		e2e.WithArgs([]string{"--labels", imagePath}...),
-		e2e.ExpectExit(0, verifyOutput),
-	)
-
-}
-
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -451,6 +410,5 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"pulls":            c.testDockerPulls,
 		"registry":         c.testDockerRegistry,
 		"whiteout symlink": c.testDockerWhiteoutSymlink,
-		"labels":           c.testDockerLabels,
 	}
 }

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -185,11 +185,6 @@ func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) 
 		return nil, fmt.Errorf("while inserting oci config: %v", err)
 	}
 
-	err = cp.insertOCILabels()
-	if err != nil {
-		return nil, fmt.Errorf("while inserting oci labels: %v", err)
-	}
-
 	return cp.b, nil
 }
 
@@ -213,6 +208,7 @@ func (cp *OCIConveyorPacker) getConfig(ctx context.Context) (imgspecv1.ImageConf
 	if err != nil {
 		return imgspecv1.ImageConfig{}, err
 	}
+
 	return imgSpec.Config, nil
 }
 
@@ -442,20 +438,6 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 	}
 
 	return nil
-}
-
-func (cp *OCIConveyorPacker) insertOCILabels() (err error) {
-	labels := cp.imgConfig.Labels
-	var text []byte
-
-	// make new map into json
-	text, err = json.MarshalIndent(labels, "", "\t")
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0644)
-	return err
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem


### PR DESCRIPTION
## Description of the Pull Request (PR):

This undoes the application of sylabs pr 152 "Inherit Docker/OCI LABELs during build" that was added in #6105 (along with other PRs) because it doesn't belong in the 3.8.1 release and is (I believe) the only thing currently in the master branch we don't want in 3.8.1.  I am opening it against the master branch but we can instead wait until the master branch is merged into release-3.8 and then change the base there.


