### PR TITLE
Remove python as a debian dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Correct library bindings for `unsquashfs` containment. Fixes errors where
   resolved library filename does not match library filename in binary (e.g. EL8,
   POWER9 with glibc-hwcaps).
+- Remove python as a dependency of the debian package.
 - Increased the TLS Handshake Timeout for the busybox bootstrap agent in
   build definition files to 60 seconds.
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -13,7 +13,6 @@ Build-Depends:
  help2man,
  libarchive-dev,
  libssl-dev,
- python,
  uuid-dev,
  devscripts,
  libseccomp-dev,
@@ -27,7 +26,7 @@ Vcs-Browser: https://github.com/apptainer/singularity
 # "singularity" is a packaged game (but the contents don't clash)
 Package: singularity-container
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, python, squashfs-tools
+Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model
  where developers can work in an environment of their choosing and


### PR DESCRIPTION
This backports apptainer/apptainer#262.