### PR TITLE
Linter Updates, from sylabs 282

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   check_source:
     name: check_source
     runs-on: ubuntu-20.04
-    container: golangci/golangci-lint:v1.42
+    container: golangci/golangci-lint:v1.42.0
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   check_source:
     name: check_source
     runs-on: ubuntu-20.04
-    container: golangci/golangci-lint:v1.41
+    container: golangci/golangci-lint:v1.42
     steps:
       - uses: actions/checkout@v2
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,13 +19,9 @@ linters:
     # - staticcheck
 
 linters-settings:
-  gofmt:
-    simplify: true
   govet:
     # we would like to enable this eventually
     check-shadowing: false
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,12 +28,3 @@ linters-settings:
 issues:
   max-per-linter: 0
   max-same-issues: 0
-
-  exclude-rules:
-    - path: internal/pkg/util/fs/overlay/
-      linters:
-        - misspell
-
-    - path: internal/pkg/util/user/cgo_lookup_unix.go
-      linters:
-        - deadcode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,6 @@ linters:
     # - staticcheck
 
 linters-settings:
-  govet:
-    # we would like to enable this eventually
-    check-shadowing: false
   misspell:
     locale: US
 

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -32,7 +32,7 @@ const (
 	nfs    int64 = 0x6969
 	fuse         = 0x65735546
 	ecrypt       = 0xF15F
-	lustre       = 0x0BD00BD0
+	lustre       = 0x0BD00BD0 //nolint:misspell
 	gpfs         = 0x47504653
 )
 
@@ -53,6 +53,7 @@ var incompatibleFs = map[int64]fs{
 		overlayDir: lowerDir | upperDir,
 	},
 	// LUSTRE filesystem
+	//nolint:misspell
 	lustre: {
 		name:       "LUSTRE",
 		overlayDir: lowerDir | upperDir,

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -107,6 +107,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
+		//nolint:misspell
 		{
 			name:                  "LUSTRE mock lower",
 			path:                  "/",
@@ -116,6 +117,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
+		//nolint:misspell
 		{
 			name:                  "LUSTRE mock upper",
 			path:                  "/",


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#282

The original PR description was:

> Bump `golangci-lint` to 1.42. Remove `linters-settings` for linters that are not enabled. Remove `exclude-rules` and unnecessary disablement of `govet` `check-shadowing`.