### PR TITLE
Update golang-x-crypto to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   - Properly escape single quotes in Docker `CMD` / `ENTRYPOINT` translation.
   - Use host uid when choosing unsquashfs flags, to avoid selinux xattr errors
     with `--fakeroot` on non-EL/Fedora distributions with recent squashfs-tools.
+  - Updated the modified golang-x-crypto module with the latest upstream 
+    version.
 
 ## v3.8.1 - [2021-08-12]
 

--- a/go.mod
+++ b/go.mod
@@ -69,5 +69,5 @@ replace (
 	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
 	github.com/docker/docker => github.com/moby/moby v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
 
-	golang.org/x/crypto => github.com/hpcng/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9
+	golang.org/x/crypto => github.com/hpcng/golang-x-crypto v0.0.0-20210830200829-e6b35e3fb874
 )

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hpcng/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9 h1:t8KUun6NE+Kv500O2sNQ6LIFvUz7QX+RJGOVoJFlyHM=
-github.com/hpcng/golang-x-crypto v0.0.0-20181006204705-4bce89e8e9a9/go.mod h1:YRpvuFxEV8iMqW8qf0+X+dTRn3labfXfykTzp8hRkSg=
+github.com/hpcng/golang-x-crypto v0.0.0-20210830200829-e6b35e3fb874 h1:mGKQ3LEDpGH3MVbBWPXw/m2xJ7s9XEnga1q5fYgK/RY=
+github.com/hpcng/golang-x-crypto v0.0.0-20210830200829-e6b35e3fb874/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 github.com/hpcng/sif v1.6.0 h1:CEYAU+PY0AFmg+G8SwJJmNA4Ixs6DOcgf/pIkVd8QBA=
 github.com/hpcng/sif v1.6.0/go.mod h1:czlq6ECeYaGHAYmZdKjAXB0S5VrfQXcT3Momvszz2qY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
This updates the "replace" for golang.org/x/crypto to an up to date version at github.com/hpcng/golang-x-crypto, catching up almost 3 years worth of changes.