### PR TITLE
fix: perform nvccli env->flags inside runtime, not CLI, from sylabs 397

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -799,11 +799,15 @@ func setNvCCLIConfig(engineConfig *singularityConfig.EngineConfig) (err error) {
 		sylog.Warningf("When using nvidia-container-cli with --contain NVIDIA_VISIBLE_DEVICES must be set or no GPUs will be available in container.")
 	}
 
-	nvCCLIFlags, err := gpu.NVCLIEnvToFlags()
-	if err != nil {
-		return err
+	// Pass NVIDIA_ env vars that will be converted to nvidia-container-cli options
+	nvCCLIEnv := []string{}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "NVIDIA_") {
+			nvCCLIEnv = append(nvCCLIEnv, e)
+		}
 	}
-	engineConfig.SetNvCCLIFlags(nvCCLIFlags)
+	engineConfig.SetNvCCLIEnv(nvCCLIEnv)
+
 	if UserNamespace && !IsWritable {
 		return fmt.Errorf("nvidia-container-cli requires --writable with user namespace/fakeroot")
 	}

--- a/internal/pkg/runtime/engine/singularity/container_linux.go
+++ b/internal/pkg/runtime/engine/singularity/container_linux.go
@@ -273,7 +273,7 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		// If we are not inside a user namespace then the NVCCLI call must exec nvidia-container-cli
 		// as the host uid 0. This may happen via the setuid starter, or from singularity being run
 		// directly as uid 0, e.g. `sudo singularity`.
