### PR TITLE
Remove --nonet flag (unused), from sylabs 240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   namespace can be specified with the `-i|--ipc` flag.
 - `--nohttps` flag has been deprecated in favour of `--no-https`. The old flag
   is still accepted, but will display a deprecation warning.
+- Removed `--nonet` flag, which was intended to disable networking for in-VM
+  execution, but has no effect.
 
 ## v3.8.2 - \[2021-08-31\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -53,7 +53,6 @@ var (
 	NoUmask         bool
 	VM              bool
 	VMErr           bool
-	NoNet           bool
 	IsSyOS          bool
 	disableCache    bool
 
@@ -268,16 +267,6 @@ var actionVMIPFlag = cmdline.Flag{
 	Usage:        "IP Address to assign for container usage. Defaults to DHCP within bridge network.",
 	Tag:          "<IP Address>",
 	EnvKeys:      []string{"VM_IP"},
-}
-
-// --nonet
-var actionNONETFlag = cmdline.Flag{
-	ID:           "actionNONETFlag",
-	Value:        &NoNet,
-	DefaultValue: false,
-	Name:         "nonet",
-	Usage:        "disable VM network handling",
-	EnvKeys:      []string{"VM_NONET"},
 }
 
 // hidden flag to handle SINGULARITY_CONTAINLIBS environment variable
@@ -673,7 +662,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionNoHomeFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoMountFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoInitFlag, actionsInstanceCmd...)
-		cmdManager.RegisterFlagForCmd(&actionNONETFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoNvidiaFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoRocmFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoPrivsFlag, actionsInstanceCmd...)


### PR DESCRIPTION
This pulls in sylabs pr
- sylabs/singularity#240
which fixed
- sylabs/singularity#239

Original PR description was:

The `--nonet` flag is confusing as it doesn't follow the `no-` hyphenation
pattern, and should apply to VM invocation only, but does not have a
`--vm-` prefix.

On further investigation the `NoNet` variable it sets is never
used. Let's just remove the flag.