### PR TITLE
Remove environment variables eval for --bind, --nv and --rocm for build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   Docker/OCI container.
 - Instances are no longer created with an IPC namespace by default. An IPC
   namespace can be specified with the `-i|--ipc` flag.
+- `--bind`, `--nv` and `--rocm` options for `build` command can't be set through
+  environment variables `SINGULARITY_BIND`, `SINGULARITY_BINDPATH`, `SINGULARITY_NV`,
+  `SINGULARITY_ROCM` anymore due to side effects reported by users in this
+  [issue](https://github.com/hpcng/singularity/pull/6211), they must be explicitely
+  requested via command line.
 
 ## v3.8.2 - \[2021-08-31\]
 

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -215,7 +215,6 @@ var buildNvFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "nv",
 	Usage:        "inject host Nvidia libraries during build for post and test sections (not supported with remote build)",
-	EnvKeys:      []string{"NV"},
 }
 
 // --rocm
@@ -225,7 +224,6 @@ var buildRocmFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "rocm",
 	Usage:        "inject host Rocm libraries during build for post and test sections (not supported with remote build)",
-	EnvKeys:      []string{"ROCM"},
 }
 
 // -B|--bind
@@ -240,8 +238,6 @@ var buildBindFlag = cmdline.Flag{
 		"it is set equal to src. Mount options ('opts') may be specified as 'ro'" +
 		"(read-only) or 'rw' (read/write, which is the default)." +
 		"Multiple bind paths can be given by a comma separated list. (not supported with remote build)",
-	EnvKeys:    []string{"BIND", "BINDPATH"},
-	EnvHandler: cmdline.EnvAppendValue,
 }
 
 // --writable-tmpfs


### PR DESCRIPTION
### This fixes or addresses the following GitHub issues:

- Fixes #6181 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
