### PR TITLE
Do not automatically create an IPC namespace for instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   regression from Singularity 2.x. Note that you will now need to use
   `--force` in a build to override a label that already exists in the source
   Docker/OCI container.
+- Instances are no longer created with an IPC namespace by default. An IPC
+  namespace can be specified with the `-i|--ipc` flag.
 
 ## v3.8.2 - \[2021-08-31\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -665,7 +665,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionFuseMountFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionHomeFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionHostnameFlag, actionsInstanceCmd...)
-		cmdManager.RegisterFlagForCmd(&actionIpcNamespaceFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionIpcNamespaceFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionKeepPrivsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNetNamespaceFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNetworkArgsFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -539,7 +539,6 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	/* if name submitted, run as instance */
 	if name != "" {
 		PidNamespace = true
-		IpcNamespace = true
 		engineConfig.SetInstance(true)
 		engineConfig.SetBootInstance(IsBoot)
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

-i|--ipc can be set to create an IPC namespace for an instance


### This fixes or addresses the following GitHub issues:

 - Fixes #6068


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
