### PR TITLE
Issue(s): #6294 - update test case which is returning a false negative condition

### DIFF
--- a/pkg/util/unix/socket_test.go
+++ b/pkg/util/unix/socket_test.go
@@ -80,13 +80,12 @@ func TestCreateSocket(t *testing.T) {
 
 		<-syncCh
 
-		// close socket implies to delete file automatically
-		os.Chdir(dir)
+		// close socket does not delete the os file
 		ln.Close()
 
-		// socket file is deleted by net package at close
-		if err := os.Remove(path); err == nil {
-			t.Errorf("unexpected success during socket removal")
+		// socket file is NOT deleted by net package at close
+		if err := os.Remove(path); err != nil {
+			t.Errorf("unexpected failure [%s] during socket file removal", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
update test case which is returning a false negative condition
1) remove extraneous chdir;
2) test that socket file removal does not present an error
3) report actual underlying error if socket file removal does not succeed

### This fixes or addresses the following GitHub issues:

 - Fixes #6294

