### PR TITLE
Fix a regression introduced by #6008 adding bind mounts without destination two times

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2270,6 +2270,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5599":            c.issue5599,           // https://github.com/hpcng/singularity/issues/5599
 		"issue 5631":            c.issue5631,           // https://github.com/hpcng/singularity/issues/5631
 		"issue 5690":            c.issue5690,           // https://github.com/hpcng/singularity/issues/5690
+		"issue 6165":            c.issue6165,           // https://github.com/hpcng/singularity/issues/6165
 		"network":               c.actionNetwork,       // test basic networking
 		"binds":                 c.actionBinds,         // test various binds
 		"exit and signals":      c.exitSignals,         // test exit and signals propagation

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -408,6 +408,8 @@ func ParseBindPath(paths []string) ([]BindPath, error) {
 				}
 				binds = append(binds, bp)
 				elem = 0
+				bind = ""
+				continue
 			}
 			// new bind path
 			bind = s


### PR DESCRIPTION
## Description of the Pull Request (PR):

Due to a logic error introduced by #6008, a bind mount without destination is added two times and display a warning telling that the destination mount point was previously added. The bind mount works as expected but display a false warning.

### This fixes or addresses the following GitHub issues:

 - Fixes #6165 
