### PR TITLE
Remove GOPATH Use, Simplify RPM Spec, from sylabs 370

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,11 +62,10 @@ wget -O /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz \
 sudo tar -C /usr/local -xzf /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz
 ```
 
-Finally, set up your environment for Go:
+Finally, add `/usr/local/go/bin` to the `PATH` environment variable:
 
 ```sh
-echo 'export GOPATH=${HOME}/go' >> ~/.bashrc
-echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -91,6 +90,13 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 ```
 
 <!-- markdownlint-enable MD013 -->
+
+Add `$(go env GOPATH)` to the `PATH` environment variable:
+
+```sh
+echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.bashrc
+source ~/.bashrc
+```
 
 ## Clone the repo
 

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -74,9 +74,14 @@ containers that can be used across host environments.
 export RPM_BUILD_ROOT="%{buildroot}"
 %endif
 
+if [ -d %{name}-%{version} ]; then
+    # Clean up old build root
+    # First clean go's modcache because directories are unwritable
+    GOPATH=$PWD/%{name}-%{version}/gopath go clean -modcache
+    rm -rf %{name}-%{version}
+fi
+
 # Create our build root
-chmod -R +w %{name}-%{version} || true
-rm -rf %{name}-%{version}
 mkdir %{name}-%{version}
 
 %build
@@ -118,7 +123,7 @@ make -C builddir old_config=
 cd %{name}-%{version}
 
 export GOPATH=$PWD/gopath
-cd %{name}-@PACKAGE_VERSION@
+cd %{name}-%{package_version}
 
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 make -C builddir DESTDIR=$RPM_BUILD_ROOT install man

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -38,10 +38,6 @@ License: BSD-3-Clause-LBNL
 URL: https://singularity.hpcng.org
 Source: %{name}-%{package_version}.tar.gz
 ExclusiveOS: linux
-# RPM_BUILD_ROOT wasn't being set ... for some reason
-%if "%{sles_version}" == "11"
-BuildRoot: /var/tmp/singularity-%{version}-build
-%endif
 
 %if "%{_target_vendor}" == "suse"
 %if "%{sles_version}" != "11"
@@ -54,9 +50,7 @@ BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make
 %if ! 0%{?el6}
-%if "%{sles_version}" != "11"
 BuildRequires: libseccomp-devel
-%endif
 %endif
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
@@ -130,11 +124,6 @@ cd %{name}-@PACKAGE_VERSION@
 
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 make -C builddir DESTDIR=$RPM_BUILD_ROOT install man
-
-%if "%{suse_version}" == "11"
-%clean
-/bin/rm -rf %{buildroot}
-%endif
 
 %files
 %attr(4755, root, root) %{_libexecdir}/singularity/bin/starter-suid

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -49,9 +49,7 @@ BuildRequires: golang
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make
-%if ! 0%{?el6}
 BuildRequires: libseccomp-devel
-%endif
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
 %else

--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -1,25 +1,25 @@
-# 
-# Copyright (c) 2017-2018, SyLabs, Inc. All rights reserved.
+#
+# Copyright (c) 2017-2021, SyLabs, Inc. All rights reserved.
 # Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 #
 # Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
-# 
+#
 # Copyright (c) 2016, The Regents of the University of California, through
 # Lawrence Berkeley National Laboratory (subject to receipt of any required
 # approvals from the U.S. Dept. of Energy).  All rights reserved.
-# 
+#
 # This software is licensed under a customized 3-clause BSD license.  Please
 # consult LICENSE file distributed with the sources of this project regarding
 # your rights to use or distribute this software.
-# 
+#
 # NOTICE.  This Software was developed under funding from the U.S. Department of
 # Energy and the U.S. Government consequently retains certain rights. As such,
 # the U.S. Government has been granted for itself and others acting on its
 # behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
 # to reproduce, distribute copies to the public, prepare derivative works, and
-# perform publicly and display publicly, and to permit other to do so. 
-# 
-# 
+# perform publicly and display publicly, and to permit other to do so.
+#
+#
 
 # Disable debugsource packages; otherwise it ends up with an empty %files
 #   file in debugsourcefiles.list on Fedora
@@ -82,26 +82,19 @@ containers that can be used across host environments.
 export RPM_BUILD_ROOT="%{buildroot}"
 %endif
 
-if [ -d %{name}-%{version} ]; then
-    # Clean up old build root
-    # First clean go's modcache because directories are unwritable
-    GOPATH=$PWD/%{name}-%{version}/gopath go clean -modcache
-    rm -rf %{name}-%{version}
-fi
-
 # Create our build root
+chmod -R +w %{name}-%{version} || true
+rm -rf %{name}-%{version}
 mkdir %{name}-%{version}
 
 %build
 cd %{name}-%{version}
 
 # Setup an empty GOPATH for the build
-mkdir -p gopath
-
 export GOPATH=$PWD/gopath
-export PATH=$GOPATH/bin:$PATH
+mkdir -p "$GOPATH"
 
-# Perform the build outside of GOPATH as we are using go modules
+# Extract the source
 tar -xf "%SOURCE0"
 cd %{name}-%{package_version}
 
@@ -127,20 +120,16 @@ done
         --mandir=%{_mandir} \
         --infodir=%{_infodir}
 
-cd builddir
-make old_config=
+make -C builddir old_config=
 
 %install
 cd %{name}-%{version}
 
 export GOPATH=$PWD/gopath
-export PATH=$GOPATH/bin:$PATH
-
-# Enter the source builddir for the install
-cd %{name}-%{package_version}/builddir
+cd %{name}-@PACKAGE_VERSION@
 
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
-make DESTDIR=$RPM_BUILD_ROOT install man
+make -C builddir DESTDIR=$RPM_BUILD_ROOT install man
 
 %if "%{suse_version}" == "11"
 %clean


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#370

The original PR description was:

> Remove unnecessary uses of `GOPATH` in `INSTALL.md` and RPM spec. Simplify RPM spec.