### PR TITLE
 Add --compat short-hand for improved OCI/Docker compatibility, from sylabs 235 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `--writable-tmpfs` can be used with `singularity build` to run
   the `%test` section of the build with a ephemeral tmpfs overlay,
   permitting tests that write to the container filesystem.
+- `--compat` flag for actions is a new short-hand to enable a number of
+  options that increase OCI/Docker compatibility. Infers `--containall,
+  --no-init, --no-umask, --writable-tmpfs`. Does not use user, uts, or
+  network namespaces as these may not be supported on many installations.
 
 ### Changed defaults / behaviours
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -39,6 +39,7 @@ var (
 	IsBoot          bool
 	IsFakeroot      bool
 	IsCleanEnv      bool
+	IsCompat        bool
 	IsContained     bool
 	IsContainAll    bool
 	IsWritable      bool
@@ -342,6 +343,16 @@ var actionCleanEnvFlag = cmdline.Flag{
 	EnvKeys:      []string{"CLEANENV"},
 }
 
+// --compat
+var actionCompatFlag = cmdline.Flag{
+	ID:           "actionCompatFlag",
+	Value:        &IsCompat,
+	DefaultValue: false,
+	Name:         "compat",
+	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --writable-tmpfs.",
+	EnvKeys:      []string{"COMPAT"},
+}
+
 // -c|--contain
 var actionContainFlag = cmdline.Flag{
 	ID:           "actionContainFlag",
@@ -643,6 +654,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionApplyCgroupsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionBindFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCleanEnvFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionCompatFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainAllFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionContainLibsFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -57,6 +57,16 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 	// set PATH after pulling images to be able to find potential
 	// docker credential helpers outside of standard paths
 	os.Setenv("PATH", defaultPath)
+
+	// --compat infers other options that give increased OCI / Docker compatibility
+	// Excludes uts/user/net namespaces as these are restrictive for many Singularity
+	// installs.
+	if IsCompat {
+		IsContainAll = true
+		IsWritableTmpfs = true
+		NoInit = true
+		NoUmask = true
+	}
 }
 
 func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, pullFrom string) (string, error) {


### PR DESCRIPTION
This pulls in sylabs pr
- sylabs/singularity#235
which fixed issue
- sylabs/singularity#75

The original pr description was:

It is common for users to run docker containers that expect more isolation than is default in Singularity, and that can create files on startup. This is a simple short-hand to enable `--contain-all, --no-init, --no-umask, --writable-tmpfs`. These options give the best chance of an OCI/Docker container working as expected but without requiring the user/uts/net namespaces that we can't rely on in all installations / configurations of Singularity.