### PR TITLE
Typos found by codespell, from sylabs 325

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
   `ldconfig path = /sbin/ldconfig` to use the host distribution `ldconfig` to
   find GPU libraries.
 - Example log-plugin rewritten as a CLI callback that can log all commands
-  executed, intead of only container execution, and has access to command
+  executed, instead of only container execution, and has access to command
   arguments.
 
 ## v3.8.3 - \[2021-09-07\]
@@ -192,7 +192,7 @@ of use:
 - Allow configuration of global custom keyservers, separate from remote
   endpoints.
 - Add a new global keyring, for public keys only (used for ECL).
-- The `remote login` commmand now supports authentication to Docker/OCI
+- The `remote login` command now supports authentication to Docker/OCI
   registries and custom keyservers.
 - New `--exclusive` option for `remote use` allows admin to lock usage to a
   specific remote.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ all your interactions with the project members and users.
 1. If possible, run `make -C builddir testall` locally, after setting the
    environment variables `E2E_DOCKER_USERNAME` and `E2E_DOCKER_PASSWORD`
    appropriately for an authorized Docker Hub account. This is required as
-   Singularity's end-to-end tests preform many tests that build from or execute
+   Singularity's end-to-end tests perform many tests that build from or execute
    docker images. Our CI is authorized to run these tests if you cannot.
 1. Ask yourself is the code human understandable? This can be accomplished via a
    clear code style as well as documentation and/or comments.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@
 - David Trudgian <david.trudgian@utsouthwestern.edu>,
   <david.trudgian@sylabs.io>, <dave@trudgian.net>
 - Diana Langenbach <dcl@dcl.sh>
+- Dimitri Papadopoulos <3234522+DimitriPapadopoulos@users.noreply.github.com>
 - Divya Cote <divya.cote@gmail.com>
 - Eduardo Arango <eduardo@sylabs.io>, <arangogutierrez@gmail.com>
 - Egbert Eich <eich@suse.com>

--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -20,7 +20,7 @@ import (
 )
 
 /*
- * This tool aims at gathering the list of Singularity commands and optionaly
+ * This tool aims at gathering the list of Singularity commands and optionally
  * the list of commands covered by the E2E tests. When gathering the list of
  * E2E tests, we also calculate the coverage compared to all the Singularity
  * commands.

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -166,7 +166,7 @@ func setVM(cmd *cobra.Command) {
 
 	// since --syos is a boolean, it cannot be added to the above list
 	if IsSyOS && !VM {
-		// let the user know that passing --syos implictly enables --vm
+		// let the user know that passing --syos implicitly enables --vm
 		sylog.Warningf("The --syos option requires a virtual machine, automatically enabling --vm option.")
 		cmd.Flags().Set("vm", "true")
 	}

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -391,7 +391,7 @@ func isImage(spec string) bool {
 // getEncryptionMaterial handles the setting of encryption environment and flag parameters to eventually be
 // passed to the crypt package for handling.
 // This handles the SINGULARITY_ENCRYPTION_PASSPHRASE/PEM_PATH envvars outside of cobra in order to
-// enforce the unique flag/env precidence for the encryption flow
+// enforce the unique flag/env precedence for the encryption flow
 func getEncryptionMaterial(cmd *cobra.Command) (cryptkey.KeyInfo, error) {
 	passphraseFlag := cmd.Flags().Lookup("passphrase")
 	PEMFlag := cmd.Flags().Lookup("pem-path")
@@ -403,7 +403,7 @@ func getEncryptionMaterial(cmd *cobra.Command) (cryptkey.KeyInfo, error) {
 		sylog.Fatalf("Unable to use container encryption. Must supply encryption material through environment variables or flags.")
 	}
 
-	// order of precidence:
+	// order of precedence:
 	// 1. PEM flag
 	// 2. Passphrase flag
 	// 3. PEM envvar

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -45,7 +45,7 @@ var (
 	pullLibraryURI string
 	// pullImageName holds the name to be given to the pulled image.
 	pullImageName string
-	// unauthenticatedPull when true; wont ask to keep a unsigned container after pulling it.
+	// unauthenticatedPull when true; won't ask to keep a unsigned container after pulling it.
 	unauthenticatedPull bool
 	// pullDir is the path that the containers will be pulled to, if set.
 	pullDir string

--- a/cmd/internal/cli/singularity.go
+++ b/cmd/internal/cli/singularity.go
@@ -170,7 +170,7 @@ var commonPEMFlag = cmdline.Flag{
 	Value:        &encryptionPEMPath,
 	DefaultValue: "",
 	Name:         "pem-path",
-	Usage:        "enter an path to a PEM formated RSA key for an encrypted container",
+	Usage:        "enter an path to a PEM formatted RSA key for an encrypted container",
 }
 
 // -F|--force
@@ -262,7 +262,7 @@ func setSylogMessageLevel() {
 }
 
 // handleRemoteConf will make sure your 'remote.yaml' config file
-// is the correct permission.
+// has the correct permission.
 func handleRemoteConf(remoteConfFile string) {
 	// Only check the permission if it exists.
 	if fs.IsFile(remoteConfFile) {

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -249,7 +249,7 @@ static void apply_privileges(struct privileges *privileges, struct capabilities 
     int last_cap = get_last_cap();
     int caps_index;
 
-    /* adjust capabilities based on the lastest capability supported by the system */
+    /* adjust capabilities based on the latest capability supported by the system */
     for ( caps_index = last_cap + 1; caps_index <= CAPSET_MAX; caps_index++ ) {
         privileges->capabilities.effective &= ~capflag(caps_index);
         privileges->capabilities.permitted &= ~capflag(caps_index);

--- a/docs/content.go
+++ b/docs/content.go
@@ -722,7 +722,7 @@ Enterprise Performance Computing (EPC)`
   image. By default, one digital signature is added for each object group in
   the file.
   
-  To generate a keypair, see 'singularity help key newpair'`
+  To generate a key pair, see 'singularity help key newpair'`
 	SignExample string = `
   $ singularity sign container.sif`
 
@@ -809,7 +809,7 @@ Enterprise Performance Computing (EPC)`
       SCIF_APPLIB        is the application's library folder that is added to the LD_LIBRARY_PATH
       SCIF_APPRUN        is the runscript
       SCIF_APPHELP       is the help file for the runscript
-      SCIF_APPTEST       is the testing script (test.sh) associated with the applicatio
+      SCIF_APPTEST       is the testing script (test.sh) associated with the application
       SCIF_APPNAME       the name for the active application
       SCIF_APPFILES      the files section associated with the application that are added to
 

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -58,7 +58,7 @@ func (c ctx) issue5426(t *testing.T) {
 	)
 }
 
