### PR TITLE
Adding environment parameters to override mksquashfs procs/mem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v3.8.2 - [2021-08-31]
 
+### New features / functionalities
+
+   - Add SINGULARITY_MKSQUASHFS_PROCS and SINGULARITY_MKSQUASHFS_MEM to override
+     mksquashfs options.
 ### Bug fixes
 
   - Fix regression when files `source`d from `%environment` contain `\` escaped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
    - Add SINGULARITY_MKSQUASHFS_PROCS and SINGULARITY_MKSQUASHFS_MEM to override
      mksquashfs options.
+     
 ### Bug fixes
 
   - Fix regression when files `source`d from `%environment` contain `\` escaped

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -92,3 +92,4 @@
     - Onur Yılmaz <csonuryilmaz@gmail.com>
     - Pranathi Locula <locula@deshaw.com>
     - Pedro Alves Batista <pedro.pesquisapb@gmail.com>
+    - Soichi Hayashi <hayashis@iu.edu>

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -7,8 +7,10 @@ package squashfs
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/hpcng/singularity/internal/pkg/buildcfg"
@@ -44,8 +46,8 @@ func GetPath() (string, error) {
 	p := c.MksquashfsPath
 
 	// If the path contains the binary name use it as is, otherwise add mksquashfs via filepath.Join
-	if !strings.HasSuffix(c.MksquashfsPath, "mksquashfs") {
-		p = filepath.Join(c.MksquashfsPath, "mksquashfs")
+	if !strings.HasSuffix(p, "mksquashfs") {
+		p = filepath.Join(p, "mksquashfs")
 	}
 
 	// exec.LookPath functions on absolute paths (ignoring $PATH) as well
@@ -60,6 +62,16 @@ func GetProcs() (uint, error) {
 	// proc is either "" or the string value in the conf file
 	proc := c.MksquashfsProcs
 
+	// let user override via ENV
+	procEnv := os.Getenv("SINGULARITY_MKSQUASHFS_PROCS")
+	if procEnv != "" {
+		procEnvint, err := strconv.Atoi(procEnv)
+		if err != nil {
+			return 0, fmt.Errorf("failed to convert SINGULARITY_MKSQUASHFS_PROCS env %d to uint: %s\n", procEnv, err)
+		}
+		proc = uint(procEnvint)
+	}
+
 	return proc, err
 }
 
@@ -70,6 +82,12 @@ func GetMem() (string, error) {
 	}
 	// mem is either "" or the string value in the conf file
 	mem := c.MksquashfsMem
+
+	// let user override via ENV
+	memEnv := os.Getenv("SINGULARITY_MKSQUASHFS_MEM")
+	if memEnv != "" {
+		mem = memEnv
+	}
 
 	return mem, err
 }

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -67,7 +67,7 @@ func GetProcs() (uint, error) {
 	if procEnv != "" {
 		procEnvint, err := strconv.Atoi(procEnv)
 		if err != nil {
-			return 0, fmt.Errorf("failed to convert SINGULARITY_MKSQUASHFS_PROCS env %d to uint: %s", procEnv, err)
+			return 0, fmt.Errorf("failed to convert SINGULARITY_MKSQUASHFS_PROCS env %s to uint: %s", procEnv, err)
 		}
 		proc = uint(procEnvint)
 	}

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -67,7 +67,7 @@ func GetProcs() (uint, error) {
 	if procEnv != "" {
 		procEnvint, err := strconv.Atoi(procEnv)
 		if err != nil {
-			return 0, fmt.Errorf("failed to convert SINGULARITY_MKSQUASHFS_PROCS env %d to uint: %s\n", procEnv, err)
+			return 0, fmt.Errorf("failed to convert SINGULARITY_MKSQUASHFS_PROCS env %d to uint: %s", procEnv, err)
 		}
 		proc = uint(procEnvint)
 	}

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -153,7 +153,7 @@ mount home = {{ if eq .MountHome true }}yes{{ else }}no{{ end }}
 # DEFAULT: yes
 # Should we automatically bind mount /tmp and /var/tmp into the container? If
 # the --contain option is used, both tmp locations will be created in the
-# session directory or can be specified via the  SINGULARITY_WORKDIR
+# session directory or can be specified via the SINGULARITY_WORKDIR
 # environment variable (or the --workingdir command line option).
 mount tmp = {{ if eq .MountTmp true }}yes{{ else }}no{{ end }}
 
@@ -342,7 +342,7 @@ memory fs type = {{ .MemoryFSType }}
 # MKSQUASHFS PATH: [STRING]
 # DEFAULT: Undefined
 # This allows the administrator to specify the location for mksquashfs if it is not
-# installed in a standard system location
+# installed in a standard system location.
 # mksquashfs path =
 {{ if ne .MksquashfsPath "" }}mksquashfs path = {{ .MksquashfsPath }}{{ end }}
 
@@ -350,7 +350,8 @@ memory fs type = {{ .MemoryFSType }}
 # DEFAULT: 0 (All CPUs)
 # This allows the administrator to specify the number of CPUs for mksquashfs 
 # to use when building an image.  The fewer processors the longer it takes.
-# To enable it to use all available CPU's set this to 0.
+# To enable it to use all available CPU's set this to 0. This can be overridden at 
+# runtime by setting SINGULARITY_MKSQUASHFS_PROCS environment parameter.
 # mksquashfs procs = 0
 mksquashfs procs = {{ .MksquashfsProcs }}
 
@@ -359,6 +360,8 @@ mksquashfs procs = {{ .MksquashfsProcs }}
 # This allows the administrator to set the maximum amount of memory for mkswapfs
 # to use when building an image.  e.g. 1G for 1gb or 500M for 500mb. Restricting memory
 # can have a major impact on the time it takes mksquashfs to create the image.
+# This can be overridden at runtime by setting SINGULARITY_MKSQUASHFS_MEM environment
+# parameter.
 # NOTE: This fuctionality did not exist in squashfs-tools prior to version 4.3
 # If using an earlier version you should not set this.
 # mksquashfs mem = 1G


### PR DESCRIPTION
## Description of the Pull Request (PR):

This adds 2 new ENV parameters SINGULARITY_MKSQUASHFS_PROCS and SINGULARITY_MKSQUASHFS_MEM. These environment variables can be used to set the -processors and -mem options to mksquashfs. These environment variables take precedence over the configuration file.

This is necessary because when I submit a job on a batch scheduler with a specific amount of cpus/mem available for the job, singularity must only use up to that number of cpu/mem available or the job will be killed while caching the SIF image. This can not be done by singularity.conf alone (and it's not the right place for that - as cluster admin won't know how much a cpu/proc each job would actually request)

This is similar to this PR #5805  (Thanks @kaczmarj !!)

I didn't add env/override for `mksquashfs path` as I am not sure if it's safe to be overridden.

### This fixes or addresses the following GitHub issues:

https://github.com/hpcng/singularity/pull/5003#issuecomment-764937035
