### PR TITLE
WIP: fix: Invalid path for --pwd is ignored instead of producing an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Changed defaults / behaviours
 
+- When starting a container, in case of problem with the cwd, istead of trying to
+  default to a different directory, return error to prevent unexpected behaviors #6086
 - LABELs from Docker/OCI images are now inherited. This fixes a longstanding
   regression from Singularity 2.x. Note that you will now need to use
   `--force` in a build to override a label that already exists in the source

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -100,4 +100,5 @@
 - Onur Yılmaz <csonuryilmaz@gmail.com>
 - Pranathi Locula <locula@deshaw.com>
 - Pedro Alves Batista <pedro.pesquisapb@gmail.com>
+- Pablo Caderno <kaderno@gmail.com>
 ```

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -70,11 +70,13 @@ func (e *EngineOperations) StartProcess(masterConnFd int) error {
 	isInstance := e.EngineConfig.GetInstance()
 	bootInstance := isInstance && e.EngineConfig.GetBootInstance()
 	shimProcess := false
-
+	// Instead of trying to use a different cwd, return error to prevent
+	// unexpected behaviors #6086
 	if err := os.Chdir(e.EngineConfig.OciConfig.Process.Cwd); err != nil {
-		if err := os.Chdir(e.EngineConfig.GetHomeDest()); err != nil {
-			os.Chdir("/")
-		}
+		return fmt.Errorf("failed to set working directory: %s", err)
+		// if err := os.Chdir(e.EngineConfig.GetHomeDest()); err != nil {
+		// 	os.Chdir("/")
+		// }
 	}
 
 	if e.EngineConfig.File.MountDev == "minimal" || e.EngineConfig.GetContain() {


### PR DESCRIPTION

Signed-off-by: Pablo Caderno <kaderno@gmail.com>

## Description of the Pull Request (PR):

Changed default behavior of switching to a different directory if ` os.Chdir(e.EngineConfig.OciConfig.Process.Cwd)` fails when starting the container. 

Whilst this approach should fix the issue, it might be "too strict" for other cases. I think some discussion about that would be beneficial. 

### This fixes or addresses the following GitHub issues:
Fixes #6086
