### PR TITLE
No longer set python=3 for e2e test that uses conda

### DIFF
--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -143,7 +143,7 @@ From: continuumio/miniconda3:latest
 %post
 
 	. /opt/conda/etc/profile.d/conda.sh
-	conda create -n env python=3
+	conda create -n env
 
 %environment
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix the e2e test for issue274


### This fixes or addresses the following GitHub issues:

 - Fixes #6281

