### PR TITLE
change scope of "defer" used inside of for loops

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,6 +52,7 @@
 - Hugo Meiland <hugo.meiland@microsoft.com>
 - Jack Morrison <morrisonjc@ornl.gov>, <jack@rescale.com>
 - Jacob Chappell <chappellind@gmail.com>, <jacob.chappell@uky.edu>
+- James Charlton <techguru@byiq.com>
 - Jarrod Johnson <jjohnson2@lenovo.com>
 - Jason Stover <jms@sylabs.io>, <jason.stover@gmail.com>
 - Jeff Kriske <jekriske@gmail.com>

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -56,7 +56,7 @@ type testCaseForNoninteractiveCacheCmd struct {
 }
 
 func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
-	tests := []testCaseForNoninteractiveCacheCmd {
+	tests := []testCaseForNoninteractiveCacheCmd{
 		{
 			name:               "clean force",
 			options:            []string{"clean", "--force"},
@@ -160,7 +160,7 @@ type testCaseForInteractiveCacheCmd struct {
 }
 
 func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
-	tests := []testCaseForInteractiveCacheCmd {
+	tests := []testCaseForInteractiveCacheCmd{
 		{
 			name:               "clean normal confirmed",
 			options:            []string{"clean"},
@@ -223,7 +223,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		},
 	}
 
-		// A directory where we store the image and used by separate commands
+	// A directory where we store the image and used by separate commands
 	tempDir, imgStoreCleanup := e2e.MakeTempDir(t, "", "", "image store")
 	defer imgStoreCleanup(t)
 	imagePath := filepath.Join(tempDir, imgName)
@@ -233,7 +233,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 	}
 }
 
-func (c cacheTests) executeTestCaseForInteractiveCacheCmd(t *testing.T, tc testCaseForInteractiveCacheCmd, imagePath string ) {
+func (c cacheTests) executeTestCaseForInteractiveCacheCmd(t *testing.T, tc testCaseForInteractiveCacheCmd, imagePath string) {
 	// Each test get its own clean cache directory
 	cacheDir, cleanup := e2e.MakeCacheDir(t, "")
 	defer cleanup(t)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -63,7 +63,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 	// use a trailing slash in tests for sandbox intentionally to make sure
 	// `singularity build -s /tmp/sand/ docker://alpine` works,
 	// see https://github.com/hpcng/singularity/issues/4407
-	tt := []testCaseForBuildFrom {
+	tt := []testCaseForBuildFrom{
 		// Disabled due to frequent download failures of the busybox tgz
 		// {
 		// 	name:      "BusyBox",
@@ -357,7 +357,7 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 	}
 	defer os.Remove(tmpfile) // clean up
 
-	tests := []testCaseForBuildMultiStageDefinition {
+	tests := []testCaseForBuildMultiStageDefinition{
 		// Simple copy from stage one to final stage
 		{
 			name: "FileCopySimple",
@@ -834,8 +834,6 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 	}
 }
 
-
-
 func (c *imgBuildTests) executeTestCaseForBuildDefinition(t *testing.T, dfd e2e.DefFileDetails, name string, profile e2e.Profile) {
 	dn, cleanup := c.tempDir(t, "build-definition")
 	defer cleanup()
@@ -1196,7 +1194,7 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 	}
 
 	// Test builds with "Fingerprint:" headers
-	tests := []testCaseForBuildWithFingerprint {
+	tests := []testCaseForBuildWithFingerprint{
 		{
 			name:       "build single signed one fingerprint",
 			definition: fmt.Sprintf("Bootstrap: localimage\nFrom: %s\nFingerprints: %s\n", singleSigned, ecl.KeyMap["key1"]),

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -558,7 +558,7 @@ func (c imgBuildTests) executeTestCaseForBuildMultiStageDefinition(t *testing.T,
 	)
 }
 
-func (c imgBuildTests) 2(t *testing.T) {
+func (c imgBuildTests) buildDefinition(t *testing.T) {
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {
 		log.Fatal(err)
@@ -833,6 +833,8 @@ func (c imgBuildTests) 2(t *testing.T) {
 		})
 	}
 }
+
+
 
 func (c *imgBuildTests) executeTestCaseForBuildDefinition(t *testing.T, dfd e2e.DefFileDetails, name string, profile e2e.Profile) {
 	dn, cleanup := c.tempDir(t, "build-definition")

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -79,7 +79,7 @@ func (c ctx) testPushCmd(t *testing.T) {
 		t.Fatalf("unable to create src file for push tests: %+v", err)
 	}
 
-	tests := []testCaseForPushCmd {
+	tests := []testCaseForPushCmd{
 		{
 			desc:             "non existent image",
 			imagePath:        filepath.Join(orasInvalidDir, "not_an_existing_file.sif"),

--- a/examples/plugins/log-plugin/main.go
+++ b/examples/plugins/log-plugin/main.go
@@ -10,11 +10,11 @@ import (
 	"log/syslog"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/hpcng/singularity/pkg/cmdline"
 	pluginapi "github.com/hpcng/singularity/pkg/plugin"
 	clicallback "github.com/hpcng/singularity/pkg/plugin/callback/cli"
 	"github.com/hpcng/singularity/pkg/sylog"
+	"github.com/spf13/cobra"
 )
 
 // Plugin is the only variable which a plugin MUST export.

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -292,10 +292,16 @@ func (cp *OCIConveyorPacker) extractArchive(src string, dst string) error {
 			if err != nil {
 				return err
 			}
-			defer f.Close()
+			err = func() error {
+				defer f.Close()
 
-			// copy over contents
-			if _, err := io.Copy(f, tr); err != nil {
+				// copy over contents
+				if _, err := io.Copy(f, tr); err != nil {
+					return err
+				}
+				return nil
+			}()
+			if err != nil {
 				return err
 			}
 		}

--- a/internal/pkg/build/sources/conveyorPacker_zypper_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper_test.go
@@ -47,33 +47,37 @@ func TestZypperConveyor(t *testing.T) {
 	}
 
 	for _, defName := range zyppDef {
-		defFile, err := os.Open(defName)
-		if err != nil {
-			t.Fatalf("unable to open file %s: %v\n", defName, err)
-		}
-		defer defFile.Close()
+		testZypperConveyorForFile(t, defName)
+	}
+}
 
-		// create bundle to build into
-		b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-zypper"), os.TempDir())
-		if err != nil {
-			return
-		}
+func testZypperConveyorForFile(t *testing.T, defName string) {
+	defFile, err := os.Open(defName)
+	if err != nil {
+		t.Fatalf("unable to open file %s: %v\n", defName, err)
+	}
+	defer defFile.Close()
 
-		b.Recipe, err = parser.ParseDefinitionFile(defFile)
-		if err != nil {
-			t.Fatalf("failed to parse definition file %s: %v\n", defName, err)
-		}
+	// create bundle to build into
+	b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-zypper"), os.TempDir())
+	if err != nil {
+		return
+	}
 
-		testForSLE(t, b)
+	b.Recipe, err = parser.ParseDefinitionFile(defFile)
+	if err != nil {
+		t.Fatalf("failed to parse definition file %s: %v\n", defName, err)
+	}
 
-		zc := &ZypperConveyorPacker{}
+	testForSLE(t, b)
 
-		err = zc.Get(context.Background(), b)
-		// clean up tmpfs since assembler isn't called
-		defer zc.b.Remove()
-		if err != nil {
-			t.Fatalf("failed to Get from %s: %v\n", defName, err)
-		}
+	zc := &ZypperConveyorPacker{}
+
+	err = zc.Get(context.Background(), b)
+	// clean up tmpfs since assembler isn't called
+	defer zc.b.Remove()
+	if err != nil {
+		t.Fatalf("failed to Get from %s: %v\n", defName, err)
 	}
 }
 
@@ -89,37 +93,41 @@ func TestZypperPacker(t *testing.T) {
 	}
 
 	for _, defName := range zyppDef {
-		defFile, err := os.Open(defName)
-		if err != nil {
-			t.Fatalf("unable to open file %s: %v\n", defName, err)
-		}
-		defer defFile.Close()
+		testZypperPackerForFile(t, defName)
+	}
+}
 
-		// create bundle to build into
-		b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-zypper"), os.TempDir())
-		if err != nil {
-			return
-		}
+func testZypperPackerForFile(t *testing.T, defName string) {
+	defFile, err := os.Open(defName)
+	if err != nil {
+		t.Fatalf("unable to open file %s: %v\n", defName, err)
+	}
+	defer defFile.Close()
 
-		b.Recipe, err = parser.ParseDefinitionFile(defFile)
-		if err != nil {
-			t.Fatalf("failed to parse definition file %s: %v\n", defName, err)
-		}
+	// create bundle to build into
+	b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-zypper"), os.TempDir())
+	if err != nil {
+		return
+	}
 
-		testForSLE(t, b)
+	b.Recipe, err = parser.ParseDefinitionFile(defFile)
+	if err != nil {
+		t.Fatalf("failed to parse definition file %s: %v\n", defName, err)
+	}
 
-		zcp := &ZypperConveyorPacker{}
+	testForSLE(t, b)
 
-		err = zcp.Get(context.Background(), b)
-		// clean up tmpfs since assembler isn't called
-		defer zcp.b.Remove()
-		if err != nil {
-			t.Fatalf("failed to Get from %s: %v\n", defName, err)
-		}
+	zcp := &ZypperConveyorPacker{}
 
-		_, err = zcp.Pack(context.Background())
-		if err != nil {
-			t.Fatalf("failed to Pack from %s: %v\n", defName, err)
-		}
+	err = zcp.Get(context.Background(), b)
+	// clean up tmpfs since assembler isn't called
+	defer zcp.b.Remove()
+	if err != nil {
+		t.Fatalf("failed to Get from %s: %v\n", defName, err)
+	}
+
+	_, err = zcp.Pack(context.Background())
+	if err != nil {
+		t.Fatalf("failed to Pack from %s: %v\n", defName, err)
 	}
 }

--- a/pkg/util/unix/socket_test.go
+++ b/pkg/util/unix/socket_test.go
@@ -93,6 +93,7 @@ func testCreateSocketForPath(t *testing.T, path string) {
 	<-syncCh
 
 	// close socket implies to delete file automatically
+	os.Chdir(dir)
 	err = ln.Close()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
change scope of "defer" used inside of for loops by adding local closure or named function -- to prevent potential leaks of "defer" stacking up from each loop iteration

## Description of the Pull Request (PR):

 - Fixes # 6266