-		if err := c.rpcOps.NvCCLI(engine.EngineConfig.GetNvCCLIFlags(), c.session.FinalPath(), c.userNS); err != nil {
+		if err := c.rpcOps.NvCCLI(engine.EngineConfig.GetNvCCLIEnv(), c.session.FinalPath(), c.userNS); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/util/gpu/nvidia_test.go
+++ b/internal/pkg/util/gpu/nvidia_test.go
@@ -6,7 +6,6 @@
 package gpu
 
 import (
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -15,7 +14,7 @@ import (
 func TestNVCLIEnvToFlags(t *testing.T) {
 	tests := []struct {
 		name      string
-		env       map[string]string
+		env       []string
 		wantFlags []string
 		wantErr   bool
 	}{
@@ -30,8 +29,8 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "device",
-			env: map[string]string{
-				"NVIDIA_VISIBLE_DEVICES": "all",
+			env: []string{
+				"NVIDIA_VISIBLE_DEVICES=all",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -43,8 +42,8 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "mig-config",
-			env: map[string]string{
-				"NVIDIA_MIG_CONFIG_DEVICES": "all",
+			env: []string{
+				"NVIDIA_MIG_CONFIG_DEVICES=all",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -56,8 +55,8 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "mig-monitor",
-			env: map[string]string{
-				"NVIDIA_MIG_MONITOR_DEVICES": "all",
+			env: []string{
+				"NVIDIA_MIG_MONITOR_DEVICES=all",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -69,8 +68,8 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "compute-only",
-			env: map[string]string{
-				"NVIDIA_DRIVER_CAPABILITIES": "compute",
+			env: []string{
+				"NVIDIA_DRIVER_CAPABILITIES=compute",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -80,8 +79,8 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "all-caps",
-			env: map[string]string{
-				"NVIDIA_DRIVER_CAPABILITIES": "compute,compat32,graphics,utility,video,display",
+			env: []string{
+				"NVIDIA_DRIVER_CAPABILITIES=compute,compat32,graphics,utility,video,display",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -96,15 +95,15 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "invalid-caps",
-			env: map[string]string{
-				"NVIDIA_DRIVER_CAPABILITIES": "notacap",
+			env: []string{
+				"NVIDIA_DRIVER_CAPABILITIES=notacap",
 			},
 			wantErr: true,
 		},
 		{
 			name: "single-require",
-			env: map[string]string{
-				"NVIDIA_REQUIRE_CUDA": "cuda>=9.0",
+			env: []string{
+				"NVIDIA_REQUIRE_CUDA=cuda>=9.0",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -116,9 +115,9 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "multi-require",
-			env: map[string]string{
-				"NVIDIA_REQUIRE_BRAND": "brand=GRID",
-				"NVIDIA_REQUIRE_CUDA":  "cuda>=9.0",
+			env: []string{
+				"NVIDIA_REQUIRE_BRAND=brand=GRID",
+				"NVIDIA_REQUIRE_CUDA=cuda>=9.0",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -131,10 +130,10 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 		},
 		{
 			name: "disable-require",
-			env: map[string]string{
-				"NVIDIA_REQUIRE_BRAND":   "brand=GRID",
-				"NVIDIA_REQUIRE_CUDA":    "cuda>=9.0",
-				"NVIDIA_DISABLE_REQUIRE": "1",
+			env: []string{
+				"NVIDIA_REQUIRE_BRAND=brand=GRID",
+				"NVIDIA_REQUIRE_CUDA=cuda>=9.0",
+				"NVIDIA_DISABLE_REQUIRE=1",
 			},
 			wantFlags: []string{
 				"--no-cgroups",
@@ -146,12 +145,7 @@ func TestNVCLIEnvToFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for key, val := range tt.env {
-				os.Setenv(key, val)
-				defer os.Unsetenv(key)
-			}
-
-			gotFlags, err := NVCLIEnvToFlags()
+			gotFlags, err := NVCLIEnvToFlags(tt.env)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NVCLIEnvToFlags() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/runtime/engine/singularity/config/config.go
+++ b/pkg/runtime/engine/singularity/config/config.go
@@ -139,7 +139,7 @@ type JSONConfig struct {
 	Contain           bool              `json:"container,omitempty"`
 	NvLegacy          bool              `json:"nvLegacy,omitempty"`
 	NvCCLI            bool              `json:"nvCCLI,omitempty"`
-	NvCCLIFlags       []string          `json:"NvCCLIFlags,omitempty"`
+	NvCCLIEnv         []string          `json:"NvCCLIEnv,omitempty"`
 	Rocm              bool              `json:"rocm,omitempty"`
 	CustomHome        bool              `json:"customHome,omitempty"`
 	Instance          bool              `json:"instance,omitempty"`
@@ -245,14 +245,14 @@ func (e *EngineConfig) GetNvCCLI() bool {
 	return e.JSON.NvCCLI
 }
 
-// SetNVCCLIFlags sets flags to call nvidia-container-cli with for CUDA setup
-func (e *EngineConfig) SetNvCCLIFlags(NvCCLIFlags []string) {
-	e.JSON.NvCCLIFlags = NvCCLIFlags
+// SetNVCCLIEnv sets env vars holding options for nvidia-container-cli GPU setup
+func (e *EngineConfig) SetNvCCLIEnv(NvCCLIEnv []string) {
+	e.JSON.NvCCLIEnv = NvCCLIEnv
 }
 
-// GetNvCCLIFlags returns the flags to use in an nvidia-container-cli call
-func (e *EngineConfig) GetNvCCLIFlags() []string {
-	return e.JSON.NvCCLIFlags
+// GetNVCCLIEnv returns env vars holding options for nvidia-container-cli GPU setup
+func (e *EngineConfig) GetNvCCLIEnv() []string {
+	return e.JSON.NvCCLIEnv
 }
 
 // SetRocm sets rocm flag to bind rocm libraries into containee.JSON.


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#397
 which fixed
- sylabs/singularity#396

The original PR description was:

> The flags that will be used as options to `nvidia-container-cli` are
> currently derived within the CLI and passed in the runtime config.
> 
> The potentially dangerous `--ldconfig` flag is always appended to the
> actual `nvidia-container-cli` call within `NVCLIConfigure`, so
> attempts to pass a malicious `--ldconfig=xxx` from a modified CLI
> binary are overridden. However, we should perform the env -> flag
> conversion in a trusted portion of code, so we only ever call
> `nvidia-container-cli` with a set of flags we directly control.