### PR TITLE
Temporarily disable TestBusyBoxPacker, from sylabs 334

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -61,6 +61,9 @@ func TestBusyBoxConveyor(t *testing.T) {
 }
 
 func TestBusyBoxPacker(t *testing.T) {
+	// 2021-09-22 - Always skip due to frequent download failures
+	t.SkipNow()
+
 	// TODO - busybox example has arch hard coded
 	require.Arch(t, "amd64")
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#334

The original PR description was:

> Missed in the previous BusyBox disabling.