### PR TITLE
Split SIF/bare types w.r.t allow container $type config, from sylabs 399

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Changes since last release
 
-### New features / functionalities
-
 - `--writable-tmpfs` can be used with `singularity build` to run
   the `%test` section of the build with a ephemeral tmpfs overlay,
   permitting tests that write to the container filesystem.
@@ -77,6 +75,17 @@
   GPUs inside a container run with `--nvccli`.
 - Build `--bind` option allows to set multiple bind mount without specifying
   the `--bind` option for each bindings.
+- The behaviour of the `allow container` directives in `singularity.conf` has
+  been modified, to support more intuitive limitations on the usage of SIF and non-SIF
+  container images. If you use these directives, _you may need to make changes
+  to singularity.conf to preserve behaviour_.
+  - A new `allow container sif` directive permits or denies usage of
+    _unencrypted_ SIF images, irrespective of the filesystem(s) inside the SIF.
+  - The `allow container encrypted` directive permits or denies usage of SIF
+    images with an encrypted root filesystem.
+  - The `allow container squashfs/extfs` directives in `singularity.conf`
+    permit or deny usage of bare SquashFS and EXT image files only.
+  - The effect of the `allow container dir` directive is unchanged.
 
 ## v3.8.3 - \[2021-09-07\]
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -253,6 +253,40 @@ func (i *Image) GetDataPartitions() ([]Section, error) {
 	return i.getPartitions(DataUsage)
 }
 
+// HasEncryptedRootFs returns true if the image contains an encrypted
+// rootfs partition.
+func (i *Image) HasEncryptedRootFs() (encrypted bool, err error) {
+	rootFsParts, err := i.GetRootFsPartitions()
+	if err != nil {
+		return false, fmt.Errorf("while getting root FS partitions: %v", err)
+	}
+
+	for _, p := range rootFsParts {
+		if p.Type == ENCRYPTSQUASHFS {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// initFile ensures file descriptor is associated to a file handle.
+func (i *Image) initFile() error {
+	if i.File != nil {
+		return nil
+	}
+	if i.Path == "" {
+		return fmt.Errorf("no image path")
+	}
+	if i.Fd == emptyFd || i.Source == "" {
+		return fmt.Errorf("%s is not open", i.Path)
+	}
+	if err := os.NewFile(i.Fd, i.Path); err == nil {
+		return fmt.Errorf("image file descriptor for %s is not valid", i.Path)
+	}
+	return nil
+}
+
 // writeLocks tracks write locks for the current process.
 var writeLocks = make(map[string][]Section)
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -270,23 +270,6 @@ func (i *Image) HasEncryptedRootFs() (encrypted bool, err error) {
 	return false, nil
 }
 
-// initFile ensures file descriptor is associated to a file handle.
-func (i *Image) initFile() error {
-	if i.File != nil {
-		return nil
-	}
-	if i.Path == "" {
-		return fmt.Errorf("no image path")
-	}
-	if i.Fd == emptyFd || i.Source == "" {
-		return fmt.Errorf("%s is not open", i.Path)
-	}
-	if err := os.NewFile(i.Fd, i.Path); err == nil {
-		return fmt.Errorf("image file descriptor for %s is not valid", i.Path)
-	}
-	return nil
-}
-
 // writeLocks tracks write locks for the current process.
 var writeLocks = make(map[string][]Section)
 

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -37,10 +37,11 @@ type File struct {
 	EnableFusemount         bool     `default:"yes" authorized:"yes,no" directive:"enable fusemount"`
 	EnableUnderlay          bool     `default:"yes" authorized:"yes,no" directive:"enable underlay"`
 	MountSlave              bool     `default:"yes" authorized:"yes,no" directive:"mount slave"`
+	AllowContainerSIF       bool     `default:"yes" authorized:"yes,no" directive:"allow container sif"`
+	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
 	AllowContainerSquashfs  bool     `default:"yes" authorized:"yes,no" directive:"allow container squashfs"`
 	AllowContainerExtfs     bool     `default:"yes" authorized:"yes,no" directive:"allow container extfs"`
 	AllowContainerDir       bool     `default:"yes" authorized:"yes,no" directive:"allow container dir"`
-	AllowContainerEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow container encrypted"`
 	AlwaysUseNv             bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
 	UseNvCCLI               bool     `default:"no" authorized:"yes,no" directive:"use nvidia-container-cli"`
 	AlwaysUseRocm           bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
@@ -265,10 +266,17 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 # DEFAULT: yes
 # This feature limits what kind of containers that Singularity will allow
 # users to use (note this does not apply for root).
+#
+# Allow use of unencrypted SIF containers
+allow container sif = {{ if eq .AllowContainerSIF true}}yes{{ else }}no{{ end }}
+#
+# Allow use of encrypted SIF containers
+allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else }}no{{ end }}
+#
+# Allow use of non-SIF image formats
 allow container squashfs = {{ if eq .AllowContainerSquashfs true }}yes{{ else }}no{{ end }}
 allow container extfs = {{ if eq .AllowContainerExtfs true }}yes{{ else }}no{{ end }}
 allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }}
-allow container encrypted = {{ if eq .AllowContainerEncrypted true }}yes{{ else }}no{{ end }}
 
 # ALLOW NET USERS: [STRING]
 # DEFAULT: NULL


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#399
 which fixed
- sylabs/singularity#398

The original PR description was:
> The `allow container $type` directives are confusing as they allow
> limiting use of SquashFS and EXT3 containers... but will also apply to
> those filesystems inside of a SIF.
> 
> We commonly present SIF as a separate container format, and users
> don't generally need to be aware that it's a wrapper format for other
> filesystem types. We generally talk about a `SquashFS` image in the
> context of a raw Singularity 2.x image, not the contents of a
> SIF. With this in mind it makes more sense to separately allow /
> disallow SIF or bare SquashFS etc.
> 
> This PR:
> 
> - Modifies the logic applying the `allow container squashfs/ext3` directive so they only apply to _bare_ images
>       in those formats, not SIFs using those formats internally.
> 
> - Modifies `allow container encrypted` so that it only controls use of
>       SIF containers where the RootFS is an encrypted SquashFS
>       filesystem.
> 
> - Adds a new `allow container sif` directive, controlling use of
>       unencrypted SIF containers, with _any_ internal FS, except an
>       encrypted RootFS (see above).