### PR TITLE
Switch ci check from centos8 to rocky8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,15 @@ jobs:
           OS_VERSION: 7
         run: ./scripts/ci-docker-run
 
-  rpmbuild-centos8:
+  rpmbuild-rocky8:
     runs-on: ubuntu-20.04
-    name: rpmbuild-centos8
+    name: rpmbuild-rocky8
     steps:
       - uses: actions/checkout@v2
 
       - name: Build and test rpm under docker
         env:
-          OS_TYPE: centos
+          OS_TYPE: rockylinux/rockylinux
           OS_VERSION: 8
         run: ./scripts/ci-docker-run
 

--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -25,7 +25,7 @@ if [[ "$OS_TYPE" = "opensuse" ]]; then
 else
     DOCKER_HUB_URI="${OS_TYPE}:$OS_VERSION"
 fi
-DOCKER_CONTAINER_NAME="test_${OS_TYPE}_${OS_VERSION}"
+DOCKER_CONTAINER_NAME="test_${OS_TYPE#*/}_${OS_VERSION}"
 
 docker run --privileged --network=host \
   -v "$(pwd):/build:rw"  \


### PR DESCRIPTION
## Description of the Pull Request (PR):

This switches CI checks from centos8 to rocky8.  Since the dockerhub name for Rocky Linux includes a slash,  (rockylinux/rockylinux), also strip off everything before a slash when setting the docker container name.


### This fixes or addresses the following GitHub issues:

None


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
