### PR TITLE
Installation instruction improvements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,8 @@ sudo apt-get install -y \
     libseccomp-dev \
     pkg-config \
     squashfs-tools \
-    cryptsetup
+    cryptsetup \
+    curl wget git
 ```
 
 On CentOS/RHEL:
@@ -39,7 +40,8 @@ sudo yum install -y epel-release
 sudo yum install -y \
     libseccomp-devel \
     squashfs-tools \
-    cryptsetup
+    cryptsetup \
+    wget git
 ```
 
 ## Install Go
@@ -55,7 +57,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.17.3 OS=linux ARCH=amd64  # change this as you need
+export GOVERSION=1.17.3 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz
@@ -86,7 +88,7 @@ run:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
 ```
 
 <!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
This fixes a bug in the installation instructions (setting VERSION instead of GOVERSION), adds installation of missing basic tools for a bare docker image (curl, wget, git), and updates the golangci-lint version to 1.43.0. 