### PR TITLE
Allow --writable-tmpfs for %test step of build, from sylabs pr 136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Singularity Changelog
 
+## Changes since last release
+
+### New features / functionalities
+
+  - `--writable-tmpfs` can be used with `singularity build` to run
+    the `%test` section of the build with a ephemeral tmpfs overlay,
+    permitting tests that write to the container filesystem.
+
 ## v3.8.2 - [2021-08-31]
 
 ### Bug fixes

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -29,25 +29,26 @@ import (
 )
 
 var buildArgs struct {
-	sections     []string
-	bindPaths    []string
-	arch         string
-	builderURL   string
-	libraryURL   string
-	keyServerURL string
-	webURL       string
-	detached     bool
-	encrypt      bool
-	fakeroot     bool
-	fixPerms     bool
-	isJSON       bool
-	noCleanUp    bool
-	noTest       bool
-	remote       bool
-	sandbox      bool
-	update       bool
-	nvidia       bool
-	rocm         bool
+	sections      []string
+	bindPaths     []string
+	arch          string
+	builderURL    string
+	libraryURL    string
+	keyServerURL  string
+	webURL        string
+	detached      bool
+	encrypt       bool
+	fakeroot      bool
+	fixPerms      bool
+	isJSON        bool
+	noCleanUp     bool
+	noTest        bool
+	remote        bool
+	sandbox       bool
+	update        bool
+	nvidia        bool
+	rocm          bool
+	writableTmpfs bool // For test section only
 }
 
 // -s|--sandbox
@@ -243,6 +244,16 @@ var buildBindFlag = cmdline.Flag{
 	EnvHandler: cmdline.EnvAppendValue,
 }
 
+// --writable-tmpfs
+var buildWritableTmpfsFlag = cmdline.Flag{
+	ID:           "buildWritableTmpfsFlag",
+	Value:        &buildArgs.writableTmpfs,
+	DefaultValue: false,
+	Name:         "writable-tmpfs",
+	Usage:        "during the %test section, makes the file system accessible as read-write with non persistent data (with overlay support only)",
+	EnvKeys:      []string{"WRITABLE_TMPFS"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(buildCmd)
@@ -276,6 +287,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&buildNvFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildRocmFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildBindFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildWritableTmpfsFlag, buildCmd)
 	})
 }
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -115,6 +115,15 @@ func runBuild(cmd *cobra.Command, args []string) {
 		}
 		os.Setenv("SINGULARITY_BINDPATH", strings.Join(buildArgs.bindPaths, ","))
 	}
+	if buildArgs.writableTmpfs {
+		if buildArgs.remote {
+			sylog.Fatalf("--writable-tmpfs option is not supported for remote build")
+		}
+		if buildArgs.fakeroot {
+			sylog.Fatalf("--writable-tmpfs option is not supported for fakeroot build")
+		}
+		os.Setenv("SINGULARITY_WRITABLE_TMPFS", "1")
+	}
 
 	if buildArgs.arch != runtime.GOARCH && !buildArgs.remote {
 		sylog.Fatalf("Requested architecture (%s) does not match host (%s). Cannot build locally.", buildArgs.arch, runtime.GOARCH)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1382,6 +1382,31 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 	)
 }
 
+// testWritableTmpfs checks that we can run the build using a writeable tmpfs in the %test step
+func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	tmpdir, cleanup := c.tempDir(t, "build-writabletmpfs-test")
+	defer cleanup()
+
+	// Definition will attempt to touch a file in /var/test during %test.
+	// This would fail without a writable tmpfs.
+	definition := fmt.Sprintf("Bootstrap: localimage\nFrom: %s\n%%test\ntouch /var/test\n", c.env.ImagePath)
+
+	defFile := e2e.RawDefFile(t, tmpdir, strings.NewReader(definition))
+	imagePath := filepath.Join(tmpdir, "image-writabletmpfs")
+	c.env.RunSingularity(
+		t,
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("-F", "--writable-tmpfs", imagePath, defFile),
+		e2e.PostRun(func(t *testing.T) {
+			os.Remove(defFile)
+		}),
+		e2e.ExpectExit(0),
+	)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := imgBuildTests{
@@ -1401,6 +1426,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"fingerprint check":               c.buildWithFingerprint,      // definition file includes fingerprint check
 		"build with bind mount":           c.buildBindMount,            // build image with bind mount
 		"library host":                    c.buildLibraryHost,          // build image with hostname in library URI
+		"test with writable tmpfs":        c.testWritableTmpfs,         // build image, using writable tmpfs in the test step
 		"issue 3848":                      c.issue3848,                 // https://github.com/hpcng/singularity/issues/3848
 		"issue 4203":                      c.issue4203,                 // https://github.com/hpcng/singularity/issues/4203
 		"issue 4407":                      c.issue4407,                 // https://github.com/hpcng/singularity/issues/4407

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -109,7 +109,7 @@ func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity()
+		cmd.Env = currentEnvNoSingularity([]string{"NV", "ROCM", "BINDPATH"})
 
 		sylog.Infof("Running post scriptlet")
 		return cmd.Run()
@@ -135,7 +135,7 @@ func (s *stage) runTestScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity()
+		cmd.Env = currentEnvNoSingularity([]string{"NV", "ROCM", "BINDPATH", "WRITABLE_TMPFS"})
 
 		sylog.Infof("Running testscript")
 		return cmd.Run()


### PR DESCRIPTION
This pulls in the PR
- sylabs/singularity#136
See also the issue it fixed:
- sylabs/singularity#109

The description there is:

Some software will unavoidably write to the container fs during reasonable tests. Using a build time bind to permit this is problematic as it is host specific (path available to bind), and the files created by the test likely shouldn't really stick around. Allow specifying `--writable-tmpfs` for a `singularity build` to use a writeable tmpfs in the `%test` section of the build only.
