### PR TITLE
Document installing golangci-lint v1.42.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,7 +87,7 @@ run:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
 ```
 
 <!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
## Description of the Pull Request (PR):

This changes the documentation for installing golangci-lint to install v1.42.0 instead of the latest version v1.42.1.  The latter causes gofumpt errors on the current master branch.


### This fixes or addresses the following GitHub issues:

 - Fixes #6232