### PR TITLE
Remove prompt to push keys on generation

### DIFF
--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -186,18 +186,5 @@ func collectInput(cmd *cobra.Command) (*keyNewPairOptions, error) {
 		genOpts.Password = p
 	}
 
-	if cmd.Flags().Changed(keyNewPairPushFlag.Name) {
-		genOpts.PushToKeyStore = keyNewPairPush
-	} else {
-		a, err := interactive.AskYNQuestion("y", "Would you like to push it to the keystore? [Y,n] ")
-		if err != nil {
-			return nil, err
-		}
-
-		if a == "y" {
-			genOpts.PushToKeyStore = true
-		}
-	}
-
 	return &genOpts, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

When creating a new key pair, Singularity automatically offers to push to the key server. I've gotten feedback, and nailed by this myself, that this shouldn't be default, especially when that is defaulting to the Sylabs commercial endpoint.

### This fixes or addresses the following GitHub issues:

- Issue #6182

