### PR TITLE
Rework --nv handling, add nvidia-container-cli option, from sylabs 144, 383, & 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@
 - Paths for `cryptsetup`, `go`, `ldconfig`, `mksquashfs`, `nvidia-container-cli`,
   `unsquashfs` are now found at build time by `mconfig` and written into
   `singularity.conf`. The path to these executables can be overridden by
-  changing the value in `singularity.conf`. If the path is not set in
-  `singularity.conf` then the the executable will be found by searching `$PATH`.
+  changing the value in `singularity.conf`. If the path for any of them other
+  than `cryptsetup` or `ldconfig` is not set in `singularity.conf` then the
+  the executable will be found by searching `$PATH`.
 - When calling `ldconfig` to find GPU libraries, singularity will *not* fall back
   to `/sbin/ldconfig` if the `ldconfig` on `$PATH` errors. If installing in a
   Guix/Nix on environment on top of a standard host distribution you *must* set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@
   network namespaces as these may not be supported on many installations.
 - `--no-https` now applies to connections made to library services specified
   in `--library://<hostname>/...` URIs.
+- The experimental `--nvccli` flag will use `nvidia-container-cli` to setup the
+  container for Nvidia GPU operation. Singularity will not bind GPU libraries
+  itself. Environment variables that are used with Nvidia's `docker-nvidia`
+  runtime to configure GPU visibility / driver capabilities & requirements are
+  parsed by the `--nvccli` flag from the environment of the calling user. By
+  default, the `compute` and `utility` GPU capabilities are configured. The `use
+  nvidia-container-cli` option in `singularity.conf` can be set to `yes` to
+  always use `nvidia-container-cli` when supported. Note that in a setuid
+  install, `nvidia-container-cli` will be run as root with required ambient
+  capabilities. `--nvccli` is not currently supported in the hybrid fakeroot
+  (setuid install + `--fakeroot`) workflow. Please see documentation for more
+  details.
 
 ### Changed defaults / behaviours
 
@@ -48,8 +60,13 @@
   is no longer included, as it is maintained as a separate plugin at:
   <https://github.com/flannel-io/cni-plugin>. If you use the flannel CNI plugin
   you should install it from this repository.
-
-### New features / functionalities
+- `--nv` will not call `nvidia-container-cli` to find host libraries, unless
+  the new experimental GPU setup flow that employs `nvidia-container-cli`
+  for all GPU related operations is enabled (see below).
+- If a container is run with `--nvcli` and `--contain`, only GPU devices
+  specified via the `NVIDIA_VISIBLE_DEVICES` environment variable will be
+  exposed within the container. Use `NVIDIA_VISIBLE_DEVICES=all` to access all
+  GPUs inside a container run with `--nvccli`.
 
 ## v3.8.3 - \[2021-09-07\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@
   parsed by the `--nvccli` flag from the environment of the calling user. By
   default, the `compute` and `utility` GPU capabilities are configured. The `use
   nvidia-container-cli` option in `singularity.conf` can be set to `yes` to
-  always use `nvidia-container-cli` when supported. Note that in a setuid
-  install, `nvidia-container-cli` will be run as root with required ambient
-  capabilities. `--nvccli` is not currently supported in the hybrid fakeroot
-  (setuid install + `--fakeroot`) workflow. Please see documentation for more
-  details.
+  always use `nvidia-container-cli` when supported.
+  `--nvccli` is not supported in the setuid workflow,
+  and it requires being used in combination with `--writable` in user
+  namespace mode.
+  Please see documentation for more details.
 
 ### Changed defaults / behaviours
 
@@ -48,7 +48,7 @@
   `singularity.conf`. The path to these executables can be overridden by
   changing the value in `singularity.conf`. If the path for any of them other
   than `cryptsetup` or `ldconfig` is not set in `singularity.conf` then the
-  the executable will be found by searching `$PATH`.
+  executable will be found by searching `$PATH`.
 - When calling `ldconfig` to find GPU libraries, singularity will *not* fall back
   to `/sbin/ldconfig` if the `ldconfig` on `$PATH` errors. If installing in a
   Guix/Nix on environment on top of a standard host distribution you *must* set
@@ -63,8 +63,8 @@
   you should install it from this repository.
 - `--nv` will not call `nvidia-container-cli` to find host libraries, unless
   the new experimental GPU setup flow that employs `nvidia-container-cli`
