### PR TITLE
Preload NSS libraries prior to mount namespace creation (or join) and pivot_root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Remove python as a dependency of the debian package.
 - Increased the TLS Handshake Timeout for the busybox bootstrap agent in
   build definition files to 60 seconds.
+- Preload NSS libraries prior to mountspace name creation to avoid
+  circumstances that can cause loading those libraries from the
+  container image instead of the host, for example in the startup
+  environment.
 
 ## v3.8.6 - [2022-02-08]
 

--- a/e2e/testdata/regressions/issue_4203.def
+++ b/e2e/testdata/regressions/issue_4203.def
@@ -39,6 +39,10 @@ bootstrap: docker
 from: ubuntu:16.04
 stage: final
 
+%environment
+    # to trigger the regression from https://github.com/apptainer/apptainer/issues/304
+    cd /usr
+
 %files from build
     /bad.so /lib/x86_64-linux-gnu/libnss_bad.so.2
     /nsswitch.conf /etc/nsswitch.conf


### PR DESCRIPTION
This backports apptainer/apptainer#322 to release-3.8.