### PR TITLE
Switch apptainer to singularity in deb release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
         run: |
           # Make a new copy of the source files for this build
           set -x
-          tar xf apptainer-*.tar.gz
-          cd `basename apptainer-*.tar.gz .tar.gz`
+          tar xf singularity-*.tar.gz
+          cd `basename singularity-*.tar.gz .tar.gz`
           ./scripts/ci-docker-run
           cp *.deb ..
           cd ..


### PR DESCRIPTION
There was a merge error when the release workflow was last updated.  This changes "apptainer" to "singularity" when extracting the tarball.