### PR TITLE
Switch from centos:8 to rockylinux:8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,15 +105,15 @@ jobs:
           OS_VERSION: 7
         run: ./scripts/ci-docker-run
 
-  rpmbuild-centos8:
+  rpmbuild-rocky8:
     runs-on: ubuntu-20.04
-    name: rpmbuild-centos8
+    name: rpmbuild-rocky8
     steps:
       - uses: actions/checkout@v2
 
       - name: Build and test rpm under docker
         env:
-          OS_TYPE: centos
+          OS_TYPE: rockylinux
           OS_VERSION: 8
         run: ./scripts/ci-docker-run
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -284,9 +284,9 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			from:                "centos:7",
 		},
 		{
-			name:                "CentOS_8",
+			name:                "RockyLinux_8",
 			kernelMajorRequired: 3,
-			from:                "centos:8",
+			from:                "rockylinux:8",
 		},
 		{
 			name:                "Ubuntu_1604",

--- a/examples/build-singularity/build-singularity.def
+++ b/examples/build-singularity/build-singularity.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: rockylinux/rockylinux:8.4
+From: rockylinux:8
 
 %post
     # Set build time env variable


### PR DESCRIPTION
CentOS 8 mirrors have disappeared, so switch to Rocky.

Includes a commit from apptainer/apptainer#217.