### PR TITLE
Give versions for Provides & Obsoletes on singularity-runtime

### DIFF
--- a/dist/rpm/singularity.spec.in
+++ b/dist/rpm/singularity.spec.in
@@ -69,8 +69,8 @@ BuildRequires: cryptsetup
 # there's no golang for ppc64, just ppc64le
 ExcludeArch: ppc64
 
-Provides: %{name}-runtime
-Obsoletes: %{name}-runtime
+Provides: %{name}-runtime = %{version}-%{release}
+Obsoletes: %{name}-runtime < 3.0
 
 %description
 Singularity provides functionality to make portable


### PR DESCRIPTION
This updates singularity.spec.in to give specific versions on the Provides and Obsoletes of singularity-runtime.  This is now required by Fedora 36 and rawhide (a.k.a Fedora 37) and is part of the Fedora packaging guidelines.