### PR TITLE
provide a local debian package builder script for testing

### DIFF
--- a/dist/debian-makepackage
+++ b/dist/debian-makepackage
@@ -1,0 +1,22 @@
+#!/bin/sh -ex
+
+# This script has been tested on ubuntu-20.04 using golang from this PPA:
+#   https://github.com/golang/go/wiki/Ubuntu
+#   https://launchpad.net/~longsleep/+archive/ubuntu/golang-backports
+
+name=singularity-container
+
+version=$(sed -ne "1s,^${name}.*(\(.*\)-.*$,\1,p" < debian/changelog)
+pwd=$(cd ${0%/*}; pwd)
+src=${pwd%/*}
+srcbase=${src##*/}
+srcname=${name}_${version}.orig.tar.gz
+
+(cd ../..; tar --exclude=${srcbase}/.\* -czf ${srcname} ${srcbase})
+cp -a debian ..
+cd ../debian
+debuild --check-dirname-level=0 -us -uc
+
+echo "---------------- Generated:"
+ls -al ../../${name}*deb
+echo ""

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -1,22 +1,19 @@
 # Creating the Debian package
 
 ## Preparation
-
 As long as the debian directory is in the sub-directory you need to link
 or copy it in the top directory.
 
 In the top directory do this:
-
-```sh
+```
 rm -rf debian
 cp -r dist/debian .
 ```
 
-Make sure all the dependencies are met. See the `INSTALL.md` for this.
-Otherwise `debuild` will complain and quit.
+Make sure all the dependencies are met. See the `INSTALL.md` for this. 
+Otherwise `debuild` will complain and quit. 
 
 ## Configuration
-
 To do some configuration for the build, some environment variables can
 be used.
 
@@ -24,7 +21,6 @@ Due to the fact, that `debuild` filters out some variables, all the
 configuration variables need to be prefixed by `DEB_`
 
 ### mconfig
-
 See `mconfig --help` for details about the configuration options.
 
 `export DEB_NOSUID=1`    adds --without-suid
@@ -37,36 +33,30 @@ See `mconfig --help` for details about the configuration options.
 
 To select a specific profile for `mconfig`.
 
-__REMINDER:__
-to build with seccomp you need to install `libseccomp-dev` package !
+__REMINDER:__ to build with seccomp you need to install `libseccomp-dev` package !
 
 For real production environment us this configuration:
-
-```sh
+```
 export DEB_SC_PROFILE=release-stripped
 ```
-
 or if debugging is needed use this.
-
-```sh
+```
 export DEB_SC_PROFILE=debug
 ```
 
 In case a different build directory is needed:
-
-```sh
+```
 export DEB_SC_BUILDDIR=builddir
 ```
 
 ### debchange
-
-One way to update the changelog would be that the developer of singularity
+One way to update the changelog would be that the developer of singularity 
 update the Debian changelog on every commit. As this is double work, because
-of the CHANGELOG.md in the top directory, the changelog is automatically
+of the CHANGELOG.md in the top directory, the changelog is automatically 
 updated with the version of the source which is currently checked out.
 Which means you can easily build Debian packages for all the different tagged
-versions of the software. See `INSTALL.md` on how to checkout a specific
-version.
+versions of the software. See `INSTALL.md` on how to checkout a specific 
+version. 
 
 Be aware, that `debchange` will complain about a lower version as the top in
 the current changelog. Which means you have to cleanup the changelog if needed.
@@ -76,62 +66,50 @@ Be aware, that the Debian install directory as you see it now, might not be avai
 in older versions (branches, tags). Make sure you have a clean copy of the debian
 directory before you switch to (checkout) an older version.
 
-Usually `debchange` is configured by the environment variables
-`DEBFULLNAME` and `EMAIL`. As `debuild` creates a clean environment it
-filters out most of the environment variables. To set `DEBFULLNAME` for
-the `debchange` command in the makefile, you have to set `DEB_FULLNAME`.
-If these variables are not set, `debchange` will try to find appropriate
-values from the system configuration. Usually by using the login name
-and the domain-name.
-
-```sh
+Usually `debchange` is configured by the environment variables `DEBFULLNAME` and 
+`EMAIL`. As `debuild` creates a clean environment it filters out most of the 
+environment variables. To set `DEBFULLNAME` for the `debchange` command in the 
+makefile, you have to set `DEB_FULLNAME`. If these variables are not set, `debchange`
+will try to find appropriate values from the system configuration. Usually by using the
+login name and the domain-name. 
+```
 export DEB_FULLNAME="Your Name"
 export EMAIL="you@example.org"
 ```
 
 ## Building
-
 As usual for creating a Debian package you can use `dpkg-buildpackage`
 or `debuild` which is a kind of wrapper for the first and includes the start
-of `lintian`, too.
+of `lintian`, too. 
 
-```sh
+```
 dpkg-buildpackage --build=binary --no-sign
 lintian --verbose --display-info --show-overrides
 ```
-
 or all in one
-
-```sh
+```
 debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
 ```
 
 After successful build the Debian package can be found in the parent directory.
 
 To clean up the temporary files created by `debuild` use the command:
-
-```sh
+```
 dh clean
 ```
-
-To cleanup the copy of the debian directory, make sure you saved your
-changes (if any) and remove it.
-
-```sh
+To cleanup the copy of the debian directory, make sure you saved your changes (if any) and remove it.
+```
 rm -rf debian
 ```
 
-For details on Debian package building see the man-page of `debuild` and
-`dpkg-buildpackage` and `lintian`
+For details on Debian package building see the man-page of `debuild` and `dpkg-buildpackage` and `lintian`
 
-## Debian Repository
+# Debian Repository
+In the current version this is by far not ready for using it in official Debian Repositories.
 
-In the current version this is by far not ready for using it in official
-Debian Repositories.
+This might change in future. I updated the old debian directory to make it just work, for people
+needing it.
 
-This might change in future. I updated the old debian directory to make
-it just work, for people needing it.
-
-Any help is welcome to provide a Debian installer which can be used for
-building a Debian package,
+Any help is welcome to provide a Debian installer which can be used for building a Debian package,
 that can be used in official Debian Repositories.
+

--- a/dist/debian/changelog
+++ b/dist/debian/changelog
@@ -1,3 +1,9 @@
+singularity-container (3.8.5-1) unstable; urgency=low
+
+  * version 3.8.5
+
+ -- singularity <singularity@apptainer.org>  Tue, 8 Feb 2022 12:00:00 +0000
+
 singularity-container (2.4.2-1) unstable; urgency=high
 
   * This fixed an issue for support of older distributions and kernels with regards to `setns()`

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -1,41 +1,22 @@
 Source: singularity-container
-Section: admin
+Section: utils
 Priority: optional
-Maintainer: Gregory M. Kurtzer <gmkurtzer@gmail.com>
-Uploaders:
- Dave Love <fx@gnu.org>,
- Mehdi Dogguy <mehdi@debian.org>,
- Yaroslav Halchenko <debian@onerussian.com>,
- Gregory M. Kurtzer <gmkurtzer@gmail.com>,
-Build-Depends:
- debhelper (>= 9),
- dh-autoreconf,
- help2man,
- libarchive-dev,
- libssl-dev,
- python,
- uuid-dev,
- devscripts,
- libseccomp-dev,
- cryptsetup,
- golang-go (>= 2:1.13~~)
+Maintainer: singularity <singularity@apptainer.org>
+Build-Depends: build-essential, uuid-dev, libgpgme-dev, squashfs-tools, libseccomp-dev, wget, pkg-config, git, cryptsetup-bin, golang (>=1.17)
 Standards-Version: 3.9.8
-Homepage: http://gmkurtzer.github.io/singularity
-Vcs-Git: https://github.com/hpcng/singularity.git
-Vcs-Browser: https://github.com/hpcng/singularity
+Homepage: https://apptainer.org/
+Vcs-Git: https://github.com/apptainer/singularity.git
+Vcs-Browser: https://github.com/apptainer/singularity
 
 # "singularity" is a packaged game (but the contents don't clash)
 Package: singularity-container
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, python, squashfs-tools
-Description: container platform focused on supporting "Mobility of Compute"
- Mobility of Compute encapsulates the development to compute model
- where developers can work in an environment of their choosing and
- creation and when the developer needs additional compute resources,
- this environment can easily be copied and executed on other platforms.
- Additionally as the primary use case for Singularity is targeted
- towards computational portability, many of the barriers to entry of
- other container solutions do not apply to Singularity making it an
- ideal solution for users (both computational and non-computational)
- and HPC centers.
-
+Depends: ${shlibs:Depends}
+Description: Apptainer is a container platform.  It allows you to create and
+ run containers that package up pieces of software in a way that is portable
+ and reproducible.  You can build a container using Apptainer on your
+ laptop, and then run it on many of the largest HPC clusters in the world,
+ local university or company clusters, a single server, in the cloud, or on
+ a workstation down the hall.  Your container is a single file, and you
+ don’t have to worry about how to install all the software you need on each
+ different operating system.

--- a/dist/debian/source/format
+++ b/dist/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
A proposed user script `dist/debian-makepackage` provides a single command to build an installable debian package.

This has been tested with ubuntu-20.04 and relies on the [recommended golang PPA](https://github.com/golang/go/wiki/Ubuntu) as stated in the user script.
