### PR TITLE
Wire up contexts in CLI package and ORAS push/pull, from sylabs 376 & 377

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -51,9 +51,7 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 
 	os.Setenv("IMAGE_ARG", args[0])
 
-	ctx := context.TODO()
-
-	replaceURIWithImage(ctx, cmd, args)
+	replaceURIWithImage(cmd.Context(), cmd, args)
 
 	// --compat infers other options that give increased OCI / Docker compatibility
 	// Excludes uts/user/net namespaces as these are restrictive for many Singularity

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -95,8 +95,6 @@ func fakerootExec(cmdArgs []string) {
 }
 
 func runBuild(cmd *cobra.Command, args []string) {
-	ctx := context.TODO()
-
 	if buildArgs.nvidia {
 		if buildArgs.remote {
 			sylog.Fatalf("--nv option is not supported for remote build")
@@ -138,9 +136,9 @@ func runBuild(cmd *cobra.Command, args []string) {
 	}
 
 	if buildArgs.remote {
-		runBuildRemote(ctx, cmd, dest, spec)
+		runBuildRemote(cmd.Context(), cmd, dest, spec)
 	} else {
-		runBuildLocal(ctx, cmd, dest, spec)
+		runBuildLocal(cmd.Context(), cmd, dest, spec)
 	}
 	sylog.Infof("Build complete: %s", dest)
 }

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -131,7 +131,7 @@ var deleteImageCmd = &cobra.Command{
 			sylog.Fatalf("Error while getting library client config: %v", err)
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(deleteImageTimeout)*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(deleteImageTimeout)*time.Second)
 		defer cancel()
 
 		if err := singularity.DeleteImage(ctx, libraryConfig, r, deleteImageArch); err != nil {

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -90,8 +89,6 @@ type keyNewPairOptions struct {
 }
 
 func runNewPairCmd(cmd *cobra.Command, args []string) {
-	ctx := context.TODO()
-
 	keyring := sypgp.NewHandle("")
 
 	opts, err := collectInput(cmd)
@@ -120,7 +117,7 @@ func runNewPairCmd(cmd *cobra.Command, args []string) {
 		sylog.Fatalf("Keyserver client failed: %s", err)
 	}
 
-	if err := sypgp.PushPubkey(ctx, key, co...); err != nil {
+	if err := sypgp.PushPubkey(cmd.Context(), key, co...); err != nil {
 		fmt.Printf("Failed to push newly created key to keystore: %s\n", err)
 	} else {
 		fmt.Println("Key successfully pushed to keystore")

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -26,14 +26,12 @@ var KeyPullCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverPullOp)
 		if err != nil {
 			sylog.Fatalf("Keyserver client failed: %s", err)
 		}
 
-		if err := doKeyPullCmd(ctx, args[0], co...); err != nil {
+		if err := doKeyPullCmd(cmd.Context(), args[0], co...); err != nil {
 			sylog.Errorf("pull failed: %s", err)
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/key_push.go
+++ b/cmd/internal/cli/key_push.go
@@ -26,14 +26,12 @@ var KeyPushCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverPushOp)
 		if err != nil {
 			sylog.Fatalf("Keyserver client failed: %s", err)
 		}
 
-		if err := doKeyPushCmd(ctx, args[0], co...); err != nil {
+		if err := doKeyPushCmd(cmd.Context(), args[0], co...); err != nil {
 			sylog.Errorf("push failed: %s", err)
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/key_search.go
+++ b/cmd/internal/cli/key_search.go
@@ -23,14 +23,12 @@ var KeySearchCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverSearchOp)
 		if err != nil {
 			sylog.Fatalf("Keyserver client failed: %s", err)
 		}
 
-		if err := doKeySearchCmd(ctx, args[0], co...); err != nil {
+		if err := doKeySearchCmd(cmd.Context(), args[0], co...); err != nil {
 			sylog.Errorf("search failed: %s", err)
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -6,8 +6,6 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/hpcng/singularity/docs"
 	"github.com/hpcng/singularity/internal/app/singularity"
 	"github.com/hpcng/singularity/pkg/cmdline"
@@ -186,9 +184,7 @@ var OciRunCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
-		if err := singularity.OciRun(ctx, args[0], &ociArgs); err != nil {
+		if err := singularity.OciRun(cmd.Context(), args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -220,9 +216,7 @@ var OciDeleteCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
-		if err := singularity.OciDelete(ctx, args[0]); err != nil {
+		if err := singularity.OciDelete(cmd.Context(), args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},
@@ -280,9 +274,7 @@ var OciAttachCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
-		if err := singularity.OciAttach(ctx, args[0]); err != nil {
+		if err := singularity.OciAttach(cmd.Context(), args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/hpcng/singularity/docs"
@@ -80,8 +79,6 @@ var PushCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		file, dest := args[0], args[1]
 
 		transport, ref := uri.Split(dest)
@@ -114,7 +111,7 @@ var PushCmd = &cobra.Command{
 				FrontendURI:   URI(),
 			}
 
-			err = singularity.LibraryPush(ctx, pushSpec, lc, co)
+			err = singularity.LibraryPush(cmd.Context(), pushSpec, lc, co)
 			if err == singularity.ErrLibraryUnsigned {
 				fmt.Printf("TIP: You can push unsigned images with 'singularity push -U %s'.\n", file)
 				fmt.Printf("TIP: Learn how to sign your own containers by using 'singularity help sign'\n\n")

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -128,7 +128,7 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}
 
-			if err := oras.UploadImage(file, ref, ociAuth); err != nil {
+			if err := oras.UploadImage(cmd.Context(), file, ref, ociAuth); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -73,7 +73,7 @@ func getResolver(ociAuth *ocitypes.DockerAuthConfig) (remotes.Resolver, error) {
 }
 
 // DownloadImage downloads a SIF image specified by an oci reference to a file using the included credentials
-func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
+func DownloadImage(ctx context.Context, imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	ref = strings.TrimPrefix(ref, "oras://")
 	ref = strings.TrimPrefix(ref, "//")
 
@@ -124,7 +124,7 @@ func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) er
 	}
 	pullHandler := oras.WithPullBaseHandler(images.HandlerFunc(handlerFunc))
 
-	_, err = oras.Copy(orasctx.Background(), resolver, spec.String(), store, "", allowedMediaTypes, pullHandler)
+	_, err = oras.Copy(orasctx.WithLoggerDiscarded(ctx), resolver, spec.String(), store, "", allowedMediaTypes, pullHandler)
 	if err != nil {
 		return fmt.Errorf("unable to pull from registry: %s", err)
 	}
@@ -146,7 +146,7 @@ func DownloadImage(imagePath, ref string, ociAuth *ocitypes.DockerAuthConfig) er
 
 // UploadImage uploads the image specified by path and pushes it to the provided oci reference,
 // it will use credentials if supplied
-func UploadImage(path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
+func UploadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 	// ensure that are uploading a SIF
 	if err := ensureSIF(path); err != nil {
 		return err
@@ -202,7 +202,7 @@ func UploadImage(path, ref string, ociAuth *ocitypes.DockerAuthConfig) error {
 		return fmt.Errorf("unable to store manifest: %w", err)
 	}
 
-	if _, err = oras.Copy(orasctx.Background(), store, spec.String(), resolver, ""); err != nil {
+	if _, err = oras.Copy(orasctx.WithLoggerDiscarded(ctx), store, spec.String(), resolver, ""); err != nil {
 		return fmt.Errorf("unable to push: %w", err)
 	}
 

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -25,7 +25,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 
 	if directTo != "" {
 		sylog.Infof("Downloading oras image")
-		if err := DownloadImage(directTo, pullFrom, ociAuth); err != nil {
+		if err := DownloadImage(ctx, directTo, pullFrom, ociAuth); err != nil {
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 		imagePath = directTo
@@ -39,7 +39,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading oras image")
 
-			if err := DownloadImage(cacheEntry.TmpPath, pullFrom, ociAuth); err != nil {
+			if err := DownloadImage(ctx, cacheEntry.TmpPath, pullFrom, ociAuth); err != nil {
 				return "", fmt.Errorf("unable to Download Image: %v", err)
 			}
 			if cacheFileHash, err := ImageHash(cacheEntry.TmpPath); err != nil {


### PR DESCRIPTION
This pulls in prs
- sylabs/singularity#376
and
- sylabs/singularity#377
which were made in response to
- sylabs/singularity#113
which is the same problem as reported in
- #6051

This in combination with
- #6235
solved the user's problem.

The original PR descriptions were:
> Replace usage of `context.TODO` with command context `cmd/internal/cli`.

> Wire up contexts in `oras.DownloadImage` and `oras.UploadImage`. I believe this is a possible fix for sylabs/singularity#113, at least in that a user interrupt should cause a push/pull to give up.
> 
> We could consider a timeout as well for push/pull, although defining a single, sensible timeout value probably isn't possible. A push/pull of a large SIF will always take a long time in certain environments.