### PR TITLE
Run e2e on any changes to .go source

### DIFF
--- a/.ci/e2e_triggers
+++ b/.ci/e2e_triggers
@@ -1,3 +1,5 @@
-^\.circleci/
+^internal/.*\.go$
+^cmd/.*\.go$
+^pkg/.*\.go$
 ^e2e/
 ^go\.mod$


### PR DESCRIPTION
This changes CI to run e2e tests whenever any .go files are modified.  There are currently too many ways that a critical change can be accepted without running e2e tests.