### PR TITLE
Disable dependabot on no longer maintained master branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: master
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
     target-branch: release-3.8
 


### PR DESCRIPTION
There's currently a dependabot error on the master branch, but it is no longer maintained.