### PR TITLE
Add seccomp, cryptsetup, devscripts, correct go version test to debian packaging

### DIFF
--- a/dist/debian/control
+++ b/dist/debian/control
@@ -15,7 +15,10 @@ Build-Depends:
  libssl-dev,
  python,
  uuid-dev,
- golang-go (>= 2:1.13)
+ devscripts,
+ libseccomp-dev,
+ cryptsetup,
+ golang-go (>= 2:1.13~~)
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity
 Vcs-Git: https://github.com/hpcng/singularity.git


### PR DESCRIPTION
## Description of the Pull Request (PR):

Useful application of e.g. singularity build --fakeroot needs seccomp support in the build. 

For creation of encrypted containers cryptsetup is needed.

Devscripts was a missing depency. 

Use of "~~" in the golang version test avoids failure with ubuntu golang packages

### This fixes or addresses the following GitHub issues:

 - Fixes #6236


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/hpcng/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)
