### PR TITLE
Reapply sylabs pr 152: Inherit Docker/OCI LABELs during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
     the `%test` section of the build with a ephemeral tmpfs overlay,
     permitting tests that write to the container filesystem.
 
+### Changed defaults / behaviours
+
+  - LABELs from Docker/OCI images are now inherited. This fixes a longstanding
+    regression from Singularity 2.x. Note that you will now need to use
+    `--force` in a build to override a label that already exists in the source
+    Docker/OCI container.
+
 ## v3.8.2 - [2021-08-31]
 
 ### Bug fixes

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -185,6 +185,11 @@ func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) 
 		return nil, fmt.Errorf("while inserting oci config: %v", err)
 	}
 
+	err = cp.insertOCILabels()
+	if err != nil {
+		return nil, fmt.Errorf("while inserting oci labels: %v", err)
+	}
+
 	return cp.b, nil
 }
 
@@ -208,7 +213,6 @@ func (cp *OCIConveyorPacker) getConfig(ctx context.Context) (imgspecv1.ImageConf
 	if err != nil {
 		return imgspecv1.ImageConfig{}, err
 	}
-
 	return imgSpec.Config, nil
 }
 
@@ -442,6 +446,20 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 	}
 
 	return nil
+}
+
+func (cp *OCIConveyorPacker) insertOCILabels() (err error) {
+	labels := cp.imgConfig.Labels
+	var text []byte
+
+	// make new map into json
+	text, err = json.MarshalIndent(labels, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0644)
+	return err
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem


### PR DESCRIPTION
This re-applies the pr
- sylabs/singularity#152
which was a fix for
- sylabs/singularity#146

It had been applied previously in #6105 but then was un-applied in #6119 because it was the only thing in the master branch that we didn't want in release 3.8.

Below is the original pr description:

When building / pulling from a Docker/OCI source, retrieve LABELs from the config, and ensure they are set in the resulting Singularity container.

This fixes a longstanding regression from Singularity 2.x. Note that you will now need to use `--force` in a build to override a label that already exists in the source Docker/OCI container.