-  for all GPU related operations is enabled (see below).
-- If a container is run with `--nvcli` and `--contain`, only GPU devices
+  for all GPU related operations is enabled (see above).
+- If a container is run with `--nvccli` and `--contain`, only GPU devices
   specified via the `NVIDIA_VISIBLE_DEVICES` environment variable will be
   exposed within the container. Use `NVIDIA_VISIBLE_DEVICES=all` to access all
   GPUs inside a container run with `--nvccli`.

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -45,6 +45,7 @@ var (
 	IsWritable      bool
 	IsWritableTmpfs bool
 	Nvidia          bool
+	NvCCLI          bool
 	Rocm            bool
 	NoHome          bool
 	NoInit          bool
@@ -370,8 +371,18 @@ var actionNvidiaFlag = cmdline.Flag{
 	Value:        &Nvidia,
 	DefaultValue: false,
 	Name:         "nv",
-	Usage:        "enable experimental Nvidia support",
+	Usage:        "enable Nvidia support",
 	EnvKeys:      []string{"NV"},
+}
+
+// --nvccli
+var actionNvCCLIFlag = cmdline.Flag{
+	ID:           "actionNvCCLIFlag",
+	Value:        &NvCCLI,
+	DefaultValue: false,
+	Name:         "nvccli",
+	Usage:        "use nvidia-container-cli for GPU setup (experimental)",
+	EnvKeys:      []string{"NVCCLI"},
 }
 
 // --rocm flag to automatically bind
@@ -666,6 +677,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionNoRocmFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoPrivsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNvidiaFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNvCCLIFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionRocmFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionOverlayFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonPromptForPassphraseFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -776,11 +776,7 @@ func SetGPUConfig(engineConfig *singularityConfig.EngineConfig) error {
 		// from  starter, so fall back to legacy NV handling until that workflow is refactored heavily.
 		fakeRootPriv := IsFakeroot && engineConfig.File.AllowSetuid && (buildcfg.SINGULARITY_SUID_INSTALL == 1)
 		if !fakeRootPriv {
-			nvCCLIPath, err := gpu.GetNvCCLIPath()
-			if err == nil {
-				return setNvCCLIConfig(engineConfig, nvCCLIPath)
-			}
-			sylog.Warningf("While looking for nividia-container-cli: %v", err)
+			return setNvCCLIConfig(engineConfig)
 		}
 		sylog.Infof("nvidia-container-cli not available / not supported - using legacy GPU configuration")
 		return setNVLegacyConfig(engineConfig)
@@ -793,10 +789,9 @@ func SetGPUConfig(engineConfig *singularityConfig.EngineConfig) error {
 }
 
 // setNvCCLIConfig sets up EngineConfig entries for NVIDIA GPU configuration via nvidia-container-cli
-func setNvCCLIConfig(engineConfig *singularityConfig.EngineConfig, nvcCLIPath string) (err error) {
+func setNvCCLIConfig(engineConfig *singularityConfig.EngineConfig) (err error) {
 	sylog.Debugf("Using nvidia-container-cli for GPU setup")
 	engineConfig.SetNvCCLI(true)
-	engineConfig.SetNvCCLIPath(nvcCLIPath)
 
 	// When we use --contain we don't mount the NV devices by default in the nvidia-container-cli flow,
 	// they must be mounted via specifying with`NVIDIA_VISIBLE_DEVICES`. This differs from the legacy

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -778,8 +778,7 @@ func SetGPUConfig(engineConfig *singularityConfig.EngineConfig) error {
 		if !fakeRootPriv {
 			return setNvCCLIConfig(engineConfig)
 		}
-		sylog.Infof("nvidia-container-cli not available / not supported - using legacy GPU configuration")
-		return setNVLegacyConfig(engineConfig)
+		return fmt.Errorf("--fakeroot does not support --nvccli in set-uid installations")
 	}
 
 	if Rocm {

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -47,6 +47,7 @@ var buildArgs struct {
 	sandbox       bool
 	update        bool
 	nvidia        bool
+	nvccli        bool
 	rocm          bool
 	writableTmpfs bool // For test section only
 }
@@ -217,6 +218,16 @@ var buildNvFlag = cmdline.Flag{
 	Usage:        "inject host Nvidia libraries during build for post and test sections (not supported with remote build)",
 }
 
+// --nvccli
+var buildNvCCLIFlag = cmdline.Flag{
+	ID:           "buildNvCCLIFlag",
+	Value:        &buildArgs.nvccli,
+	DefaultValue: false,
+	Name:         "nvccli",
+	Usage:        "use nvidia-container-cli for GPU setup (experimental)",
+	EnvKeys:      []string{"NVCCLI"},
+}
+
 // --rocm
 var buildRocmFlag = cmdline.Flag{
 	ID:           "rocmFlag",
@@ -281,6 +292,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonPEMFlag, buildCmd)
 
 		cmdManager.RegisterFlagForCmd(&buildNvFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildNvCCLIFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildRocmFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildBindFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildWritableTmpfsFlag, buildCmd)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -103,6 +103,12 @@ func runBuild(cmd *cobra.Command, args []string) {
 		}
 		os.Setenv("SINGULARITY_NV", "1")
 	}
+	if buildArgs.nvccli {
+		if buildArgs.remote {
+			sylog.Fatalf("--nvccli option is not supported for remote build")
+		}
+		os.Setenv("SINGULARITY_NVCCLI", "1")
+	}
 	if buildArgs.rocm {
 		if buildArgs.remote {
 			sylog.Fatalf("--rocm option is not supported for remote build")

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -36,6 +36,11 @@ import (
 )
 
 func fakerootExec(cmdArgs []string) {
+	if buildArgs.nvccli && !buildArgs.noTest {
+		sylog.Warningf("Due to writable-tmpfs limitations, %%test sections will fail with --nvccli & --fakeroot")
+		sylog.Infof("Use -T / --notest to disable running tests during the build")
+	}
+
 	useSuid := buildcfg.SINGULARITY_SUID_INSTALL == 1
 
 	short := "-" + buildFakerootFlag.ShortHand

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -154,6 +154,9 @@ struct starter {
     bool masterPropagateMount;
     /* hybrid workflow where master process and container doesn't share user namespace */
     bool hybridWorkflow;
+
+    /* bounding capability set will include caps needed by nvidia-container-cli */
+    bool nvCCLICaps;
 };
 
 /* engine configuration */

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -385,6 +385,22 @@ static void set_rpc_privileges(void) {
     priv->capabilities.bounding = capflag(CAP_SYS_ADMIN);
     priv->capabilities.bounding |= capflag(CAP_IPC_LOCK);
     priv->capabilities.bounding |= capflag(CAP_MKNOD);
+    /* required by nvidia-container-cli */
+    if (sconfig->starter.nvCCLICaps) {
+        debugf("Enabling bounding capabilities for nvidia-container-cli\n");
+        priv->capabilities.bounding |= capflag(CAP_CHOWN);
+        priv->capabilities.bounding |= capflag(CAP_DAC_OVERRIDE);
+        priv->capabilities.bounding |= capflag(CAP_DAC_READ_SEARCH);
+        priv->capabilities.bounding |= capflag(CAP_FOWNER);
+        priv->capabilities.bounding |= capflag(CAP_KILL);
+        priv->capabilities.bounding |= capflag(CAP_MKNOD);
+        priv->capabilities.bounding |= capflag(CAP_SETGID);
+        priv->capabilities.bounding |= capflag(CAP_SETPCAP);
+        priv->capabilities.bounding |= capflag(CAP_SETUID);
+        priv->capabilities.bounding |= capflag(CAP_SYS_CHROOT);
+        priv->capabilities.bounding |= capflag(CAP_SYS_PTRACE);
+    }
+    
 
     debugf("Set RPC privileges\n");
     apply_privileges(priv, current);

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -93,7 +93,7 @@ func (c ctx) testNvidiaLegacy(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.args...),
 			e2e.WithEnv(tt.env),
@@ -135,21 +135,21 @@ func (c ctx) testNvCCLI(t *testing.T) {
 	}{
 		{
 			name:       "User",
-			profile:    e2e.UserProfile,
+			profile:    e2e.RootProfile,
 			args:       []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
 			expectExit: 0,
 		},
 		{
 			// With --contain, we should only see NVIDIA_VISIBLE_DEVICES configured GPUs
 			name:        "UserContainNoDevices",
-			profile:     e2e.UserProfile,
+			profile:     e2e.RootProfile,
 			args:        []string{"--contain", "--nv", "--nvccli", imagePath, "nvidia-smi"},
 			expectMatch: e2e.ExpectOutput(e2e.ContainMatch, "No devices were found"),
 			expectExit:  6,
 		},
 		{
 			name:       "UserContainAllDevices",
-			profile:    e2e.UserProfile,
+			profile:    e2e.RootProfile,
 			args:       []string{"--contain", "--nv", "--nvccli", imagePath, "nvidia-smi"},
 			env:        []string{"NVIDIA_VISIBLE_DEVICES=all"},
 			expectExit: 0,
@@ -157,7 +157,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 		{
 			// If we only request compute, not utility, then nvidia-smi should not be present
 			name:        "UserNoUtility",
-			profile:     e2e.UserProfile,
+			profile:     e2e.RootProfile,
 			args:        []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
 			env:         []string{"NVIDIA_DRIVER_CAPABILITIES=compute"},
 			expectMatch: e2e.ExpectError(e2e.ContainMatch, "\"nvidia-smi\": executable file not found in $PATH"),
@@ -166,7 +166,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 		{
 			// Require CUDA version >8 should be fine!
 			name:       "UserValidRequire",
-			profile:    e2e.UserProfile,
+			profile:    e2e.RootProfile,
 			args:       []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
 			env:        []string{"NVIDIA_REQUIRE_CUDA=cuda>8"},
 			expectExit: 0,
@@ -174,7 +174,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 		{
 			// Require CUDA version >999 should not be satisfied
 			name:        "UserInvalidRequire",
-			profile:     e2e.UserProfile,
+			profile:     e2e.RootProfile,
 			args:        []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
 			env:         []string{"NVIDIA_REQUIRE_CUDA=cuda>999"},
 			expectMatch: e2e.ExpectError(e2e.ContainMatch, "requirement error: unsatisfied condition: cuda>99"),
@@ -185,18 +185,13 @@ func (c ctx) testNvCCLI(t *testing.T) {
 			profile: e2e.UserNamespaceProfile,
 			args:    []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
 		},
-		{
-			name:    "Root",
-			profile: e2e.RootProfile,
-			args:    []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
-		},
 	}
 
 	for _, tt := range tests {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.args...),
 			e2e.WithEnv(tt.env),
@@ -263,7 +258,7 @@ func (c ctx) testRocm(t *testing.T) {
 		c.env.RunSingularity(
 			t,
 			e2e.AsSubtest(tt.name),
-			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithProfile(tt.profile),
 			e2e.WithCommand("exec"),
 			e2e.WithArgs(tt.args...),
 			e2e.ExpectExit(0),

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -109,7 +109,7 @@ func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity([]string{"NV", "ROCM", "BINDPATH"})
+		cmd.Env = currentEnvNoSingularity([]string{"NV", "NVCCLI", "ROCM", "BINDPATH"})
 
 		sylog.Infof("Running post scriptlet")
 		return cmd.Run()
@@ -135,7 +135,7 @@ func (s *stage) runTestScript(configFile, sessionResolv, sessionHosts string) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = "/"
-		cmd.Env = currentEnvNoSingularity([]string{"NV", "ROCM", "BINDPATH", "WRITABLE_TMPFS"})
+		cmd.Env = currentEnvNoSingularity([]string{"NV", "NVCCLI", "ROCM", "BINDPATH", "WRITABLE_TMPFS"})
 
 		sylog.Infof("Running testscript")
 		return cmd.Run()

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -157,6 +157,17 @@ func (c *Config) KeepFileDescriptor(fd int) error {
 	return nil
 }
 
+// SetNvCCLICaps sets the flag to tell starter container setup
+// to configure a bounding capabilities set that will permit execution of
+// nvidia-container-cli
+func (c *Config) SetNvCCLICaps(enabled bool) {
+	if enabled {
+		c.config.starter.nvCCLICaps = C.true
+	} else {
+		c.config.starter.nvCCLICaps = C.false
+	}
+}
+
 // SetHybridWorkflow sets the flag to tell starter container setup
 // will require a hybrid workflow. Typically used for fakeroot.
 // In a hybrid workflow, the master process lives in host user namespace

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -270,8 +270,10 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		}
 
 		sylog.Debugf("nvidia-container-cli")
-		runAsRoot := !c.userNS || c.engine.EngineConfig.GetFakeroot()
-		if err := c.rpcOps.NvCCLI(engine.EngineConfig.GetNvCCLIPath(), engine.EngineConfig.GetNvCCLIFlags(), c.session.FinalPath(), runAsRoot); err != nil {
+		// If we are not inside a user namespace then the NVCCLI call must exec nvidia-container-cli
+		// as the host uid 0. This may happen via the setuid starter, or from singularity being run
+		// directly as uid 0, e.g. `sudo singularity`.
+		if err := c.rpcOps.NvCCLI(engine.EngineConfig.GetNvCCLIFlags(), c.session.FinalPath(), c.userNS); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -189,6 +189,13 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		e.EngineConfig.SetUnixSocketPair([2]int{-1, -1})
 	}
 
+	// nvidia-container-cli requires additional caps in the starter bounding set.
+	// These are within the capability set for the starter process itself, *not* the capabilities
+	// that will be set on the running container process, which are defined with SetCapabilities above.
+	if e.EngineConfig.GetNvCCLI() {
+		starterConfig.SetNvCCLICaps(true)
+	}
+
 	return nil
 }
 

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -193,6 +193,12 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	// These are within the capability set for the starter process itself, *not* the capabilities
 	// that will be set on the running container process, which are defined with SetCapabilities above.
 	if e.EngineConfig.GetNvCCLI() {
+		// Disallow this feature under setuid mode because running
+		// the external command is too risky
+		if starterConfig.GetIsSUID() && os.Geteuid() != 0 {
+			return fmt.Errorf("nvidia-container-cli not allowed in setuid mode")
+		}
+
 		starterConfig.SetNvCCLICaps(true)
 	}
 

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -134,7 +134,7 @@ type WriteFileArgs struct {
 type NvCCLIArgs struct {
 	Flags      []string
 	RootFsPath string
-	RunAsRoot  bool
+	UserNS     bool
 }
 
 // FileInfo returns FileInfo interface to be passed as RPC argument.

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -132,7 +132,6 @@ type WriteFileArgs struct {
 
 // NvCCLIArgs defines the arguments to NvCCLI.
 type NvCCLIArgs struct {
-	NvCCLIPath string
 	Flags      []string
 	RootFsPath string
 	RunAsRoot  bool

--- a/internal/pkg/runtime/engine/singularity/rpc/args.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/args.go
@@ -130,6 +130,14 @@ type WriteFileArgs struct {
 	Perm     os.FileMode
 }
 
+// NvCCLIArgs defines the arguments to NvCCLI.
+type NvCCLIArgs struct {
+	NvCCLIPath string
+	Flags      []string
+	RootFsPath string
+	RunAsRoot  bool
+}
+
 // FileInfo returns FileInfo interface to be passed as RPC argument.
 func FileInfo(fi os.FileInfo) os.FileInfo {
 	return &fileInfo{

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -237,9 +237,8 @@ func (t *RPC) WriteFile(filename string, data []byte, perm os.FileMode) error {
 }
 
 // NvCCLI will call nvidia-container-cli to configure GPU(s) for the container.
-func (t *RPC) NvCCLI(nvCCLIPath string, flags []string, rootFsPath string, runAsRoot bool) error {
+func (t *RPC) NvCCLI(flags []string, rootFsPath string, runAsRoot bool) error {
 	arguments := &args.NvCCLIArgs{
-		NvCCLIPath: nvCCLIPath,
 		Flags:      flags,
 		RootFsPath: rootFsPath,
 		RunAsRoot:  runAsRoot,

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -235,3 +235,14 @@ func (t *RPC) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	}
 	return t.Client.Call(t.Name+".WriteFile", arguments, nil)
 }
+
+// NvCCLI will call nvidia-container-cli to configure GPU(s) for the container.
+func (t *RPC) NvCCLI(nvCCLIPath string, flags []string, rootFsPath string, runAsRoot bool) error {
+	arguments := &args.NvCCLIArgs{
+		NvCCLIPath: nvCCLIPath,
+		Flags:      flags,
+		RootFsPath: rootFsPath,
+		RunAsRoot:  runAsRoot,
+	}
+	return t.Client.Call(t.Name+".NvCCLI", arguments, nil)
+}

--- a/internal/pkg/runtime/engine/singularity/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/client/client.go
@@ -237,11 +237,11 @@ func (t *RPC) WriteFile(filename string, data []byte, perm os.FileMode) error {
 }
 
 // NvCCLI will call nvidia-container-cli to configure GPU(s) for the container.
-func (t *RPC) NvCCLI(flags []string, rootFsPath string, runAsRoot bool) error {
+func (t *RPC) NvCCLI(flags []string, rootFsPath string, userNS bool) error {
 	arguments := &args.NvCCLIArgs{
 		Flags:      flags,
 		RootFsPath: rootFsPath,
-		RunAsRoot:  runAsRoot,
+		UserNS:     userNS,
 	}
 	return t.Client.Call(t.Name+".NvCCLI", arguments, nil)
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -438,5 +438,5 @@ func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, reply *int) (err error) {
 		}
 	}()
 
-	return gpu.NVCLIConfigure(arguments.NvCCLIPath, arguments.Flags, arguments.RootFsPath, arguments.RunAsRoot)
+	return gpu.NVCLIConfigure(arguments.Flags, arguments.RootFsPath, arguments.RunAsRoot)
 }

--- a/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/singularity/rpc/server/server_linux.go
@@ -424,7 +424,7 @@ func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, reply *int) (err error) {
 	// In the setuid flow we need CAP_CHOWN here to be able to start
 	// nvidia-container-cli successfully as root.
 	caps := defaultEffective
-	if arguments.RunAsRoot {
+	if !arguments.UserNS {
 		caps |= uint64(1 << capabilities.Map["CAP_CHOWN"].Value)
 	}
 	oldEffective, err := capabilities.SetProcessEffective(caps)
@@ -438,5 +438,5 @@ func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, reply *int) (err error) {
 		}
 	}()
 
-	return gpu.NVCLIConfigure(arguments.Flags, arguments.RootFsPath, arguments.RunAsRoot)
+	return gpu.NVCLIConfigure(arguments.Flags, arguments.RootFsPath, arguments.UserNS)
 }

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -159,6 +159,14 @@ func Nvidia(t *testing.T) {
 	}
 }
 
+// NvCCLI checks that nvidia-container-cli is available
+func NvCCLI(t *testing.T) {
+	_, err := exec.LookPath("nvidia-container-cli")
+	if err != nil {
+		t.Skipf("nvidia-container-cli not found on PATH: %v", err)
+	}
+}
+
 // Rocm checks that a Rocm stack is available
 func Rocm(t *testing.T) {
 	rocminfo, err := exec.LookPath("rocminfo")

--- a/internal/pkg/util/gpu/nvidia_legacy.go
+++ b/internal/pkg/util/gpu/nvidia_legacy.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package gpu
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hpcng/singularity/pkg/sylog"
+)
+
+// NvidiaPaths returns a list of Nvidia libraries/binaries that should be
+// mounted into the container in order to use Nvidia GPUs
+func NvidiaPaths(configFilePath string) ([]string, []string, error) {
+	nvidiaFiles, err := gpuliblist(configFilePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not read %s: %v", filepath.Base(configFilePath), err)
+	}
+
+	return paths(nvidiaFiles)
+}
+
+// NvidiaIpcsPath returns a list of nvidia driver ipcs.
+// Currently this is only the persistenced socket (if found).
+func NvidiaIpcsPath() ([]string, error) {
+	const persistencedSocket = "/var/run/nvidia-persistenced/socket"
+	var nvidiaFiles []string
+	_, err := os.Stat(persistencedSocket)
+	// If it doesn't exist that's okay - probably persistenced isn't running.
+	if os.IsNotExist(err) {
+		sylog.Verbosef("persistenced socket %s not found", persistencedSocket)
+		return nil, nil
+	}
+	// If we can't stat it, we probably can't bind mount it.
+	if err != nil {
+		return nil, fmt.Errorf("could not stat %s: %v", persistencedSocket, err)
+	}
+
+	nvidiaFiles = append(nvidiaFiles, persistencedSocket)
+	return nvidiaFiles, nil
+}
+
+// NvidiaDevices return list of all non-GPU nvidia devices present on host. If withGPU
+// is true all GPUs are included in the resulting list as well.
+func NvidiaDevices(withGPU bool) ([]string, error) {
+	nvidiaGlob := "/dev/nvidia*"
+	if !withGPU {
+		nvidiaGlob = "/dev/nvidia[^0-9]*"
+	}
+	devs, err := filepath.Glob(nvidiaGlob)
+	if err != nil {
+		return nil, fmt.Errorf("could not list nvidia devices: %v", err)
+	}
+	return devs, nil
+}

--- a/internal/pkg/util/gpu/nvidia_test.go
+++ b/internal/pkg/util/gpu/nvidia_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package gpu
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hpcng/singularity/internal/pkg/util/bin"
+)
+
+func TestNVCLIEnvToFlags(t *testing.T) {
+	ldConfig, err := bin.FindBin("ldconfig")
+	if err != nil {
+		t.Fatalf("Could not find ldconfig: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		env       map[string]string
+		wantFlags []string
+		wantErr   bool
+	}{
+		{
+			name: "defaults",
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--compute",
+				"--utility",
+			},
+			wantErr: false,
+		},
+		{
+			name: "device",
+			env: map[string]string{
+				"NVIDIA_VISIBLE_DEVICES": "all",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--device=all",
+				"--compute",
+				"--utility",
+			},
+			wantErr: false,
+		},
+		{
+			name: "mig-config",
+			env: map[string]string{
+				"NVIDIA_MIG_CONFIG_DEVICES": "all",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--mig-config=all",
+				"--compute",
+				"--utility",
+			},
+			wantErr: false,
+		},
+		{
+			name: "mig-monitor",
+			env: map[string]string{
+				"NVIDIA_MIG_MONITOR_DEVICES": "all",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--mig-monitor=all",
+				"--compute",
+				"--utility",
+			},
+			wantErr: false,
+		},
+		{
+			name: "compute-only",
+			env: map[string]string{
+				"NVIDIA_DRIVER_CAPABILITIES": "compute",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--compute",
+			},
+			wantErr: false,
+		},
+		{
+			name: "all-caps",
+			env: map[string]string{
+				"NVIDIA_DRIVER_CAPABILITIES": "compute,compat32,graphics,utility,video,display",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--compute",
+				"--compat32",
+				"--graphics",
+				"--utility",
+				"--video",
+				"--display",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid-caps",
+			env: map[string]string{
+				"NVIDIA_DRIVER_CAPABILITIES": "notacap",
+			},
+			wantErr: true,
+		},
+		{
+			name: "single-require",
+			env: map[string]string{
+				"NVIDIA_REQUIRE_CUDA": "cuda>=9.0",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--compute",
+				"--utility",
+				"--require=cuda>=9.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "multi-require",
+			env: map[string]string{
+				"NVIDIA_REQUIRE_BRAND": "brand=GRID",
+				"NVIDIA_REQUIRE_CUDA":  "cuda>=9.0",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--compute",
+				"--utility",
+				"--require=brand=GRID",
+				"--require=cuda>=9.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "disable-require",
+			env: map[string]string{
+				"NVIDIA_REQUIRE_BRAND":   "brand=GRID",
+				"NVIDIA_REQUIRE_CUDA":    "cuda>=9.0",
+				"NVIDIA_DISABLE_REQUIRE": "1",
+			},
+			wantFlags: []string{
+				"--no-cgroups",
+				"--ldconfig=@" + ldConfig,
+				"--compute",
+				"--utility",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, val := range tt.env {
+				os.Setenv(key, val)
+				defer os.Unsetenv(key)
+			}
+
+			gotFlags, err := NVCLIEnvToFlags()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NVCLIEnvToFlags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			sort.Strings(gotFlags)
+			sort.Strings(tt.wantFlags)
+			if !reflect.DeepEqual(gotFlags, tt.wantFlags) {
+				t.Errorf("NVCLIEnvToFlags() = %v, want %v", gotFlags, tt.wantFlags)
+			}
+		})
+	}
+}

--- a/internal/pkg/util/gpu/nvidia_test.go
+++ b/internal/pkg/util/gpu/nvidia_test.go
@@ -10,16 +10,9 @@ import (
 	"reflect"
 	"sort"
 	"testing"
-
-	"github.com/hpcng/singularity/internal/pkg/util/bin"
 )
 
 func TestNVCLIEnvToFlags(t *testing.T) {
-	ldConfig, err := bin.FindBin("ldconfig")
-	if err != nil {
-		t.Fatalf("Could not find ldconfig: %v", err)
-	}
-
 	tests := []struct {
 		name      string
 		env       map[string]string
@@ -30,7 +23,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			name: "defaults",
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--compute",
 				"--utility",
 			},
@@ -43,7 +35,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--device=all",
 				"--compute",
 				"--utility",
@@ -57,7 +48,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--mig-config=all",
 				"--compute",
 				"--utility",
@@ -71,7 +61,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--mig-monitor=all",
 				"--compute",
 				"--utility",
@@ -85,7 +74,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--compute",
 			},
 			wantErr: false,
@@ -97,7 +85,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--compute",
 				"--compat32",
 				"--graphics",
@@ -121,7 +108,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--compute",
 				"--utility",
 				"--require=cuda>=9.0",
@@ -136,7 +122,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--compute",
 				"--utility",
 				"--require=brand=GRID",
@@ -153,7 +138,6 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 			},
 			wantFlags: []string{
 				"--no-cgroups",
-				"--ldconfig=@" + ldConfig,
 				"--compute",
 				"--utility",
 			},

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -356,9 +356,16 @@ if test "${host}" = "unix" ; then
    fi
 
    printf " checking: ldconfig... "
-   ldconfig_path=`PATH=${SBIN_PATH} command -v ldconfig || true`
+   # Look for ldconfig.real first, as we need the executable, not the
+   # wrapper script on Ubuntu.
+   ldconfig_path=`PATH=${SBIN_PATH} command -v ldconfig.real || true`
    if test -z "${ldconfig_path}" ; then
-      echo "no"
+      ldconfig_path=`PATH=${SBIN_PATH} command -v ldconfig || true`
+      if test -z "${ldconfig_path}" ; then
+         echo "no"
+      else
+         echo "yes (${ldconfig_path})"
+      fi
    else
       echo "yes (${ldconfig_path})"
    fi

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -139,7 +139,6 @@ type JSONConfig struct {
 	Contain           bool              `json:"container,omitempty"`
 	NvLegacy          bool              `json:"nvLegacy,omitempty"`
 	NvCCLI            bool              `json:"nvCCLI,omitempty"`
-	NvCCLIPath        string            `json:"nvCCLIPath,omitempty"`
 	NvCCLIFlags       []string          `json:"NvCCLIFlags,omitempty"`
 	Rocm              bool              `json:"rocm,omitempty"`
 	CustomHome        bool              `json:"customHome,omitempty"`
@@ -244,16 +243,6 @@ func (e *EngineConfig) SetNvCCLI(nvCCLI bool) {
 // GetNvCCLI returns if NvCCLI flag is set or not.
 func (e *EngineConfig) GetNvCCLI() bool {
 	return e.JSON.NvCCLI
-}
-
-// SetNvCCLIPath sets the path to nvidia-container-cli to use for GPU setup
-func (e *EngineConfig) SetNvCCLIPath(nvCCLIPath string) {
-	e.JSON.NvCCLIPath = nvCCLIPath
-}
-
-// GetNvCCLIPath returns the path to nvidia-container-cli to use for GPU setup
-func (e *EngineConfig) GetNvCCLIPath() string {
-	return e.JSON.NvCCLIPath
 }
 
 // SetNVCCLIFlags sets flags to call nvidia-container-cli with for CUDA setup

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -137,7 +137,10 @@ type JSONConfig struct {
 	WritableImage     bool              `json:"writableImage,omitempty"`
 	WritableTmpfs     bool              `json:"writableTmpfs,omitempty"`
 	Contain           bool              `json:"container,omitempty"`
-	Nv                bool              `json:"nv,omitempty"`
+	NvLegacy          bool              `json:"nvLegacy,omitempty"`
+	NvCCLI            bool              `json:"nvCCLI,omitempty"`
+	NvCCLIPath        string            `json:"nvCCLIPath,omitempty"`
+	NvCCLIFlags       []string          `json:"NvCCLIFlags,omitempty"`
 	Rocm              bool              `json:"rocm,omitempty"`
 	CustomHome        bool              `json:"customHome,omitempty"`
 	Instance          bool              `json:"instance,omitempty"`
@@ -223,14 +226,44 @@ func (e *EngineConfig) GetContain() bool {
 	return e.JSON.Contain
 }
 
-// SetNv sets nv flag to bind cuda libraries into containee.JSON.
-func (e *EngineConfig) SetNv(nv bool) {
-	e.JSON.Nv = nv
+// SetNvLegacy sets nvLegacy flag to bind cuda libraries into containee.JSON.
+func (e *EngineConfig) SetNvLegacy(nv bool) {
+	e.JSON.NvLegacy = nv
 }
 
-// GetNv returns if nv flag is set or not.
-func (e *EngineConfig) GetNv() bool {
-	return e.JSON.Nv
+// GetNvLegacy returns if nv flag is set or not.
+func (e *EngineConfig) GetNvLegacy() bool {
+	return e.JSON.NvLegacy
+}
+
+// SetNvCCLI sets nvcontainer flag to use nvidia-container-cli for CUDA setup
+func (e *EngineConfig) SetNvCCLI(nvCCLI bool) {
+	e.JSON.NvCCLI = nvCCLI
+}
+
+// GetNvCCLI returns if NvCCLI flag is set or not.
+func (e *EngineConfig) GetNvCCLI() bool {
+	return e.JSON.NvCCLI
+}
+
+// SetNvCCLIPath sets the path to nvidia-container-cli to use for GPU setup
+func (e *EngineConfig) SetNvCCLIPath(nvCCLIPath string) {
+	e.JSON.NvCCLIPath = nvCCLIPath
+}
+
+// GetNvCCLIPath returns the path to nvidia-container-cli to use for GPU setup
+func (e *EngineConfig) GetNvCCLIPath() string {
+	return e.JSON.NvCCLIPath
+}
+
+// SetNVCCLIFlags sets flags to call nvidia-container-cli with for CUDA setup
+func (e *EngineConfig) SetNvCCLIFlags(NvCCLIFlags []string) {
+	e.JSON.NvCCLIFlags = NvCCLIFlags
+}
+
+// GetNvCCLIFlags returns the flags to use in an nvidia-container-cli call
+func (e *EngineConfig) GetNvCCLIFlags() []string {
+	return e.JSON.NvCCLIFlags
 }
 
 // SetRocm sets rocm flag to bind rocm libraries into containee.JSON.

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -42,6 +42,7 @@ type File struct {
 	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
 	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
 	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
+	UseNvCCLI               bool     `default:"no" authorized:"yes,no" directive:"use nvidia-container-cli"`
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
 	SharedLoopDevices       bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
 	MaxLoopDevices          uint     `default:"256" directive:"max loop devices"`
@@ -309,6 +310,14 @@ allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else 
 # should be executed implicitly with the --nv option (useful for GPU only 
 # environments). 
 always use nv = {{ if eq .AlwaysUseNv true }}yes{{ else }}no{{ end }}
+
+# USE NVIDIA-NVIDIA-CONTAINER-CLI ${TYPE}: [BOOL]
+# DEFAULT: no
+# EXPERIMENTAL
+# If set to yes, Singularity will attempt to use nvidia-container-cli to setup
+# GPUs within a container when the --nv flag is enabled.
+# If no (default), the legacy binding of entries in nvbliblist.conf will be performed.
+use nvidia-container-cli = {{ if eq .UseNvCCLI true }}yes{{ else }}no{{ end }}
 
 # ALWAYS USE ROCM ${TYPE}: [BOOL]
 # DEFAULT: no

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -356,10 +356,8 @@ memory fs type = {{ .MemoryFSType }}
 # CRYPTSETUP PATH: [STRING]
 # DEFAULT: Undefined
 # Path to the cryptsetup executable, used to work with encrypted containers.
-# If not set, Singularity will search $PATH, /usr/local/sbin, /usr/local/bin,
-# /usr/sbin, /usr/bin, /sbin, /bin for cryptsetup.
-# NOTE - cryptsetup is called as root, and is *required* to be owned by the
-# root user for security reasons.
+# Must be set to build or run encrypted containers.
+# Executable must be owned by root for security reasons.
 # cryptsetup path =
 {{ if ne .CryptsetupPath "" }}cryptsetup path = {{ .CryptsetupPath }}{{ end }}
 
@@ -367,15 +365,15 @@ memory fs type = {{ .MemoryFSType }}
 # DEFAULT: Undefined
 # Path to the go executable, used to compile plugins.
 # If not set, Singularity will search $PATH, /usr/local/sbin, /usr/local/bin,
-# /usr/sbin, /usr/bin, /sbin, /bin for go.
+# /usr/sbin, /usr/bin, /sbin, /bin.
 # go path =
 {{ if ne .GoPath "" }}go path = {{ .GoPath }}{{ end }}
 
 # LDCONFIG PATH: [STRING]
 # DEFAULT: Undefined
 # Path to the ldconfig executable, used to find GPU libraries.
-# If not set, Singularity will search $PATH, /usr/local/sbin, /usr/local/bin,
-# /usr/sbin, /usr/bin, /sbin, /bin for ldconfig.
+# Must be set to use --nv / --nvccli.
+# Executable must be owned by root for security reasons.
 # ldconfig path =
 {{ if ne .LdconfigPath "" }}ldconfig path = {{ .LdconfigPath }}{{ end }}
 
@@ -383,7 +381,7 @@ memory fs type = {{ .MemoryFSType }}
 # DEFAULT: Undefined
 # Path to the mksquashfs executable, used to create SIF and SquashFS containers.
 # If not set, Singularity will search $PATH, /usr/local/sbin, /usr/local/bin,
-# /usr/sbin, /usr/bin, /sbin, /bin for mksquashfs.
+# /usr/sbin, /usr/bin, /sbin, /bin.
 # mksquashfs path =
 {{ if ne .MksquashfsPath "" }}mksquashfs path = {{ .MksquashfsPath }}{{ end }}
 
@@ -408,16 +406,16 @@ mksquashfs procs = {{ .MksquashfsProcs }}
 # NVIDIA-CONTAINER-CLI PATH: [STRING]
 # DEFAULT: Undefined
 # Path to the nvidia-container-cli executable, used to find GPU libraries.
-# If not set, Singularity will search $PATH plus /bin, /usr/bin, /sbin,
-# /usr/sbin, /usr/local/bin, /usr/local/sbin for nvidia-container-cli.
-# mksquashfs path =
+# Must be set to use --nvccli.
+# Executable must be owned by root for security reasons.
+# nvidia-container-cli path =
 {{ if ne .NvidiaContainerCliPath "" }}nvidia-container-cli path = {{ .NvidiaContainerCliPath }}{{ end }}
 
 # UNSQUASHFS PATH: [STRING]
 # DEFAULT: Undefined
 # Path to the unsquashfs executable, used to extract SIF and SquashFS containers
 # If not set, Singularity will search $PATH, /usr/local/sbin, /usr/local/bin,
-# /usr/sbin, /usr/bin, /sbin, /bin for nvidia-container-cli.
+# /usr/sbin, /usr/bin, /sbin, /bin.
 # unsquashfs path =
 {{ if ne .UnsquashfsPath "" }}unsquashfs path = {{ .UnsquashfsPath }}{{ end }}
 

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -373,7 +373,7 @@ memory fs type = {{ .MemoryFSType }}
 # DEFAULT: Undefined
 # Path to the ldconfig executable, used to find GPU libraries.
 # Must be set to use --nv / --nvccli.
-# Executable must be owned by root for security reasons.
+# When run as root, executable must be owned by root for security reasons.
 # ldconfig path =
 {{ if ne .LdconfigPath "" }}ldconfig path = {{ .LdconfigPath }}{{ end }}
 
@@ -407,7 +407,7 @@ mksquashfs procs = {{ .MksquashfsProcs }}
 # DEFAULT: Undefined
 # Path to the nvidia-container-cli executable, used to find GPU libraries.
 # Must be set to use --nvccli.
-# Executable must be owned by root for security reasons.
+# When run as root, executable must be owned by root for security reasons
 # nvidia-container-cli path =
 {{ if ne .NvidiaContainerCliPath "" }}nvidia-container-cli path = {{ .NvidiaContainerCliPath }}{{ end }}
 


### PR DESCRIPTION
This pulls in sylabs pr
- sylabs/singularity#144
which addressed issue
- sylabs/singularity#73
which was a continuation of 
- #5829

This is the original pr description:

> Refactor the container setup code for GPU library binding.
> 
> Add a new `--nvccli` flag that will call `nvidia-container-cli` from the RPC server process to setup the container with required library, binary binds etc. This flow is optional and marked experimental. A `use nvidia-container-cli` directive in `singularity.conf` is provided to enable it globally. The nvccli flow implies `--writable-tmpfs` and is not currently supported for hybrid fakeroot container execution.
> 
> The `--nvccli` code will parse the same environment variables that are used by the `nvidia-docker` runtime, and set appropriate flags when calling `nvidia-container-cli`.
> 
> Change the semantics of `--contain` when used in conjunction with `--nvccli`, so that `/dev/nvidia` devices are _not_ blanket mounted into the container. This allows specific GPUs to be available, others masked, via `NVIDIA_VISIBLE_DEVICES`.
> 
> Remove the use of `nvidia-container-cli` for library discovery in the existing binding approach. Previously `nvidia-container-cli list --ipcs` was used for library discovery if the binary was present, otherwise the `nvliblist.conf` is used. This simplifies the legacy code and ensures that we have only 2 paths.. entirely dependent on `nvidia-container-cli`, or not requiring it at all.
> 
> 
> **Testing notes**
> 
> e2e tests are running and passing on an EC2 g4dn.xlarge (Tesla T4) with the NVIDIA GPU Cloud Image based on Ubuntu 20.04 with CUDA 11.2. (https://aws.amazon.com/marketplace/pp/prodview-e7zxdqduz4cbs). Note - change umask to `0022` in `/etc/login.defs` as our tests aren't compatible with umask `0077` in this image (will file separate issue).
> 
> The tests exercise a subset of env vars influencing `nvidia-container-cli` which are testable on a single GPU instance.
> 
> AMI ID:
> 
> ```
>         --- PASS: TestE2E/PAR/GPU (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/rocm (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/build_rocm (0.00s)
>             --- PASS: TestE2E/PAR/GPU/build_nvccli (10.02s)
>                 --- PASS: TestE2E/PAR/GPU/build_nvccli/WithNvccliRoot (2.74s)
>                 --- PASS: TestE2E/PAR/GPU/build_nvccli/WithoutNvccliRoot (1.95s)
>             --- PASS: TestE2E/PAR/GPU/build_nvidia (13.19s)
>                 --- PASS: TestE2E/PAR/GPU/build_nvidia/WithNvRoot (2.74s)
>                 --- PASS: TestE2E/PAR/GPU/build_nvidia/WithNvFakeroot (3.63s)
>                 --- PASS: TestE2E/PAR/GPU/build_nvidia/WithoutNvRoot (1.58s)
>                 --- PASS: TestE2E/PAR/GPU/build_nvidia/WithoutNvFakeroot (1.21s)
>             --- PASS: TestE2E/PAR/GPU/nvidia (14.80s)
>                 --- PASS: TestE2E/PAR/GPU/nvidia/User (0.24s)
>                 --- PASS: TestE2E/PAR/GPU/nvidia/UserContain (0.24s)
>                 --- PASS: TestE2E/PAR/GPU/nvidia/UserNamespace (0.26s)
>                 --- PASS: TestE2E/PAR/GPU/nvidia/Fakeroot (0.26s)
>                 --- PASS: TestE2E/PAR/GPU/nvidia/Root (0.27s)
>             --- PASS: TestE2E/PAR/GPU/nvccli (15.49s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/User (0.33s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/UserContainNoDevices (0.24s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/UserContainAllDevices (0.33s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/UserNoUtility (0.26s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/UserValidRequire (0.40s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/UserInvalidRequire (0.09s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/UserNamespace (0.29s)
>                 --- PASS: TestE2E/PAR/GPU/nvccli/Root (0.29s)
>     --- PASS: TestE2E/SEQ (0.00s)
>         --- PASS: TestE2E/SEQ/GPU (0.00s)
> ```

