### PR TITLE
added debian package dependencies according to issue #6257

### DIFF
--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -33,6 +33,8 @@ See `mconfig --help` for details about the configuration options.
 
 To select a specific profile for `mconfig`.
 
+__REMINDER:__ to build with seccomp you need to install `libseccomp-dev` package !
+
 For real production environment us this configuration:
 ```
 export DEB_SC_PROFILE=release-stripped

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -9,13 +9,15 @@ Uploaders:
  Gregory M. Kurtzer <gmkurtzer@gmail.com>,
 Build-Depends:
  debhelper (>= 9),
+ devscripts,
  dh-autoreconf,
  help2man,
  libarchive-dev,
  libssl-dev,
  python,
  uuid-dev,
- golang-go (>= 2:1.13)
+ cryptsetup,
+ golang-go (>= 2:1.13~~)
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity
 Vcs-Git: https://github.com/hpcng/singularity.git


### PR DESCRIPTION
## Description of the Pull Request (PR):

- correct golang-go dependency version
- add devscripts dependency
- add cryptsetup dependency
- add a note about "libseccomp" to DEBIAN_PACKAGE.md


### This fixes or addresses the following GitHub issues:

 - Fixes #6236