-// Check that we hit engine configuation size limit with a rather big
+// Check that we hit engine configuration size limit with a rather big
 // configuration by passing some big environment variables.
 func (c ctx) issue5057(t *testing.T) {
 	e2e.EnsureImage(t, c.env)

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -24,7 +24,7 @@ import (
 // This test will build an image from a multi-stage definition
 // file, the first stage compile a bad NSS library containing
 // a constructor forcing program to exit with code 255 when loaded,
-// the second stage will copy the bad NSS library in its root filesytem
+// the second stage will copy the bad NSS library in its root filesystem
 // to check that the post section executed by the build engine doesn't
 // load the bad NSS library from container image.
 // Most if not all NSS services point to the bad NSS library in

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -108,7 +108,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 		{
 			name:      "label_E2E",
 			insType:   "--labels",
-			compareFn: compareLabel("E2E", "AWSOME", ""),
+			compareFn: compareLabel("E2E", "AWESOME", ""),
 		},
 		{
 			name:      "label_HI",
@@ -118,7 +118,7 @@ func (c ctx) singularityInspect(t *testing.T) {
 		{
 			name:      "label_e2e",
 			insType:   "--labels",
-			compareFn: compareLabel("e2e", "awsome", ""),
+			compareFn: compareLabel("e2e", "awesome", ""),
 		},
 		{
 			name:      "label_hi",

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -220,7 +220,7 @@ var tests = []testStruct{
 
 func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 	// We use a string rather than a slice of strings to avoid having an empty
-	// element in the slice, which would cause the command to fail, wihtout
+	// element in the slice, which would cause the command to fail, without
 	// over-complicating the code.
 	argv := ""
 
@@ -559,24 +559,24 @@ func (c ctx) testPullUmask(t *testing.T) {
 			expectPerm: 0o750,
 		},
 
-		// With the force flag, and overide the image. The permission will
+		// With the force flag, and override the image. The permission will
 		// reset to 0666 after every test.
 		{
-			name:       "0022 umask pull overide",
+			name:       "0022 umask pull override",
 			imagePath:  filepath.Join(c.env.TestDir, umask22Image),
 			umask:      0o022,
 			expectPerm: 0o755,
 			force:      true,
 		},
 		{
-			name:       "0077 umask pull overide",
+			name:       "0077 umask pull override",
 			imagePath:  filepath.Join(c.env.TestDir, umask77Image),
 			umask:      0o077,
 			expectPerm: 0o700,
 			force:      true,
 		},
 		{
-			name:       "0027 umask pull overide",
+			name:       "0027 umask pull override",
 			imagePath:  filepath.Join(c.env.TestDir, umask27Image),
 			umask:      0o027,
 			expectPerm: 0o750,

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -32,7 +32,7 @@ func (c ctx) testSecurityUnpriv(t *testing.T) {
 		expectOp   e2e.SingularityCmdResultOp
 		expectExit int
 	}{
-		// taget UID/GID
+		// target UID/GID
 		{
 			name:       "Set_uid",
 			argv:       []string{"id", "-u"},
@@ -133,7 +133,7 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 		expectOp   e2e.SingularityCmdResultOp
 		expectExit int
 	}{
-		// taget UID/GID
+		// target UID/GID
 		{
 			name:       "Set_uid",
 			argv:       []string{"id", "-u"},

--- a/e2e/testdata/inspecter_container.def
+++ b/e2e/testdata/inspecter_container.def
@@ -8,8 +8,8 @@ in the "e2e/testdata" directory of Singularity.
 
 %labels
 MAINTAINER "WestleyK <westley@sylabs.io>"
-e2e awsome
-E2E AWSOME
+e2e awesome
+E2E AWESOME
 hi "hello world"
 HI "HELLO WORLD"
 

--- a/etc/conf/testdata/test_1.out.correct
+++ b/etc/conf/testdata/test_1.out.correct
@@ -192,7 +192,7 @@ allow container dir = yes
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command
-# should be executed implicitely with the --nv option (useful for GPU only 
+# should be executed implicitly with the --nv option (useful for GPU only 
 # environments). 
 always use nv = no
 

--- a/etc/conf/testdata/test_2.in
+++ b/etc/conf/testdata/test_2.in
@@ -192,7 +192,7 @@ allow container dir = yes
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command
-# should be executed implicitely with the --nv option (useful for GPU only 
+# should be executed implicitly with the --nv option (useful for GPU only 
 # environments). 
 always use nv = no
 

--- a/etc/conf/testdata/test_2.out.correct
+++ b/etc/conf/testdata/test_2.out.correct
@@ -192,7 +192,7 @@ allow container dir = yes
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command
-# should be executed implicitely with the --nv option (useful for GPU only 
+# should be executed implicitly with the --nv option (useful for GPU only 
 # environments). 
 always use nv = no
 

--- a/etc/conf/testdata/test_3.in
+++ b/etc/conf/testdata/test_3.in
@@ -183,7 +183,7 @@ allow container dir = yes
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command
-# should be executed implicitely with the --nv option (useful for GPU only 
+# should be executed implicitly with the --nv option (useful for GPU only 
 # environments). 
 always use nv = no
 

--- a/etc/conf/testdata/test_3.out.correct
+++ b/etc/conf/testdata/test_3.out.correct
@@ -192,7 +192,7 @@ allow container dir = yes
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command
-# should be executed implicitely with the --nv option (useful for GPU only 
+# should be executed implicitly with the --nv option (useful for GPU only 
 # environments). 
 always use nv = no
 

--- a/etc/conf/testdata/test_default.tmpl
+++ b/etc/conf/testdata/test_default.tmpl
@@ -203,7 +203,7 @@ allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }
 # ALWAYS USE NV ${TYPE}: [BOOL]
 # DEFAULT: no
 # This feature allows an administrator to determine that every action command
-# should be executed implicitely with the --nv option (useful for GPU only 
+# should be executed implicitly with the --nv option (useful for GPU only 
 # environments). 
 always use nv = {{ if eq .AlwaysUseNv true }}yes{{ else }}no{{ end }}
 

--- a/examples/legacy/2.2/contrib/debian85-tensorflow-0.10.def
+++ b/examples/legacy/2.2/contrib/debian85-tensorflow-0.10.def
@@ -5,7 +5,7 @@
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 # SINGULARITY BOOTSTRAP: TENSORFLOW
-# Installation proceedure copied from:
+# Installation procedure copied from:
 # https://www.tensorflow.org/versions/r0.10/get_started/os_setup.html#pip-installation
 
 

--- a/internal/app/singularity/remote_add_test.go
+++ b/internal/app/singularity/remote_add_test.go
@@ -171,7 +171,7 @@ func TestRemoteAdd(t *testing.T) {
 			shallPass:  true,
 		},
 		{
-			// This test checks both RemoteAdd() and RemoteRemove(), we stil
+			// This test checks both RemoteAdd() and RemoteRemove(), we still
 			// have a separate test for corner cases in the context of
 			// RemoveRemove().
 			name:       "9: valid config file; valid remote name; valid URI; local",

--- a/internal/app/singularity/verify.go
+++ b/internal/app/singularity/verify.go
@@ -47,7 +47,7 @@ func OptVerifyUseKeyServer(opts ...client.Option) VerifyOpt {
 }
 
 // OptVerifyGroup adds a verification task for the group with the specified groupID. This may be
-// called multliple times to request verification of more than one group.
+// called multiple times to request verification of more than one group.
 func OptVerifyGroup(groupID uint32) VerifyOpt {
 	return func(v *verifier) error {
 		v.groupIDs = append(v.groupIDs, groupID)
@@ -56,7 +56,7 @@ func OptVerifyGroup(groupID uint32) VerifyOpt {
 }
 
 // OptVerifyObject adds a verification task for the object with the specified id. This may be
-// called multliple times to request verification of more than one object.
+// called multiple times to request verification of more than one object.
 func OptVerifyObject(id uint32) VerifyOpt {
 	return func(v *verifier) error {
 		v.objectIDs = append(v.objectIDs, id)

--- a/internal/app/singularity/verify_test.go
+++ b/internal/app/singularity/verify_test.go
@@ -220,7 +220,7 @@ func Test_verifier_getOpts(t *testing.T) {
 			wantOpts: 2,
 		},
 		{
-			name:     "Callcack",
+			name:     "Callback",
 			v:        verifier{cb: cb},
 			f:        &oneGroupImage,
 			wantOpts: 2,

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -40,7 +40,7 @@ func TestMakeParentDir(t *testing.T) {
 		},
 	}
 
-	// while running tests, make sure to remove everything past the tmp dir created so tests to accidentially collide
+	// while running tests, make sure to remove everything past the tmp dir created so tests to accidentally collide
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// create tmpdir for each test

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -173,7 +173,7 @@ func insertDefinition(b *types.Bundle) error {
 	// if update, check for existing definition and move it to bootstrap history
 	if b.Opts.Update {
 		if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity")); err == nil {
-			// make bootstrap_history directory if it doesnt exist
+			// make bootstrap_history directory if it doesn't exist
 			if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history")); err != nil {
 				err = os.Mkdir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"), 0o755)
 				if err != nil {
@@ -246,7 +246,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 					sylog.Warningf("Label: %s already exists and force option is false, not overwriting", key)
 				}
 			} else {
-				// set if it doesnt
+				// set if it doesn't
 				labels[key] = value
 			}
 		}

--- a/internal/pkg/build/sources/conveyorPacker_arch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_test.go
@@ -56,7 +56,7 @@ func TestArchConveyor(t *testing.T) {
 	cp := &sources.ArchConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", archDef, err)
@@ -94,7 +94,7 @@ func TestArchPacker(t *testing.T) {
 	cp := &sources.ArchConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", archDef, err)

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -53,7 +53,7 @@ func TestBusyBoxConveyor(t *testing.T) {
 	c := &sources.BusyBoxConveyor{}
 
 	err = c.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer c.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", busyBoxDef, err)
@@ -86,7 +86,7 @@ func TestBusyBoxPacker(t *testing.T) {
 	cp := &sources.BusyBoxConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", busyBoxDef, err)

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -228,7 +228,7 @@ func (cp *DebootstrapConveyorPacker) Pack(context.Context) (*types.Bundle, error
 
 	err := cp.insertBaseEnv(cp.b)
 	if err != nil {
-		return nil, fmt.Errorf("while inserting base environtment: %v", err)
+		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 
 	err = cp.insertRunScript(cp.b)

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -43,7 +43,7 @@ func TestDebootstrapConveyor(t *testing.T) {
 	cp := sources.DebootstrapConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("Debootstrap Get failed: %v", err)
@@ -76,7 +76,7 @@ func TestDebootstrapPacker(t *testing.T) {
 	cp := sources.DebootstrapConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("Debootstrap Get failed: %v", err)

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -49,7 +49,7 @@ func TestLibraryConveyor(t *testing.T) {
 	b.Opts.ImgCache = imgCache
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", libraryURI, err)
@@ -80,7 +80,7 @@ func TestLibraryPacker(t *testing.T) {
 	b.Opts.ImgCache = imgCache
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", libraryURI, err)

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -71,7 +71,7 @@ func TestOCIConveyorDocker(t *testing.T) {
 	cp := &sources.OCIConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", dockerURI, err)
@@ -110,7 +110,7 @@ func TestOCIConveyorDockerArchive(t *testing.T) {
 	cp := &sources.OCIConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", archiveURI, err)
@@ -157,7 +157,7 @@ func TestOCIConveyorDockerDaemon(t *testing.T) {
 	cp := &sources.OCIConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", daemonURI, err)
@@ -192,7 +192,7 @@ func TestOCIConveyorOCIArchive(t *testing.T) {
 	cp := &sources.OCIConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", archiveURI, err)
@@ -240,7 +240,7 @@ func TestOCIConveyorOCILayout(t *testing.T) {
 	cp := &sources.OCIConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", layoutURI, err)
@@ -271,7 +271,7 @@ func TestOCIPacker(t *testing.T) {
 	b.Opts.ImgCache = imgCache
 
 	err = ocp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer ocp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", dockerURI, err)

--- a/internal/pkg/build/sources/conveyorPacker_scratch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch_test.go
@@ -46,7 +46,7 @@ func TestScratchConveyor(t *testing.T) {
 	c := &sources.ScratchConveyor{}
 
 	err = c.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer c.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", scratchDef, err)
@@ -76,7 +76,7 @@ func TestScratchPacker(t *testing.T) {
 	cp := &sources.ScratchConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", scratchDef, err)

--- a/internal/pkg/build/sources/conveyorPacker_shub_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub_test.go
@@ -45,7 +45,7 @@ func TestShubConveyor(t *testing.T) {
 	cp := &sources.ShubConveyorPacker{}
 
 	err = cp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer cp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)
@@ -72,7 +72,7 @@ func TestShubPacker(t *testing.T) {
 	scp := &sources.ShubConveyorPacker{}
 
 	err = scp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer scp.CleanUp()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", shubURI, err)

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -58,7 +58,7 @@ func TestYumConveyor(t *testing.T) {
 	yc := &YumConveyor{}
 
 	err = yc.Get(context.Background(), b)
-	// clean up bundle since assembler isnt called
+	// clean up bundle since assembler isn't called
 	defer yc.b.Remove()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", yumDef, err)
@@ -102,7 +102,7 @@ func TestYumPacker(t *testing.T) {
 	ycp := &YumConveyorPacker{}
 
 	err = ycp.Get(context.Background(), b)
-	// clean up tmpfs since assembler isnt called
+	// clean up tmpfs since assembler isn't called
 	defer ycp.b.Remove()
 	if err != nil {
 		t.Fatalf("failed to Get from %s: %v\n", yumDef, err)

--- a/internal/pkg/build/sources/conveyorPacker_zypper_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper_test.go
@@ -69,7 +69,7 @@ func TestZypperConveyor(t *testing.T) {
 		zc := &ZypperConveyorPacker{}
 
 		err = zc.Get(context.Background(), b)
-		// clean up tmpfs since assembler isnt called
+		// clean up tmpfs since assembler isn't called
 		defer zc.b.Remove()
 		if err != nil {
 			t.Fatalf("failed to Get from %s: %v\n", defName, err)
@@ -111,7 +111,7 @@ func TestZypperPacker(t *testing.T) {
 		zcp := &ZypperConveyorPacker{}
 
 		err = zcp.Get(context.Background(), b)
-		// clean up tmpfs since assembler isnt called
+		// clean up tmpfs since assembler isn't called
 		defer zcp.b.Remove()
 		if err != nil {
 			t.Fatalf("failed to Get from %s: %v\n", defName, err)

--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hpcng/singularity/pkg/util/loop"
 )
 
-// Ext3Packer holds the locations of where to back from and to, aswell as image offset info
+// Ext3Packer holds the locations of where to back from and to, as well as image offset info
 type Ext3Packer struct {
 	srcfile string
 	b       *types.Bundle

--- a/internal/pkg/build/sources/packer_sandbox.go
+++ b/internal/pkg/build/sources/packer_sandbox.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SandboxPacker holds the locations of where to pack from and to
-// Ext3Packer holds the locations of where to back from and to, aswell as image offset info
+// Ext3Packer holds the locations of where to back from and to, as well as image offset info
 type SandboxPacker struct {
 	srcdir string
 	b      *types.Bundle

--- a/internal/pkg/build/sources/packer_squashfs.go
+++ b/internal/pkg/build/sources/packer_squashfs.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hpcng/singularity/pkg/image"
 )
 
-// SquashfsPacker holds the locations of where to pack from and to, aswell as image offset info
+// SquashfsPacker holds the locations of where to pack from and to, as well as image offset info
 type SquashfsPacker struct {
 	srcfile string
 	b       *types.Bundle

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -124,7 +124,7 @@ func main() {
 	}
 	defer outFile.Close()
 
-	// Determin if this is a setuid install
+	// Determine if this is a setuid install
 	b, err := ioutil.ReadFile(os.Args[1])
 	if err != nil {
 		fmt.Println(err)

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -147,7 +147,7 @@ func (c *Config) SetWorkingDirectoryFd(fd int) {
 // KeepFileDescriptor adds a file descriptor to an array of file
 // descriptors that starter will keep open. All files opened during
 // stage 1 will be shared with starter process. Once stage 1 returns,
-// all file descriptor whichs are not listed here will be closed.
+// all file descriptors which are not listed here will be closed.
 func (c *Config) KeepFileDescriptor(fd int) error {
 	if c.config.starter.numfds >= C.MAX_STARTER_FDS {
 		return fmt.Errorf("maximum number of kept file descriptors reached")

--- a/internal/pkg/runtime/engine/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engine/singularity/prepare_linux.go
@@ -960,7 +960,7 @@ func (e *EngineOperations) checkSignalPropagation() {
 		// - ENOTTY will also return 0 as process group
 		pgrp, _ = unix.IoctlGetInt(i, unix.TIOCGPGRP)
 		// based on kernel source a 0 value for process group
-		// theorically be set but really not sure it can happen
+		// theoretically be set but really not sure it can happen
 		// with linux tty behavior
 		if pgrp != 0 {
 			break

--- a/internal/pkg/runtime/engine/singularity/process_linux.go
+++ b/internal/pkg/runtime/engine/singularity/process_linux.go
@@ -288,7 +288,7 @@ func (e *EngineOperations) StartProcess(masterConnFd int) error {
 				statusChan <- status
 			} else if e, ok := err.(*os.SyscallError); ok {
 				// handle possible race with Wait4 call above by ignoring ECHILD
-				// error because child process was already catched
+				// error because child process was already caught
 				if e.Err.(syscall.Errno) != syscall.ECHILD {
 					sylog.Fatalf("error while waiting container process: %s", e.Error())
 				}

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -69,7 +69,7 @@ func TestLoadSeccompConfig(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	if err := LoadSeccompConfig(nil, false, 1); err == nil {
-		t.Errorf("shoud have failed with an empty config")
+		t.Errorf("should have failed with an empty config")
 	}
 	if err := LoadSeccompConfig(defaultProfile(), true, 1); err != nil {
 		t.Errorf("%s", err)
@@ -85,7 +85,7 @@ func TestLoadProfileFromFile(t *testing.T) {
 	gen := generate.New(nil)
 
 	if err := LoadProfileFromFile("test_profile/fake.json", gen); err == nil {
-		t.Errorf("shoud have failed with inexistent file")
+		t.Errorf("should have failed with inexistent file")
 	}
 
 	if err := LoadProfileFromFile("test_profile/test.json", gen); err != nil {

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -158,7 +158,7 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 	// to explicitly set cmd's uid or gid here
 	// TODO (schebro): Fix #3818, #3821
 	// Currently we are relying on host's cryptsetup utility to encrypt and decrypt
-	// the SIF. The possiblity to saving a version of cryptsetup inside the container should be
+	// the SIF. The possibility to saving a version of cryptsetup inside the container should be
 	// investigated. To do that, at least one additional partition is required, which is
 	// not encrypted.
 

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -38,7 +38,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 		t.Errorf("Unable to create test file: %s", err)
 	}
 
-	// Ensure the test file is the currect permission.
+	// Ensure the test file has the correct permission.
 	err = fp.Chmod(0o755)
 	if err != nil {
 		t.Errorf("Unable to change file permission: %s", err)
@@ -52,7 +52,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	// Double check the permission is what we expect.
 	if currentMode := finfo.Mode(); currentMode != 0o755 {
-		t.Errorf("Unexpect file permission: expecting 755, got %o", currentMode)
+		t.Errorf("Unexpected file permission: expecting 755, got %o", currentMode)
 	}
 
 	// Now the actral test!
@@ -69,7 +69,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	// Finally, check the file permission.
 	if currentMode := finfo.Mode(); currentMode != 0o655 {
-		t.Errorf("Unexpect file permission: expecting 655, got %o", currentMode)
+		t.Errorf("Unexpected file permission: expecting 655, got %o", currentMode)
 	}
 
 	// Test again with another permission.
@@ -86,7 +86,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	// Finally, check the file permission.
 	if currentMode := finfo.Mode(); currentMode != 0o777 {
-		t.Errorf("Unexpect file permission: expecting 777, got %o", currentMode)
+		t.Errorf("Unexpected file permission: expecting 777, got %o", currentMode)
 	}
 
 	// And close the file.
@@ -114,7 +114,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	// Finally, check the file permission.
 	if currentMode := einfo.Mode(); currentMode != 0o755 {
-		t.Errorf("Unexpect file permission: expecting 755, got %o", currentMode)
+		t.Errorf("Unexpected file permission: expecting 755, got %o", currentMode)
 	}
 
 	// Test again with another permission.
@@ -131,7 +131,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	// Finally, check the file permission.
 	if currentMode := einfo.Mode(); currentMode != 0o544 {
-		t.Errorf("Unexpect file permission: expecting 544, got %o", currentMode)
+		t.Errorf("Unexpected file permission: expecting 544, got %o", currentMode)
 	}
 
 	// Cleanup.

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -135,12 +135,12 @@ func (u *Underlay) createLayer(rootFsPath string, system *mount.System) error {
 						return err
 					}
 				}
-				// if the directory is overrided by a bind mount we won't
+				// if the directory is overridden by a bind mount we won't
 				// need to duplicate the container image directory
 				if _, ok := destinations[p]; ok {
 					continue
 				}
-				// directory not overrided, duplicate it
+				// directory not overridden, duplicate it
 				if err := u.duplicateDir(p, system, pl.path); err != nil {
 					return err
 				}

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -165,7 +165,7 @@ func (m *Manager) createParentDir(path string) {
 				d := &dir{mode: m.DirMode, uid: uid, gid: gid}
 				m.entries[p] = d
 				m.dirs = append(m.dirs, d)
-				// check if the parent directory is part of the overrided
+				// check if the parent directory is part of the overridden
 				// directories to force the creation of the destination
 				// directory in the right parent directory (nested binds)
 				if ovDirs, ok := m.ovDirs[filepath.Dir(p)]; ok {

--- a/internal/pkg/util/fs/layout/manager_test.go
+++ b/internal/pkg/util/fs/layout/manager_test.go
@@ -54,13 +54,13 @@ func TestLayout(t *testing.T) {
 	}
 
 	if err := session.SetRootPath("/fakedirectory"); err == nil {
-		t.Error("shoud have failed with invalid root path directory")
+		t.Error("should have failed with invalid root path directory")
 	}
 	if err := session.SetRootPath(dir); err != nil {
 		t.Fatal(err)
 	}
 	if err := session.SetRootPath(dir); err == nil {
-		t.Error("shoud have failed with root path already set error")
+		t.Error("should have failed with root path already set error")
 	}
 
 	if err := session.AddDir("etc"); err == nil {
@@ -70,7 +70,7 @@ func TestLayout(t *testing.T) {
 		t.Error(err)
 	}
 	if err := session.AddDir("/etc"); err == nil {
-		t.Error("shoud have failed with existent path")
+		t.Error("should have failed with existent path")
 	}
 
 	if _, err := session.GetPath("/etcd"); err == nil {

--- a/internal/pkg/util/fs/layout/session_linux.go
+++ b/internal/pkg/util/fs/layout/session_linux.go
@@ -97,23 +97,23 @@ func (s *Session) RootFsPath() string {
 }
 
 func (s *Session) createLayout(system *mount.System) error {
-	// create directory for registered overrided directory
+	// create directory for registered overridden directory
 	for _, tag := range mount.GetTagList() {
 		for _, point := range system.Points.GetByTag(tag) {
 			if point.Source == "" {
 				continue
 			}
 
-			// search until we find a parent overrided directory
-			overrided := false
+			// search until we find a parent overridden directory
+			overridden := false
 			for baseDir := filepath.Dir(point.Destination); baseDir != "/"; {
 				if _, err := s.GetOverridePath(baseDir); err == nil {
-					overrided = true
+					overridden = true
 					break
 				}
 				baseDir = filepath.Dir(baseDir)
 			}
-			if !overrided {
+			if !overridden {
 				continue
 			}
 

--- a/internal/pkg/util/user/identity_unix_test.go
+++ b/internal/pkg/util/user/identity_unix_test.go
@@ -96,7 +96,7 @@ func TestCurrentOriginal(t *testing.T) {
 
 	// to fully test CurrentOriginal, we would need
 	// to execute it from a user namespace, actually
-	// we just ensure that current user informations
+	// we just ensure that current user information
 	// are returned
 	testCurrent(t, CurrentOriginal)
 

--- a/makeit/install.sh
+++ b/makeit/install.sh
@@ -61,7 +61,7 @@ fi
 
 name=$1
 if ! rootdir=`(cd $2 2>/dev/null && pwd -P)`; then
-	echo "error: $2 non-existant or permission denied"
+	echo "error: $2 non-existent or permission denied"
 	exit 2
 fi
 

--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -169,7 +169,7 @@ func populateRaw(d *Definition, w io.Writer) {
 	}
 
 	for k, v := range d.Header {
-		// filter out bootsrap parameter since it should already be added
+		// filter out bootstrap parameter since it should already be added
 		if k == "bootstrap" {
 			continue
 		}

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -54,7 +54,7 @@ func IsInvalidSectionError(err error) bool {
 //
 // Scanner behavior:
 //     1. The *first* time `s.Text()` is non-nil (which can be after infinitely many calls to
-//        `s.Scan()`), that text is *guaranteed* to be the header, unless the header doesnt exist.
+//        `s.Scan()`), that text is *guaranteed* to be the header, unless the header doesn't exist.
 //		  In that case it returns the first section it finds.
 //     2. The next `n` times that `s.Text()` is non-nil (again, each could take many calls to
 //        `s.Scan()`), that text is guaranteed to be one specific section of the definition file.

--- a/pkg/image/doc.go
+++ b/pkg/image/doc.go
@@ -11,7 +11,7 @@ a Singularity image, whether through OCI or directly.
 
 type ImageFormat interface {
     Root() *spec.Root - Root() returns the OCI compliant root of the
-                        Image. This function may preform some action,
+                        Image. This function may perform some action,
                         such as extracting the filesystem to a dir.
 
 }

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -518,7 +518,7 @@ func testBadBridge(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdout
 func TestAddDelNetworks(t *testing.T) {
 	test.EnsurePrivilege(t)
 
-	// centos 6 doesn't support brigde/veth, only macvlan
+	// centos 6 doesn't support bridge/veth, only macvlan
 	// just skip tests on centos 6, rhel 6
 	b, err := ioutil.ReadFile("/etc/system-release-cpe")
 	if err == nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -54,7 +54,7 @@ type Plugin struct {
 	// Install is a function called during singularity
 	// plugin install, the function take the directory
 	// where plugin object will reside and can be used
-	// to store configuration files/datas needed by a
+	// to store configuration files/data needed by a
 	// plugin.
 	Install func(string) error
 }

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -100,7 +100,7 @@ func (b *BindPath) Readonly() bool {
 	return b.Options != nil && b.Options["ro"] != nil
 }
 
-// JSONConfig stores engine specific confguration that is allowed to be set by the user.
+// JSONConfig stores engine specific configuration that is allowed to be set by the user.
 type JSONConfig struct {
 	ScratchDir        []string          `json:"scratchdir,omitempty"`
 	OverlayImage      []string          `json:"overlayImage,omitempty"`

--- a/pkg/util/sysctl/sysctl_linux_test.go
+++ b/pkg/util/sysctl/sysctl_linux_test.go
@@ -29,10 +29,10 @@ func TestGetSet(t *testing.T) {
 
 	value, err = Get("net.ipv4.ip_forward2")
 	if err == nil {
-		t.Errorf("shoud have failed, key doesn't exists")
+		t.Errorf("should have failed, key doesn't exists")
 	}
 
 	if err := Set("net.ipv4.ip_forward2", value); err == nil {
-		t.Errorf("shoud have failed, key doesn't exists")
+		t.Errorf("should have failed, key doesn't exists")
 	}
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#325

The original PR description was:

> Fix typos found by [codespell](https://github.com/codespell-project/codespell).
> 
> I have left out:
> 
> - **splitted** → **split** : This is used in actual code in multiple places. Perhaps on purpose?
> - **reenable** → **re-enable** : Found in a standardized comment appearing in multiple places:
>       `// TODO(mem): reenable this; disabled while shub is down`
> 
> 
> Should I fix **splitted**?