### PR TITLE
Fix TestFindOnPath, from sylabs 393

### DIFF
--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -19,6 +19,7 @@ type ctx struct {
 func (c ctx) testOverlayCreate(t *testing.T) {
 	require.Filesystem(t, "overlay")
 	require.MkfsExt3(t)
+	e2e.EnsureImage(t, c.env)
 
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "overlay", "")
 	defer cleanup(t)


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#393
which fixed
- sylabs/singularity#392

The original PR description was:

> Unfortunately, on some distributions or user environments, variations
> in `/bin` symlinking, PATH ordering and propagation / non propagation
> across tests run under sudo lead to situations where TestFindOnPath
> doesn't work, as the truth value may have the symlink path, while the
> function under test returns the target path (or vice versa).
> 
> We can't resolve symlinks out in findOnPath to match the test, as the
> symlink name can impact the function of the program. E.g. resolving
> `mkfs.ext3` to `mke2fs` and calling that will result in an ext2
> filesystem, rather than an ext3 filesystem being created.
> 
> The best approach here seems to be to force a specific PATH in the
> test, instead.
> 
> Also add an ensureImage call to e2e overlay tests - found this was missing when running a subset of the e2e and it failed here.