### PR TITLE
Fix for issue #6091: Unable to build ArchLinux image due to pacman config download problem.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
     - Amanda Duffy <aduffy@lenovo.com>
     - Ana Guerrero Lopez <aguerrero@suse.com>
     - Ángel Bejarano <abejarano@ontropos.com>
+    - Apuã Paquola <apuapaquola@gmail.com>
     - Aron Öfjörð Jóhannesson <aron1991@gmail.com>
     - Bernard Li <bernardli@lbl.gov>
     - Brian Bockelman <bbockelm@cse.unl.edu>

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	pacmanConfURL = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/pacman.conf?h=packages/pacman"
+	pacmanConfURL = "https://github.com/archlinux/svntogit-packages/raw/master/pacman/trunk/pacman.conf"
 )
 
 var (
@@ -126,14 +126,9 @@ func (cp *ArchConveyorPacker) getPacConf(pacmanConfURL string) (pacConf string, 
 	}
 	defer resp.Body.Close()
 
-	bytesWritten, err := io.Copy(pacConfFile, resp.Body)
+	_, err = io.Copy(pacConfFile, resp.Body)
 	if err != nil {
 		return
-	}
-
-	//Simple check to make sure file received is the correct size
-	if bytesWritten != resp.ContentLength {
-		return "", fmt.Errorf("file received is not the right size. supposed to be: %v actually: %v", resp.ContentLength, bytesWritten)
 	}
 
 	return pacConfFile.Name(), nil


### PR DESCRIPTION
### Description of the Pull Request (PR):

This fixes #6091 . 

Update Arch Linux pacman.conf URL. 

Remove file size verification for downloaded pacman.conf. File size verification was failing even when downloading the correct pacman.conf file.
