### PR TITLE
Merge release-3.8 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 - Fix the oras contexts to avoid hangs upon failed pushed to Harbor registry.
 
 ### Enhancements
- 
+
 - Added seccomp, cryptsetup, devscripts & correct go version test to
   debian packaging.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@
 - Build `--bind` option allows to set multiple bind mount without specifying
   the `--bind` option for each bindings.
 
+## v3.8.4 - \[2021-11-09\]
+
+### Bug fixes
+
+- Fix the oras contexts to avoid hangs upon failed pushed to Harbor registry.
+
+### Enhancements
+ 
+- Added seccomp, cryptsetup, devscripts & correct go version test to
+  debian packaging.
+
 ## v3.8.3 - \[2021-09-07\]
 
 ### Bug fixes

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,7 +117,7 @@ To build a specific version of Singularity, check out a
 for example:
 
 ```sh
-git checkout v3.8.3
+git checkout v3.8.4
 ```
 
 ## Compiling Singularity
@@ -173,7 +173,7 @@ To build from a release source tarball do these commands:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-export VERSION=3.8.3  # this is the singularity version, change as you need
+export VERSION=3.8.4  # this is the singularity version, change as you need
 
 # Fetch the source
 wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz
@@ -199,7 +199,7 @@ Then use the `rpm` make target to build Singularity as an rpm package:
 ```sh
 ./mconfig --only-rpm
 make -C builddir rpm
-sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.8.3*.x86_64.rpm # or whatever version you built
+sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-3.8.4*.x86_64.rpm # or whatever version you built
 ```
 
 <!-- markdownlint-enable MD013 -->

--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"context"
 	"runtime"
 
 	"github.com/hpcng/singularity/docs"
@@ -72,8 +71,6 @@ var SearchCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.TODO()
-
 		config, err := getLibraryClientConfig(SearchLibraryURI)
 		if err != nil {
 			sylog.Fatalf("Error while getting library client config: %v", err)
@@ -84,7 +81,7 @@ var SearchCmd = &cobra.Command{
 			sylog.Fatalf("Error initializing library client: %v", err)
 		}
 
-		if err := library.SearchLibrary(ctx, libraryClient, args[0], SearchArch, SearchSigned); err != nil {
+		if err := library.SearchLibrary(cmd.Context(), libraryClient, args[0], SearchArch, SearchSigned); err != nil {
 			sylog.Fatalf("Couldn't search library: %v", err)
 		}
 	},

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -37,6 +37,8 @@ See `mconfig --help` for details about the configuration options.
 
 To select a specific profile for `mconfig`.
 
+__REMINDER:__ to build with seccomp you need to install `libseccomp-dev` package !
+
 For real production environment us this configuration:
 
 ```sh

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -37,7 +37,8 @@ See `mconfig --help` for details about the configuration options.
 
 To select a specific profile for `mconfig`.
 
-__REMINDER:__ to build with seccomp you need to install `libseccomp-dev` package !
+__REMINDER:__
+to build with seccomp you need to install `libseccomp-dev` package !
 
 For real production environment us this configuration:
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -15,7 +15,10 @@ Build-Depends:
  libssl-dev,
  python,
  uuid-dev,
- golang-go (>= 2:1.13)
+ devscripts,
+ libseccomp-dev,
+ cryptsetup,
+ golang-go (>= 2:1.13~~)
 Standards-Version: 3.9.8
 Homepage: http://gmkurtzer.github.io/singularity
 Vcs-Git: https://github.com/hpcng/singularity.git

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -652,7 +652,8 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("pullDisableCache", c.testPullDisableCacheCmd)
 
 			// Regressions
-			t.Run("issue5808", c.issue5808)
+			// Disable for now, see issue #6299
+			// t.Run("issue5808", c.issue5808)
 		}),
 	}
 }


### PR DESCRIPTION
This merges the release-3.8 branch into master.  It includes a change that Sylabs left out of their master branch and fixed in sylabs/singularity#424.
