### PR TITLE
Fix LGTM uint32 parse warnings, from sylabs 317

### DIFF
--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -141,7 +141,7 @@ func (c *Config) parseEntry(line string) {
 		e.disabled = true
 	}
 
-	uid, err := strconv.Atoi(username)
+	uid, err := strconv.ParseUint(username, 10, 32)
 	if err == nil {
 		e.UID = uint32(uid)
 	} else {

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -1059,7 +1059,7 @@ func (c *container) addImageBindMount(system *mount.System) error {
 
 		imagePath := bind.Source
 		destination := bind.Destination
-		id := 0
+		partID := uint32(0)
 		imageSource := "/"
 
 		if src := bind.ImageSrc(); src != "" {
@@ -1067,14 +1067,13 @@ func (c *container) addImageBindMount(system *mount.System) error {
 		}
 
 		if idStr := bind.ID(); idStr != "" {
-			var err error
-
-			id, err = strconv.Atoi(idStr)
+			p, err := strconv.ParseUint(idStr, 10, 32)
 			if err != nil {
 				return fmt.Errorf("while parsing id bind option: %s", err)
-			} else if id <= 0 {
+			} else if p <= 0 {
 				return fmt.Errorf("id number must be greater than 0")
 			}
+			partID = uint32(p)
 		}
 
 		for _, img := range imageList {
@@ -1088,13 +1087,13 @@ func (c *container) addImageBindMount(system *mount.System) error {
 			data := (*image.Section)(nil)
 
 			// id is only meaningful for SIF images
-			if img.Type == image.SIF && id > 0 {
+			if img.Type == image.SIF && partID > 0 {
 				partitions, err := img.GetAllPartitions()
 				if err != nil {
 					return fmt.Errorf("while getting partitions for %s: %s", img.Path, err)
 				}
 				for _, part := range partitions {
-					if part.ID == uint32(id) {
+					if part.ID == partID {
 						data = &part
 						break
 					}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#317
which fixed
- sylabs/singularity#318

The original PR description was:

> Explicitly parse 32-bit uint, instead of using strconv.Atoi.
> 
> Fixes remaining warnings listed at: https://lgtm.com/projects/g/sylabs/singularity/alerts/?mode=list