### PR TITLE
Bump to Go 1.17, from sylabs 281

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-20.04
-    container: golang:1.16
+    container: golang:1.17
     steps:
       - uses: actions/checkout@v2
 
@@ -21,7 +21,7 @@ jobs:
   lint_markdown:
     name: lint_markdown
     runs-on: ubuntu-20.04
-    container: node:16-slim
+    container: node:17-slim
     steps:
       - uses: actions/checkout@v2
 
@@ -46,7 +46,7 @@ jobs:
   debian:
     name: debian
     runs-on: ubuntu-20.04
-    container: golang:1.16-buster
+    container: golang:1.17-buster
     steps:
       - name: Fetch deps
         run: |
@@ -62,7 +62,7 @@ jobs:
   alpine:
     name: alpine
     runs-on: ubuntu-20.04
-    container: golang:1.16-alpine
+    container: golang:1.17-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.7
+          go-version: 1.17
 
       - name: Fetch deps
         run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -145,7 +145,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.7
+          go-version: 1.17
 
       - name: Fetch deps
         run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -189,7 +189,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.7
+          go-version: 1.17
 
       - name: Fetch deps
         if: env.run_tests
@@ -224,7 +224,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.7
+          go-version: 1.17
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export GOVERSION=1.16.9 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.17 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz

--- a/cmd/starter/engines/fakeroot_linux.go
+++ b/cmd/starter/engines/fakeroot_linux.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build fakeroot_engine
 // +build fakeroot_engine
 
 package engines

--- a/cmd/starter/engines/oci_linux.go
+++ b/cmd/starter/engines/oci_linux.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build oci_engine
 // +build oci_engine
 
 package engines

--- a/cmd/starter/engines/singularity_linux.go
+++ b/cmd/starter/engines/singularity_linux.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build singularity_engine
 // +build singularity_engine
 
 package engines

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build e2e_test
 // +build e2e_test
 
 package e2e

--- a/internal/pkg/image/unpacker/squashfs_no_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_no_singularity.go
@@ -1,8 +1,10 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build !singularity_engine
 // +build !singularity_engine
 
 package unpacker

--- a/internal/pkg/image/unpacker/squashfs_singularity.go
+++ b/internal/pkg/image/unpacker/squashfs_singularity.go
@@ -1,8 +1,10 @@
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build singularity_engine
 // +build singularity_engine
 
 package unpacker

--- a/internal/pkg/runtime/engine/singularity/plugins_linux.go
+++ b/internal/pkg/runtime/engine/singularity/plugins_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,6 +10,7 @@
 // If you need to add a new plugin, simply add it to this import list.
 // The build system will pick it up from here.
 
+//go:build cni_plugins
 // +build cni_plugins
 
 package singularity

--- a/internal/pkg/security/apparmor/apparmor_supported.go
+++ b/internal/pkg/security/apparmor/apparmor_supported.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build apparmor
 // +build apparmor
 
 package apparmor

--- a/internal/pkg/security/apparmor/apparmor_unsupported.go
+++ b/internal/pkg/security/apparmor/apparmor_unsupported.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build !apparmor
 // +build !apparmor
 
 package apparmor

--- a/internal/pkg/security/seccomp/seccomp_supported.go
+++ b/internal/pkg/security/seccomp/seccomp_supported.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build seccomp
 // +build seccomp
 
 package seccomp

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build seccomp
 // +build seccomp
 
 package seccomp

--- a/internal/pkg/security/seccomp/seccomp_unsupported.go
+++ b/internal/pkg/security/seccomp/seccomp_unsupported.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build !seccomp
 // +build !seccomp
 
 package seccomp

--- a/internal/pkg/security/selinux/selinux_supported.go
+++ b/internal/pkg/security/selinux/selinux_supported.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build selinux
 // +build selinux
 
 package selinux

--- a/internal/pkg/security/selinux/selinux_unsupported.go
+++ b/internal/pkg/security/selinux/selinux_unsupported.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build !selinux
 // +build !selinux
 
 package selinux

--- a/internal/pkg/util/gpu/paths_test.go
+++ b/internal/pkg/util/gpu/paths_test.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build linux
 // +build linux
 
 package gpu

--- a/internal/pkg/util/user/cgo_lookup_unix.go
+++ b/internal/pkg/util/user/cgo_lookup_unix.go
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (aix || darwin || dragonfly || freebsd || (!android && linux) || netbsd || openbsd || solaris) && cgo && !osusergo
 // +build aix darwin dragonfly freebsd !android,linux netbsd openbsd solaris
-// +build cgo,!osusergo
+// +build cgo
+// +build !osusergo
 
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build integration_test
 // +build integration_test
 
 package network

--- a/pkg/sylog/sylog.go
+++ b/pkg/sylog/sylog.go
@@ -3,6 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build sylog
 // +build sylog
 
 package sylog

--- a/pkg/sylog/sylog_dummy.go
+++ b/pkg/sylog/sylog_dummy.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build !sylog
 // +build !sylog
 
 package sylog

--- a/pkg/sylog/sylog_dummy_test.go
+++ b/pkg/sylog/sylog_dummy_test.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build !sylog
 // +build !sylog
 
 package sylog

--- a/pkg/sylog/sylog_test.go
+++ b/pkg/sylog/sylog_test.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build sylog
 // +build sylog
 
 package sylog

--- a/pkg/util/fs/lock/var_linux_32bit.go
+++ b/pkg/util/fs/lock/var_linux_32bit.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build (linux && 386) || (linux && arm) || (linux && mips) || (linux && mipsle)
 // +build linux,386 linux,arm linux,mips linux,mipsle
 
 package lock

--- a/pkg/util/loop/loop_no_singularity.go
+++ b/pkg/util/loop/loop_no_singularity.go
@@ -1,3 +1,9 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build !singularity_engine
 // +build !singularity_engine
 
 package loop

--- a/pkg/util/loop/loop_singularity.go
+++ b/pkg/util/loop/loop_singularity.go
@@ -1,3 +1,9 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build singularity_engine
 // +build singularity_engine
 
 package loop

--- a/pkg/util/namespaces/setns_linux.go
+++ b/pkg/util/namespaces/setns_linux.go
@@ -1,8 +1,9 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build go1.10
 // +build go1.10
 
 package namespaces


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#281

The original PR description was:

> Bump Go version to 1.17. Add `//go:build` format build constraints [introduced in Go 1.17](https://golang.org/doc/go1.17#build-lines). Move `pkg/image/packer` and `pkg/image/unpacker` to `internal/`, as they depend on `buildcfg`.