### PR TITLE
Add seccomp, cryptsetup, devscripts, correct go version test to debian packaging

### DIFF
--- a/dist/debian/control
+++ b/dist/debian/control
@@ -15,7 +15,10 @@ Build-Depends:
  libssl-dev,
  python,
  uuid-dev,
- golang-go (>= 2:1.13)
+ devscripts,
+ libseccomp-dev,
+ cryptsetup,
+ golang-go (>= 2:1.13~~)
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity
 Vcs-Git: https://github.com/hpcng/singularity.git


### PR DESCRIPTION
## Description of the Pull Request (PR):

Useful application of e.g. singularity build --fakeroot needs seccomp support in the build.

For creation of encrypted containers cryptsetup is needed.

Devscripts was a missing dependency.

Use of "~~" in the golang version test avoids failure with ubuntu golang packages

### This fixes or addresses the following GitHub issues:

 - Fixes #6236

