### PR TITLE
Use gofumpt for stricter formatting, from sylabs 242

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
   enable-all: false
   enable:
     - deadcode
-    - gofmt
+    - gofumpt
     - goimports
     - gosimple
     - govet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,9 @@ all your interactions with the project members and users.
 1. Make sure your code passes linting, by running `make check` before submitting
    the PR. We use `golangci-lint` as our linter. You may need to address linting
    errors by:
-   - Running `go fmt ./...` to format all `.go` files.
+   - Running `gofumpt .` to format all `.go` files. We use
+     [gofumpt](https://github.com/mvdan/gofumpt) instead of `gofmt` as it adds
+     additional formatting rules which are helpful for clarity.
    - Leaving a function comment on **every** new exported function and package
      that your PR has introduced. To learn about how to properly comment Go
      code, read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ all your interactions with the project members and users.
 1. Make sure your code passes linting, by running `make check` before submitting
    the PR. We use `golangci-lint` as our linter. You may need to address linting
    errors by:
-   - Running `gofumpt .` to format all `.go` files. We use
+   - Running `gofumpt -w .` to format all `.go` files. We use
      [gofumpt](https://github.com/mvdan/gofumpt) instead of `gofmt` as it adds
      additional formatting rules which are helpful for clarity.
    - Leaving a function comment on **every** new exported function and package

--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -124,7 +124,7 @@ func analyseData(singularityCmds string, e2eCmds string, report string, verbose 
 	if report == "" {
 		resultFile, err = ioutil.TempFile("", "singularity-cmd-coverage-")
 	} else {
-		resultFile, err = os.OpenFile(report, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		resultFile, err = os.OpenFile(report, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	}
 	if err != nil {
 		return "", fmt.Errorf("failed to create file to store coverage results: %s", err)

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -57,7 +57,7 @@ func rstDocs(rootCmd *cobra.Command, outDir string) {
 
 func main() {
 	var dir string
-	var rootCmd = &cobra.Command{
+	rootCmd := &cobra.Command{
 		ValidArgs: []string{"markdown", "man", "rst"},
 		Args:      cobra.ExactArgs(1),
 		Use:       "makeDocs {markdown | man | rst}",

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -105,7 +105,7 @@ func convertImage(filename string, unsquashfsPath string) (tempDir, imageDir str
 
 	// create an inner dir to extract to, so we don't clobber the secure permissions on the tmpDir.
 	imageDir = filepath.Join(tempDir, "root")
-	if err := os.Mkdir(imageDir, 0755); err != nil {
+	if err := os.Mkdir(imageDir, 0o755); err != nil {
 		return "", "", fmt.Errorf("could not create root directory: %s", err)
 	}
 
@@ -209,7 +209,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 
 	generator.SetProcessArgs(args)
 
-	currMask := syscall.Umask(0022)
+	currMask := syscall.Umask(0o022)
 	if !NoUmask {
 		// Save the current umask, to be set for the process run in the container
 		// https://github.com/hpcng/singularity/issues/5214

--- a/cmd/internal/cli/config_fakeroot_linux.go
+++ b/cmd/internal/cli/config_fakeroot_linux.go
@@ -17,6 +17,7 @@ import (
 
 // -a|--add
 var fakerootConfigAdd bool
+
 var fakerootConfigAddFlag = cmdline.Flag{
 	ID:           "fakerootConfigAddFlag",
 	Value:        &fakerootConfigAdd,
@@ -28,6 +29,7 @@ var fakerootConfigAddFlag = cmdline.Flag{
 
 // -r|--remove
 var fakerootConfigRemove bool
+
 var fakerootConfigRemoveFlag = cmdline.Flag{
 	ID:           "fakerootConfigRemoveFlag",
 	Value:        &fakerootConfigRemove,
@@ -39,6 +41,7 @@ var fakerootConfigRemoveFlag = cmdline.Flag{
 
 // -e|--enable
 var fakerootConfigEnable bool
+
 var fakerootConfigEnableFlag = cmdline.Flag{
 	ID:           "fakerootConfigEnableFlag",
 	Value:        &fakerootConfigEnable,
@@ -50,6 +53,7 @@ var fakerootConfigEnableFlag = cmdline.Flag{
 
 // -d|--disable
 var fakerootConfigDisable bool
+
 var fakerootConfigDisableFlag = cmdline.Flag{
 	ID:           "fakerootConfigDisableFlag",
 	Value:        &fakerootConfigDisable,

--- a/cmd/internal/cli/config_global_linux.go
+++ b/cmd/internal/cli/config_global_linux.go
@@ -17,6 +17,7 @@ import (
 
 // -s|--set
 var globalConfigSet bool
+
 var globalConfigSetFlag = cmdline.Flag{
 	ID:           "globalConfigSetFlag",
 	Value:        &globalConfigSet,
@@ -28,6 +29,7 @@ var globalConfigSetFlag = cmdline.Flag{
 
 // -u|--unset
 var globalConfigUnset bool
+
 var globalConfigUnsetFlag = cmdline.Flag{
 	ID:           "globalConfigUnsetFlag",
 	Value:        &globalConfigUnset,
@@ -39,6 +41,7 @@ var globalConfigUnsetFlag = cmdline.Flag{
 
 // -g|--get
 var globalConfigGet bool
+
 var globalConfigGetFlag = cmdline.Flag{
 	ID:           "globalConfigGetFlag",
 	Value:        &globalConfigGet,
@@ -50,6 +53,7 @@ var globalConfigGetFlag = cmdline.Flag{
 
 // -r|--reset
 var globalConfigReset bool
+
 var globalConfigResetFlag = cmdline.Flag{
 	ID:           "globalConfigResetFlag",
 	Value:        &globalConfigReset,
@@ -61,6 +65,7 @@ var globalConfigResetFlag = cmdline.Flag{
 
 // -d|--dry-run
 var globalConfigDryRun bool
+
 var globalConfigDryRunFlag = cmdline.Flag{
 	ID:           "globalConfigDryRunFlag",
 	Value:        &globalConfigDryRun,

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -29,8 +29,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var errNoSIFMetadata = errors.New("no SIF metadata found")
-var errNoSIF = errors.New("invalid SIF")
+var (
+	errNoSIFMetadata = errors.New("no SIF metadata found")
+	errNoSIF         = errors.New("invalid SIF")
+)
 
 var (
 	allData     bool
@@ -223,7 +225,7 @@ func newCommand(allData bool, appName string, img *image.Image) *command {
 		allVar = "ALL_DATA=1"
 	}
 
-	var snippet = `%[1]s
+	snippet := `%[1]s
 	for app in %[2]s/scif/apps/*; do
 	if [ -d "$app/scif" ]; then
 		echo "%[3]s apps"
@@ -407,7 +409,7 @@ func (c *command) getMetadata() (*inspect.Metadata, error) {
 }
 
 func (c *command) addSingleFileCommand(file string, label string) {
-	var snippet = `
+	snippet := `
 	for prefix in ${ALL_PATH}; do
 		file="$prefix/%[1]s"
 		if [ -f "$file" ]; then

--- a/cmd/internal/cli/instance_list_linux.go
+++ b/cmd/internal/cli/instance_list_linux.go
@@ -25,6 +25,7 @@ func init() {
 
 // -u|--user
 var instanceListUser string
+
 var instanceListUserFlag = cmdline.Flag{
 	ID:           "instanceListUserFlag",
 	Value:        &instanceListUser,
@@ -38,6 +39,7 @@ var instanceListUserFlag = cmdline.Flag{
 
 // -j|--json
 var instanceListJSON bool
+
 var instanceListJSONFlag = cmdline.Flag{
 	ID:           "instanceListJSONFlag",
 	Value:        &instanceListJSON,
@@ -50,6 +52,7 @@ var instanceListJSONFlag = cmdline.Flag{
 
 // -l|--logs
 var instanceListLogs bool
+
 var instanceListLogsFlag = cmdline.Flag{
 	ID:           "instanceListLogsFlag",
 	Value:        &instanceListLogs,

--- a/cmd/internal/cli/instance_start_linux.go
+++ b/cmd/internal/cli/instance_start_linux.go
@@ -21,6 +21,7 @@ func init() {
 
 // --pid-file
 var instanceStartPidFile string
+
 var instanceStartPidFileFlag = cmdline.Flag{
 	ID:           "instanceStartPidFileFlag",
 	Value:        &instanceStartPidFile,

--- a/cmd/internal/cli/instance_stop_linux.go
+++ b/cmd/internal/cli/instance_stop_linux.go
@@ -31,6 +31,7 @@ func init() {
 
 // -u|--user
 var instanceStopUser string
+
 var instanceStopUserFlag = cmdline.Flag{
 	ID:           "instanceStopUserFlag",
 	Value:        &instanceStopUser,
@@ -44,6 +45,7 @@ var instanceStopUserFlag = cmdline.Flag{
 
 // -a|--all
 var instanceStopAll bool
+
 var instanceStopAllFlag = cmdline.Flag{
 	ID:           "instanceStopAllFlag",
 	Value:        &instanceStopAll,
@@ -56,6 +58,7 @@ var instanceStopAllFlag = cmdline.Flag{
 
 // -f|--force
 var instanceStopForce bool
+
 var instanceStopForceFlag = cmdline.Flag{
 	ID:           "instanceStopForceFlag",
 	Value:        &instanceStopForce,
@@ -68,6 +71,7 @@ var instanceStopForceFlag = cmdline.Flag{
 
 // -s|--signal
 var instanceStopSignal string
+
 var instanceStopSignalFlag = cmdline.Flag{
 	ID:           "instanceStopSignalFlag",
 	Value:        &instanceStopSignal,
@@ -81,6 +85,7 @@ var instanceStopSignalFlag = cmdline.Flag{
 
 // -t|--timeout
 var instanceStopTimeout int
+
 var instanceStopTimeoutFlag = cmdline.Flag{
 	ID:           "instanceStopTimeoutFlag",
 	Value:        &instanceStopTimeout,

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -17,8 +17,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var secretExport bool
-var armor bool
+var (
+	secretExport bool
+	armor        bool
+)
 
 // -s|--secret
 var keyExportSecretFlag = cmdline.Flag{

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -30,14 +30,16 @@ var KeyImportCmd = &cobra.Command{
 	Example: docs.KeyImportExample,
 }
 
-var keyImportWithNewPassword bool
-var keyImportWithNewPasswordFlag = cmdline.Flag{
-	ID:           "keyImportWithNewPasswordFlag",
-	Value:        &keyImportWithNewPassword,
-	DefaultValue: false,
-	Name:         "new-password",
-	Usage:        `set a new password to the private key`,
-}
+var (
+	keyImportWithNewPassword     bool
+	keyImportWithNewPasswordFlag = cmdline.Flag{
+		ID:           "keyImportWithNewPasswordFlag",
+		Value:        &keyImportWithNewPassword,
+		DefaultValue: false,
+		Name:         "new-password",
+		Usage:        `set a new password to the private key`,
+	}
+)
 
 func importRun(cmd *cobra.Command, args []string) {
 	var opts []sypgp.HandleOpt
@@ -53,5 +55,4 @@ func importRun(cmd *cobra.Command, args []string) {
 		sylog.Errorf("key import command failed: %s", err)
 		os.Exit(2)
 	}
-
 }

--- a/cmd/internal/cli/key_newpair_test.go
+++ b/cmd/internal/cli/key_newpair_test.go
@@ -89,7 +89,8 @@ func TestCollectInput(t *testing.T) {
 					Comment:  testComment,
 					Password: testPassword,
 				},
-				PushToKeyStore: true},
+				PushToKeyStore: true,
+			},
 			Error: nil,
 		},
 		{
@@ -102,7 +103,8 @@ func TestCollectInput(t *testing.T) {
 					Comment:  testComment,
 					Password: "",
 				},
-				PushToKeyStore: true},
+				PushToKeyStore: true,
+			},
 			Error: nil,
 		},
 		{

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -49,12 +49,12 @@ func doKeyPullCmd(ctx context.Context, fingerprint string, co ...client.Option) 
 	var count int
 	var opts []sypgp.HandleOpt
 	path := ""
-	mode := os.FileMode(0600)
+	mode := os.FileMode(0o600)
 
 	if keyGlobalPubKey {
 		path = buildcfg.SINGULARITY_CONFDIR
 		opts = append(opts, sypgp.GlobalHandleOpt())
-		mode = os.FileMode(0644)
+		mode = os.FileMode(0o644)
 	}
 
 	keyring := sypgp.NewHandle(path, opts...)

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -33,7 +33,6 @@ var KeyRemoveCmd = &cobra.Command{
 		if err != nil {
 			sylog.Fatalf("Unable to remove public key: %s", err)
 		}
-
 	},
 
 	Use:     docs.KeyRemoveUse,

--- a/cmd/internal/cli/plugin_compile_linux.go
+++ b/cmd/internal/cli/plugin_compile_linux.go
@@ -19,6 +19,7 @@ import (
 
 // -o|--out
 var out string
+
 var pluginCompileOutFlag = cmdline.Flag{
 	ID:           "pluginCompileOutFlag",
 	Value:        &out,
@@ -30,6 +31,7 @@ var pluginCompileOutFlag = cmdline.Flag{
 
 // --disable-minor-check
 var disableMinorCheck bool
+
 var pluginCompileDisableMinorCheckFlag = cmdline.Flag{
 	ID:           "pluginCompileDisableMinorCheckFlag",
 	Value:        &disableMinorCheck,

--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -87,7 +87,6 @@ var SearchCmd = &cobra.Command{
 		if err := library.SearchLibrary(ctx, libraryClient, args[0], SearchArch, SearchSigned); err != nil {
 			sylog.Fatalf("Couldn't search library: %v", err)
 		}
-
 	},
 
 	Use:     docs.SearchUse,

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -257,7 +257,7 @@ func handleRemoteConf(remoteConfFile string) {
 	// Only check the permission if it exists.
 	if fs.IsFile(remoteConfFile) {
 		sylog.Debugf("Ensuring file permission of 0600 on %s", remoteConfFile)
-		if err := fs.EnsureFileWithPermission(remoteConfFile, 0600); err != nil {
+		if err := fs.EnsureFileWithPermission(remoteConfFile, 0o600); err != nil {
 			sylog.Fatalf("Unable to correct the permission on %s: %s", remoteConfFile, err)
 		}
 	}
@@ -266,17 +266,17 @@ func handleRemoteConf(remoteConfFile string) {
 // handleConfDir tries to create the user's configuration directory and handles
 // messages and/or errors.
 func handleConfDir(confDir string) {
-	if err := fs.Mkdir(confDir, 0700); err != nil {
+	if err := fs.Mkdir(confDir, 0o700); err != nil {
 		if os.IsExist(err) {
 			sylog.Debugf("%s already exists. Not creating.", confDir)
 			fi, err := os.Stat(confDir)
 			if err != nil {
 				sylog.Fatalf("Failed to retrieve information for %s: %s", confDir, err)
 			}
-			if fi.Mode().Perm() != 0700 {
+			if fi.Mode().Perm() != 0o700 {
 				sylog.Debugf("Enforce permission 0700 on %s", confDir)
 				// enforce permission on user configuration directory
-				if err := os.Chmod(confDir, 0700); err != nil {
+				if err := os.Chmod(confDir, 0o700); err != nil {
 					// best effort as chmod could fail for various reasons (eg: readonly FS)
 					sylog.Warningf("Couldn't enforce permission 0700 on %s: %s", confDir, err)
 				}
@@ -482,7 +482,7 @@ var VersionCmd = &cobra.Command{
 }
 
 func loadRemoteConf(filepath string) (*remote.Config, error) {
-	f, err := os.OpenFile(filepath, os.O_RDONLY, 0600)
+	f, err := os.OpenFile(filepath, os.O_RDONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/cmd/internal/cli/startvm.go
+++ b/cmd/internal/cli/startvm.go
@@ -86,12 +86,11 @@ func startVM(sifImage, singAction, cliExtra string, isInternal bool) error {
 	}
 
 	err := cmd.Run()
-
 	if err != nil {
 		sylog.Debugf("Hypervisor exit code: %v\n", err)
 
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			//Program exited with non-zero return code
+			// Program exited with non-zero return code
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 				sylog.Debugf("Process exited with non-zero return code: %d\n", status.ExitStatus())
 				return nil

--- a/docs/content.go
+++ b/docs/content.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-//TODO Provide some guidelines for writing these docs
+// TODO Provide some guidelines for writing these docs
 
 package docs
 

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -86,7 +86,7 @@ func (c actionTests) issue4755(t *testing.T) {
 	// create a file in image /tmp in order to trigger the issue
 	// with underlay layer
 	baseDir := filepath.Join(sandbox, filepath.Dir(c.env.TestDir))
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
+	if err := os.MkdirAll(baseDir, 0o700); err != nil {
 		t.Fatalf("can't create image directory %s: %s", baseDir, err)
 	}
 	path := filepath.Join(baseDir, "underlay-test")
@@ -191,7 +191,7 @@ func (c actionTests) issue4836(t *testing.T) {
 
 	// $TMPDIR/issue-4836-XXXX/dir/child directory
 	dir := filepath.Join(issueDir, "dir", "child")
-	if err := os.MkdirAll(filepath.Join(issueDir, "dir", "child"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(issueDir, "dir", "child"), 0o755); err != nil {
 		t.Fatalf("failed to create dir %s: %s", dir, err)
 	}
 
@@ -232,7 +232,7 @@ func (c actionTests) issue4823(t *testing.T) {
 	issueDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-4823-", "")
 	defer cleanup(t)
 	issueImage := path.Join(issueDir, "test.sif")
-	if err := fs.CopyFile(c.env.ImagePath, issueImage, 0755); err != nil {
+	if err := fs.CopyFile(c.env.ImagePath, issueImage, 0o755); err != nil {
 		t.Fatalf("Could not copy test image file: %v", err)
 	}
 
@@ -372,7 +372,6 @@ func (c actionTests) issue5211(t *testing.T) {
 			e2e.ExpectOutput(e2e.ExactMatch, "/root"),
 		),
 	)
-
 }
 
 // Check that we can create a directory in container image with --writable-tmpfs.
@@ -409,7 +408,6 @@ func (c actionTests) issue5307(t *testing.T) {
 // Check we can fakeroot exec an image containing a system xattr, which we may
 // not be able to set in the SIF -> sandbox extraction.
 func (c actionTests) issue5399(t *testing.T) {
-
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue5399-", "")
 	defer e2e.Privileged(cleanup)(t)
 	image := filepath.Join(dir, "issue_5399.sif")
@@ -456,10 +454,10 @@ func (c actionTests) issue5455(t *testing.T) {
 				return
 			}
 			permDir := filepath.Join(dir, "perm")
-			if err := os.Mkdir(permDir, 0777); err != nil {
+			if err := os.Mkdir(permDir, 0o777); err != nil {
 				t.Errorf("while creating %s: %s", permDir, err)
 			}
-			if err := os.Chmod(permDir, 0777); err != nil {
+			if err := os.Chmod(permDir, 0o777); err != nil {
 				t.Errorf("while setting permission on %s: %s", permDir, err)
 			}
 		}),
@@ -490,7 +488,7 @@ func (c actionTests) issue5631(t *testing.T) {
 		e2e.PreRun(
 			// Custom config file must exist and be root owned with tight permissions
 			func(t *testing.T) {
-				err := fs.EnsureFileWithPermission(tmpConfig, 0600)
+				err := fs.EnsureFileWithPermission(tmpConfig, 0o600)
 				if err != nil {
 					t.Fatalf("while creating temporary config file: %s", err)
 				}
@@ -682,7 +680,6 @@ func (c actionTests) invalidRemote(t *testing.T) {
 		e2e.WithArgs(argv...),
 		e2e.ExpectExit(255),
 	)
-
 }
 
 // Check that a bind mount without a destination is not added two times.

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -47,11 +47,11 @@ func (c cacheTests) issue5097(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not remove cached image '%s': %v", cachePath, err)
 	}
-	err = os.Mkdir(cachePath, 0700)
+	err = os.Mkdir(cachePath, 0o700)
 	if err != nil {
 		t.Fatalf("Could not create directory '%s': %v", cachePath, err)
 	}
-	err = fs.CopyFile(imagePath, path.Join(cachePath, hash), 0700)
+	err = fs.CopyFile(imagePath, path.Join(cachePath, hash), 0o700)
 	if err != nil {
 		t.Fatalf("Could not copy file to directory '%s': %v", cachePath, err)
 	}
@@ -69,13 +69,11 @@ func (c cacheTests) issue5097(t *testing.T) {
 	if !fs.IsFile(cachePath) {
 		t.Fatalf("Cache entry '%s' is not a file", cachePath)
 	}
-
 }
 
 // issue5350 - need to handle the cache being inside a non-accssible directory
 // e.g. home directory without perms to access
 func (c cacheTests) issue5350(t *testing.T) {
-
 	outerDir, cleanupOuter := e2e.MakeTempDir(t, c.env.TestDir, "issue5350-cache-", "")
 	defer e2e.Privileged(cleanupOuter)(t)
 
@@ -102,5 +100,4 @@ func (c cacheTests) issue5350(t *testing.T) {
 	if err := os.Chmod(outerDir, 0o755); err != nil {
 		t.Fatalf("Could not chmod 755 cache outer dir: %v", err)
 	}
-
 }

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -143,7 +143,6 @@ func ls(t *testing.T, dir string) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Logf("E: error walking the path %q: %v\n", dir, err)
 		return
@@ -205,7 +204,7 @@ func (c ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
 	defer cleanup(t)
 
 	// Change the mode of the image cache to read-only
-	err := os.Chmod(c.env.ImgCacheDir, 0555)
+	err := os.Chmod(c.env.ImgCacheDir, 0o555)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}
@@ -216,7 +215,7 @@ func (c ctx) testSingularityReadOnlyCacheDir(t *testing.T) {
 	// can delete the cache if it was created. Do this _before_
 	// calling c.assertCacheDoesNotExist because that function will
 	// fail if it find a cache.
-	err = os.Chmod(c.env.ImgCacheDir, 0755)
+	err = os.Chmod(c.env.ImgCacheDir, 0o755)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -639,7 +639,7 @@ func (c configTests) configFile(t *testing.T) {
 	}
 
 	// Create a temp testfile
-	f, err := fs.MakeTmpFile(c.env.TestDir, "config-", 0644)
+	f, err := fs.MakeTmpFile(c.env.TestDir, "config-", 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -654,7 +654,7 @@ func (c configTests) configFile(t *testing.T) {
 			e2e.WithGlobalOptions("--config", configFile),
 			e2e.WithProfile(tt.profile),
 			e2e.PreRun(func(t *testing.T) {
-				if err := ioutil.WriteFile(configFile, []byte(tt.conf), 0644); err != nil {
+				if err := ioutil.WriteFile(configFile, []byte(tt.conf), 0o644); err != nil {
 					t.Errorf("could not write configuration file %s: %s", configFile, err)
 				}
 			}),

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -27,7 +27,7 @@ type ctx struct {
 func (c ctx) testDockerPulls(t *testing.T) {
 	const tmpContainerFile = "test_container.sif"
 
-	tmpPath, err := fs.MakeTmpDir(c.env.TestDir, "docker-", 0755)
+	tmpPath, err := fs.MakeTmpDir(c.env.TestDir, "docker-", 0o755)
 	err = errors.Wrapf(err, "creating temporary directory in %q for docker pull test", c.env.TestDir)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %+v", err)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -27,7 +27,7 @@ import (
 func TestE2E(t *testing.T) {
 	targetCoverageFilePath := os.Getenv("SINGULARITY_E2E_COVERAGE")
 	if targetCoverageFilePath != "" {
-		logFile, err := os.OpenFile(targetCoverageFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		logFile, err := os.OpenFile(targetCoverageFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o666)
 		if err != nil {
 			log.Fatalf("failed to create log file: %s", err)
 		}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -34,19 +34,19 @@ func (c ctx) singularityEnv(t *testing.T) {
 	c.env.ImgCacheDir = imgCacheDir
 
 	// Singularity defines a path by default. See singularityware/singularity/etc/init.
-	var defaultImage = "docker://alpine:3.8"
+	defaultImage := "docker://alpine:3.8"
 
 	// This image sets a custom path.
-	var customImage = "docker://sylabsio/lolcow"
-	var customPath = "/usr/games:" + defaultPath
+	customImage := "docker://sylabsio/lolcow"
+	customPath := "/usr/games:" + defaultPath
 
 	// Append or prepend this path.
-	var partialPath = "/foo"
+	partialPath := "/foo"
 
 	// Overwrite the path with this one.
-	var overwrittenPath = "/usr/bin:/bin"
+	overwrittenPath := "/usr/bin:/bin"
 
-	var tests = []struct {
+	tests := []struct {
 		name  string
 		image string
 		path  string
@@ -127,7 +127,7 @@ func (c ctx) singularityEnvOption(t *testing.T) {
 	defer cleanCache(t)
 	c.env.ImgCacheDir = imgCacheDir
 
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		image    string
 		envOpt   []string
@@ -333,7 +333,7 @@ func (c ctx) singularityEnvFile(t *testing.T) {
 	defer cleanCache(t)
 	c.env.ImgCacheDir = imgCacheDir
 
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		image    string
 		envFile  string
@@ -414,7 +414,7 @@ func (c ctx) singularityEnvFile(t *testing.T) {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
 		}
 		if tt.envFile != "" {
-			ioutil.WriteFile(p, []byte(tt.envFile), 0644)
+			ioutil.WriteFile(p, []byte(tt.envFile), 0o644)
 			args = append(args, "--env-file", p)
 		}
 		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -43,7 +43,7 @@ func (c ctx) issue5426(t *testing.T) {
 	}
 	// Copy in the test environment file
 	testEnvironment := path.Join("testdata", "regressions", "legacy-environment")
-	if err := fs.CopyFile(testEnvironment, path.Join(sandboxDir, "environment"), 0755); err != nil {
+	if err := fs.CopyFile(testEnvironment, path.Join(sandboxDir, "environment"), 0o755); err != nil {
 		t.Fatalf("Could not add legacy /environment to sandbox: %s", err)
 	}
 

--- a/e2e/gpu/regressions.go
+++ b/e2e/gpu/regressions.go
@@ -23,7 +23,7 @@ func (c ctx) issue5002(t *testing.T) {
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-5631-", "")
 	defer e2e.Privileged(cleanup)(t)
 	fakeLdconfig := filepath.Join(tmpDir, "ldconfig")
-	err := fs.EnsureFileWithPermission(fakeLdconfig, 0755)
+	err := fs.EnsureFileWithPermission(fakeLdconfig, 0o755)
 	if err != nil {
 		t.Fatalf("Could not create fake ldconfig: %s", err)
 	}

--- a/e2e/help/help.go
+++ b/e2e/help/help.go
@@ -149,7 +149,6 @@ func (c ctx) testCommands(t *testing.T) {
 		}
 
 	}
-
 }
 
 func (c ctx) testFailure(t *testing.T) {
@@ -168,7 +167,6 @@ func (c ctx) testFailure(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
@@ -181,7 +179,6 @@ func (c ctx) testFailure(t *testing.T) {
 			}),
 			e2e.ExpectExit(0))
 	}
-
 }
 
 // Expected first lines of the help command output based on what options is used
@@ -256,7 +253,6 @@ func (c ctx) testSingularity(t *testing.T) {
 			),
 		)
 	}
-
 }
 
 // E2ETests is the main func to trigger the test suite

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -29,7 +29,7 @@ type imgBuildTests struct {
 }
 
 func (c imgBuildTests) tempDir(t *testing.T, namespace string) (string, func()) {
-	dn, err := fs.MakeTmpDir(c.env.TestDir, namespace+".", 0755)
+	dn, err := fs.MakeTmpDir(c.env.TestDir, namespace+".", 0o755)
 	if err != nil {
 		t.Errorf("failed to create temporary directory: %#v", err)
 	}
@@ -217,7 +217,6 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 			e2e.PreRun(func(t *testing.T) {
 				if tc.requireArch != "" {
 					require.Arch(t, tc.requireArch)
-
 				}
 			}),
 
@@ -1242,7 +1241,6 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 			),
 		)
 	}
-
 }
 
 // buildBindMount checks that we can bind host files/directories during build.

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -71,7 +71,7 @@ func (c *imgBuildTests) issue4407(t *testing.T) {
 			log.Fatalf("failed to create temporary directory for sandbox: %v", err)
 		}
 
-		if err := os.Chmod(name, 0755); err != nil {
+		if err := os.Chmod(name, 0o755); err != nil {
 			log.Fatalf("failed to chmod temporary directory for sandbox: %v", err)
 		}
 
@@ -125,7 +125,6 @@ func (c *imgBuildTests) issue4524(t *testing.T) {
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--fix-perms", "--sandbox", sandbox, "docker://sylabsio/issue4524"),
 		e2e.PostRun(func(t *testing.T) {
-
 			// If we failed to build the sandbox completely, leave what we have for
 			// investigation.
 			if t.Failed() {
@@ -133,10 +132,10 @@ func (c *imgBuildTests) issue4524(t *testing.T) {
 				return
 			}
 
-			if !e2e.PathPerms(t, path.Join(sandbox, "directory"), 0700) {
+			if !e2e.PathPerms(t, path.Join(sandbox, "directory"), 0o700) {
 				t.Error("Expected 0700 permissions on 000 test directory in rootless sandbox")
 			}
-			if !e2e.PathPerms(t, path.Join(sandbox, "file"), 0600) {
+			if !e2e.PathPerms(t, path.Join(sandbox, "file"), 0o600) {
 				t.Error("Expected 0600 permissions on 000 test file in rootless sandbox")
 			}
 
@@ -151,7 +150,6 @@ func (c *imgBuildTests) issue4524(t *testing.T) {
 			if err != nil {
 				t.Logf("Cannot remove sandbox directory: %#v", err)
 			}
-
 		}),
 		e2e.ExpectExit(0),
 	)
@@ -206,7 +204,6 @@ func (c imgBuildTests) issue4837(t *testing.T) {
 }
 
 func (c *imgBuildTests) issue4943(t *testing.T) {
-
 	require.Arch(t, "amd64")
 
 	const (
@@ -220,7 +217,6 @@ func (c *imgBuildTests) issue4943(t *testing.T) {
 		e2e.WithArgs("--force", "/dev/null", image),
 		e2e.ExpectExit(0),
 	)
-
 }
 
 // Test -c section parameter is correctly handled.
@@ -267,7 +263,7 @@ func (c *imgBuildTests) issue5166(t *testing.T) {
 	sensibleDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "sensible-dir-", "")
 
 	secret := filepath.Join(sensibleDir, "secret")
-	if err := ioutil.WriteFile(secret, []byte("secret"), 0644); err != nil {
+	if err := ioutil.WriteFile(secret, []byte("secret"), 0o644); err != nil {
 		t.Fatalf("could not create %s: %s", secret, err)
 	}
 
@@ -323,14 +319,14 @@ func (c *imgBuildTests) issue5172(t *testing.T) {
 	regFile := filepath.Join(regDir, "registries.conf")
 	imagePath := filepath.Join(c.env.TestDir, "issue-5172")
 
-	if err := os.MkdirAll(regDir, 0755); err != nil {
+	if err := os.MkdirAll(regDir, 0o755); err != nil {
 		t.Fatalf("can't create directory %s: %s", regDir, err)
 	}
 
 	// add our test registry as insecure and test build/pull
 	b := new(bytes.Buffer)
 	b.WriteString("[registries.insecure]\nregistries = ['localhost']")
-	if err := ioutil.WriteFile(regFile, b.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(regFile, b.Bytes(), 0o644); err != nil {
 		t.Fatalf("can't create %s: %s", regFile, err)
 	}
 	defer os.RemoveAll(regDir)

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -111,7 +111,7 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 
 	// Create and populate a temporary file.
 	tempFile := filepath.Join(dir, fileName)
-	err = ioutil.WriteFile(tempFile, fileContents, 0644)
+	err = ioutil.WriteFile(tempFile, fileContents, 0o644)
 	err = errors.Wrapf(err, "creating temporary test file %s", tempFile)
 	if err != nil {
 		t.Fatalf("Failed to create file: %+v", err)

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -43,7 +43,6 @@ func PrepRegistry(t *testing.T, env TestEnv) {
 	defer registrySetup.Unlock()
 
 	registrySetup.Do(func() {
-
 		t.Log("Preparing docker registry instance.")
 
 		EnsureImage(t, env)

--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -40,7 +40,7 @@ func WriteTempFile(dir, pattern, content string) (string, error) {
 // This function shall not set the environment variable to specify the
 // image cache location since it would create thread safety problems.
 func MakeTempDir(t *testing.T, baseDir string, prefix string, context string) (string, func(t *testing.T)) {
-	dir, err := fs.MakeTmpDir(baseDir, prefix, 0755)
+	dir, err := fs.MakeTmpDir(baseDir, prefix, 0o755)
 	err = errors.Wrapf(err, "creating temporary %s at %s", context, baseDir)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %+v", err)
@@ -86,7 +86,6 @@ func PathExists(t *testing.T, path string) bool {
 // PathPerms return true if the path (file or directory) has specified permissions, false otherwise.
 func PathPerms(t *testing.T, path string, perms os.FileMode) bool {
 	s, err := os.Stat(path)
-
 	if err != nil {
 		t.Fatalf("While stating file: %v", err)
 	}

--- a/e2e/internal/e2e/home.go
+++ b/e2e/internal/e2e/home.go
@@ -72,7 +72,7 @@ func SetupHomeDirectories(t *testing.T) {
 		oldUmask := syscall.Umask(0)
 		defer syscall.Umask(oldUmask)
 
-		if err := os.Mkdir(unprivSessionHome, 0700); err != nil {
+		if err := os.Mkdir(unprivSessionHome, 0o700); err != nil {
 			err = errors.Wrapf(err, "creating temporary home directory at %s", unprivSessionHome)
 			t.Fatalf("failed to create temporary home: %+v", err)
 		}
@@ -80,7 +80,7 @@ func SetupHomeDirectories(t *testing.T) {
 			err = errors.Wrapf(err, "changing temporary home directory ownership at %s", unprivSessionHome)
 			t.Fatalf("failed to set temporary home owner: %+v", err)
 		}
-		if err := os.Mkdir(privSessionHome, 0700); err != nil {
+		if err := os.Mkdir(privSessionHome, 0o700); err != nil {
 			err = errors.Wrapf(err, "changing temporary home directory %s", privSessionHome)
 			t.Fatalf("failed to create temporary home: %+v", err)
 		}
@@ -93,7 +93,7 @@ func SetupHomeDirectories(t *testing.T) {
 		if strings.HasPrefix(sourceDir, unprivResolvedHome) {
 			trimmedSourceDir := strings.TrimPrefix(sourceDir, unprivResolvedHome)
 			sessionSourceDir := filepath.Join(unprivSessionHome, trimmedSourceDir)
-			if err := os.MkdirAll(sessionSourceDir, 0755); err != nil {
+			if err := os.MkdirAll(sessionSourceDir, 0o755); err != nil {
 				err = errors.Wrapf(err, "creating temporary source directory at %q", sessionSourceDir)
 				t.Fatalf("failed to create temporary home source directory: %+v", err)
 			}
@@ -131,12 +131,12 @@ func SetupHomeDirectories(t *testing.T) {
 
 		// create .rpmmacros files for yum bootstrap builds
 		macrosFile := filepath.Join(unprivSessionHome, ".rpmmacros")
-		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0444); err != nil {
+		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
 			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
 			t.Fatalf("could not write macros file: %+v", err)
 		}
 		macrosFile = filepath.Join(privSessionHome, ".rpmmacros")
-		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0444); err != nil {
+		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
 			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
 			t.Fatalf("could not write macros file: %+v", err)
 		}
@@ -155,7 +155,7 @@ func shadowInstanceDirectory(t *testing.T, env TestEnv) func(t *testing.T) {
 	fakeInstanceSymlink := filepath.Join(fakeSingularityDir, "instances")
 
 	// create directory $TESTDIR/.singularity
-	if err := os.Mkdir(fakeSingularityDir, 0755); err != nil && !os.IsExist(err) {
+	if err := os.Mkdir(fakeSingularityDir, 0o755); err != nil && !os.IsExist(err) {
 		err = errors.Wrapf(err, "create temporary singularity data directory at %q", fakeSingularityDir)
 		t.Fatalf("failed to create fake singularity directory: %+v", err)
 	}

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 )
 
-var ensureMutex sync.Mutex
-var pullMutex sync.Mutex
+var (
+	ensureMutex sync.Mutex
+	pullMutex   sync.Mutex
+)
 
 // EnsureImage checks if e2e test image is already built or built
 // it otherwise.

--- a/e2e/internal/e2e/imagebuild.go
+++ b/e2e/internal/e2e/imagebuild.go
@@ -119,7 +119,7 @@ func PrepareMultiStageDefFile(dfd []DefFileDetails) (outputPath string) {
 }
 
 func RawDefFile(t *testing.T, dir string, r io.Reader) (outputPath string) {
-	f, err := fs.MakeTmpFile(dir, "raw-deffile", 0644)
+	f, err := fs.MakeTmpFile(dir, "raw-deffile", 0o644)
 	if err != nil {
 		t.Fatalf("while making temporal definition file: %v", err)
 	}

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -283,7 +283,6 @@ func DefinitionImageVerify(t *testing.T, cmdPath, imagePath string, dfd DefFileD
 			}
 		}
 	}
-
 }
 
 func verifyFile(t *testing.T, original, copy string) error {
@@ -329,7 +328,7 @@ func verifyHelp(t *testing.T, fileName string, contents []string) error {
 	}
 
 	// do perm check
-	if fi.Mode().Perm() != 0644 {
+	if fi.Mode().Perm() != 0o644 {
 		return fmt.Errorf("Incorrect help script perms: %v", fi.Mode().Perm())
 	}
 
@@ -355,7 +354,7 @@ func verifyScript(t *testing.T, fileName string, contents []string) error {
 	}
 
 	// do perm check
-	if fi.Mode().Perm() != 0755 {
+	if fi.Mode().Perm() != 0o755 {
 		return fmt.Errorf("Incorrect script perms: %v", fi.Mode().Perm())
 	}
 

--- a/e2e/internal/e2e/plugin.go
+++ b/e2e/internal/e2e/plugin.go
@@ -18,11 +18,11 @@ func SetupPluginDir(t *testing.T, testDir string) {
 	Privileged(func(t *testing.T) {
 		path := buildcfg.PLUGIN_ROOTDIR
 
-		if err := os.Mkdir(path, 0755); err != nil && !os.IsExist(err) {
+		if err := os.Mkdir(path, 0o755); err != nil && !os.IsExist(err) {
 			t.Fatalf("while creating plugin directory %s: %s", path, err)
 		}
 		dir := filepath.Join(testDir, "plugin-install")
-		if err := os.Mkdir(dir, 0755); err != nil {
+		if err := os.Mkdir(dir, 0o755); err != nil {
 			t.Fatalf("while creating plugin temporary directory %s: %s", dir, err)
 		}
 		if err := unix.Mount(dir, path, "", unix.MS_BIND, ""); err != nil {

--- a/e2e/internal/e2e/remote.go
+++ b/e2e/internal/e2e/remote.go
@@ -24,7 +24,7 @@ func SetupSystemRemoteFile(t *testing.T, testDir string) {
 		if err != nil {
 			t.Fatalf("while reading %s: %s", orig, err)
 		}
-		if err := ioutil.WriteFile(source, data, 0644); err != nil {
+		if err := ioutil.WriteFile(source, data, 0o644); err != nil {
 			t.Fatalf("while creating %s: %s", source, err)
 		}
 		if err := unix.Mount(source, dest, "", unix.MS_BIND, ""); err != nil {

--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -46,7 +46,7 @@ func (s *Suite) AddGroup(name string, group Group) {
 }
 
 func (s *Suite) Run() {
-	var tests = make(map[string]Tests)
+	tests := make(map[string]Tests)
 
 	for name, gr := range s.groups {
 		env := s.env

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -492,7 +492,7 @@ func (c *ctx) checkKeyLength(t *testing.T, expectedKeyLength int) {
 }
 
 func (c *ctx) globalKeyring(t *testing.T) {
-	var keyMap = map[string]string{
+	keyMap := map[string]string{
 		"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
 		"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
 	}

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -543,20 +543,20 @@ func (c ctx) testPullUmask(t *testing.T) {
 		{
 			name:       "0022 umask pull",
 			imagePath:  filepath.Join(c.env.TestDir, umask22Image),
-			umask:      0022,
-			expectPerm: 0755,
+			umask:      0o022,
+			expectPerm: 0o755,
 		},
 		{
 			name:       "0077 umask pull",
 			imagePath:  filepath.Join(c.env.TestDir, umask77Image),
-			umask:      0077,
-			expectPerm: 0700,
+			umask:      0o077,
+			expectPerm: 0o700,
 		},
 		{
 			name:       "0027 umask pull",
 			imagePath:  filepath.Join(c.env.TestDir, umask27Image),
-			umask:      0027,
-			expectPerm: 0750,
+			umask:      0o027,
+			expectPerm: 0o750,
 		},
 
 		// With the force flag, and overide the image. The permission will
@@ -564,22 +564,22 @@ func (c ctx) testPullUmask(t *testing.T) {
 		{
 			name:       "0022 umask pull overide",
 			imagePath:  filepath.Join(c.env.TestDir, umask22Image),
-			umask:      0022,
-			expectPerm: 0755,
+			umask:      0o022,
+			expectPerm: 0o755,
 			force:      true,
 		},
 		{
 			name:       "0077 umask pull overide",
 			imagePath:  filepath.Join(c.env.TestDir, umask77Image),
-			umask:      0077,
-			expectPerm: 0700,
+			umask:      0o077,
+			expectPerm: 0o700,
 			force:      true,
 		},
 		{
 			name:       "0027 umask pull overide",
 			imagePath:  filepath.Join(c.env.TestDir, umask27Image),
-			umask:      0027,
-			expectPerm: 0750,
+			umask:      0o027,
+			expectPerm: 0o750,
 			force:      true,
 		},
 	}
@@ -594,7 +594,7 @@ func (c ctx) testPullUmask(t *testing.T) {
 	}
 
 	// Set a common umask, then reset it back later.
-	oldUmask := unix.Umask(0022)
+	oldUmask := unix.Umask(0o022)
 	defer unix.Umask(oldUmask)
 
 	// TODO: should also check the cache umask.
@@ -610,7 +610,7 @@ func (c ctx) testPullUmask(t *testing.T) {
 			e2e.WithProfile(e2e.UserProfile),
 			e2e.PreRun(func(t *testing.T) {
 				// Reset the file permission after every pull.
-				err := os.Chmod(tc.imagePath, 0666)
+				err := os.Chmod(tc.imagePath, 0o666)
 				if !os.IsNotExist(err) && err != nil {
 					t.Fatalf("failed chmod-ing file: %s", err)
 				}

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -68,5 +68,4 @@ func (c ctx) issue5808(t *testing.T) {
 		e2e.WithArgs(argv...),
 		e2e.ExpectExit(0),
 	)
-
 }

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -453,7 +453,6 @@ func (c ctx) remoteTestFlag(t *testing.T) {
 				e2e.ExpectOutput(e2e.RegexMatch, `^`+tt.expectedOutput),
 			),
 		)
-
 	}
 }
 
@@ -608,9 +607,7 @@ func (c ctx) remoteLoginRepeated(t *testing.T) {
 	e2e.EnsureRegistry(t)
 	e2e.EnsureImage(t, c.env)
 
-	var (
-		registry = fmt.Sprintf("oras://%s", c.env.TestRegistry)
-	)
+	registry := fmt.Sprintf("oras://%s", c.env.TestRegistry)
 
 	tests := []struct {
 		name       string

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -28,7 +28,7 @@ func (c ctx) testRun555Cache(t *testing.T) {
 	tempDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 	defer cleanup(t)
 	cacheDir := filepath.Join(tempDir, "image-cache")
-	err := os.Mkdir(cacheDir, 0555)
+	err := os.Mkdir(cacheDir, 0o555)
 	if err != nil {
 		t.Fatalf("failed to create a temporary image cache: %s", err)
 	}

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -22,8 +22,10 @@ type ctx struct {
 	passphraseInput []e2e.SingularityConsoleOp
 }
 
-const imgURL = "library://sylabs/tests/unsigned:1.0.0"
-const imgName = "testImage.sif"
+const (
+	imgURL  = "library://sylabs/tests/unsigned:1.0.0"
+	imgName = "testImage.sif"
+)
 
 func (c ctx) singularitySignHelpOption(t *testing.T) {
 	c.env.KeyringDir = c.keyringDir

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -94,7 +94,7 @@ func Run(t *testing.T) {
 		os.RemoveAll(name)
 	})(t)
 
-	if err := os.Chmod(name, 0755); err != nil {
+	if err := os.Chmod(name, 0o755); err != nil {
 		log.Fatalf("failed to chmod temporary directory: %v", err)
 	}
 	testenv.TestDir = name

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -31,8 +31,10 @@ type verifyOutput struct {
 	dataCheck   bool
 }
 
-const successURL = "library://sylabs/tests/verify_success:1.0.2"
-const corruptedURL = "library://sylabs/tests/verify_corrupted:1.0.1"
+const (
+	successURL   = "library://sylabs/tests/verify_success:1.0.2"
+	corruptedURL = "library://sylabs/tests/verify_corrupted:1.0.1"
+)
 
 func getNameJSON(keyNum int) []string {
 	return []string{"SignerKeys", fmt.Sprintf("[%d]", keyNum), "Signer", "Name"}

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -27,7 +27,7 @@ var tests = []struct {
 	{"version flag", []string{"--version"}},
 }
 
-//Test that this version uses the semantic version format
+// Test that this version uses the semantic version format
 func (c ctx) testSemanticVersion(t *testing.T) {
 	for _, tt := range tests {
 
@@ -54,10 +54,10 @@ func (c ctx) testSemanticVersion(t *testing.T) {
 	}
 }
 
-//Test that both versions when running: singularity --version and
+// Test that both versions when running: singularity --version and
 // singularity version give the same result
 func (c ctx) testEqualVersion(t *testing.T) {
-	var tmpVersion = ""
+	tmpVersion := ""
 	for _, tt := range tests {
 
 		checkEqualVersionFn := func(t *testing.T, r *e2e.SingularityCmdResult) {
@@ -74,7 +74,7 @@ func (c ctx) testEqualVersion(t *testing.T) {
 					err = errors.Wrapf(err, "creating semver version from %q", tmpVersion)
 					t.Fatalf("Creating semver version: %+v", err)
 				}
-				//compare versions and see if they are equal
+				// compare versions and see if they are equal
 				if semanticVersion.Compare(versionTmp) != 0 {
 					err = errors.Wrapf(err, "comparing versions %q and %q", outputVer, tmpVersion)
 					t.Fatalf("singularity version command and singularity --version give a non-matching version result: %+v", err)

--- a/etc/conf/gen.go
+++ b/etc/conf/gen.go
@@ -41,7 +41,7 @@ func genConf(tmpl, in, out string) {
 		os.Exit(1)
 	}
 
-	newOutFile, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	newOutFile, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		fmt.Printf("Unable to create file %s: %v\n", out, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
+	mvdan.cc/gofumpt v0.1.1 // indirect
 	mvdan.cc/sh/v3 v3.3.1
 	oras.land/oras-go v0.4.0
 	rsc.io/letsencrypt v0.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
-	mvdan.cc/gofumpt v0.1.1 // indirect
 	mvdan.cc/sh/v3 v3.3.1
 	oras.land/oras-go v0.4.0
 	rsc.io/letsencrypt v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -775,7 +775,6 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rootless-containers/proto v0.1.0 h1:gS1JOMEtk1YDYHCzBAf/url+olMJbac7MTrgSeP6zh4=
 github.com/rootless-containers/proto v0.1.0/go.mod h1:vgkUFZbQd0gcE/K/ZwtE4MYjZPu0UNHLXIQxhyqAFh8=
@@ -989,7 +988,6 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1220,11 +1218,9 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1420,8 +1416,6 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 mvdan.cc/editorconfig v0.2.0/go.mod h1:lvnnD3BNdBYkhq+B4uBuFFKatfp02eB6HixDvEz91C0=
-mvdan.cc/gofumpt v0.1.1 h1:bi/1aS/5W00E2ny5q65w9SnKpWEF/UIOqDYBILpo9rA=
-mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/sh/v3 v3.3.1 h1:aA0i7NZOc1oV5jfAH20FCz+QsmI/TX7FiAquC5Rdo5o=
 mvdan.cc/sh/v3 v3.3.1/go.mod h1:DpbFT2B4fXpKiq69fEoMe+71JrmUn5aUekYy9fNKnQw=
 oras.land/oras-go v0.4.0 h1:u6+7D+raZDYHwlz/uOwNANiRmyYDSSMW7A9E1xXycUQ=

--- a/go.sum
+++ b/go.sum
@@ -775,6 +775,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rootless-containers/proto v0.1.0 h1:gS1JOMEtk1YDYHCzBAf/url+olMJbac7MTrgSeP6zh4=
 github.com/rootless-containers/proto v0.1.0/go.mod h1:vgkUFZbQd0gcE/K/ZwtE4MYjZPu0UNHLXIQxhyqAFh8=
@@ -988,6 +989,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1218,9 +1220,11 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1416,6 +1420,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 mvdan.cc/editorconfig v0.2.0/go.mod h1:lvnnD3BNdBYkhq+B4uBuFFKatfp02eB6HixDvEz91C0=
+mvdan.cc/gofumpt v0.1.1 h1:bi/1aS/5W00E2ny5q65w9SnKpWEF/UIOqDYBILpo9rA=
+mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/sh/v3 v3.3.1 h1:aA0i7NZOc1oV5jfAH20FCz+QsmI/TX7FiAquC5Rdo5o=
 mvdan.cc/sh/v3 v3.3.1/go.mod h1:DpbFT2B4fXpKiq69fEoMe+71JrmUn5aUekYy9fNKnQw=
 oras.land/oras-go v0.4.0 h1:u6+7D+raZDYHwlz/uOwNANiRmyYDSSMW7A9E1xXycUQ=

--- a/internal/app/singularity/cache_clean_linux.go
+++ b/internal/app/singularity/cache_clean_linux.go
@@ -14,9 +14,7 @@ import (
 	"github.com/hpcng/singularity/pkg/util/slice"
 )
 
-var (
-	errInvalidCacheHandle = errors.New("invalid cache handle")
-)
+var errInvalidCacheHandle = errors.New("invalid cache handle")
 
 // cleanCache cleans the given type of cache cacheType. It will return a
 // error if one occurs.

--- a/internal/app/singularity/cache_list_linux.go
+++ b/internal/app/singularity/cache_list_linux.go
@@ -33,9 +33,7 @@ func listTypeCache(printList bool, name, cachePath string) (int, int64, error) {
 		return 0, 0, fmt.Errorf("unable to open cache %s at directory %s: %v", name, cachePath, err)
 	}
 
-	var (
-		totalSize int64
-	)
+	var totalSize int64
 
 	for _, entry := range cacheEntries {
 

--- a/internal/app/singularity/capability_list_linux.go
+++ b/internal/app/singularity/capability_list_linux.go
@@ -30,7 +30,7 @@ func CapabilityList(capFile string, c CapListConfig) error {
 	oldmask := syscall.Umask(0)
 	defer syscall.Umask(oldmask)
 
-	file, err := os.OpenFile(capFile, os.O_RDONLY, 0644)
+	file, err := os.OpenFile(capFile, os.O_RDONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
 	}

--- a/internal/app/singularity/capability_manage_linux.go
+++ b/internal/app/singularity/capability_manage_linux.go
@@ -63,7 +63,7 @@ func manageCaps(capFile string, c CapManageConfig, t manageType) error {
 	oldmask := syscall.Umask(0)
 	defer syscall.Umask(oldmask)
 
-	file, err := os.OpenFile(capFile, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := os.OpenFile(capFile, os.O_RDWR|os.O_CREATE, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
 	}

--- a/internal/app/singularity/config_global_linux.go
+++ b/internal/app/singularity/config_global_linux.go
@@ -44,7 +44,7 @@ func generateConfig(path string, directives singularityconf.Directives, dry bool
 		unix.Umask(0)
 
 		flags := os.O_CREATE | os.O_TRUNC | unix.O_NOFOLLOW | os.O_RDWR
-		nf, err := os.OpenFile(path, flags, 0644)
+		nf, err := os.OpenFile(path, flags, 0o644)
 		if err != nil {
 			return fmt.Errorf("while creating configuration file %s: %s", path, err)
 		}
@@ -81,7 +81,7 @@ func GlobalConfig(args []string, configFile string, dry bool, op GlobalConfigOp)
 		return fmt.Errorf("%q is not a valid configuration directive", directive)
 	}
 
-	f, err := os.OpenFile(configFile, os.O_RDONLY, 0644)
+	f, err := os.OpenFile(configFile, os.O_RDONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening configuration file %s: %s", configFile, err)
 	}

--- a/internal/app/singularity/instance_linux.go
+++ b/internal/app/singularity/instance_linux.go
@@ -104,13 +104,12 @@ func WriteInstancePidFile(name, pidFile string) error {
 	inst, err := instance.List("", name, instance.SingSubDir)
 	if err != nil {
 		return fmt.Errorf("could not retrieve instance list: %v", err)
-
 	}
 	if len(inst) != 1 {
 		return fmt.Errorf("unexpected instance count: %d", len(inst))
 	}
 
-	f, err := os.OpenFile(pidFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0644)
+	f, err := os.OpenFile(pidFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return fmt.Errorf("could not create pid file: %v", err)
 	}

--- a/internal/app/singularity/oci_run_linux.go
+++ b/internal/app/singularity/oci_run_linux.go
@@ -25,7 +25,7 @@ func OciRun(ctx context.Context, containerID string, args *OciArgs) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	args.SyncSocketPath = filepath.Join(dir, "run.sock")

--- a/internal/app/singularity/overlay_create.go
+++ b/internal/app/singularity/overlay_create.go
@@ -129,7 +129,7 @@ func OverlayCreate(size int, imgPath string, overlayDirs ...string) error {
 	}
 	errBuf.Reset()
 
-	if err := os.Chmod(tmpFile, 0600); err != nil {
+	if err := os.Chmod(tmpFile, 0o600); err != nil {
 		return fmt.Errorf("while setting 0600 permission on %s: %s", tmpFile, err)
 	}
 
@@ -141,10 +141,10 @@ func OverlayCreate(size int, imgPath string, overlayDirs ...string) error {
 		_ = os.RemoveAll(tmpDir)
 	}()
 
-	perm := os.FileMode(0755)
+	perm := os.FileMode(0o755)
 
 	if os.Getuid() > 65535 || os.Getgid() > 65535 {
-		perm = 0777
+		perm = 0o777
 	}
 
 	upperDir := filepath.Join(tmpDir, "upper")

--- a/internal/app/singularity/plugin_compile_linux.go
+++ b/internal/app/singularity/plugin_compile_linux.go
@@ -88,7 +88,7 @@ func checkGoVersion(tmpDir, goPath string) error {
 	var out bytes.Buffer
 
 	path := filepath.Join(tmpDir, "rt_version.go")
-	if err := ioutil.WriteFile(path, []byte(goVersionFile), 0600); err != nil {
+	if err := ioutil.WriteFile(path, []byte(goVersionFile), 0o600); err != nil {
 		return fmt.Errorf("while writing go file %s: %s", path, err)
 	}
 	defer os.Remove(path)
@@ -179,7 +179,7 @@ func CompilePlugin(sourceDir, destSif, buildTags string, disableMinorCheck bool)
 	}
 
 	goMod := filepath.Join(pluginDir, "go.mod")
-	if err := ioutil.WriteFile(goMod, modData, 0600); err != nil {
+	if err := ioutil.WriteFile(goMod, modData, 0o600); err != nil {
 		return fmt.Errorf("while generating %s: %s", goMod, err)
 	}
 
@@ -259,7 +259,7 @@ func generateManifest(sourceDir string, bTool buildToolchain) error {
 		return fmt.Errorf("while loading plugin %s: %s", in, err)
 	}
 
-	f, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("while creating manifest %s: %s", out, err)
 	}

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -23,11 +23,9 @@ import (
 	"github.com/vbauerster/mpb/v4/decor"
 )
 
-var (
-	// ErrLibraryUnsigned indicated that the image intended to be used is
-	// not signed, nor has an override for requiring a signature been provided
-	ErrLibraryUnsigned = errors.New("image is not signed")
-)
+// ErrLibraryUnsigned indicated that the image intended to be used is
+// not signed, nor has an override for requiring a signature been provided
+var ErrLibraryUnsigned = errors.New("image is not signed")
 
 // LibraryPushSpec describes how a source image file should be pushed to a library server
 type LibraryPushSpec struct {

--- a/internal/app/singularity/remote_add.go
+++ b/internal/app/singularity/remote_add.go
@@ -29,9 +29,9 @@ func RemoteAdd(configFile, name, uri string, global bool) (err error) {
 	c := &remote.Config{}
 
 	// system config should be world readable
-	perm := os.FileMode(0600)
+	perm := os.FileMode(0o600)
 	if global {
-		perm = os.FileMode(0644)
+		perm = os.FileMode(0o644)
 	}
 
 	// opening config file

--- a/internal/app/singularity/remote_add_keyserver.go
+++ b/internal/app/singularity/remote_add_keyserver.go
@@ -21,7 +21,7 @@ func RemoteAddKeyserver(name, uri string, order uint32, insecure bool) error {
 	}
 
 	// opening config file
-	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_list.go
+++ b/internal/app/singularity/remote_list.go
@@ -22,7 +22,7 @@ func RemoteList(usrConfigFile string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no remote configurations")

--- a/internal/app/singularity/remote_login.go
+++ b/internal/app/singularity/remote_login.go
@@ -36,7 +36,7 @@ func RemoteLogin(usrConfigFile string, args *LoginArgs) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_logout.go
+++ b/internal/app/singularity/remote_logout.go
@@ -19,7 +19,7 @@ func RemoteLogout(usrConfigFile, name string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_remove.go
+++ b/internal/app/singularity/remote_remove.go
@@ -17,7 +17,7 @@ func RemoteRemove(configFile, name string) (err error) {
 	c := &remote.Config{}
 
 	// opening config file
-	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_remove_keyserver.go
+++ b/internal/app/singularity/remote_remove_keyserver.go
@@ -21,7 +21,7 @@ func RemoteRemoveKeyserver(name, uri string) error {
 	}
 
 	// opening config file
-	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening remote config file: %s", err)
 	}

--- a/internal/app/singularity/remote_status.go
+++ b/internal/app/singularity/remote_status.go
@@ -40,7 +40,7 @@ func RemoteStatus(usrConfigFile, name string) (err error) {
 	}
 
 	// opening config file
-	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0600)
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("no remote configurations")

--- a/internal/app/singularity/remote_use.go
+++ b/internal/app/singularity/remote_use.go
@@ -15,7 +15,7 @@ import (
 
 func syncSysConfig(cUsr *remote.Config) error {
 	// opening system config file
-	f, err := os.OpenFile(remote.SystemConfigPath, os.O_RDONLY, 0600)
+	f, err := os.OpenFile(remote.SystemConfigPath, os.O_RDONLY, 0o600)
 	if err != nil && os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
@@ -31,7 +31,6 @@ func syncSysConfig(cUsr *remote.Config) error {
 
 	// sync cUsr with system config cSys
 	return cUsr.SyncFrom(cSys)
-
 }
 
 // RemoteUse sets remote to use
@@ -47,9 +46,9 @@ func RemoteUse(usrConfigFile, name string, global, exclusive bool) (err error) {
 	}
 
 	// system config should be world readable
-	perm := os.FileMode(0600)
+	perm := os.FileMode(0o600)
 	if global {
-		perm = os.FileMode(0644)
+		perm = os.FileMode(0o644)
 	}
 
 	// opening config file

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -36,17 +36,15 @@ const (
 	sectionLabels  = "applabels"
 )
 
-var (
-	sections = map[string]bool{
-		sectionInstall: true,
-		sectionFiles:   true,
-		sectionEnv:     true,
-		sectionTest:    true,
-		sectionHelp:    true,
-		sectionRun:     true,
-		sectionLabels:  true,
-	}
-)
+var sections = map[string]bool{
+	sectionInstall: true,
+	sectionFiles:   true,
+	sectionEnv:     true,
+	sectionTest:    true,
+	sectionHelp:    true,
+	sectionRun:     true,
+	sectionLabels:  true,
+}
 
 var reg = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
@@ -124,7 +122,6 @@ func New() *BuildApp {
 	return &BuildApp{
 		Apps: make(map[string]*App),
 	}
-
 }
 
 // Name returns this handler's name [singularity_apps]
@@ -244,41 +241,41 @@ func (pl *BuildApp) createAllApps(b *types.Bundle) error {
 		globalEnv94 += globalAppEnv(b, app)
 	}
 
-	return ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94), 0755)
+	return ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94), 0o755)
 }
 
 func createAppRoot(b *types.Bundle, a *App) error {
-	if err := os.MkdirAll(appBase(b, a), 0755); err != nil {
+	if err := os.MkdirAll(appBase(b, a), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/bin/"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/bin/"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/lib/"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/lib/"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/env/"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/env/"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appData(b, a), "/input/"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(appData(b, a), "/input/"), 0o755); err != nil {
 		return err
 	}
 
-	return os.MkdirAll(filepath.Join(appData(b, a), "/output/"), 0755)
+	return os.MkdirAll(filepath.Join(appData(b, a), "/output/"), 0o755)
 }
 
 // %appenv and 01-base.sh
 func writeEnvFile(b *types.Bundle, a *App) error {
 	content := fmt.Sprintf(scifEnv01Base, a.Name)
-	if err := ioutil.WriteFile(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0755); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0o755); err != nil {
 		return err
 	}
 
@@ -286,7 +283,7 @@ func writeEnvFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0755)
+	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0o755)
 }
 
 func globalAppEnv(b *types.Bundle, a *App) string {
@@ -316,7 +313,7 @@ func writeRunscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifRunscriptBase, a.Run)
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0755)
+	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0o755)
 }
 
 // %apptest
@@ -326,7 +323,7 @@ func writeTestFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifTestBase, a.Test)
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0755)
+	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0o755)
 }
 
 // %apphelp
@@ -335,7 +332,7 @@ func writeHelpFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0644)
+	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0o644)
 }
 
 // %appfile
@@ -408,11 +405,11 @@ func writeLabels(b *types.Bundle, a *App) error {
 	}
 
 	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
-	err = ioutil.WriteFile(filepath.Join(appBase, "scif/labels.json"), text, 0644)
+	err = ioutil.WriteFile(filepath.Join(appBase, "scif/labels.json"), text, 0o644)
 	return err
 }
 
-//util funcs
+// util funcs
 
 func appBase(b *types.Bundle, a *App) string {
 	return filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -75,7 +75,7 @@ func New(defs []types.Definition, conf Config) (*Build, error) {
 
 func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 	sandboxCopy := false
-	oldumask := syscall.Umask(0002)
+	oldumask := syscall.Umask(0o002)
 	defer syscall.Umask(oldumask)
 
 	dest, err := fs.Abs(conf.Dest)
@@ -338,7 +338,7 @@ func (b *Build) Full(ctx context.Context) error {
 	// clean up build normally
 	defer b.cleanUp()
 
-	oldumask := syscall.Umask(0002)
+	oldumask := syscall.Umask(0o002)
 
 	// generate the default configuration
 	config, err := singularityconf.Parse("")
@@ -439,7 +439,7 @@ func (b *Build) Full(ctx context.Context) error {
 
 		// write the build configuration used for %post and %test sections
 		configFile := filepath.Join(stage.b.TmpDir, "singularity.conf")
-		if err := ioutil.WriteFile(configFile, configData, 0644); err != nil {
+		if err := ioutil.WriteFile(configFile, configData, 0o644); err != nil {
 			return fmt.Errorf("while creating %s: %s", configFile, err)
 		}
 		defer os.Remove(configFile)

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -29,14 +29,14 @@ func makeParentDir(path string) error {
 	// if path ends with a trailing '/' always ensure the full path exists as a directory
 	// because 'cp' is expecting a dir in these cases
 	if strings.HasSuffix(path, "/") {
-		if err := os.MkdirAll(filepath.Clean(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Clean(path), 0o755); err != nil {
 			return fmt.Errorf("while creating full path: %s", err)
 		}
 		return nil
 	}
 
 	// only make parent directory
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("while creating parent of path: %s", err)
 	}
 

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -92,28 +92,28 @@ func TestCopyFromHost(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(dir, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcFileGlob := filepath.Join(dir, "srcFi?*")
 	srcSpaceFile := filepath.Join(dir, "src File")
-	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
 	srcDir := filepath.Join(dir, "srcDir")
-	if err := os.Mkdir(srcDir, 0755); err != nil {
+	if err := os.Mkdir(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	srcDirGlob := filepath.Join(dir, "srcD?*")
 	srcSpaceDir := filepath.Join(dir, "src Dir")
-	if err := os.Mkdir(srcSpaceDir, 0755); err != nil {
+	if err := os.Mkdir(srcSpaceDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	srcGlob := filepath.Join(dir, "src*")
 	// Nested File (to test multi level glob)
 	srcFileNested := filepath.Join(dir, "srcDir/srcFileNested")
-	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcFileNestedGlob := filepath.Join(dir, "srcDi?/srcFil?Nested")
@@ -381,17 +381,17 @@ func TestCopyFromHostNested(t *testing.T) {
 
 	// All our test files/dirs/links will be nested inside innerDir
 	innerDir := filepath.Join(dir, "innerDir")
-	if err := os.Mkdir(innerDir, 0755); err != nil {
+	if err := os.Mkdir(innerDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Source Files
 	srcFile := filepath.Join(innerDir, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
 	srcDir := filepath.Join(innerDir, "srcDir")
-	if err := os.Mkdir(srcDir, 0755); err != nil {
+	if err := os.Mkdir(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Source Symlinks
@@ -475,7 +475,6 @@ func TestCopyFromHostNested(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 // TestCopyFromStage tests that copying non-nested source dirs, files, links to various
@@ -491,25 +490,25 @@ func TestCopyFromStage(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcSpaceFile := filepath.Join(srcRoot, "src File")
-	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
 	srcDir := filepath.Join(srcRoot, "srcDir")
-	if err := os.Mkdir(srcDir, 0755); err != nil {
+	if err := os.Mkdir(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	srcSpaceDir := filepath.Join(srcRoot, "src Dir")
-	if err := os.Mkdir(srcSpaceDir, 0755); err != nil {
+	if err := os.Mkdir(srcSpaceDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Nested File (to test multi level glob)
 	srcFileNested := filepath.Join(srcRoot, "srcDir/srcFileNested")
-	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Symlinks
@@ -794,17 +793,17 @@ func TestCopyFromStageNested(t *testing.T) {
 
 	// All our test files/dirs/links will be nested inside innerDir
 	innerDir := filepath.Join(srcRoot, "innerDir")
-	if err := os.Mkdir(innerDir, 0755); err != nil {
+	if err := os.Mkdir(innerDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Source Files
 	srcFile := filepath.Join(innerDir, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0644); err != nil {
+	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
 	srcDir := filepath.Join(innerDir, "srcDir")
-	if err := os.Mkdir(srcDir, 0755); err != nil {
+	if err := os.Mkdir(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Source Symlinks
@@ -897,5 +896,4 @@ func TestCopyFromStageNested(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/pkg/build/files/files_test.go
+++ b/internal/pkg/build/files/files_test.go
@@ -95,7 +95,7 @@ func createTestDirLayout(t *testing.T) string {
 	}
 
 	for _, d := range dirList {
-		if err := os.Mkdir(filepath.Join(testDirName, d), 0755); err != nil {
+		if err := os.Mkdir(filepath.Join(testDirName, d), 0o755); err != nil {
 			t.Fatalf("while making directory %s: %s", d, err)
 		}
 	}

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -75,13 +75,13 @@ func insertEnvScript(b *types.Bundle) error {
 		envScriptPath := filepath.Join(b.RootfsPath, "/.singularity.d/env/90-environment.sh")
 		_, err := os.Stat(envScriptPath)
 		if os.IsNotExist(err) {
-			err := ioutil.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment.Script+"\n"), 0755)
+			err := ioutil.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment.Script+"\n"), 0o755)
 			if err != nil {
 				return err
 			}
 		} else {
 			// append to script if it already exists
-			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY, 0755)
+			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY, 0o755)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ func insertRunScript(b *types.Bundle) error {
 	if b.RunSection("runscript") && b.Recipe.ImageData.Runscript.Script != "" {
 		sylog.Infof("Adding runscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Runscript)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0755)
+		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func insertStartScript(b *types.Bundle) error {
 	if b.RunSection("startscript") && b.Recipe.ImageData.Startscript.Script != "" {
 		sylog.Infof("Adding startscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Startscript)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0755)
+		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -145,7 +145,7 @@ func insertStartScript(b *types.Bundle) error {
 func insertTestScript(b *types.Bundle) error {
 	if b.RunSection("test") && b.Recipe.ImageData.Test.Script != "" {
 		sylog.Infof("Adding testscript")
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Test.Script+"\n"), 0755)
+		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Test.Script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -158,7 +158,7 @@ func insertHelpScript(b *types.Bundle) error {
 		_, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"))
 		if err != nil || b.Opts.Force {
 			sylog.Infof("Adding help info")
-			err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help.Script+"\n"), 0644)
+			err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help.Script+"\n"), 0o644)
 			if err != nil {
 				return err
 			}
@@ -175,7 +175,7 @@ func insertDefinition(b *types.Bundle) error {
 		if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity")); err == nil {
 			// make bootstrap_history directory if it doesnt exist
 			if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history")); err != nil {
-				err = os.Mkdir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"), 0755)
+				err = os.Mkdir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"), 0o755)
 				if err != nil {
 					return err
 				}
@@ -196,10 +196,9 @@ func insertDefinition(b *types.Bundle) error {
 				return err
 			}
 		}
-
 	}
 
-	err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.Raw, 0644)
+	err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.Raw, 0o644)
 	if err != nil {
 		return err
 	}
@@ -259,7 +258,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0644)
+	err = ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
 	return err
 }
 

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -56,7 +56,6 @@ func ConvertReference(ctx context.Context, imgCache *cache.Handle, src types.Ima
 		source:         src,
 		ImageReference: c,
 	}, nil
-
 }
 
 // NewImageSource wraps the cache's oci-layout ref to first download the real source image to the cache

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -95,7 +95,7 @@ func createIndexFile(t *testing.T, dir string, sum string) {
 	if jsonErr != nil {
 		t.Fatalf("cannot unmarshal JSON: %s\n", jsonErr)
 	}
-	err := ioutil.WriteFile(path, data, 0664)
+	err := ioutil.WriteFile(path, data, 0o664)
 	if err != nil {
 		t.Fatalf("cannot create index file: %s\n", err)
 	}
@@ -119,7 +119,7 @@ func createDummyOCICache(t *testing.T) (string, string) {
 	sum := sha256.New()
 	sumFilename := hex.EncodeToString(sum.Sum(nil))
 	path := filepath.Join(shaPath, sumFilename)
-	err = os.MkdirAll(shaPath, 0755)
+	err = os.MkdirAll(shaPath, 0o755)
 	if err != nil {
 		os.RemoveAll(dir)
 		t.Fatalf("cannot create cache directory: %s\n", err)

--- a/internal/pkg/build/remotebuilder/remotebuilder.go
+++ b/internal/pkg/build/remotebuilder/remotebuilder.go
@@ -135,7 +135,7 @@ func (rb *RemoteBuilder) Build(ctx context.Context) (err error) {
 
 	// If image destination is local file, pull image.
 	if !strings.HasPrefix(rb.ImagePath, "library://") {
-		f, err := os.OpenFile(rb.ImagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0777)
+		f, err := os.OpenFile(rb.ImagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o777)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to open file %s for writing", rb.ImagePath))
 		}

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -279,37 +279,37 @@ echo "There is no runscript defined for this container\n";
 )
 
 func makeDirs(rootPath string) error {
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "libs"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "libs"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "actions"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "actions"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "env"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "env"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "dev"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, "dev"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "proc"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, "proc"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "root"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, "root"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "var", "tmp"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, "var", "tmp"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "tmp"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, "tmp"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "etc"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, "etc"), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "sys"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootPath, "sys"), 0o755); err != nil {
 		return err
 	}
-	return os.MkdirAll(filepath.Join(rootPath, "home"), 0755)
+	return os.MkdirAll(filepath.Join(rootPath, "home"), 0o755)
 }
 
 func makeSymlinks(rootPath string) error {
@@ -368,50 +368,49 @@ func makeFile(name string, perm os.FileMode, s string) (err error) {
 }
 
 func makeFiles(rootPath string) error {
-	if err := makeFile(filepath.Join(rootPath, "etc", "hosts"), 0644, ""); err != nil {
+	if err := makeFile(filepath.Join(rootPath, "etc", "hosts"), 0o644, ""); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, "etc", "resolv.conf"), 0644, ""); err != nil {
+	if err := makeFile(filepath.Join(rootPath, "etc", "resolv.conf"), 0o644, ""); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "exec"), 0755, execFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "exec"), 0o755, execFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "run"), 0755, runFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "run"), 0o755, runFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "shell"), 0755, shellFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "shell"), 0o755, shellFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "start"), 0755, startFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "start"), 0o755, startFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "test"), 0755, testFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "test"), 0o755, testFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "01-base.sh"), 0755, baseShFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "01-base.sh"), 0o755, baseShFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "90-environment.sh"), 0755, environmentShFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "90-environment.sh"), 0o755, environmentShFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "95-apps.sh"), 0755, appsShFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "95-apps.sh"), 0o755, appsShFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-base.sh"), 0755, base99ShFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-base.sh"), 0o755, base99ShFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-runtimevars.sh"), 0755, base99runtimevarsShFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-runtimevars.sh"), 0o755, base99runtimevarsShFileContent); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "runscript"), 0755, runscriptFileContent); err != nil {
+	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "runscript"), 0o755, runscriptFileContent); err != nil {
 		return err
 	}
-	return makeFile(filepath.Join(rootPath, ".singularity.d", "startscript"), 0755, startscriptFileContent)
+	return makeFile(filepath.Join(rootPath, ".singularity.d", "startscript"), 0o755, startscriptFileContent)
 }
 
 func makeBaseEnv(rootPath string) (err error) {
-
 	var info os.FileInfo
 
 	// Ensure we can write into the root of rootPath
@@ -419,9 +418,9 @@ func makeBaseEnv(rootPath string) (err error) {
 		err = fmt.Errorf("build: failed to stat rootPath: %v", err)
 		return err
 	}
-	if info.Mode()&0200 == 0 {
+	if info.Mode()&0o200 == 0 {
 		sylog.Infof("Adding owner write permission to build path: %s\n", rootPath)
-		if err = os.Chmod(rootPath, info.Mode()|0200); err != nil {
+		if err = os.Chmod(rootPath, info.Mode()|0o200); err != nil {
 			err = fmt.Errorf("build: failed to make rootPath writable: %v", err)
 			return err
 		}

--- a/internal/pkg/build/sources/base_environment_test.go
+++ b/internal/pkg/build/sources/base_environment_test.go
@@ -66,7 +66,7 @@ func TestMakeFiles(t *testing.T) {
 		if err := makeDirs(d); err != nil {
 			return err
 		}
-		err := fs.EnsureFileWithPermission(filepath.Join(d, "etc", "hosts"), 0400)
+		err := fs.EnsureFileWithPermission(filepath.Join(d, "etc", "hosts"), 0o400)
 		if err != nil {
 			t.Fatalf("Failed to make test hosts file: %s", err)
 		}

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -27,12 +27,10 @@ const (
 	pacmanConfURL = "https://github.com/archlinux/svntogit-packages/raw/master/pacman/trunk/pacman.conf"
 )
 
-var (
-	// Default list of packages to install when bootstrapping arch
-	// As of 2019-10-06 there is a base metapackage instead of a base group
-	// https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/
-	instList = []string{"base"}
-)
+// Default list of packages to install when bootstrapping arch
+// As of 2019-10-06 there is a base metapackage instead of a base group
+// https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/
+var instList = []string{"base"}
 
 // ArchConveyorPacker only needs to hold the conveyor to have the needed data to pack
 type ArchConveyorPacker struct {
@@ -63,11 +61,11 @@ func (cp *ArchConveyorPacker) prepareFakerootEnv(ctx context.Context) (func(), e
 	}
 
 	devPath := filepath.Join(cp.b.RootfsPath, "dev")
-	if err := os.Mkdir(devPath, 0755); err != nil {
+	if err := os.Mkdir(devPath, 0o755); err != nil {
 		return nil, fmt.Errorf("while creating %s: %s", devPath, err)
 	}
 	procPath := filepath.Join(cp.b.RootfsPath, "proc")
-	if err := os.Mkdir(procPath, 0755); err != nil {
+	if err := os.Mkdir(procPath, 0o755); err != nil {
 		return nil, fmt.Errorf("while creating %s: %s", procPath, err)
 	}
 
@@ -112,13 +110,13 @@ func (cp *ArchConveyorPacker) prepareFakerootEnv(ctx context.Context) (func(), e
 func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
 	cp.b = b
 
-	//check for pacstrap on system
+	// check for pacstrap on system
 	pacstrapPath, err := exec.LookPath("pacstrap")
 	if err != nil {
 		return fmt.Errorf("pacstrap is not in PATH: %v", err)
 	}
 
-	//make sure architecture is supported
+	// make sure architecture is supported
 	if arch := runtime.GOARCH; arch != `amd64` {
 		return fmt.Errorf("%v architecture is not supported", arch)
 	}
@@ -151,7 +149,7 @@ func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 		return fmt.Errorf("while pacstrapping: %v", err)
 	}
 
-	//Pacman package signing setup
+	// Pacman package signing setup
 	cmd := exec.Command("arch-chroot", cp.b.RootfsPath, "/bin/sh", "-c", "haveged -w 1024; pacman-key --init; pacman-key --populate archlinux")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -159,7 +157,7 @@ func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 		return fmt.Errorf("while setting up package signing: %v", err)
 	}
 
-	//Clean up haveged
+	// Clean up haveged
 	cmd = exec.Command("arch-chroot", cp.b.RootfsPath, "pacman", "-Rs", "--noconfirm", "haveged")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -213,7 +211,7 @@ func (cp *ArchConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *ArchConveyorPacker) insertRunScript() (err error) {
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0755)
+	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_arch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_test.go
@@ -22,7 +22,6 @@ import (
 const archDef = "../../../../examples/arch/Singularity"
 
 func TestArchConveyor(t *testing.T) {
-
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -77,19 +77,19 @@ func (cp *BusyBoxConveyorPacker) Pack(context.Context) (b *types.Bundle, err err
 }
 
 func (c *BusyBoxConveyor) insertBaseFiles() error {
-	if err := ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0664); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0664); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0o664); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0664)
+	return ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
 }
 
 func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, err error) {
-	os.Mkdir(filepath.Join(c.b.RootfsPath, "/bin"), 0755)
+	os.Mkdir(filepath.Join(c.b.RootfsPath, "/bin"), 0o755)
 
 	resp, err := http.Get(mirrorurl)
 	if err != nil {
@@ -108,12 +108,12 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 		return
 	}
 
-	//Simple check to make sure file received is the correct size
+	// Simple check to make sure file received is the correct size
 	if bytesWritten != resp.ContentLength {
 		return "", fmt.Errorf("file received is not the right size. supposed to be: %v actually: %v", resp.ContentLength, bytesWritten)
 	}
 
-	err = os.Chmod(f.Name(), 0755)
+	err = os.Chmod(f.Name(), 0o755)
 	if err != nil {
 		return
 	}
@@ -129,7 +129,7 @@ func (c *BusyBoxConveyor) insertBaseEnv() (err error) {
 }
 
 func (cp *BusyBoxConveyorPacker) insertRunScript() error {
-	return ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0755)
+	return ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -21,7 +21,6 @@ import (
 const busyBoxDef = "../../../../examples/busybox/Singularity"
 
 func TestBusyBoxConveyor(t *testing.T) {
-
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -72,7 +72,7 @@ func (cp *DebootstrapConveyorPacker) prepareFakerootEnv(ctx context.Context) (fu
 	}
 
 	devPath := filepath.Join(cp.b.RootfsPath, "dev")
-	if err := os.Mkdir(devPath, 0755); err != nil {
+	if err := os.Mkdir(devPath, 0o755); err != nil {
 		return nil, fmt.Errorf("while creating %s: %s", devPath, err)
 	}
 
@@ -220,9 +220,8 @@ func (cp *DebootstrapConveyorPacker) Get(ctx context.Context, b *types.Bundle) (
 
 // Pack puts relevant objects in a Bundle!
 func (cp *DebootstrapConveyorPacker) Pack(context.Context) (*types.Bundle, error) {
-
-	//change root directory permissions to 0755
-	if err := os.Chmod(cp.b.RootfsPath, 0755); err != nil {
+	// change root directory permissions to 0755
+	if err := os.Chmod(cp.b.RootfsPath, 0o755); err != nil {
 		return nil, fmt.Errorf("while changing bundle rootfs perms: %v", err)
 	}
 
@@ -242,7 +241,7 @@ func (cp *DebootstrapConveyorPacker) Pack(context.Context) (*types.Bundle, error
 func (cp *DebootstrapConveyorPacker) getRecipeHeaderInfo() (err error) {
 	var ok bool
 
-	//get mirrorURL, OSVerison, and Includes components to definition
+	// get mirrorURL, OSVerison, and Includes components to definition
 	cp.mirrorurl, ok = cp.b.Recipe.Header["mirrorurl"]
 	if !ok {
 		return fmt.Errorf("invalid debootstrap header, no mirrorurl specified")
@@ -255,13 +254,13 @@ func (cp *DebootstrapConveyorPacker) getRecipeHeaderInfo() (err error) {
 
 	include := cp.b.Recipe.Header["include"]
 
-	//check for include environment variable and add it to requires string
+	// check for include environment variable and add it to requires string
 	include += ` ` + os.Getenv("INCLUDE")
 
-	//trim leading and trailing whitespace
+	// trim leading and trailing whitespace
 	include = strings.TrimSpace(include)
 
-	//convert Requires string to comma separated list
+	// convert Requires string to comma separated list
 	cp.include = strings.Replace(include, ` `, `,`, -1)
 
 	return nil
@@ -293,7 +292,7 @@ func (cp *DebootstrapConveyorPacker) insertRunScript(b *types.Bundle) (err error
 
 	f.Sync()
 
-	err = os.Chmod(b.RootfsPath+"/.singularity.d/runscript", 0755)
+	err = os.Chmod(b.RootfsPath+"/.singularity.d/runscript", 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestDebootstrapConveyor(t *testing.T) {
-
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -35,7 +35,6 @@ type LocalConveyorPacker struct {
 
 // GetLocalPacker ...
 func GetLocalPacker(ctx context.Context, src string, b *types.Bundle) (LocalPacker, error) {
-
 	imageObject, err := image.Init(src, false)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -50,7 +50,6 @@ type OCIConveyorPacker struct {
 
 // Get downloads container information from the specified source
 func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err error) {
-
 	cp.b = b
 
 	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
@@ -238,7 +237,7 @@ func (cp *OCIConveyorPacker) extractArchive(src string, dst string) error {
 	defer f.Close()
 
 	r := bufio.NewReader(f)
-	header, err := r.Peek(10) //read a few bytes without consuming
+	header, err := r.Peek(10) // read a few bytes without consuming
 	if err != nil {
 		return err
 	}
@@ -283,7 +282,7 @@ func (cp *OCIConveyorPacker) extractArchive(src string, dst string) error {
 		// if its a dir and it doesn't exist create it
 		case tar.TypeDir:
 			if _, err := os.Stat(target); err != nil {
-				if err := os.MkdirAll(target, 0755); err != nil {
+				if err := os.MkdirAll(target, 0o755); err != nil {
 					return err
 				}
 			}
@@ -399,7 +398,7 @@ exec "$@"
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0755)
+	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
 	if err != nil {
 		return
 	}
@@ -440,7 +439,7 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", 0755)
+	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", 0o755)
 	if err != nil {
 		return
 	}
@@ -458,7 +457,7 @@ func (cp *OCIConveyorPacker) insertOCILabels() (err error) {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0644)
+	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
 	return err
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -54,7 +54,7 @@ func (c *ScratchConveyor) insertBaseEnv() (err error) {
 }
 
 func (cp *ScratchConveyorPacker) insertRunScript() (err error) {
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0755)
+	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_scratch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch_test.go
@@ -20,7 +20,6 @@ import (
 const scratchDef = "../../../../pkg/build/types/parser/testdata_good/scratch/scratch"
 
 func TestScratchConveyor(t *testing.T) {
-
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -246,12 +246,12 @@ func (c *YumConveyor) genYumConfig() (err error) {
 		fileContent += "\n"
 	}
 
-	err = os.Mkdir(filepath.Join(c.b.RootfsPath, "/etc"), 0775)
+	err = os.Mkdir(filepath.Join(c.b.RootfsPath, "/etc"), 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, "/etc"), err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0664)
+	err = ioutil.WriteFile(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0o664)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, yumConf), err)
 	}
@@ -303,7 +303,7 @@ func (c *YumConveyor) importGPGKey() (err error) {
 
 func (c *YumConveyor) makePseudoDevices() (err error) {
 	devPath := filepath.Join(c.b.RootfsPath, "dev")
-	err = os.Mkdir(devPath, 0775)
+	err = os.Mkdir(devPath, 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", devPath, err)
 	}
@@ -314,10 +314,10 @@ func (c *YumConveyor) makePseudoDevices() (err error) {
 		path  string
 		mode  uint32
 	}{
-		{1, 3, "/dev/null", syscall.S_IFCHR | 0666},
-		{1, 8, "/dev/random", syscall.S_IFCHR | 0666},
-		{1, 9, "/dev/urandom", syscall.S_IFCHR | 0666},
-		{1, 5, "/dev/zero", syscall.S_IFCHR | 0666},
+		{1, 3, "/dev/null", syscall.S_IFCHR | 0o666},
+		{1, 8, "/dev/random", syscall.S_IFCHR | 0o666},
+		{1, 9, "/dev/urandom", syscall.S_IFCHR | 0o666},
+		{1, 5, "/dev/zero", syscall.S_IFCHR | 0o666},
 	}
 
 	for _, dev := range devs {
@@ -340,7 +340,7 @@ func (cp *YumConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *YumConveyorPacker) insertRunScript() (err error) {
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0755)
+	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -246,10 +246,10 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err e
 			rpmsys = "/usr/lib/sysimage"
 			rpmrel = "../../.."
 		}
-		if err = os.MkdirAll(cp.b.RootfsPath+rpmbase+`/rpm`, 0755); err != nil {
+		if err = os.MkdirAll(cp.b.RootfsPath+rpmbase+`/rpm`, 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
-		if err = os.MkdirAll(cp.b.RootfsPath+rpmsys, 0755); err != nil {
+		if err = os.MkdirAll(cp.b.RootfsPath+rpmsys, 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
 		if err = os.RemoveAll(cp.b.RootfsPath + rpmsys + `/rpm`); err != nil {
@@ -270,10 +270,12 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err e
 	}
 
 	if suseconnectPath != "" {
-		args := []string{`--root`, cp.b.RootfsPath,
+		args := []string{
+			`--root`, cp.b.RootfsPath,
 			`--product`, suseconnectProduct,
 			`--email`, sleuser,
-			`--regcode`, sleregcode}
+			`--regcode`, sleregcode,
+		}
 		if sleurlOk {
 			args = append(args, `--url`, sleurl)
 		}
@@ -374,7 +376,7 @@ func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0755)
+	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
 	if err != nil {
 		return
 	}
@@ -383,12 +385,12 @@ func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
 }
 
 func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
-	err = os.MkdirAll(filepath.Join(cp.b.RootfsPath, "/etc/zypp"), 0775)
+	err = os.MkdirAll(filepath.Join(cp.b.RootfsPath, "/etc/zypp"), 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.RootfsPath, "/etc/zypp"), err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0664)
+	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0o664)
 	if err != nil {
 		return
 	}
@@ -398,7 +400,7 @@ func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
 
 func (cp *ZypperConveyorPacker) copyPseudoDevices() (err error) {
 	devPath := filepath.Join(cp.b.RootfsPath, "dev")
-	err = os.Mkdir(devPath, 0775)
+	err = os.Mkdir(devPath, 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", devPath, err)
 	}
@@ -409,10 +411,10 @@ func (cp *ZypperConveyorPacker) copyPseudoDevices() (err error) {
 		path  string
 		mode  uint32
 	}{
-		{1, 3, "/dev/null", syscall.S_IFCHR | 0666},
-		{1, 8, "/dev/random", syscall.S_IFCHR | 0666},
-		{1, 9, "/dev/urandom", syscall.S_IFCHR | 0666},
-		{1, 5, "/dev/zero", syscall.S_IFCHR | 0666},
+		{1, 3, "/dev/null", syscall.S_IFCHR | 0o666},
+		{1, 8, "/dev/random", syscall.S_IFCHR | 0o666},
+		{1, 9, "/dev/urandom", syscall.S_IFCHR | 0o666},
+		{1, 5, "/dev/zero", syscall.S_IFCHR | 0o666},
 	}
 
 	for _, dev := range devs {

--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -6,17 +6,17 @@
 package sources
 
 import (
-	"github.com/hpcng/singularity/pkg/build/types"
-	"github.com/hpcng/singularity/pkg/image"
-	"github.com/hpcng/singularity/pkg/sylog"
-	"github.com/hpcng/singularity/pkg/util/archive"
-	"github.com/hpcng/singularity/pkg/util/loop"
-
 	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"syscall"
+
+	"github.com/hpcng/singularity/pkg/build/types"
+	"github.com/hpcng/singularity/pkg/image"
+	"github.com/hpcng/singularity/pkg/sylog"
+	"github.com/hpcng/singularity/pkg/util/archive"
+	"github.com/hpcng/singularity/pkg/util/loop"
 )
 
 // Ext3Packer holds the locations of where to back from and to, aswell as image offset info

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -6,14 +6,14 @@
 package sources
 
 import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
 	"github.com/hpcng/singularity/pkg/build/types"
 	"github.com/hpcng/singularity/pkg/image"
 	"github.com/hpcng/singularity/pkg/image/unpacker"
 	"github.com/hpcng/singularity/pkg/sylog"
-
-	"context"
-	"fmt"
-	"io/ioutil"
 )
 
 // SIFPacker holds the locations of where to pack from and to.

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -90,7 +90,7 @@ func createStageFile(source string, b *types.Bundle, warnMsg string) (string, er
 }
 
 func createScript(path string, content []byte) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o755)
 	if err != nil {
 		return fmt.Errorf("failed to create script: %s", err)
 	}

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -136,7 +136,7 @@ func (h *Handle) GetEntry(cacheType string, hash string) (e *Entry, err error) {
 
 	if !pathExists {
 		e.Exists = false
-		f, err := fs.MakeTmpFile(cacheDir, "tmp_", 0700)
+		f, err := fs.MakeTmpFile(cacheDir, "tmp_", 0o700)
 		if err != nil {
 			return nil, err
 		}
@@ -208,7 +208,6 @@ func (h *Handle) cleanAllCaches() {
 			sylog.Verbosef("unable to clean %s cache, directory %s: %v", ct, dir, err)
 		}
 	}
-
 }
 
 // IsDisabled returns true if the cache is disabled
@@ -316,15 +315,15 @@ func getCacheParentDir() string {
 func initCacheDir(dir string) error {
 	if fi, err := os.Stat(dir); os.IsNotExist(err) {
 		sylog.Debugf("Creating cache directory: %s", dir)
-		if err := fs.MkdirAll(dir, 0700); err != nil {
+		if err := fs.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("couldn't create cache directory %v: %v", dir, err)
 		}
 	} else if err != nil {
 		return fmt.Errorf("unable to stat %s: %s", dir, err)
-	} else if fi.Mode().Perm() != 0700 {
+	} else if fi.Mode().Perm() != 0o700 {
 		// enforce permission on cache directory to prevent
 		// potential information leak
-		if err := os.Chmod(dir, 0700); err != nil {
+		if err := os.Chmod(dir, 0o700); err != nil {
 			return fmt.Errorf("couldn't enforce permission 0700 on %s: %s", dir, err)
 		}
 	}

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -187,5 +187,5 @@ func PutConfig(config Config, confPath string) (err error) {
 		return
 	}
 
-	return ioutil.WriteFile(confPath, data, 0600)
+	return ioutil.WriteFile(confPath, data, 0o600)
 }

--- a/internal/pkg/client/library/library.go
+++ b/internal/pkg/client/library/library.go
@@ -56,7 +56,7 @@ func NormalizeLibraryRef(ref string) (*scslibrary.Ref, error) {
 // DownloadImage is a helper function to wrap library image download operation
 func DownloadImage(ctx context.Context, c *scslibrary.Client, imagePath, arch string, libraryRef *scslibrary.Ref, callback client.ProgressCallback) error {
 	// open destination file for writing
-	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0777)
+	f, err := os.OpenFile(imagePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o777)
 	if err != nil {
 		return fmt.Errorf("error opening file %s for writing: %v", imagePath, err)
 	}

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -113,7 +113,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pull
 
 	if directTo == "" {
 		// mode is before umask if pullTo doesn't exist
-		err = fs.CopyFileAtomic(src, pullTo, 0777)
+		err = fs.CopyFileAtomic(src, pullTo, 0o777)
 		if err != nil {
 			return "", fmt.Errorf("error copying image out of cache: %v", err)
 		}

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -38,7 +38,6 @@ func IsNetPullRef(netRef string) bool {
 // DownloadImage will retrieve an image from an http(s) URI,
 // saving it into the specified file
 func DownloadImage(ctx context.Context, filePath string, netURL string) error {
-
 	if !IsNetPullRef(netURL) {
 		return fmt.Errorf("not a valid url reference: %s", netURL)
 	}
@@ -83,7 +82,7 @@ func DownloadImage(ctx context.Context, filePath string, netURL string) error {
 	sylog.Debugf("OK response received, beginning body download\n")
 
 	// Perms are 777 *prior* to umask
-	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
+	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o777)
 	if err != nil {
 		return err
 	}
@@ -176,7 +175,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 // Pull will pull a http(s) image to the cache or direct to a temporary file if cache is disabled
 func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, tmpDir string) (imagePath string, err error) {
-
 	directTo := ""
 
 	if imgCache.IsDisabled() {
@@ -193,7 +191,6 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, tmpDir s
 
 // PullToFile will pull an http(s) image to the specified location, through the cache, or directly if cache is disabled
 func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string) (imagePath string, err error) {
-
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo
@@ -207,7 +204,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, t
 
 	if directTo == "" {
 		// mode is before umask if pullTo doesn't exist
-		err = fs.CopyFileAtomic(src, pullTo, 0777)
+		err = fs.CopyFileAtomic(src, pullTo, 0o777)
 		if err != nil {
 			return "", fmt.Errorf("error copying image out of cache: %v", err)
 		}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -80,7 +80,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 
 // Pull will build a SIF image to the cache or direct to a temporary file if cache is disabled
 func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
-
 	directTo := ""
 
 	if imgCache.IsDisabled() {
@@ -97,7 +96,6 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 
 // PullToFile will build a SIF image from the specified oci URI and place it at the specified dest
 func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
-
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo
@@ -111,7 +109,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, t
 
 	if directTo == "" {
 		// mode is before umask if pullTo doesn't exist
-		err = fs.CopyFileAtomic(src, pullTo, 0777)
+		err = fs.CopyFileAtomic(src, pullTo, 0o777)
 		if err != nil {
 			return "", fmt.Errorf("error copying image out of cache: %v", err)
 		}

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -137,7 +137,7 @@ func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) er
 	}
 
 	// ensure container is executable
-	if err := os.Chmod(imagePath, 0755); err != nil {
+	if err := os.Chmod(imagePath, 0o755); err != nil {
 		return fmt.Errorf("unable to set image perms: %s", err)
 	}
 

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -64,7 +64,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 // Pull will pull an oras image to the cache or direct to a temporary file if cache is disabled
 func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig) (imagePath string, err error) {
-
 	directTo := ""
 
 	if imgCache.IsDisabled() {
@@ -81,7 +80,6 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 
 // PullToFile will pull an oras image to the specified location, through the cache, or directly if cache is disabled
 func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig) (imagePath string, err error) {
-
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo
@@ -95,7 +93,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, t
 
 	if directTo == "" {
 		// mode is before umask if pullTo doesn't exist
-		err = fs.CopyFileAtomic(src, pullTo, 0777)
+		err = fs.CopyFileAtomic(src, pullTo, 0o777)
 		if err != nil {
 			return "", fmt.Errorf("error copying image out of cache: %v", err)
 		}

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -24,7 +24,6 @@ type ProgressCallback func(int64, io.Reader, io.Writer) error
 
 // ProgressBarCallback returns a progress bar callback unless e.g. --quiet or lower loglevel is set
 func ProgressBarCallback(ctx context.Context) ProgressCallback {
-
 	if sylog.GetLevel() <= -1 {
 		// If we don't need a bar visible, we just copy data through the callback func
 		return func(totalSize int64, r io.Reader, w io.Writer) error {

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -87,7 +87,7 @@ func DownloadImage(ctx context.Context, manifest APIResponse, filePath, shubRef 
 	}
 
 	// Perms are 777 *prior* to umask
-	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0777)
+	out, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o777)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,6 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 // Pull will pull a shub image to the cache or direct to a temporary file if cache is disabled
 func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, noHTTPS bool) (imagePath string, err error) {
-
 	directTo := ""
 
 	if imgCache.IsDisabled() {
@@ -191,12 +190,10 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 	}
 
 	return pull(ctx, imgCache, directTo, pullFrom, noHTTPS)
-
 }
 
 // PullToFile will pull a shub image to the specified location, through the cache, or directly if cache is disabled
 func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, noHTTPS bool) (imagePath string, err error) {
-
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo
@@ -210,7 +207,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, t
 
 	if directTo == "" {
 		// mode is before umask if pullTo doesn't exist
-		err = fs.CopyFileAtomic(src, pullTo, 0777)
+		err = fs.CopyFileAtomic(src, pullTo, 0o777)
 		if err != nil {
 			return "", fmt.Errorf("error copying image out of cache: %v", err)
 		}

--- a/internal/pkg/client/shub/util_test.go
+++ b/internal/pkg/client/shub/util_test.go
@@ -14,21 +14,19 @@ import (
 	useragent "github.com/hpcng/singularity/pkg/util/user-agent"
 )
 
-var (
-	validShubURIs = []string{
-		`shub://username/container`,
-		`shub://username/container:tag`,
-		`shub://username/container@00000000000000000000000000000000`,
-		`shub://registry/username/container`,
-		`shub://registry/with/levels/username/container`,
-		`shub://registry/user-name/container-with-dash`,
-		`shub://registry/username/container.with.period`,
-		`shub://username/container:tag-with-dash`,
-		`shub://username/container:tag_wtih_underscore`,
-		`shub://username/container:tag.with.period`,
-		`shub://myprivateregistry.sylabs.io/sylabs/container:latest`,
-	}
-)
+var validShubURIs = []string{
+	`shub://username/container`,
+	`shub://username/container:tag`,
+	`shub://username/container@00000000000000000000000000000000`,
+	`shub://registry/username/container`,
+	`shub://registry/with/levels/username/container`,
+	`shub://registry/user-name/container-with-dash`,
+	`shub://registry/username/container.with.period`,
+	`shub://username/container:tag-with-dash`,
+	`shub://username/container:tag_wtih_underscore`,
+	`shub://username/container:tag.with.period`,
+	`shub://myprivateregistry.sylabs.io/sylabs/container:latest`,
+}
 
 func TestMain(m *testing.M) {
 	useragent.InitValue("singularity", "3.0.0-alpha.1-303-gaed8d30-dirty")

--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -87,7 +87,7 @@ func GetConfig(filename string, edit bool, getUserFn GetUserFn) (*Config, error)
 		defer syscall.Umask(umask)
 	}
 
-	config.file, err = os.OpenFile(filename, flags, 0644)
+	config.file, err = os.OpenFile(filename, flags, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open: %s: %s", filename, err)
 	}
@@ -336,8 +336,10 @@ func (c *Config) GetUserEntry(username string) (*Entry, error) {
 }
 
 // getPwUID is also used for mocking purpose
-var getPwUID = user.GetPwUID
-var getPwNam = user.GetPwNam
+var (
+	getPwUID = user.GetPwUID
+	getPwNam = user.GetPwNam
+)
 
 // GetIDRange determines UID/GID mappings based on configuration
 // file provided in path.

--- a/internal/pkg/fakeroot/fakeroot_test.go
+++ b/internal/pkg/fakeroot/fakeroot_test.go
@@ -118,13 +118,13 @@ func TestGetIDRangePath(t *testing.T) {
 		getPwNam = user.GetPwNam
 	}()
 
-	f, err := fs.MakeTmpFile("", "subid-", 0700)
+	f, err := fs.MakeTmpFile("", "subid-", 0o700)
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}
 	defer os.Remove(f.Name())
 
-	var subIDContent = `
+	subIDContent := `
 root:100000:65536
 1:165536:1
 1:165536:165536
@@ -231,7 +231,7 @@ func getUserFn(username string) (*user.User, error) {
 }
 
 func createConfig(t *testing.T) string {
-	f, err := fs.MakeTmpFile("", "subid-", 0644)
+	f, err := fs.MakeTmpFile("", "subid-", 0o644)
 	if err != nil {
 		t.Fatalf("failed to create temporary config: %s", err)
 	}

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -239,10 +239,10 @@ func (i *File) Update() error {
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
-	if err := os.MkdirAll(path, 0700); err != nil {
+	if err := os.MkdirAll(path, 0o700); err != nil {
 		return err
 	}
-	file, err := os.OpenFile(i.Path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|syscall.O_NOFOLLOW, 0644)
+	file, err := os.OpenFile(i.Path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|syscall.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return err
 	}
@@ -281,19 +281,19 @@ func SetLogFile(name string, uid int, subDir string) (*os.File, *os.File, error)
 	oldumask := syscall.Umask(0)
 	defer syscall.Umask(oldumask)
 
-	if err := os.MkdirAll(filepath.Dir(stderrPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(stderrPath), 0o700); err != nil {
 		return nil, nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(stdoutPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(stdoutPath), 0o700); err != nil {
 		return nil, nil, err
 	}
 
-	stderr, err := os.OpenFile(stderrPath, os.O_RDWR|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW, 0644)
+	stderr, err := os.OpenFile(stderrPath, os.O_RDWR|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	stdout, err := os.OpenFile(stdoutPath, os.O_RDWR|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW, 0644)
+	stdout, err := os.OpenFile(stdoutPath, os.O_RDWR|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW, 0o644)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/pkg/instance/logger.go
+++ b/internal/pkg/instance/logger.go
@@ -84,7 +84,7 @@ func (l *Logger) openFile(path string) (err error) {
 	oldmask := syscall.Umask(0)
 	defer syscall.Umask(oldmask)
 
-	l.file, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0640)
+	l.file, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o640)
 	return err
 }
 

--- a/internal/pkg/plugin/create.go
+++ b/internal/pkg/plugin/create.go
@@ -68,27 +68,27 @@ func Create(path, name string) error {
 		return fmt.Errorf("could not determine absolute path for %s: %s", path, err)
 	}
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("while creating plugin directory %s: %s", dir, err)
 	}
 
 	// create go.mod skeleton
 	filename := filepath.Join(dir, "go.mod")
 	content := fmt.Sprintf(goMod, name)
-	if err := ioutil.WriteFile(filename, []byte(content), 0644); err != nil {
+	if err := ioutil.WriteFile(filename, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("while creating plugin %s: %s", filename, err)
 	}
 
 	// create main.go skeleton
 	filename = filepath.Join(dir, "main.go")
 	content = fmt.Sprintf(mainGo, name)
-	if err := ioutil.WriteFile(filename, []byte(content), 0644); err != nil {
+	if err := ioutil.WriteFile(filename, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("while creating plugin %s: %s", filename, err)
 	}
 
 	// create .gitignore skeleton
 	filename = filepath.Join(dir, ".gitignore")
-	if err := ioutil.WriteFile(filename, []byte(gitIgnore), 0644); err != nil {
+	if err := ioutil.WriteFile(filename, []byte(gitIgnore), 0o644); err != nil {
 		return fmt.Errorf("while creating plugin %s: %s", filename, err)
 	}
 

--- a/internal/pkg/plugin/load.go
+++ b/internal/pkg/plugin/load.go
@@ -156,5 +156,4 @@ func getPluginObject(pl *plugin.Plugin) (*pluginapi.Plugin, error) {
 	}
 
 	return p, nil
-
 }

--- a/internal/pkg/plugin/meta.go
+++ b/internal/pkg/plugin/meta.go
@@ -88,7 +88,7 @@ func metaPath(name string) string {
 // install installs the plugin represented by m into the plugin installation
 // directory. This should normally only be called in InstallFromSIF.
 func (m *Meta) install(img *image.Image) error {
-	if err := os.MkdirAll(m.path(), 0755); err != nil {
+	if err := os.MkdirAll(m.path(), 0o755); err != nil {
 		return err
 	}
 

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -55,7 +55,7 @@ type ServiceConfig struct {
 func cacheDir() string {
 	cacheDir := syfs.RemoteCacheDir()
 	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
-		if err := os.Mkdir(cacheDir, 0700); err != nil {
+		if err := os.Mkdir(cacheDir, 0o700); err != nil {
 			return ""
 		}
 	}
@@ -87,5 +87,5 @@ func updateCachedConfig(uri string, data []byte) {
 		return
 	}
 	config := filepath.Join(dir, uri+".json")
-	ioutil.WriteFile(config, data, 0600)
+	ioutil.WriteFile(config, data, 0o600)
 }

--- a/internal/pkg/remote/endpoint/keyserver_test.go
+++ b/internal/pkg/remote/endpoint/keyserver_test.go
@@ -23,7 +23,7 @@ func TestAddRemoveKeyserver(t *testing.T) {
 	)
 
 	var testErr error
-	var token = "test"
+	token := "test"
 
 	scsDefaultCredential := &credential.Config{
 		URI:  SCSDefaultKeyserverURI,

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -45,11 +45,9 @@ var errorCodeMap = map[int]string{
 	500: "Internal Server Error",
 }
 
-var (
-	// ErrStatusNotSupported represents the error returned by
-	// a service which doesn't support SCS status check.
-	ErrStatusNotSupported = errors.New("status not supported")
-)
+// ErrStatusNotSupported represents the error returned by
+// a service which doesn't support SCS status check.
+var ErrStatusNotSupported = errors.New("status not supported")
 
 // Service defines a simple service interface which can be exposed
 // to retrieve service URI and check the service status.

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -23,10 +23,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-var (
-	// ErrNoDefault indicates no default remote being set
-	ErrNoDefault = errors.New("no default remote")
-)
+// ErrNoDefault indicates no default remote being set
+var ErrNoDefault = errors.New("no default remote")
 
 const (
 	// DefaultRemoteName is the default remote name

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -19,7 +19,7 @@ import (
 
 const testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
 
-//NOTE: VerifyToken() cannot be fully tested unless we have a dummy token for the token service to authenticate, so we basically only test a few error cases.
+// NOTE: VerifyToken() cannot be fully tested unless we have a dummy token for the token service to authenticate, so we basically only test a few error cases.
 func TestVerifyToken(t *testing.T) {
 	ep := new(endpoint.Config)
 
@@ -123,11 +123,9 @@ func TestWriteToReadFrom(t *testing.T) {
 		var r bytes.Buffer
 
 		_, err := ReadFrom(&r)
-
 		if err != nil {
 			t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
 		}
-
 	})
 }
 
@@ -1064,7 +1062,6 @@ func TestGetServiceURI(t *testing.T) {
 		},
 	}
 	for _, test := range testsFail {
-
 		t.Run(test.name, func(t *testing.T) {
 			var ep *endpoint.Config
 			ep, err := test.old.GetRemote(test.id)

--- a/internal/pkg/runtime/engine/config/oci/generate/generate.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate.go
@@ -307,7 +307,7 @@ func (g *Generator) Save(w io.Writer) (err error) {
 func (g *Generator) SaveToFile(path string) error {
 	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC | unix.O_NOFOLLOW
 
-	f, err := os.OpenFile(path, flags, 0600)
+	f, err := os.OpenFile(path, flags, 0o600)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -14,6 +14,7 @@ package starter
 */
 // #cgo CFLAGS: -I../../../../../../cmd/starter/c/include
 import "C"
+
 import (
 	"encoding/json"
 	"fmt"

--- a/internal/pkg/runtime/engine/oci/create_linux.go
+++ b/internal/pkg/runtime/engine/oci/create_linux.go
@@ -54,12 +54,12 @@ type device struct {
 }
 
 var devices = []device{
-	{1, 7, "/dev/full", syscall.S_IFCHR | 0666, 0, 0},
-	{1, 3, "/dev/null", syscall.S_IFCHR | 0666, 0, 0},
-	{1, 8, "/dev/random", syscall.S_IFCHR | 0666, 0, 0},
-	{5, 0, "/dev/tty", syscall.S_IFCHR | 0666, 0, 0},
-	{1, 9, "/dev/urandom", syscall.S_IFCHR | 0666, 0, 0},
-	{1, 5, "/dev/zero", syscall.S_IFCHR | 0666, 0, 0},
+	{1, 7, "/dev/full", syscall.S_IFCHR | 0o666, 0, 0},
+	{1, 3, "/dev/null", syscall.S_IFCHR | 0o666, 0, 0},
+	{1, 8, "/dev/random", syscall.S_IFCHR | 0o666, 0, 0},
+	{5, 0, "/dev/tty", syscall.S_IFCHR | 0o666, 0, 0},
+	{1, 9, "/dev/urandom", syscall.S_IFCHR | 0o666, 0, 0},
+	{1, 5, "/dev/zero", syscall.S_IFCHR | 0o666, 0, 0},
 }
 
 func int64ptr(i int) *int64 {
@@ -661,7 +661,7 @@ func (c *container) addDefaultDevices(system *mount.System) error {
 
 	devPath := filepath.Join(rootfsPath, fs.EvalRelative("/dev", rootfsPath))
 	if _, err := os.Lstat(devPath); os.IsNotExist(err) {
-		if err := os.Mkdir(devPath, 0755); err != nil {
+		if err := os.Mkdir(devPath, 0o755); err != nil {
 			return err
 		}
 	}
@@ -716,7 +716,7 @@ func (c *container) addDefaultDevices(system *mount.System) error {
 					continue
 				}
 				dirpath := filepath.Dir(path)
-				if _, err := c.rpcOps.MkdirAll(dirpath, 0755); err != nil {
+				if _, err := c.rpcOps.MkdirAll(dirpath, 0o755); err != nil {
 					return fmt.Errorf("could not create parent directory %s: %s", dirpath, err)
 				}
 				if _, err := c.rpcOps.Touch(path); err != nil {
@@ -727,7 +727,7 @@ func (c *container) addDefaultDevices(system *mount.System) error {
 				}
 			} else {
 				dirpath := filepath.Dir(path)
-				if err := os.MkdirAll(dirpath, 0755); err != nil {
+				if err := os.MkdirAll(dirpath, 0o755); err != nil {
 					return fmt.Errorf("could not create parent directory %s: %s", dirpath, err)
 				}
 				if err := syscall.Mknod(path, uint32(device.mode), dev); err != nil {
@@ -757,7 +757,7 @@ func (c *container) addDevices(system *mount.System) error {
 		if d.FileMode != nil {
 			dev.mode = *d.FileMode
 		} else {
-			dev.mode = 0644
+			dev.mode = 0o644
 		}
 
 		switch d.Type {
@@ -826,7 +826,7 @@ func (c *container) addMaskedPathsMount(system *mount.System) error {
 		oldmask := syscall.Umask(0)
 		defer syscall.Umask(oldmask)
 
-		if err := os.Mkdir(nullPath, 0755); err != nil {
+		if err := os.Mkdir(nullPath, 0o755); err != nil {
 			return err
 		}
 	}
@@ -897,11 +897,11 @@ func (c *container) mount(point *mount.Point, system *mount.System) error {
 			if point.Type != "" {
 				sylog.Debugf("Creating %s", procDest)
 				if c.userNS {
-					if _, err := c.rpcOps.MkdirAll(dest, 0755); err != nil {
+					if _, err := c.rpcOps.MkdirAll(dest, 0o755); err != nil {
 						return err
 					}
 				} else {
-					if err := os.MkdirAll(procDest, 0755); err != nil {
+					if err := os.MkdirAll(procDest, 0o755); err != nil {
 						return err
 					}
 				}
@@ -912,11 +912,11 @@ func (c *container) mount(point *mount.Point, system *mount.System) error {
 				if _, err := os.Stat(dir); os.IsNotExist(err) {
 					sylog.Debugf("Creating parent %s", dir)
 					if c.userNS {
-						if err := c.rpcOps.Mkdir(filepath.Dir(dest), 0755); err != nil {
+						if err := c.rpcOps.Mkdir(filepath.Dir(dest), 0o755); err != nil {
 							return err
 						}
 					} else {
-						if err := os.MkdirAll(dir, 0755); err != nil {
+						if err := os.MkdirAll(dir, 0o755); err != nil {
 							return err
 						}
 					}
@@ -930,11 +930,11 @@ func (c *container) mount(point *mount.Point, system *mount.System) error {
 				case syscall.S_IFDIR:
 					sylog.Debugf("Creating dir %s", filepath.Base(procDest))
 					if c.userNS {
-						if err := c.rpcOps.Mkdir(dest, 0755); err != nil {
+						if err := c.rpcOps.Mkdir(dest, 0o755); err != nil {
 							return err
 						}
 					} else {
-						if err := os.Mkdir(procDest, 0755); err != nil {
+						if err := os.Mkdir(procDest, 0o755); err != nil {
 							return err
 						}
 					}

--- a/internal/pkg/runtime/engine/oci/process_linux.go
+++ b/internal/pkg/runtime/engine/oci/process_linux.go
@@ -210,7 +210,7 @@ func (e *EngineOperations) PreStartProcess(ctx context.Context, pid int, masterC
 
 	pidFile := e.EngineConfig.GetPidFile()
 	if pidFile != "" {
-		if err := ioutil.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0644); err != nil {
+		if err := ioutil.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0o644); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -49,11 +49,13 @@ import (
 // - setup
 // - cleanup
 // - post start process
-var cryptDev string
-var networkSetup *network.Setup
-var cgroupManager *cgroups.Manager
-var imageDriver image.Driver
-var umountPoints []string
+var (
+	cryptDev      string
+	networkSetup  *network.Setup
+	cgroupManager *cgroups.Manager
+	imageDriver   image.Driver
+	umountPoints  []string
+)
 
 // defaultCNIConfPath is the default directory to CNI network configuration files.
 var defaultCNIConfPath = filepath.Join(buildcfg.SYSCONFDIR, "singularity", "network")
@@ -869,7 +871,7 @@ func (c *container) overlayUpperWork(system *mount.System) error {
 	createUpperWork := func(path, label string) error {
 		fi, err := c.rpcOps.Lstat(path)
 		if os.IsNotExist(err) {
-			if err := c.rpcOps.Mkdir(path, 0755); err != nil {
+			if err := c.rpcOps.Mkdir(path, 0o755); err != nil {
 				return fmt.Errorf("failed to create %s directory: %s", path, err)
 			}
 		} else if err == nil && !fi.IsDir() {
@@ -1808,10 +1810,10 @@ func (c *container) addTmpMount(system *mount.System) error {
 			tmpSource = filepath.Join(workdir, tmpSource)
 			vartmpSource = filepath.Join(workdir, vartmpSource)
 
-			if err := fs.Mkdir(tmpSource, os.ModeSticky|0777); err != nil && !os.IsExist(err) {
+			if err := fs.Mkdir(tmpSource, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("failed to create %s: %s", tmpSource, err)
 			}
-			if err := fs.Mkdir(vartmpSource, os.ModeSticky|0777); err != nil && !os.IsExist(err) {
+			if err := fs.Mkdir(vartmpSource, os.ModeSticky|0o777); err != nil && !os.IsExist(err) {
 				return fmt.Errorf("failed to create %s: %s", vartmpSource, err)
 			}
 		} else {
@@ -1819,7 +1821,7 @@ func (c *container) addTmpMount(system *mount.System) error {
 				if err := c.session.AddDir(tmpSource); err != nil {
 					return err
 				}
-				if err := c.session.Chmod(tmpSource, os.ModeSticky|0777); err != nil {
+				if err := c.session.Chmod(tmpSource, os.ModeSticky|0o777); err != nil {
 					return err
 				}
 			}
@@ -1827,7 +1829,7 @@ func (c *container) addTmpMount(system *mount.System) error {
 				if err := c.session.AddDir(vartmpSource); err != nil {
 					return err
 				}
-				if err := c.session.Chmod(vartmpSource, os.ModeSticky|0777); err != nil {
+				if err := c.session.Chmod(vartmpSource, os.ModeSticky|0o777); err != nil {
 					return err
 				}
 			}
@@ -1878,7 +1880,7 @@ func (c *container) addScratchMount(system *mount.System) error {
 	if hasWorkdir {
 		workdir = filepath.Clean(workdir)
 		sourceDir := filepath.Join(workdir, scratchSessionDir)
-		if err := fs.MkdirAll(sourceDir, 0750); err != nil {
+		if err := fs.MkdirAll(sourceDir, 0o750); err != nil {
 			return fmt.Errorf("could not create scratch working directory %s: %s", sourceDir, err)
 		}
 	}
@@ -1891,7 +1893,7 @@ func (c *container) addScratchMount(system *mount.System) error {
 		fullSourceDir, _ := c.session.GetPath(src)
 		if hasWorkdir {
 			fullSourceDir = filepath.Join(workdir, scratchSessionDir, dir)
-			if err := fs.MkdirAll(fullSourceDir, 0750); err != nil {
+			if err := fs.MkdirAll(fullSourceDir, 0o750); err != nil {
 				return fmt.Errorf("could not create scratch working directory %s: %s", fullSourceDir, err)
 			}
 		}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -200,7 +200,7 @@ func (e *EngineOperations) prepareUserCaps(enforced bool) error {
 
 	e.EngineConfig.OciConfig.SetProcessNoNewPrivileges(true)
 
-	file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0644)
+	file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("while opening capability config file: %s", err)
 	}
@@ -326,7 +326,7 @@ func (e *EngineOperations) prepareRootCaps() error {
 		e.EngineConfig.OciConfig.SetupPrivileged(true)
 		commonCaps = e.EngineConfig.OciConfig.Process.Capabilities.Permitted
 	case "file":
-		file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0644)
+		file, err := os.OpenFile(buildcfg.CAPABILITY_FILE, os.O_RDONLY, 0o644)
 		if err != nil {
 			return fmt.Errorf("while opening capability config file: %s", err)
 		}

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -90,7 +90,7 @@ func (e *EngineOperations) StartProcess(masterConnFd int) error {
 			if !terminal.IsTerminal(fd) {
 				continue
 			}
-			consfile, err := os.OpenFile("/dev/console", os.O_RDWR, 0600)
+			consfile, err := os.OpenFile("/dev/console", os.O_RDWR, 0o600)
 			if err != nil {
 				sylog.Debugf("Could not open minimal /dev/console, skipping replacing tty descriptors")
 				break

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -26,8 +26,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var diskGID = -1
-var defaultEffective = uint64(0)
+var (
+	diskGID          = -1
+	defaultEffective = uint64(0)
+)
 
 func init() {
 	defaultEffective |= uint64(1 << capabilities.Map["CAP_SETUID"].Value)
@@ -254,7 +256,7 @@ func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) (err error) {
 		image = os.NewFile(uintptr(fd), "")
 	} else {
 		var err error
-		image, err = os.OpenFile(arguments.Image, arguments.Mode, 0600)
+		image, err = os.OpenFile(arguments.Image, arguments.Mode, 0o600)
 		if err != nil {
 			return fmt.Errorf("could not open image file: %v", err)
 		}

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -26,7 +26,7 @@ func defaultProfile() *specs.LinuxSeccomp {
 			Args: []specs.LinuxSeccompArg{
 				{
 					Index: 1,
-					Value: 0777,
+					Value: 0o777,
 					Op:    specs.OpEqualTo,
 				},
 			},
@@ -50,14 +50,14 @@ func testFchmod(t *testing.T) {
 
 	if hasConditionSupport() {
 		// all modes except 0777 are permitted
-		if err := syscall.Fchmod(int(tmpfile.Fd()), 0755); err != nil {
+		if err := syscall.Fchmod(int(tmpfile.Fd()), 0o755); err != nil {
 			t.Errorf("fchmod syscall failed: %s", err)
 		}
-		if err := syscall.Fchmod(int(tmpfile.Fd()), 0777); err == nil {
+		if err := syscall.Fchmod(int(tmpfile.Fd()), 0o777); err == nil {
 			t.Errorf("fchmod syscall didn't return operation not permitted")
 		}
 	} else {
-		if err := syscall.Fchmod(int(tmpfile.Fd()), 0755); err == nil {
+		if err := syscall.Fchmod(int(tmpfile.Fd()), 0o755); err == nil {
 			t.Errorf("fchmod syscall didn't return operation not permitted")
 		}
 	}

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -72,7 +72,7 @@ func PutConfig(ecl EclConfig, confPath string) (err error) {
 		return
 	}
 
-	return ioutil.WriteFile(confPath, data, 0644)
+	return ioutil.WriteFile(confPath, data, 0o644)
 }
 
 // ValidateConfig makes sure paths from configs are fully resolved and that

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -18,8 +18,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var origUID, origGID, unprivUID, unprivGID int
-var origHome, unprivHome string
+var (
+	origUID, origGID, unprivUID, unprivGID int
+	origHome, unprivHome                   string
+)
 
 // EnsurePrivilege ensures elevated privileges are available during a test.
 func EnsurePrivilege(t *testing.T) {
@@ -33,7 +35,6 @@ func EnsurePrivilege(t *testing.T) {
 // not require elevated privileges. A matching call to ResetPrivilege must
 // occur before the test completes (a defer statement is recommended.)
 func DropPrivilege(t *testing.T) {
-
 	// setresuid/setresgid modifies the current thread only. To ensure our new
 	// uid/gid sticks, we need to lock ourselves to the current OS thread.
 	runtime.LockOSThread()
@@ -137,7 +138,6 @@ func init() {
 	origUID = os.Getuid()
 	origGID = os.Getgid()
 	origUser, err := user.LookupId(strconv.Itoa(origUID))
-
 	if err != nil {
 		log.Fatalf("err: %s", err)
 	}
@@ -146,7 +146,6 @@ func init() {
 
 	unprivUID, unprivGID = getUnprivIDs(os.Getpid())
 	unprivUser, err := user.LookupId(strconv.Itoa(unprivUID))
-
 	if err != nil {
 		log.Fatalf("err: %s", err)
 	}

--- a/internal/pkg/test/tool/cache/cache.go
+++ b/internal/pkg/test/tool/cache/cache.go
@@ -24,7 +24,7 @@ import (
 func MakeDir(t *testing.T, basedir string) string {
 	// We create a unique temporary directory for the image cache since Go run
 	// tests concurrently.
-	dir, err := fs.MakeTmpDir(basedir, "image_cache-", 0755)
+	dir, err := fs.MakeTmpDir(basedir, "image_cache-", 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -24,8 +24,10 @@ import (
 	"github.com/hpcng/singularity/pkg/util/fs/proc"
 )
 
-var hasUserNamespace bool
-var hasUserNamespaceOnce sync.Once
+var (
+	hasUserNamespace     bool
+	hasUserNamespaceOnce sync.Once
+)
 
 // UserNamespace checks that the current test could use
 // user namespace, if user namespaces are not enabled or
@@ -54,8 +56,10 @@ func UserNamespace(t *testing.T) {
 	}
 }
 
-var supportNetwork bool
-var supportNetworkOnce sync.Once
+var (
+	supportNetwork     bool
+	supportNetworkOnce sync.Once
+)
 
 // Network check that bridge network is supported by
 // system, if not the current test is skipped with a
@@ -205,7 +209,6 @@ func Arch(t *testing.T, arch string) {
 	if arch != "" && runtime.GOARCH != arch {
 		t.Skipf("test requires architecture %s", arch)
 	}
-
 }
 
 // ArchIn checks the test machine is one of the specified archs.

--- a/internal/pkg/util/auth/auth_test.go
+++ b/internal/pkg/util/auth/auth_test.go
@@ -17,7 +17,6 @@ const (
 )
 
 func Test_ReadToken(t *testing.T) {
-
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -60,7 +60,7 @@ func TestCryptsetup(t *testing.T) {
 			defer os.Remove(f.Name())
 
 			cfg := fmt.Sprintf("cryptsetup path = %s\n", tc.config)
-			ioutil.WriteFile(f.Name(), []byte(cfg), 0644)
+			ioutil.WriteFile(f.Name(), []byte(cfg), 0o644)
 
 			path, err := cryptsetup(f.Name())
 

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -165,7 +165,6 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 
 	cmd := exec.Command(cryptsetup, "luksFormat", "--batch-mode", "--type", "luks2", "--key-file", "-", loop)
 	stdin, err := cmd.StdinPipe()
-
 	if err != nil {
 		return "", err
 	}
@@ -211,13 +210,13 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 func copyDeviceContents(source, dest string, size int64) error {
 	sylog.Debugf("Copying %s to %s, size %d", source, dest, size)
 
-	sourceFd, err := syscall.Open(source, syscall.O_RDONLY, 0000)
+	sourceFd, err := syscall.Open(source, syscall.O_RDONLY, 0o000)
 	if err != nil {
 		return fmt.Errorf("unable to open the file %s", source)
 	}
 	defer syscall.Close(sourceFd)
 
-	destFd, err := syscall.Open(dest, syscall.O_WRONLY, 0666)
+	destFd, err := syscall.Open(dest, syscall.O_WRONLY, 0o666)
 	if err != nil {
 		return fmt.Errorf("unable to open the file: %s", dest)
 	}

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -43,7 +43,7 @@ func TestEncrypt(t *testing.T) {
 	// We create a few more sub-directories; note that they will be
 	// removed when the top-directory (dummyDir) will be removed.
 	dummyRootDir := filepath.Join(dummyDir, "root")
-	err = os.MkdirAll(dummyRootDir, 0755)
+	err = os.MkdirAll(dummyRootDir, 0o755)
 	if err != nil {
 		t.Fatalf("failed to create %s: %s", dummyRootDir, err)
 	}

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -266,7 +266,7 @@ func EvalRelative(path string, root string) string {
 
 // Touch behaves like touch command.
 func Touch(path string) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,6 @@ func CopyFile(from, to string, mode os.FileMode) (err error) {
 // file has permission bits set to the mode prior to umask. To honor umask
 // correctly the resulting file must not exist.
 func CopyFileAtomic(from, to string, mode os.FileMode) (err error) {
-
 	// MakeTmpFile forces mode with chmod, so manually apply umask to mode so we
 	// act like other file copy functions that respect umask
 	oldmask := syscall.Umask(0)
@@ -451,7 +450,7 @@ func ForceRemoveAll(path string) error {
 		// Directories must have the owner 'rx' bits to allow traversal, reading content, and the 'w' bit
 		// so their content can be deleted by the user when the bundle is deleted
 		if f.Mode().IsDir() {
-			if err := os.Chmod(path, f.Mode().Perm()|0700); err != nil {
+			if err := os.Chmod(path, f.Mode().Perm()|0o700); err != nil {
 				sylog.Errorf("Error setting permissions to remove %s: %s", path, err)
 				errors++
 			}

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -33,13 +33,13 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	existFile := filepath.Join(tmpDir, "already-exists")
 
 	// Create the test file.
-	fp, err := os.OpenFile(existFile, os.O_CREATE, 0755)
+	fp, err := os.OpenFile(existFile, os.O_CREATE, 0o755)
 	if err != nil {
 		t.Errorf("Unable to create test file: %s", err)
 	}
 
 	// Ensure the test file is the currect permission.
-	err = fp.Chmod(0755)
+	err = fp.Chmod(0o755)
 	if err != nil {
 		t.Errorf("Unable to change file permission: %s", err)
 	}
@@ -51,12 +51,12 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	}
 
 	// Double check the permission is what we expect.
-	if currentMode := finfo.Mode(); currentMode != 0755 {
+	if currentMode := finfo.Mode(); currentMode != 0o755 {
 		t.Errorf("Unexpect file permission: expecting 755, got %o", currentMode)
 	}
 
 	// Now the actral test!
-	err = EnsureFileWithPermission(existFile, 0655)
+	err = EnsureFileWithPermission(existFile, 0o655)
 	if err != nil {
 		t.Errorf("Failed to ensure file permission: %s", err)
 	}
@@ -68,12 +68,12 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	}
 
 	// Finally, check the file permission.
-	if currentMode := finfo.Mode(); currentMode != 0655 {
+	if currentMode := finfo.Mode(); currentMode != 0o655 {
 		t.Errorf("Unexpect file permission: expecting 655, got %o", currentMode)
 	}
 
 	// Test again with another permission.
-	err = EnsureFileWithPermission(existFile, 0777)
+	err = EnsureFileWithPermission(existFile, 0o777)
 	if err != nil {
 		t.Errorf("Failed to ensure file permission: %s", err)
 	}
@@ -85,7 +85,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	}
 
 	// Finally, check the file permission.
-	if currentMode := finfo.Mode(); currentMode != 0777 {
+	if currentMode := finfo.Mode(); currentMode != 0o777 {
 		t.Errorf("Unexpect file permission: expecting 777, got %o", currentMode)
 	}
 
@@ -101,7 +101,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	// This test, EnsureFileWithPermission will need to create
 	// this file, with the correct permission.
-	err = EnsureFileWithPermission(nonExistFile, 0755)
+	err = EnsureFileWithPermission(nonExistFile, 0o755)
 	if err != nil {
 		t.Errorf("Failed to create/ensure file permission: %s", err)
 	}
@@ -113,12 +113,12 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	}
 
 	// Finally, check the file permission.
-	if currentMode := einfo.Mode(); currentMode != 0755 {
+	if currentMode := einfo.Mode(); currentMode != 0o755 {
 		t.Errorf("Unexpect file permission: expecting 755, got %o", currentMode)
 	}
 
 	// Test again with another permission.
-	err = EnsureFileWithPermission(nonExistFile, 0544)
+	err = EnsureFileWithPermission(nonExistFile, 0o544)
 	if err != nil {
 		t.Errorf("Failed to ensure file permission: %s", err)
 	}
@@ -130,7 +130,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 	}
 
 	// Finally, check the file permission.
-	if currentMode := einfo.Mode(); currentMode != 0544 {
+	if currentMode := einfo.Mode(); currentMode != 0o544 {
 		t.Errorf("Unexpect file permission: expecting 544, got %o", currentMode)
 	}
 
@@ -199,7 +199,7 @@ func TestRootDir(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	var tests = []struct {
+	tests := []struct {
 		path     string
 		expected string
 	}{
@@ -235,20 +235,20 @@ func TestMkdirAll(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	if err := MkdirAll(filepath.Join(tmpdir, "test"), 0777); err != nil {
+	if err := MkdirAll(filepath.Join(tmpdir, "test"), 0o777); err != nil {
 		t.Error(err)
 	}
-	if err := MkdirAll(filepath.Join(tmpdir, "test/test"), 0000); err != nil {
+	if err := MkdirAll(filepath.Join(tmpdir, "test/test"), 0o000); err != nil {
 		t.Error(err)
 	}
-	if err := MkdirAll(filepath.Join(tmpdir, "test/test/test"), 0755); err == nil {
+	if err := MkdirAll(filepath.Join(tmpdir, "test/test/test"), 0o755); err == nil {
 		t.Errorf("should have failed with a permission denied")
 	}
 	fi, err := os.Stat(filepath.Join(tmpdir, "test"))
 	if err != nil {
 		t.Error(err)
 	}
-	if fi.Mode().Perm() != 0777 {
+	if fi.Mode().Perm() != 0o777 {
 		t.Errorf("bad mode applied on %s, got %v", filepath.Join(tmpdir, "test"), fi.Mode().Perm())
 	}
 }
@@ -264,14 +264,14 @@ func TestMkdir(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	test := filepath.Join(tmpdir, "test")
-	if err := Mkdir(test, 0777); err != nil {
+	if err := Mkdir(test, 0o777); err != nil {
 		t.Error(err)
 	}
 	fi, err := os.Stat(test)
 	if err != nil {
 		t.Error(err)
 	}
-	if fi.Mode().Perm() != 0777 {
+	if fi.Mode().Perm() != 0o777 {
 		t.Errorf("bad mode applied on %s, got %v", test, fi.Mode().Perm())
 	}
 }
@@ -301,9 +301,9 @@ func TestEvalRelative(t *testing.T) {
 	os.Symlink("usr/sbin", filepath.Join(tmpdir, "sbin"))
 
 	// directory $TMP/usr/bin
-	MkdirAll(filepath.Join(tmpdir, "usr", "bin"), 0755)
+	MkdirAll(filepath.Join(tmpdir, "usr", "bin"), 0o755)
 	// directory $TMP/usr/sbin
-	MkdirAll(filepath.Join(tmpdir, "usr", "sbin"), 0755)
+	MkdirAll(filepath.Join(tmpdir, "usr", "sbin"), 0o755)
 
 	// symlink $TMP/usr/bin/bin -> /bin
 	os.Symlink("/bin", filepath.Join(tmpdir, "bin", "bin"))
@@ -391,11 +391,11 @@ func TestMakeTempDir(t *testing.T) {
 		mode          os.FileMode
 		expectSuccess bool
 	}{
-		{"tmp directory with 0700", "", "atmp-", 0700, true},
-		{"tmp directory with 0755", "", "btmp-", 0755, true},
-		{"root directory 0700", "/", "bad-", 0700, false},
-		{"with non-existent basedir", "/tmp/__utest__", "ctmp-", 0700, false},
-		{"with existent basedir", "/var/tmp", "dtmp-", 0700, true},
+		{"tmp directory with 0700", "", "atmp-", 0o700, true},
+		{"tmp directory with 0755", "", "btmp-", 0o755, true},
+		{"root directory 0700", "/", "bad-", 0o700, false},
+		{"with non-existent basedir", "/tmp/__utest__", "ctmp-", 0o700, false},
+		{"with existent basedir", "/var/tmp", "dtmp-", 0o700, true},
 	}
 	for _, tt := range tests {
 		d, err := MakeTmpDir(tt.basedir, tt.pattern, tt.mode)
@@ -441,11 +441,11 @@ func TestMakeTempFile(t *testing.T) {
 		mode          os.FileMode
 		expectSuccess bool
 	}{
-		{"tmp file with 0700", "", "atmp-", 0700, true},
-		{"tmp file with 0755", "", "btmp-", 0755, true},
-		{"root directory tmp file 0700", "/", "bad-", 0700, false},
-		{"with non-existent basedir", "/tmp/__utest__", "ctmp-", 0700, false},
-		{"with existent basedir", "/var/tmp", "dtmp-", 0700, true},
+		{"tmp file with 0700", "", "atmp-", 0o700, true},
+		{"tmp file with 0755", "", "btmp-", 0o755, true},
+		{"root directory tmp file 0700", "/", "bad-", 0o700, false},
+		{"with non-existent basedir", "/tmp/__utest__", "ctmp-", 0o700, false},
+		{"with existent basedir", "/var/tmp", "dtmp-", 0o700, true},
 	}
 	for _, tt := range tests {
 		f, err := MakeTmpFile(tt.basedir, tt.pattern, tt.mode)
@@ -498,7 +498,7 @@ func testCopyFileFunc(t *testing.T, fn copyFileFunc) {
 	defer os.RemoveAll(tmpDir)
 
 	source := filepath.Join(tmpDir, "source")
-	err = ioutil.WriteFile(source, testData, 0644)
+	err = ioutil.WriteFile(source, testData, 0o644)
 	if err != nil {
 		t.Fatalf("failed to create test source file: %v", err)
 	}
@@ -514,27 +514,27 @@ func testCopyFileFunc(t *testing.T, fn copyFileFunc) {
 			name:        "non existent source",
 			from:        filepath.Join(tmpDir, "not-there"),
 			to:          filepath.Join(tmpDir, "invalid"),
-			mode:        0644,
+			mode:        0o644,
 			expectError: "no such file or directory",
 		},
 		{
 			name:        "non existent target",
 			from:        source,
 			to:          filepath.Join(os.TempDir(), "not-there", "invalid"),
-			mode:        0644,
+			mode:        0o644,
 			expectError: "no such file or directory",
 		},
 		{
 			name: "change mode",
 			from: source,
 			to:   filepath.Join(tmpDir, "executable"),
-			mode: 0755,
+			mode: 0o755,
 		},
 		{
 			name: "simple copy",
 			from: source,
 			to:   filepath.Join(tmpDir, "copy"),
-			mode: 0644,
+			mode: 0o644,
 		},
 	}
 
@@ -583,13 +583,13 @@ func TestIsWritable(t *testing.T) {
 	test.EnsurePrivilege(t)
 
 	// Directories owned by root, we will check later if the unprivileged user can access it.
-	validRoot755Dir, err := MakeTmpDir("", "", 0755)
+	validRoot755Dir, err := MakeTmpDir("", "", 0o755)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s: %s", validRoot755Dir, err)
 	}
 	defer os.RemoveAll(validRoot755Dir)
 
-	validRoot777Dir, err := MakeTmpDir("", "", 0777)
+	validRoot777Dir, err := MakeTmpDir("", "", 0o777)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s: %s", validRoot777Dir, err)
 	}
@@ -612,19 +612,19 @@ func TestIsWritable(t *testing.T) {
 	validNotWritablePath := filepath.Join(tempDir, "notWritableDir")
 	valid700Dir := filepath.Join(tempDir, "700Dir")
 	valid555Dir := filepath.Join(tempDir, "555Dir")
-	err = os.MkdirAll(validWritablePath, 0755)
+	err = os.MkdirAll(validWritablePath, 0o755)
 	if err != nil {
 		t.Fatalf("failed to create directory %s: %s", validWritablePath, err)
 	}
-	err = os.MkdirAll(validNotWritablePath, 0444)
+	err = os.MkdirAll(validNotWritablePath, 0o444)
 	if err != nil {
 		t.Fatalf("failed to create directory %s: %s", validNotWritablePath, err)
 	}
-	err = os.MkdirAll(valid700Dir, 0700)
+	err = os.MkdirAll(valid700Dir, 0o700)
 	if err != nil {
 		t.Fatalf("failed to create directory %s: %s", valid700Dir, err)
 	}
-	err = os.MkdirAll(valid555Dir, 0555)
+	err = os.MkdirAll(valid555Dir, 0o555)
 	if err != nil {
 		t.Fatalf("failed to create directory %s: %s", valid555Dir, err)
 	}
@@ -680,17 +680,16 @@ func TestIsWritable(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestFirstExistingParent(t *testing.T) {
-	testDir, err := MakeTmpDir("", "dir", 0755)
+	testDir, err := MakeTmpDir("", "dir", 0o755)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s: %s", testDir, err)
 	}
 	defer os.RemoveAll(testDir)
 
-	testFile, err := MakeTmpFile(testDir, "file", 0644)
+	testFile, err := MakeTmpFile(testDir, "file", 0o644)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s: %s", testFile.Name(), err)
 	}
@@ -752,17 +751,17 @@ func TestForceRemoveAll(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 	// Setup a structure that os.RemoveAll should fail to remove
-	testDir, err := MakeTmpDir("", "dir", 0755)
+	testDir, err := MakeTmpDir("", "dir", 0o755)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s: %s", testDir, err)
 	}
-	testFile, err := MakeTmpFile(testDir, "file", 0644)
+	testFile, err := MakeTmpFile(testDir, "file", 0o644)
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s: %s", testFile.Name(), err)
 	}
 	testFile.Close()
 	// Change the perm on testDir so that RemoveAll should fail
-	err = os.Chmod(testDir, 000)
+	err = os.Chmod(testDir, 0o00)
 	if err != nil {
 		t.Fatalf("failed to set permissions on temporary directory %s: %s", testDir, err)
 	}

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	dirMode  os.FileMode = 0755
-	fileMode             = 0644
+	dirMode  os.FileMode = 0o755
+	fileMode             = 0o644
 )
 
 type file struct {
@@ -193,10 +193,10 @@ func (m *Manager) SetRootPath(path string) error {
 	if m.dirs == nil {
 		m.dirs = make([]*dir, 0)
 	}
-	if m.DirMode == 0000 {
+	if m.DirMode == 0o000 {
 		m.DirMode = dirMode
 	}
-	if m.FileMode == 0000 {
+	if m.FileMode == 0o000 {
 		m.FileMode = fileMode
 	}
 	d := &dir{mode: m.DirMode, uid: os.Getuid(), gid: os.Getgid()}

--- a/internal/pkg/util/fs/layout/manager_test.go
+++ b/internal/pkg/util/fs/layout/manager_test.go
@@ -84,10 +84,10 @@ func TestLayout(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := session.Chmod("/etc", 0777); err != nil {
+	if err := session.Chmod("/etc", 0o777); err != nil {
 		t.Error(err)
 	}
-	if err := session.Chmod("/etcd", 0777); err == nil {
+	if err := session.Chmod("/etcd", 0o777); err == nil {
 		t.Error("should have failed with non existent path")
 	}
 
@@ -98,7 +98,7 @@ func TestLayout(t *testing.T) {
 		t.Error("should have failed with non existent path")
 	}
 
-	if err := session.Chmod("/etc/passwd", 0600); err != nil {
+	if err := session.Chmod("/etc/passwd", 0o600); err != nil {
 		t.Error(err)
 	}
 	if err := session.Chown("/etc/passwd", uid, gid); err != nil {

--- a/internal/pkg/util/fs/layout/session_linux.go
+++ b/internal/pkg/util/fs/layout/session_linux.go
@@ -14,8 +14,10 @@ import (
 	"github.com/hpcng/singularity/pkg/sylog"
 )
 
-const rootFsDir = "/rootfs"
-const finalDir = "/final"
+const (
+	rootFsDir = "/rootfs"
+	finalDir  = "/final"
+)
 
 // Session directory layout manager
 type Session struct {

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -349,7 +349,7 @@ func (p *Points) init() {
 }
 
 func (p *Points) add(tag AuthorizedTag, source string, dest string, fstype string, flags uintptr, options string) error {
-	var bind = false
+	bind := false
 
 	p.init()
 

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -601,7 +601,6 @@ func TestImport(t *testing.T) {
 	if len(points.GetByTag(UserbindsTag)) != 3 {
 		t.Errorf("returned a wrong number of mount kernel mount points %d instead of 3", len(points.GetByTag(UserbindsTag)))
 	}
-
 }
 
 func TestTag(t *testing.T) {

--- a/internal/pkg/util/interactive/interactive.go
+++ b/internal/pkg/util/interactive/interactive.go
@@ -18,9 +18,11 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-var errInvalidChoice = errors.New("invalid choice")
-var errPassphraseMismatch = errors.New("passphrases do not match")
-var errTooManyRetries = errors.New("too many retries while getting a passphrase")
+var (
+	errInvalidChoice      = errors.New("invalid choice")
+	errPassphraseMismatch = errors.New("passphrases do not match")
+	errTooManyRetries     = errors.New("too many retries while getting a passphrase")
+)
 
 // askQuestionUsingGenericDescr reads from a file descriptor (more precisely
 // from a *os.File object) one line at a time. The file can be a normal file or

--- a/internal/pkg/util/interactive/interactive_test.go
+++ b/internal/pkg/util/interactive/interactive_test.go
@@ -117,7 +117,6 @@ func TestAskNYQuestion(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestAskNumberInRange(t *testing.T) {

--- a/internal/pkg/util/machine/machine.go
+++ b/internal/pkg/util/machine/machine.go
@@ -195,7 +195,7 @@ func ArchFromContainer(container string) string {
 			return nil
 		}
 		// ignore not executable files
-		if info.Mode().Perm()&0111 == 0 {
+		if info.Mode().Perm()&0o111 == 0 {
 			return nil
 		}
 

--- a/internal/pkg/util/shell/escape_test.go
+++ b/internal/pkg/util/shell/escape_test.go
@@ -8,7 +8,7 @@ package shell
 import "testing"
 
 func TestArgsQuoted(t *testing.T) {
-	var quoteTests = []struct {
+	quoteTests := []struct {
 		name     string
 		input    []string
 		expected string
@@ -27,11 +27,10 @@ func TestArgsQuoted(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestEscape(t *testing.T) {
-	var escapeTests = []struct {
+	escapeTests := []struct {
 		input    string
 		expected string
 	}{
@@ -49,7 +48,6 @@ func TestEscape(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestEscapeDoubleQuotes(t *testing.T) {
@@ -90,5 +88,4 @@ func TestEscapeSingleQuotes(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/pkg/util/uri/uri.go
+++ b/internal/pkg/util/uri/uri.go
@@ -39,7 +39,6 @@ var validURIs = map[string]bool{
 
 // IsValid returns whether or not the given source is valid
 func IsValid(source string) (valid bool, err error) {
-
 	u := strings.SplitN(source, ":", 2)
 
 	if len(u) != 2 {

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -126,7 +126,7 @@ func canChown(rootfs string) (bool, error) {
 
 	chownFile := filepath.Join(rootfs, ".chownTest")
 
-	f, err := os.OpenFile(chownFile, os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, 0600)
+	f, err := os.OpenFile(chownFile, os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return false, fmt.Errorf("could not create %q: %v", chownFile, err)
 	}
@@ -166,7 +166,7 @@ func newBundle(parentPath, tempDir string, keyInfo *cryptkey.KeyInfo) (*Bundle, 
 	}
 	sylog.Debugf("Created temporary directory %q for the bundle", tmpPath)
 
-	if err := os.MkdirAll(rootfsPath, 0755); err != nil {
+	if err := os.MkdirAll(rootfsPath, 0o755); err != nil {
 		cleanupDir(tmpPath)
 		cleanupDir(parentPath)
 		return nil, fmt.Errorf("could not create %q: %v", rootfsPath, err)
@@ -194,7 +194,7 @@ func newBundle(parentPath, tempDir string, keyInfo *cryptkey.KeyInfo) (*Bundle, 
 			}
 			// Create an inner dir, so we don't clobber the secure permissions on the surrounding dir.
 			rootfsNewPath := filepath.Join(parentPath, "rootfs")
-			if err := os.Mkdir(rootfsNewPath, 0755); err != nil {
+			if err := os.Mkdir(rootfsNewPath, 0o755); err != nil {
 				cleanupDir(tmpPath)
 				cleanupDir(parentPath)
 				return nil, fmt.Errorf("could not create rootfs dir in %q: %v", rootfsNewPath, err)

--- a/pkg/build/types/bundle_test.go
+++ b/pkg/build/types/bundle_test.go
@@ -83,7 +83,6 @@ func TestNewBundle(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestBundle_RunSections(t *testing.T) {

--- a/pkg/build/types/definition_test.go
+++ b/pkg/build/types/definition_test.go
@@ -19,7 +19,8 @@ func TestNewDefinitionFromURI(t *testing.T) {
 		{uri: "test", shouldPass: false},
 		{uri: "//test", shouldPass: false},
 		{uri: "://test", shouldPass: true},
-		{uri: ":test", shouldPass: true}}
+		{uri: ":test", shouldPass: true},
+	}
 
 	for _, testCase := range cases {
 		_, myerr := NewDefinitionFromURI(testCase.uri)
@@ -38,7 +39,8 @@ func TestNewDefinitionFromJSON(t *testing.T) {
 		shouldPass bool
 	}{
 		{JSON: `{"test"}`, shouldPass: false},
-		{JSON: `{"Key1": "Value1", "Key2": "Value2."}`, shouldPass: true}}
+		{JSON: `{"Key1": "Value1", "Key2": "Value2."}`, shouldPass: true},
+	}
 
 	const singularityJSON = "parser/testdata_good/docker/docker.json"
 	// We do not have a valid example file that we can use to reach the corner cases, so we define a fake JSON

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -122,7 +122,6 @@ func scanDefinitionFile(data []byte, atEOF bool) (advance int, token []byte, err
 	}
 
 	return advance, retbuf.Bytes(), nil
-
 }
 
 func getSectionName(line string) string {

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -72,7 +72,6 @@ func TestScanDefinitionFile(t *testing.T) {
 			if s.Text() != d[0].Header {
 				t.Fatal("scanDefinitionFile does not produce same header as reference")
 			}
-
 		}))
 	}
 }
@@ -200,7 +199,7 @@ func TestParseDefinitionFile(t *testing.T) {
 			}
 			defer defFile.Close()
 
-			jsonFile, err := os.OpenFile(tt.jsonPath, os.O_RDWR, 0644)
+			jsonFile, err := os.OpenFile(tt.jsonPath, os.O_RDWR, 0o644)
 			if err != nil {
 				t.Fatal("failed to open:", err)
 			}
@@ -256,7 +255,6 @@ func TestParseDefinitionFileFailure(t *testing.T) {
 
 // Specific tests to cover some corner cases of IsInvalidSectionError()
 func TestIsInvalidSectionErrors(t *testing.T) {
-
 	// Test of IsInvalidSectionError()
 	dummyKeys := []string{"dummy_key1", "dummy_key2"}
 	myValidErr1 := &InvalidSectionError{dummyKeys, errInvalidSection}
@@ -334,7 +332,6 @@ func TestDoHeader(t *testing.T) {
 }
 
 func TestIsValidDefinition(t *testing.T) {
-
 	//
 	// Test with a bunch of valid files
 	//
@@ -427,7 +424,7 @@ func TestParseAll(t *testing.T) {
 			}
 			defer defFile.Close()
 
-			jsonFile, err := os.OpenFile(tt.jsonPath, os.O_RDWR, 0644)
+			jsonFile, err := os.OpenFile(tt.jsonPath, os.O_RDWR, 0o644)
 			if err != nil {
 				t.Fatal("failed to open:", err)
 			}

--- a/pkg/cmdline/cmd_test.go
+++ b/pkg/cmdline/cmd_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{Use: "root"}
-var parentCmd = &cobra.Command{Use: "parent"}
-var childCmd = &cobra.Command{Use: "child"}
+var (
+	rootCmd   = &cobra.Command{Use: "root"}
+	parentCmd = &cobra.Command{Use: "parent"}
+	childCmd  = &cobra.Command{Use: "child"}
+)
 
 func newCommandManager(cmd *cobra.Command) (cm *CommandManager, err error) {
 	defer func() {

--- a/pkg/cmdline/flag_test.go
+++ b/pkg/cmdline/flag_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var testString string
-var testBool bool
-var testStringSlice []string
-var testInt int
-var testUint32 uint32
+var (
+	testString      string
+	testBool        bool
+	testStringSlice []string
+	testInt         int
+	testUint32      uint32
+)
 
 var ttData = []struct {
 	desc            string

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -51,7 +51,7 @@ func copyImage(t *testing.T) string {
 	name := f.Name()
 	f.Close()
 
-	if err := fs.CopyFileAtomic(busyboxSIF, name, 0755); err != nil {
+	if err := fs.CopyFileAtomic(busyboxSIF, name, 0o755); err != nil {
 		t.Fatalf("Could not copy test image: %v", err)
 	}
 	return name
@@ -202,7 +202,8 @@ func TestAuthorizedPath(t *testing.T) {
 		{
 			name:       "valid path",
 			path:       []string{"/"},
-			shouldPass: true},
+			shouldPass: true,
+		},
 	}
 
 	// XXX(mem): This is what makes this test slow

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	//SIFDescOCIConfigJSON is the name of the SIF descriptor holding the OCI configuration.
+	// SIFDescOCIConfigJSON is the name of the SIF descriptor holding the OCI configuration.
 	SIFDescOCIConfigJSON = "oci-config.json"
 	// SIFDescInspectMetadataJSON is the name of the SIF descriptor holding the container metadata.
 	SIFDescInspectMetadataJSON = "inspect-metadata.json"

--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -19,7 +19,7 @@ import (
 const testSquash = "./testdata/squashfs.v4"
 
 func createSIF(t *testing.T, inputDesc []sif.DescriptorInput, corrupted bool) string {
-	sifFile, err := fs.MakeTmpFile("", "sif-", 0644)
+	sifFile, err := fs.MakeTmpFile("", "sif-", 0o644)
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}

--- a/pkg/image/unpacker/squashfs.go
+++ b/pkg/image/unpacker/squashfs.go
@@ -149,7 +149,7 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 		}
 		// create $rootfs/dev as it has been excluded
 		rootfsDev := filepath.Join(dest, "dev")
-		devErr := os.Mkdir(rootfsDev, 0755)
+		devErr := os.Mkdir(rootfsDev, 0o755)
 		if devErr != nil && !os.IsExist(devErr) {
 			err = fmt.Errorf("could not create %s: %s", rootfsDev, devErr)
 		}

--- a/pkg/image/unpacker/squashfs_singularity.go
+++ b/pkg/image/unpacker/squashfs_singularity.go
@@ -146,7 +146,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	}
 
 	for _, d := range rootfsDirs {
-		if err := os.Mkdir(d, 0700); err != nil {
+		if err := os.Mkdir(d, 0o700); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", d, err)
 		}
 	}
@@ -203,10 +203,10 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	for _, b := range roFiles {
 		file := filepath.Join(rootfs, b)
 		dir := filepath.Dir(file)
-		if err := os.MkdirAll(dir, 0700); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", dir, err)
 		}
-		if err := ioutil.WriteFile(file, []byte(""), 0600); err != nil {
+		if err := ioutil.WriteFile(file, []byte(""), 0o600); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", file, err)
 		}
 		args = append(args, "-B", fmt.Sprintf("%s:%s:ro", b, b))

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -127,7 +127,7 @@ func TestGetAllNetworkConfigList(t *testing.T) {
 	}
 	defer os.Remove(emptyDir)
 
-	var testCNIPath = []struct {
+	testCNIPath := []struct {
 		name           string
 		cniPath        *CNIPath
 		success        bool
@@ -189,7 +189,7 @@ func TestGetAllNetworkConfigList(t *testing.T) {
 }
 
 func testSetArgs(setup *Setup, t *testing.T) {
-	var testArgs = []struct {
+	testArgs := []struct {
 		desc    string
 		args    []string
 		success bool
@@ -293,11 +293,11 @@ func testSetArgs(setup *Setup, t *testing.T) {
 func TestNewSetup(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	var cniPath = &CNIPath{
+	cniPath := &CNIPath{
 		Conf:   defaultCNIConfPath,
 		Plugin: defaultCNIPluginPath,
 	}
-	var testSetup = []struct {
+	testSetup := []struct {
 		desc     string
 		networks []string
 		id       string
@@ -530,7 +530,7 @@ func TestAddDelNetworks(t *testing.T) {
 		}
 	}
 
-	var cniPath = &CNIPath{
+	cniPath := &CNIPath{
 		Conf:   defaultCNIConfPath,
 		Plugin: defaultCNIPluginPath,
 	}
@@ -624,7 +624,7 @@ func TestMain(m *testing.M) {
 	for _, conf := range confFiles {
 		testNetworks = append(testNetworks, conf.name)
 		path := filepath.Join(defaultCNIConfPath, conf.file)
-		if err := ioutil.WriteFile(path, []byte(conf.content), 0644); err != nil {
+		if err := ioutil.WriteFile(path, []byte(conf.content), 0o644); err != nil {
 			os.RemoveAll(defaultCNIConfPath)
 			os.Exit(1)
 		}

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -73,7 +73,7 @@ func (s *sifBundle) writeConfig(img *image.Image, g *generate.Generator) error {
 	for dst := range imgConfig.Volumes {
 		replacer := strings.NewReplacer(string(os.PathSeparator), "_")
 		src := filepath.Join(volumes, replacer.Replace(dst))
-		if err := os.MkdirAll(src, 0755); err != nil {
+		if err := os.MkdirAll(src, 0o755); err != nil {
 			return fmt.Errorf("failed to create volume directory %s: %s", src, err)
 		}
 		g.AddMount(specs.Mount{

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -37,7 +37,7 @@ func TestFromSif(t *testing.T) {
 	f.Close()
 	defer os.Remove(sifFile)
 
-	if err := fs.CopyFileAtomic(busyboxSIF, sifFile, 0755); err != nil {
+	if err := fs.CopyFileAtomic(busyboxSIF, sifFile, 0o755); err != nil {
 		t.Fatalf("Could not copy test image: %v", err)
 	}
 
@@ -61,7 +61,6 @@ func TestFromSif(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			if tt.writable {
 				requireFilesystem(t, "overlay")
 			}
@@ -99,10 +98,8 @@ func TestFromSif(t *testing.T) {
 			if err := bundle.Delete(); err != nil {
 				t.Error(err)
 			}
-
 		})
 	}
-
 }
 
 // TODO: This is a duplicate from internal/pkg/test/tool/require

--- a/pkg/ocibundle/tools/oci.go
+++ b/pkg/ocibundle/tools/oci.go
@@ -54,11 +54,11 @@ func GenerateBundleConfig(bundlePath string, config *specs.Spec) (*generate.Gene
 	defer syscall.Umask(oldumask)
 
 	rootFsDir := RootFs(bundlePath).Path()
-	if err := os.MkdirAll(rootFsDir, 0700); err != nil {
+	if err := os.MkdirAll(rootFsDir, 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create %s: %s", rootFsDir, err)
 	}
 	volumesDir := Volumes(bundlePath).Path()
-	if err := os.MkdirAll(volumesDir, 0755); err != nil {
+	if err := os.MkdirAll(volumesDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create %s: %s", volumesDir, err)
 	}
 	defer func() {

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -20,7 +20,7 @@ func CreateOverlay(bundlePath string) error {
 	defer syscall.Umask(oldumask)
 
 	overlayDir := filepath.Join(bundlePath, "overlay")
-	if err = os.Mkdir(overlayDir, 0700); err != nil {
+	if err = os.Mkdir(overlayDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create %s: %s", overlayDir, err)
 	}
 	// delete overlay directory in case of error
@@ -46,11 +46,11 @@ func CreateOverlay(bundlePath string) error {
 	}
 
 	upperDir := filepath.Join(overlayDir, "upper")
-	if err = os.Mkdir(upperDir, 0755); err != nil {
+	if err = os.Mkdir(upperDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create %s: %s", upperDir, err)
 	}
 	workDir := filepath.Join(overlayDir, "work")
-	if err = os.Mkdir(workDir, 0700); err != nil {
+	if err = os.Mkdir(workDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create %s: %s", workDir, err)
 	}
 	rootFsDir := RootFs(bundlePath).Path()

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -298,7 +298,7 @@ func (e *EngineConfig) GetCustomHome() bool {
 func ParseBindPath(paths []string) ([]BindPath, error) {
 	var binds []BindPath
 
-	var validOptions = map[string]bool{
+	validOptions := map[string]bool{
 		"ro":        true,
 		"rw":        true,
 		"image-src": false,

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -44,7 +44,6 @@ func ConfigDir() string {
 
 func configDir() string {
 	user, err := user.Current()
-
 	if err != nil {
 		sylog.Warningf("Could not lookup the current user's information: %s", err)
 
@@ -76,7 +75,6 @@ func DockerConf() string {
 // configuration and data for the specified username is located.
 func ConfigDirForUsername(username string) (string, error) {
 	u, err := user.Lookup(username)
-
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sylog/sylog_test.go
+++ b/pkg/sylog/sylog_test.go
@@ -294,7 +294,6 @@ const testStr = "test message"
 type fnOut func(format string, a ...interface{})
 
 func runTestLogFn(t *testing.T, errFd *os.File, fn fnOut) {
-
 	if errFd != nil {
 		fn("%s", testStr)
 		return
@@ -336,7 +335,6 @@ func runTestLogFn(t *testing.T, errFd *os.File, fn fnOut) {
 }
 
 func TestStderrOutput(t *testing.T) {
-
 	tests := []struct {
 		name string
 		out  *os.File

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -154,9 +154,9 @@ func (keyring *Handle) PublicPath() string {
 //
 // TODO(mem): move this function to a common location
 func ensureDirPrivate(dn string) error {
-	mode := os.FileMode(0700)
+	mode := os.FileMode(0o700)
 
-	oldumask := syscall.Umask(0077)
+	oldumask := syscall.Umask(0o077)
 
 	err := os.MkdirAll(dn, mode)
 
@@ -225,11 +225,11 @@ func (keyring *Handle) PathsCheck() error {
 	if err := ensureDirPrivate(keyring.path); err != nil {
 		return err
 	}
-	if err := fs.EnsureFileWithPermission(keyring.SecretPath(), 0600); err != nil {
+	if err := fs.EnsureFileWithPermission(keyring.SecretPath(), 0o600); err != nil {
 		return err
 	}
 
-	return fs.EnsureFileWithPermission(keyring.PublicPath(), 0600)
+	return fs.EnsureFileWithPermission(keyring.PublicPath(), 0o600)
 }
 
 func loadKeyring(fn string) (openpgp.EntityList, error) {
@@ -303,7 +303,6 @@ func printEntity(w io.Writer, index int, e *openpgp.Entity) {
 	fmt.Fprintf(w, "   F: %0X\n", e.PrimaryKey.Fingerprint)
 	bits, _ := e.PrimaryKey.BitLength()
 	fmt.Fprintf(w, "   L: %d\n", bits)
-
 }
 
 func printEntities(w io.Writer, entities openpgp.EntityList) {
@@ -359,7 +358,7 @@ func (keyring *Handle) appendPrivateKey(e *openpgp.Entity) error {
 		return fmt.Errorf("global keyring can't contain private keys")
 	}
 
-	f, err := createOrAppendFile(keyring.SecretPath(), 0600)
+	f, err := createOrAppendFile(keyring.SecretPath(), 0o600)
 	if err != nil {
 		return err
 	}
@@ -381,9 +380,9 @@ func storePubKeys(w io.Writer, list openpgp.EntityList) error {
 
 // appendPubKey appends a public key entity to the local keyring
 func (keyring *Handle) appendPubKey(e *openpgp.Entity) error {
-	mode := os.FileMode(0600)
+	mode := os.FileMode(0o600)
 	if keyring.global {
-		mode = os.FileMode(0644)
+		mode = os.FileMode(0o644)
 	}
 
 	f, err := createOrAppendFile(keyring.PublicPath(), mode)
@@ -397,9 +396,9 @@ func (keyring *Handle) appendPubKey(e *openpgp.Entity) error {
 
 // storePubKeyring overwrites the public keyring with the listed keys
 func (keyring *Handle) storePubKeyring(keys openpgp.EntityList) error {
-	mode := os.FileMode(0600)
+	mode := os.FileMode(0o600)
 	if keyring.global {
-		mode = os.FileMode(0644)
+		mode = os.FileMode(0o644)
 	}
 
 	f, err := createOrTruncateFile(keyring.PublicPath(), mode)
@@ -649,7 +648,7 @@ func formatMROutput(mrString string) (int, []byte, error) {
 func SearchPubkey(ctx context.Context, search string, longOutput bool, opts ...client.Option) error {
 	// If the search term is 8+ hex chars then it's a fingerprint, and
 	// we need to prefix with 0x for the search.
-	var IsFingerprint = regexp.MustCompile(`^[0-9A-F]{8,}$`).MatchString
+	IsFingerprint := regexp.MustCompile(`^[0-9A-F]{8,}$`).MatchString
 	if IsFingerprint(search) {
 		search = "0x" + search
 	}
@@ -667,7 +666,7 @@ func SearchPubkey(ctx context.Context, search string, longOutput bool, opts ...c
 	}
 
 	// set the machine readable output on
-	var options = []string{client.OptionMachineReadable}
+	options := []string{client.OptionMachineReadable}
 	// Retrieve first page of search results from Key Service.
 	keyText, err := c.PKSLookup(ctx, &pd, search, client.OperationIndex, true, false, options)
 	if err != nil {
@@ -730,7 +729,7 @@ func getEncryptionAlgorithmName(n string) (string, error) {
 	return algorithmName, nil
 }
 
-//function to obtain a date format from linux epoch time
+// function to obtain a date format from linux epoch time
 func date(s string) string {
 	if s == "" {
 		return "[ultimate]"
@@ -844,7 +843,6 @@ func formatMROutputLongList(mrString string) (int, []byte, error) {
 
 // FetchPubkey pulls a public key from the Key Service.
 func FetchPubkey(ctx context.Context, fingerprint string, noPrompt bool, opts ...client.Option) (openpgp.EntityList, error) {
-
 	// Decode fingerprint and ensure proper length.
 	var fp []byte
 	fp, err := hex.DecodeString(fingerprint)

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -32,9 +32,7 @@ const (
 	testEmail   = "test@test.com"
 )
 
-var (
-	testEntity *openpgp.Entity
-)
+var testEntity *openpgp.Entity
 
 type mockPKSLookup struct {
 	code int
@@ -249,10 +247,10 @@ func TestEnsureDirPrivate(t *testing.T) {
 			entry:       "d2",
 			expectError: false,
 			preFunc: func(d string) error {
-				if err := os.MkdirAll(d, 0777); err != nil {
+				if err := os.MkdirAll(d, 0o777); err != nil {
 					return err
 				}
-				return os.Chmod(d, 0777)
+				return os.Chmod(d, 0o777)
 			},
 		},
 	}
@@ -291,7 +289,7 @@ func TestEnsureDirPrivate(t *testing.T) {
 				t.Errorf("Expecting a directory after calling ensureDirPrivate(%q), found something else", testEntry)
 			}
 
-			if actual, expected := fi.Mode() & ^os.ModeDir, os.FileMode(0700); actual != expected {
+			if actual, expected := fi.Mode() & ^os.ModeDir, os.FileMode(0o700); actual != expected {
 				t.Errorf("Expecting mode %o, got %o after calling ensureDirPrivate(%q)", expected, actual, testEntry)
 			}
 		}
@@ -313,7 +311,6 @@ func getPublicKey(data string) *packet.PublicKey {
 }
 
 func TestPrintEntity(t *testing.T) {
-
 	cases := []struct {
 		name     string
 		index    int

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestCopyWithTar(t *testing.T) {
-
 	t.Run("privileged", func(t *testing.T) {
 		test.EnsurePrivilege(t)
 		testCopyWithTar(t)
@@ -28,7 +27,6 @@ func TestCopyWithTar(t *testing.T) {
 		defer test.ResetPrivilege(t)
 		testCopyWithTar(t)
 	})
-
 }
 
 func testCopyWithTar(t *testing.T) {
@@ -40,12 +38,12 @@ func testCopyWithTar(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte("test"), 0644); err != nil {
+	if err := ioutil.WriteFile(srcFile, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
 	srcDir := filepath.Join(srcRoot, "srcDir")
-	if err := os.Mkdir(srcDir, 0755); err != nil {
+	if err := os.Mkdir(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Source Symlink

--- a/pkg/util/capabilities/config_test.go
+++ b/pkg/util/capabilities/config_test.go
@@ -61,13 +61,10 @@ func TestReadFromWriteTo(t *testing.T) {
 		var r bytes.Buffer
 
 		_, err := ReadFrom(&r)
-
 		if err != nil {
 			t.Errorf("unexpected failure running %s test: %s", t.Name(), err)
 		}
-
 	})
-
 }
 
 type capTest struct {
@@ -600,8 +597,6 @@ func TestCheckCaps(t *testing.T) {
 			if !reflect.DeepEqual(uGroup, test.unauthorized) {
 				t.Errorf("returned incorrect unauthorized group caps:\n\thave: %v\n\twant: %v", test.unauthorized, uGroup)
 			}
-
 		})
 	}
-
 }

--- a/pkg/util/cryptkey/key.go
+++ b/pkg/util/cryptkey/key.go
@@ -192,7 +192,7 @@ func savePEMMessage(w io.Writer, msg []byte) error {
 		return err
 	}
 
-	var b = &pem.Block{
+	b := &pem.Block{
 		Type:  "MESSAGE",
 		Bytes: asn1Bytes,
 	}

--- a/pkg/util/cryptkey/rsa.go
+++ b/pkg/util/cryptkey/rsa.go
@@ -32,7 +32,6 @@ func GenerateRSAKey(keySize int) (*rsa.PrivateKey, error) {
 	}
 
 	key, err := rsa.GenerateKey(reader, keySize)
-
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate RSA key: %v", err)
 	}
@@ -58,7 +57,7 @@ func publicPEM(key *rsa.PrivateKey) (string, error) {
 		return "", fmt.Errorf("unable to encode public key: %v", err)
 	}
 
-	var pemkey = &pem.Block{
+	pemkey := &pem.Block{
 		Type:  "RSA PUBLIC KEY",
 		Bytes: asn1Bytes,
 	}
@@ -110,7 +109,7 @@ func SavePrivatePEM(fileName string, key *rsa.PrivateKey) error {
 
 	defer outFile.Close()
 
-	var privateKey = &pem.Block{
+	privateKey := &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}

--- a/pkg/util/fs/lock/lock_test.go
+++ b/pkg/util/fs/lock/lock_test.go
@@ -66,7 +66,7 @@ func TestByteRange(t *testing.T) {
 	f.Close()
 
 	// write some content in test file
-	if err := ioutil.WriteFile(testFile, []byte("testing\n"), 0644); err != nil {
+	if err := ioutil.WriteFile(testFile, []byte("testing\n"), 0o644); err != nil {
 		t.Fatalf("failed to write content in testfile %s: %s", testFile, err)
 	}
 

--- a/pkg/util/gpu/paths_test.go
+++ b/pkg/util/gpu/paths_test.go
@@ -109,7 +109,6 @@ func TestSoLinks(t *testing.T) {
 	if !reflect.DeepEqual(gotLinks, expectedLinks) {
 		t.Errorf("soList() gave unexpected results, got: %v expected: %v", gotLinks, expectedLinks)
 	}
-
 }
 
 func TestPaths(t *testing.T) {

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -121,7 +121,7 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 		path = fmt.Sprintf("/dev/loop%d", device)
 		if fi, err := os.Stat(path); err != nil {
 			dev := int((7 << 8) | (device & 0xff) | ((device & 0xfff00) << 12))
-			esys := syscall.Mknod(path, syscall.S_IFBLK|0660, dev)
+			esys := syscall.Mknod(path, syscall.S_IFBLK|0o660, dev)
 			if errno, ok := esys.(syscall.Errno); ok {
 				if errno != syscall.EEXIST {
 					return esys
@@ -131,7 +131,7 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 			return fmt.Errorf("%s is not a block device", path)
 		}
 
-		if loopFd, err = syscall.Open(path, mode, 0600); err != nil {
+		if loopFd, err = syscall.Open(path, mode, 0o600); err != nil {
 			continue
 		}
 		if loop.Shared {
@@ -201,7 +201,7 @@ func (loop *Device) AttachFromFile(image *os.File, mode int, number *int) error 
 // AttachFromPath finds a free loop device, opens it, and stores file descriptor
 // of opened image path
 func (loop *Device) AttachFromPath(image string, mode int, number *int) error {
-	file, err := os.OpenFile(image, mode, 0600)
+	file, err := os.OpenFile(image, mode, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/sysctl/sysctl_linux.go
+++ b/pkg/util/sysctl/sysctl_linux.go
@@ -53,5 +53,5 @@ func Set(key string, value string) error {
 		return fmt.Errorf("can't retrieve key %s: %s", key, err)
 	}
 
-	return ioutil.WriteFile(path, []byte(value), 0000)
+	return ioutil.WriteFile(path, []byte(value), 0o000)
 }

--- a/pkg/util/unix/socket.go
+++ b/pkg/util/unix/socket.go
@@ -66,7 +66,7 @@ func Dial(path string) (net.Conn, error) {
 
 // CreateSocket creates an unix socket and returns connection listener.
 func CreateSocket(path string) (net.Listener, error) {
-	oldmask := syscall.Umask(0177)
+	oldmask := syscall.Umask(0o177)
 	defer syscall.Umask(oldmask)
 	return Listen(path)
 }
@@ -74,7 +74,6 @@ func CreateSocket(path string) (net.Listener, error) {
 // WriteSocket writes data over unix socket
 func WriteSocket(path string, data []byte) error {
 	c, err := Dial(path)
-
 	if err != nil {
 		return fmt.Errorf("failed to connect to %s socket: %s", path, err)
 	}

--- a/pkg/util/unix/socket_test.go
+++ b/pkg/util/unix/socket_test.go
@@ -42,7 +42,7 @@ func TestCreateSocket(t *testing.T) {
 		syncCh := make(chan bool, 1)
 
 		dir := filepath.Dir(path)
-		os.Mkdir(dir, 0700)
+		os.Mkdir(dir, 0o700)
 
 		defer os.RemoveAll(dir)
 


### PR DESCRIPTION
This pulls in sylabs pr
- sylabs/singularity#242

I ran `go get mvdan.cc/gofumpt@latest` and `gofumpt -w .` to make the big commit touching many files, I didn't cherry-pick that commit.

The original PR description was:

Use `gofumpt` for stricter formatting. Mainly clarifies octal literals and does some `var x =` to `x :=` simplification in our codebase.