### PR TITLE
Change `--nohttps` flag to `--no-https` & honor it for `library://hostname/...` URIs, from sylabs 241 & 247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   options that increase OCI/Docker compatibility. Infers `--containall,
   --no-init, --no-umask, --writable-tmpfs`. Does not use user, uts, or
   network namespaces as these may not be supported on many installations.
+- `--no-https` now applies to connections made to library services specified
+  in `--library://<hostname>/...` URIs.
 
 ### Changed defaults / behaviours
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   Docker/OCI container.
 - Instances are no longer created with an IPC namespace by default. An IPC
   namespace can be specified with the `-i|--ipc` flag.
+- `--nohttps` flag has been deprecated in favour of `--no-https`. The old flag
+  is still accepted, but will display a deprecation warning.
 
 ## v3.8.2 - \[2021-08-31\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -700,6 +700,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionWritableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionWritableTmpfsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&commonOldNoHTTPSFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerLoginFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerPasswordFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerUsernameFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -94,7 +94,11 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string)
 	// Default "" = use current remote endpoint
 	var libraryURI string
 	if r.Host != "" {
-		libraryURI = "https://" + r.Host
+		if noHTTPS {
+			libraryURI = "http://" + r.Host
+		} else {
+			libraryURI = "https://" + r.Host
+		}
 	}
 
 	c, err := getLibraryClientConfig(libraryURI)

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -28,6 +28,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&deleteImageArchFlag, deleteImageCmd)
 		cmdManager.RegisterFlagForCmd(&deleteImageTimeoutFlag, deleteImageCmd)
 		cmdManager.RegisterFlagForCmd(&deleteLibraryURIFlag, deleteImageCmd)
+		cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, deleteImageCmd)
 	})
 }
 
@@ -90,8 +91,6 @@ var deleteImageCmd = &cobra.Command{
 	Example: docs.DeleteExample,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		sylog.Debugf("Using library service URI: %s", deleteLibraryURI)
-
 		imageRef, err := library.NormalizeLibraryRef(args[0])
 		if err != nil {
 			sylog.Fatalf("Error parsing library ref: %v", err)
@@ -106,8 +105,14 @@ var deleteImageCmd = &cobra.Command{
 			libraryURI = deleteLibraryURI
 		} else if imageRef.Host != "" {
 			// override libraryURI if ref contains host name
-			libraryURI = "https://" + imageRef.Host
+			if noHTTPS {
+				libraryURI = "http://" + imageRef.Host
+			} else {
+				libraryURI = "https://" + imageRef.Host
+			}
 		}
+
+		sylog.Debugf("Using library service URI: %s", libraryURI)
 
 		r := fmt.Sprintf("%s:%s", imageRef.Path, imageRef.Tags[0])
 

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -217,7 +217,11 @@ func pullRun(cmd *cobra.Command, args []string) {
 			libraryURI = pullLibraryURI
 		} else if ref.Host != "" {
 			// override libraryURI if ref contains host name
-			libraryURI = "https://" + ref.Host
+			if noHTTPS {
+				libraryURI = "http://" + ref.Host
+			} else {
+				libraryURI = "https://" + ref.Host
+			}
 		}
 
 		lc, err := getLibraryClientConfig(libraryURI)

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -184,14 +184,24 @@ var commonForceFlag = cmdline.Flag{
 	EnvKeys:      []string{"FORCE"},
 }
 
-// --nohttps
+// --no-https
 var commonNoHTTPSFlag = cmdline.Flag{
 	ID:           "commonNoHTTPSFlag",
 	Value:        &noHTTPS,
 	DefaultValue: false,
+	Name:         "no-https",
+	Usage:        "use http instead of https for docker:// oras:// and library://<hostname>/... URIs",
+	EnvKeys:      []string{"NOHTTPS", "NO_HTTPS"},
+}
+
+// --nohttps (deprecated)
+var commonOldNoHTTPSFlag = cmdline.Flag{
+	ID:           "commonOldNoHTTPSFlag",
+	Value:        &noHTTPS,
+	DefaultValue: false,
 	Name:         "nohttps",
-	Usage:        "do NOT use HTTPS with the docker:// transport (useful for local docker registries without a certificate)",
-	EnvKeys:      []string{"NOHTTPS"},
+	Deprecated:   "use --no-https",
+	Usage:        "use http instead of https for docker:// oras:// and library://<hostname>/... URIs",
 }
 
 // --tmpdir

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -382,7 +382,7 @@ func (c ctx) testDockerRegistry(t *testing.T) {
 			t,
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs("--nohttps", imagePath, defFile),
+			e2e.WithArgs("--no-https", imagePath, defFile),
 			e2e.PostRun(func(t *testing.T) {
 				defer os.Remove(imagePath)
 				defer os.Remove(defFile)

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -59,7 +59,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		return err
 	}
 
-	// DockerInsecureSkipTLSVerify is set only if --nohttps is specified to honor
+	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
 	// can have three possible values true/false and undefined, so we left it as undefined instead
 	// of forcing it to false in order to delegate decision to /etc/containers/registries.conf:

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -23,7 +23,7 @@ import (
 
 // pull will build a SIF image into the cache if directTo="", or a specific file if directTo is set.
 func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS, noCleanUp bool) (imagePath string, err error) {
-	// DockerInsecureSkipTLSVerify is set only if --nohttps is specified to honor
+	// DockerInsecureSkipTLSVerify is set only if --no-https is specified to honor
 	// configuration from /etc/containers/registries.conf because DockerInsecureSkipTLSVerify
 	// can have three possible values true/false and undefined, so we left it as undefined instead
 	// of forcing it to false in order to delegate decision to /etc/containers/registries.conf:


### PR DESCRIPTION
This pulls in sylabs prs
- sylabs/singularity#241
- sylabs/singularity#247
which fixed
- sylabs/singularity#238
- sylabs/singularity#236

The original pr descriptions were:

The `--nohttps` flag does not fit into the pattern of `--no-` prefixes
with a hyphen for negative flags.

Add a `--no-https` flag and deprecate the existing `--nohttps` flag.

When a l`ibrary://hostname/...` is specified to a command, the
`--no-https` flag should be honored, to connect to hostname via http
instead of https.