### PR TITLE
Ignore prelease part of go version

### DIFF
--- a/mlocal/scripts/check-min-go-version
+++ b/mlocal/scripts/check-min-go-version
@@ -17,6 +17,10 @@ if [ "$GOMINOR" = "$GOPATCH" ]; then
 else
     GOMINOR="${GOMINOR/.*}"
 fi
+# ignore GO pre-release extensions
+if ! [[ $GOMINOR =~ ^[0-9]$ ]]; then
+    GOMINOR="$(echo $GOMINOR|sed 's/^\([0-9]*\).*/\1/')"
+fi
 
 MINVERSION="$2"
 MINMAJOR="${MINVERSION/.*}"


### PR DESCRIPTION
Fix mlocal/scripts/check-min-go-version to handle go versions like `1.18beta2` such as currently on Fedora 36.